### PR TITLE
ISV Operator Automation

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -29,7 +29,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		Only the portion of the openshift/conformance test suite that run in parallel.
 		`),
 		Matches: func(name string) bool {
-			return strings.Contains(name, "[Suite:openshift/conformance/parallel")
+			return strings.Contains(name, "[Suite:openshift/conformance/parallel") && !strings.Contains(name, "[Suite:openshift/isv")
 		},
 		Parallelism:          30,
 		MaximumAllowedFlakes: 15,
@@ -154,6 +154,17 @@ var staticSuites = []*ginkgo.TestSuite{
 		Parallelism: 30,
 		Count:       15,
 		TestTimeout: 20 * time.Minute,
+	},
+	{
+		Name: "openshift/isv",
+		Description: templates.LongDesc(`
+		This test suite verifies the Operators execution on Openshift
+		`),
+		Matches: func(name string) bool {
+			return strings.Contains(name, "[Suite:openshift/isv]")
+		},
+		Parallelism: 5,
+		TestTimeout: 60 * time.Minute,
 	},
 	{
 		Name: "all",

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -53,4 +53,5 @@ import (
 	_ "github.com/openshift/origin/test/extended/security"
 	_ "github.com/openshift/origin/test/extended/templates"
 	_ "github.com/openshift/origin/test/extended/user"
+	_ "github.com/openshift/origin/test/extended/isv"
 )

--- a/test/extended/isv/isv.go
+++ b/test/extended/isv/isv.go
@@ -1,0 +1,206 @@
+package isv
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/storage/names"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+type packagemanifest struct {
+	name                    string
+	supportsOwnNamespace    bool
+	supportsSingleNamespace bool
+	supportsAllNamespaces   bool
+	csvVersion              string
+	namespace               string
+	defaultChannel          string
+	catalogSource           string
+	catalogSourceNamespace  string
+}
+
+var _ = g.Describe("[Suite:openshift/isv] Operator", func() {
+	var (
+		oc                = exutil.NewCLI("isv", exutil.KubeConfigPath())
+		catalogLabels     = []string{"redhat-operators", "certified-operators"}
+		output, _         = oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "-l catalog="+catalogLabels[0], "-o=jsonpath={range .items[*].metadata}{.name}{'\\n'}{end}").Output()
+		redhatPackages    = strings.Split(output, "\n")
+		output1, _        = oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "-l catalog="+catalogLabels[1], "-o=jsonpath={range .items[*].metadata}{.name}{'\\n'}{end}").Output()
+		certifiedPackages = strings.Split(output1, "\n")
+		packages          = append(redhatPackages, certifiedPackages...)
+		//packages       = []string{"serverless-operator"}
+		currentPackage packagemanifest
+	)
+	defer g.GinkgoRecover()
+
+	g.AfterEach(func() {
+		if currentPackage.supportsSingleNamespace || currentPackage.supportsOwnNamespace {
+			_, err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("ns", currentPackage.namespace).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+	})
+
+	for i := range packages {
+
+		isv := packages[i]
+		g.It(isv+" should work properly", func() {
+			g.By("by installing", func() {
+				currentPackage = createSubscription(isv, oc)
+				checkDeployment(currentPackage, oc)
+			})
+			g.By("by unistalling", func() {
+				removeOperatorDependencies(currentPackage, oc, true)
+			})
+		})
+	}
+
+})
+
+func checkOperatorInstallModes(p packagemanifest, oc *exutil.CLI) packagemanifest {
+	supportsAllNamespaces, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", p.name, "-o=jsonpath={.status.channels[?(.name=='"+p.defaultChannel+"')].currentCSVDesc.installModes[?(.type=='AllNamespaces')].supported}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	supportsAllNamespacesAsBool, _ := strconv.ParseBool(supportsAllNamespaces)
+
+	supportsSingleNamespace, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", p.name, "-o=jsonpath={.status.channels[?(.name=='"+p.defaultChannel+"')].currentCSVDesc.installModes[?(.type=='SingleNamespace')].supported}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	supportsSingleNamespaceAsBool, _ := strconv.ParseBool(supportsSingleNamespace)
+
+	supportsOwnNamespace, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", p.name, "-o=jsonpath={.status.channels[?(.name=='"+p.defaultChannel+"')].currentCSVDesc.installModes[?(.type=='OwnNamespace')].supported}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	supportsOwnNamespaceAsBool, _ := strconv.ParseBool(supportsOwnNamespace)
+
+	p.supportsAllNamespaces = supportsAllNamespacesAsBool
+	p.supportsSingleNamespace = supportsSingleNamespaceAsBool
+	p.supportsOwnNamespace = supportsOwnNamespaceAsBool
+	return p
+}
+
+func createSubscription(isv string, oc *exutil.CLI) packagemanifest {
+
+	msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", isv, "-o=jsonpath={.status.catalogSource}:{.status.catalogSourceNamespace}:{.status.defaultChannel}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	packageData := strings.Split(msg, ":")
+	p := packagemanifest{catalogSource: packageData[0], catalogSourceNamespace: packageData[1], defaultChannel: packageData[2], name: isv}
+
+	csvVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", p.name, "-o=jsonpath={.status.channels[?(.name=='"+p.defaultChannel+"')].currentCSV}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	p.csvVersion = csvVersion
+
+	p = checkOperatorInstallModes(p, oc)
+
+	if p.supportsSingleNamespace || p.supportsOwnNamespace {
+		p = createNamespace(p, oc)
+		createOperatorGroup(p, oc)
+	} else if p.supportsAllNamespaces {
+		p.namespace = "openshift-operators"
+	} else {
+		g.Skip("Install Modes AllNamespaces and  SingleNamespace are disabled for Operator: " + isv)
+	}
+
+	templateSubscriptionYAML := writeSubscription(p)
+	_, err = oc.SetNamespace(p.namespace).AsAdmin().Run("create").Args("-f", templateSubscriptionYAML).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	return p
+}
+
+func createNamespace(p packagemanifest, oc *exutil.CLI) packagemanifest {
+	p.namespace = names.SimpleNameGenerator.GenerateName("test-operators-")
+	_, err := oc.AsAdmin().WithoutNamespace().Run("create").Args("ns", p.namespace).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	return p
+}
+
+func createOperatorGroup(p packagemanifest, oc *exutil.CLI) {
+
+	templateOperatorGroupYAML := writeOperatorGroup(p.namespace)
+	_, err := oc.SetNamespace(p.namespace).AsAdmin().Run("create").Args("-f", templateOperatorGroupYAML).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func writeOperatorGroup(namespace string) (templateOperatorYAML string) {
+	isvBaseDir := exutil.FixturePath("testdata", "isv")
+	operatorGroupYAML := filepath.Join(isvBaseDir, "operator_group.yaml")
+	fileOperatorGroup, _ := os.Open(operatorGroupYAML)
+	operatorGroup, _ := ioutil.ReadAll(fileOperatorGroup)
+	operatorGroupTemplate := string(operatorGroup)
+	templateOperatorYAML = strings.ReplaceAll(operatorGroupYAML, "operator_group.yaml", "operator_group_"+namespace+"_.yaml")
+	operatorGroupString := strings.ReplaceAll(operatorGroupTemplate, "$OPERATOR_NAMESPACE", namespace)
+	ioutil.WriteFile(templateOperatorYAML, []byte(operatorGroupString), 0644)
+	return
+}
+
+func writeSubscription(p packagemanifest) (templateSubscriptionYAML string) {
+	isvBaseDir := exutil.FixturePath("testdata", "isv")
+	subscriptionYAML := filepath.Join(isvBaseDir, "subscription.yaml")
+	fileSubscription, _ := os.Open(subscriptionYAML)
+	subscription, _ := ioutil.ReadAll(fileSubscription)
+	subscriptionTemplate := string(subscription)
+
+	templateSubscriptionYAML = strings.ReplaceAll(subscriptionYAML, "subscription.yaml", "subscription_"+p.csvVersion+"_.yaml")
+	operatorSubscription := strings.ReplaceAll(subscriptionTemplate, "$OPERATOR_PACKAGE_NAME", p.name)
+	operatorSubscription = strings.ReplaceAll(operatorSubscription, "$OPERATOR_CHANNEL", "\""+p.defaultChannel+"\"")
+	operatorSubscription = strings.ReplaceAll(operatorSubscription, "$OPERATOR_NAMESPACE", p.namespace)
+	operatorSubscription = strings.ReplaceAll(operatorSubscription, "$OPERATOR_SOURCE", p.catalogSource)
+	operatorSubscription = strings.ReplaceAll(operatorSubscription, "$OPERATOR_CATALOG_NAMESPACE", p.catalogSourceNamespace)
+	operatorSubscription = strings.ReplaceAll(operatorSubscription, "$OPERATOR_CURRENT_CSV_VERSION", p.csvVersion)
+	ioutil.WriteFile(templateSubscriptionYAML, []byte(operatorSubscription), 0644)
+	e2e.Logf("Subscription: %s", operatorSubscription)
+	return
+}
+func checkDeployment(p packagemanifest, oc *exutil.CLI) {
+	poolErr := wait.Poll(10*time.Second, 300*time.Second, func() (bool, error) {
+		msg, _ := oc.SetNamespace(p.namespace).AsAdmin().Run("get").Args("csv", p.csvVersion, "-o=jsonpath={.status.phase}").Output()
+		if strings.Contains(msg, "Succeeded") {
+			return true, nil
+		}
+		return false, nil
+	})
+	if poolErr != nil {
+		removeOperatorDependencies(p, oc, false)
+		g.Fail("Could not obtain CSV:" + p.csvVersion)
+	}
+}
+
+func removeOperatorDependencies(p packagemanifest, oc *exutil.CLI, checkDeletion bool) {
+	ip, _ := oc.SetNamespace(p.namespace).AsAdmin().Run("get").Args("sub", p.name, "-o=jsonpath={.status.installplan.name}").Output()
+	e2e.Logf("IP: %s", ip)
+	if len(strings.TrimSpace(ip)) > 0 {
+		msg, _ := oc.SetNamespace(p.namespace).AsAdmin().Run("get").Args("ip", ip, "-o=jsonpath={.spec.clusterServiceVersionNames}").Output()
+		msg = strings.ReplaceAll(msg, "[", "")
+		msg = strings.ReplaceAll(msg, "]", "")
+		e2e.Logf("CSVS: %s", msg)
+		csvs := strings.Split(msg, " ")
+		for i := range csvs {
+			e2e.Logf("CSV_: %s", csvs[i])
+			msg, err := oc.SetNamespace(p.namespace).AsAdmin().Run("delete").Args("csv", csvs[i]).Output()
+			if checkDeletion {
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(msg).To(o.ContainSubstring("deleted"))
+			}
+		}
+
+		subsOutput, _ := oc.SetNamespace(p.namespace).AsAdmin().Run("get").Args("subs", "-o=jsonpath={range .items[?(.status.installplan.name=='"+ip+"')].metadata}{.name}{' '}").Output()
+		e2e.Logf("SUBS OUTPUT: %s", subsOutput)
+		if len(strings.TrimSpace(subsOutput)) > 0 {
+			subs := strings.Split(subsOutput, " ")
+			e2e.Logf("SUBS: %s", subs)
+			for i := range subs {
+				e2e.Logf("SUB_: %s", subs[i])
+				msg, err := oc.SetNamespace(p.namespace).AsAdmin().Run("delete").Args("subs", subs[i]).Output()
+				if checkDeletion {
+					o.Expect(err).NotTo(o.HaveOccurred())
+					o.Expect(msg).To(o.ContainSubstring("deleted"))
+				}
+			}
+		}
+	}
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -384,6 +384,8 @@
 // test/extended/testdata/image_ecosystem/perl-hotdeploy/perl.json
 // test/extended/testdata/imagestream-jenkins-slave-pods.yaml
 // test/extended/testdata/imagestreamtag-jenkins-slave-pods.yaml
+// test/extended/testdata/isv/operator_group.yaml
+// test/extended/testdata/isv/subscription.yaml
 // test/extended/testdata/jenkins-plugin/build-job-clone.xml
 // test/extended/testdata/jenkins-plugin/build-job-slave.xml
 // test/extended/testdata/jenkins-plugin/build-job.xml
@@ -50875,6 +50877,57 @@ func testExtendedTestdataImagestreamtagJenkinsSlavePodsYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataIsvOperator_groupYaml = []byte(`apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: test-operators
+spec:
+  targetNamespaces:
+  - $OPERATOR_NAMESPACE`)
+
+func testExtendedTestdataIsvOperator_groupYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataIsvOperator_groupYaml, nil
+}
+
+func testExtendedTestdataIsvOperator_groupYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataIsvOperator_groupYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/isv/operator_group.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataIsvSubscriptionYaml = []byte(`apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: $OPERATOR_PACKAGE_NAME
+  namespace: $OPERATOR_NAMESPACE
+spec:
+  channel: $OPERATOR_CHANNEL
+  installPlanApproval: Automatic
+  name: $OPERATOR_PACKAGE_NAME
+  source: $OPERATOR_SOURCE
+  sourceNamespace: $OPERATOR_CATALOG_NAMESPACE
+  startingCSV: $OPERATOR_CURRENT_CSV_VERSION`)
+
+func testExtendedTestdataIsvSubscriptionYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataIsvSubscriptionYaml, nil
+}
+
+func testExtendedTestdataIsvSubscriptionYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataIsvSubscriptionYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/isv/subscription.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataJenkinsPluginBuildJobCloneXml = []byte(`<?xml version='1.0' encoding='UTF-8'?>                                                                                                                                                                                                                         
 <flow-definition plugin="workflow-job@2.8">                                                                                                                                                                                                                    
   <actions/>                                                                                                                                                                                                                                                   
@@ -58638,6 +58691,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/image_ecosystem/perl-hotdeploy/perl.json": testExtendedTestdataImage_ecosystemPerlHotdeployPerlJson,
 	"test/extended/testdata/imagestream-jenkins-slave-pods.yaml": testExtendedTestdataImagestreamJenkinsSlavePodsYaml,
 	"test/extended/testdata/imagestreamtag-jenkins-slave-pods.yaml": testExtendedTestdataImagestreamtagJenkinsSlavePodsYaml,
+	"test/extended/testdata/isv/operator_group.yaml": testExtendedTestdataIsvOperator_groupYaml,
+	"test/extended/testdata/isv/subscription.yaml": testExtendedTestdataIsvSubscriptionYaml,
 	"test/extended/testdata/jenkins-plugin/build-job-clone.xml": testExtendedTestdataJenkinsPluginBuildJobCloneXml,
 	"test/extended/testdata/jenkins-plugin/build-job-slave.xml": testExtendedTestdataJenkinsPluginBuildJobSlaveXml,
 	"test/extended/testdata/jenkins-plugin/build-job.xml": testExtendedTestdataJenkinsPluginBuildJobXml,
@@ -59351,6 +59406,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				}},
 				"imagestream-jenkins-slave-pods.yaml": &bintree{testExtendedTestdataImagestreamJenkinsSlavePodsYaml, map[string]*bintree{}},
 				"imagestreamtag-jenkins-slave-pods.yaml": &bintree{testExtendedTestdataImagestreamtagJenkinsSlavePodsYaml, map[string]*bintree{}},
+				"isv": &bintree{nil, map[string]*bintree{
+					"operator_group.yaml": &bintree{testExtendedTestdataIsvOperator_groupYaml, map[string]*bintree{}},
+					"subscription.yaml": &bintree{testExtendedTestdataIsvSubscriptionYaml, map[string]*bintree{}},
+				}},
 				"jenkins-plugin": &bintree{nil, map[string]*bintree{
 					"build-job-clone.xml": &bintree{testExtendedTestdataJenkinsPluginBuildJobCloneXml, map[string]*bintree{}},
 					"build-job-slave.xml": &bintree{testExtendedTestdataJenkinsPluginBuildJobSlaveXml, map[string]*bintree{}},

--- a/test/extended/testdata/isv/operator_group.yaml
+++ b/test/extended/testdata/isv/operator_group.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: test-operators
+spec:
+  targetNamespaces:
+  - $OPERATOR_NAMESPACE

--- a/test/extended/testdata/isv/subscription.yaml
+++ b/test/extended/testdata/isv/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: $OPERATOR_PACKAGE_NAME
+  namespace: $OPERATOR_NAMESPACE
+spec:
+  channel: $OPERATOR_CHANNEL
+  installPlanApproval: Automatic
+  name: $OPERATOR_PACKAGE_NAME
+  source: $OPERATOR_SOURCE
+  sourceNamespace: $OPERATOR_CATALOG_NAMESPACE
+  startingCSV: $OPERATOR_CURRENT_CSV_VERSION

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -240,7 +240,7 @@ func (r *ginkgoTestRenamer) maybeRenameTest(name string, node types.TestNode) {
 		}
 	}
 
-	if !r.excludedTestsFilter.MatchString(name) {
+	if !r.excludedTestsFilter.MatchString(name) && !strings.Contains(name, "openshift/isv") {
 		isSerial := strings.Contains(name, "[Serial]")
 		isConformance := strings.Contains(name, "[Conformance]")
 		switch {
@@ -554,6 +554,9 @@ var (
 		},
 		"[Suite:openshift/csi]": {
 			`External Storage \[Driver:`,
+		},
+		"[Suite:openshift/isv]": {
+			`\[Suite:openshift/isv\]`,
 		},
 	}
 


### PR DESCRIPTION
PR Created to automate `ISV Operators` test, now it's covering `Basic Testing` as explained on https://github.com/openshift/osde2e#operator-testing . 

Features implemented:

- It does a basic test for all operators in redhat and certified `OperatorSources`
- It creates a subscription based on each packagemanifest description and installModes. For packages that supportes `SingleNamespace` and `OwnNamespace`, a specific project is created with specific `OperatorGroup`. For `AllNamespaces` it creates a subscription into `openshift-operators` namespace. After creating the a `Subscription` and wait for `ClusterServiceVersion` succeed. And if so, it removes all Operator dependencies to unsure that Operator can be successfully uninstalled.
- Can be extensible to conver Intermediate and Advanced Testing.
- Runs 5 Operators test cases in parallel.
- A specific test suite is created. It does not belong to conformance test suite. Test failures should not interfere at OCP build.

Dry run execution:

```shell
./openshift-tests run openshift/isv --dry-run 
Jan 21 16:26:29.640: INFO: Running 'oc --kubeconfig=/home/bandrade/QE/ocp4-aws-ipi-vagrant-4.4/cluster/auth/kubeconfig get packagemanifest -l catalog=redhat-operators -o=jsonpath={range .items[*].metadata}{.name}{'\n'}{end}'
Jan 21 16:26:33.061: INFO: Running 'oc --kubeconfig=/home/bandrade/QE/ocp4-aws-ipi-vagrant-4.4/cluster/auth/kubeconfig get packagemanifest -l catalog=certified-operators -o=jsonpath={range .items[*].metadata}{.name}{'\n'}{end}'
I0121 16:26:50.674041   23391 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
"[Suite:openshift/isv] Operator 3scale-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator akka-cluster-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator amq-broker should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator amq-online should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator amq-streams should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator amq7-cert-manager should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator amq7-interconnect-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator anchore-engine should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator appdynamics-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator appsody-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator aqua-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator businessautomation-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator cam-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator cic-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator citrix-adc-istio-ingress-gateway-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator citrix-cpx-istio-sidecar-injector-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator cluster-logging should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator cockroachdb-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator codeready-workspaces should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator cortex-certifai-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator cortex-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator couchbase-enterprise-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator couchdb-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator cpx-cic-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator crunchy-postgres-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator datagrid should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator dotscience-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator driverlessai-deployment-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator dv-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator eap should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator eddi-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator elasticsearch-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator federatorai-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator fuse-apicurito should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator fuse-camel-k should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator fuse-online should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator hazelcast-enterprise-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator hazelcast-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator ibm-block-csi-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator ibm-spectrum-scale-csi should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator insightedge-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator instana-agent should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator ivory-server-app should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator jaeger-product should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator joget-openshift-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator kiali-ossm should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator kong should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator kube-arangodb should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator kubeturbo-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator kubevirt-hyperconverged should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator local-storage-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator memql-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator metering-ocp should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator mongodb-enterprise should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator neuvector-certified-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator newrelic-infrastructure should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator nfd should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator nuodb-ce-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator ocs-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator oneagent-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator open-enterprise-spinnaker should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator open-liberty-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator openshiftansibleservicebroker should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator openshifttemplateservicebroker should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator openunison-ocp-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator orca should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator perceptilabs-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator percona-server-mongodb-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator percona-xtradb-cluster-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator planetscale-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator portworx-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator presto-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator redis-enterprise-operator-aplpha-cert should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator redis-enterprise-operator-cert should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator robin-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator seldon-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator sematext should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator serverless-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator servicemeshoperator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator sriov-network-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator storageos should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator synopsys-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator sysdig-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator t8c-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator tidb-operator-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator twistlock-certified should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator ubix-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator uma-operator should work properly [Suite:openshift]"
"[Suite:openshift/isv] Operator wavefront-operator should work properly [Suite:openshift]
```

[@ecordell](https://github.com/ecordell) [@njhale](https://github.com/njhale) [@kevinrizza](https://github.com/kevinrizza). please have a review. Thanks! cc:  [@scolange](https://github.com/scolange) [@chengzhang1016](https://github.com/chengzhang1016) [@emmajiafan](https://github.com/emmajiafan) [@jianzhangbjz](https://github.com/jianzhangbjz) [@tbuskey](https://github.com/tbuskey) @shawn-hurley 