### PR TITLE
UPSTREAM: 85898: Fix multinode storage e2e tests for multizone clusters

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/pod/node_selection.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/pod/node_selection.go
@@ -48,6 +48,28 @@ func setNodeAffinityRequirement(nodeSelection *NodeSelection, operator v1.NodeSe
 		})
 }
 
+// SetNodeAffinityTopologyRequirement sets node affinity to a specified topology
+func SetNodeAffinityTopologyRequirement(nodeSelection *NodeSelection, topology map[string]string) {
+	if nodeSelection.Affinity == nil {
+		nodeSelection.Affinity = &v1.Affinity{}
+	}
+	if nodeSelection.Affinity.NodeAffinity == nil {
+		nodeSelection.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+	if nodeSelection.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		nodeSelection.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+	}
+	for k, v := range topology {
+		nodeSelection.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(nodeSelection.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+			v1.NodeSelectorTerm{
+				MatchExpressions: []v1.NodeSelectorRequirement{
+					{Key: k, Operator: v1.NodeSelectorOpIn, Values: []string{v}},
+				},
+			})
+
+	}
+}
+
 // SetAffinity sets affinity to nodeName to nodeSelection
 func SetAffinity(nodeSelection *NodeSelection, nodeName string) {
 	setNodeAffinityRequirement(nodeSelection, v1.NodeSelectorOpIn, nodeName)

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/in_tree.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/in_tree.go
@@ -364,12 +364,14 @@ func InitISCSIDriver() testsuites.TestDriver {
 				//"ext3",
 				"ext4",
 			),
+			TopologyKeys: []string{v1.LabelHostname},
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence: true,
 				testsuites.CapFsGroup:     true,
 				testsuites.CapBlock:       true,
 				testsuites.CapExec:        true,
 				testsuites.CapMultiPODs:   true,
+				testsuites.CapTopology:    true,
 			},
 		},
 	}
@@ -709,10 +711,12 @@ func InitHostPathDriver() testsuites.TestDriver {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
+			TopologyKeys: []string{v1.LabelHostname},
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence:      true,
 				testsuites.CapMultiPODs:        true,
 				testsuites.CapSingleNodeVolume: true,
+				testsuites.CapTopology:         true,
 			},
 		},
 	}
@@ -784,10 +788,12 @@ func InitHostPathSymlinkDriver() testsuites.TestDriver {
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
+			TopologyKeys: []string{v1.LabelHostname},
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence:      true,
 				testsuites.CapMultiPODs:        true,
 				testsuites.CapSingleNodeVolume: true,
+				testsuites.CapTopology:         true,
 			},
 		},
 	}
@@ -998,6 +1004,7 @@ func InitCinderDriver() testsuites.TestDriver {
 				"", // Default fsType
 				"ext3",
 			),
+			TopologyKeys: []string{v1.LabelZoneFailureDomain},
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence: true,
 				testsuites.CapFsGroup:     true,
@@ -1006,6 +1013,7 @@ func InitCinderDriver() testsuites.TestDriver {
 				// Cinder supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
 				testsuites.CapVolumeLimits: false,
+				testsuites.CapTopology:     true,
 			},
 		},
 	}
@@ -1305,11 +1313,13 @@ func InitVSphereDriver() testsuites.TestDriver {
 				"", // Default fsType
 				"ext4",
 			),
+			TopologyKeys: []string{v1.LabelZoneFailureDomain},
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence: true,
 				testsuites.CapFsGroup:     true,
 				testsuites.CapExec:        true,
 				testsuites.CapMultiPODs:   true,
+				testsuites.CapTopology:    true,
 			},
 		},
 	}
@@ -1427,6 +1437,7 @@ func InitAzureDriver() testsuites.TestDriver {
 				"", // Default fsType
 				"ext4",
 			),
+			TopologyKeys: []string{v1.LabelZoneFailureDomain},
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence: true,
 				testsuites.CapFsGroup:     true,
@@ -1436,6 +1447,7 @@ func InitAzureDriver() testsuites.TestDriver {
 				// Azure supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
 				testsuites.CapVolumeLimits: false,
+				testsuites.CapTopology:     true,
 			},
 		},
 	}
@@ -1566,6 +1578,7 @@ func InitAwsDriver() testsuites.TestDriver {
 				"ntfs",
 			),
 			SupportedMountOption: sets.NewString("debug", "nouid32"),
+			TopologyKeys:         []string{v1.LabelZoneFailureDomain},
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence:         true,
 				testsuites.CapFsGroup:             true,
@@ -1577,6 +1590,7 @@ func InitAwsDriver() testsuites.TestDriver {
 				// AWS supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
 				testsuites.CapVolumeLimits: false,
+				testsuites.CapTopology:     true,
 			},
 		},
 	}

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/multivolume.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/multivolume.go
@@ -179,6 +179,14 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		if l.config.ClientNodeName != "" {
 			framework.Skipf("Driver %q requires to deploy on a specific node - skipping", l.driver.GetDriverInfo().Name)
 		}
+		// For multi-node tests there must be enough nodes with the same toopology to schedule the pods
+		nodeSelection := e2epod.NodeSelection{Name: l.config.ClientNodeName}
+		topologyKeys := dInfo.TopologyKeys
+		if len(topologyKeys) != 0 {
+			if err = ensureTopologyRequirements(&nodeSelection, nodes, l.cs, topologyKeys, 2); err != nil {
+				framework.Failf("Error setting topology requirements: %v", err)
+			}
+		}
 
 		var pvcs []*v1.PersistentVolumeClaim
 		numVols := 2
@@ -191,7 +199,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		}
 
 		TestAccessMultipleVolumesAcrossPodRecreation(l.config.Framework, l.cs, l.ns.Name,
-			e2epod.NodeSelection{Name: l.config.ClientNodeName}, pvcs, false /* sameNode */)
+			nodeSelection, pvcs, false /* sameNode */)
 	})
 
 	// This tests below configuration (only <block, filesystem> pattern is tested):
@@ -265,6 +273,14 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		if l.config.ClientNodeName != "" {
 			framework.Skipf("Driver %q requires to deploy on a specific node - skipping", l.driver.GetDriverInfo().Name)
 		}
+		// For multi-node tests there must be enough nodes with the same toopology to schedule the pods
+		nodeSelection := e2epod.NodeSelection{Name: l.config.ClientNodeName}
+		topologyKeys := dInfo.TopologyKeys
+		if len(topologyKeys) != 0 {
+			if err = ensureTopologyRequirements(&nodeSelection, nodes, l.cs, topologyKeys, 2); err != nil {
+				framework.Failf("Error setting topology requirements: %v", err)
+			}
+		}
 
 		var pvcs []*v1.PersistentVolumeClaim
 		numVols := 2
@@ -282,7 +298,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		}
 
 		TestAccessMultipleVolumesAcrossPodRecreation(l.config.Framework, l.cs, l.ns.Name,
-			e2epod.NodeSelection{Name: l.config.ClientNodeName}, pvcs, false /* sameNode */)
+			nodeSelection, pvcs, false /* sameNode */)
 	})
 
 	// This tests below configuration:
@@ -334,6 +350,14 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		if l.config.ClientNodeName != "" {
 			framework.Skipf("Driver %q requires to deploy on a specific node - skipping", l.driver.GetDriverInfo().Name)
 		}
+		// For multi-node tests there must be enough nodes with the same toopology to schedule the pods
+		nodeSelection := e2epod.NodeSelection{Name: l.config.ClientNodeName}
+		topologyKeys := dInfo.TopologyKeys
+		if len(topologyKeys) != 0 {
+			if err = ensureTopologyRequirements(&nodeSelection, nodes, l.cs, topologyKeys, 2); err != nil {
+				framework.Failf("Error setting topology requirements: %v", err)
+			}
+		}
 
 		// Create volume
 		testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
@@ -342,7 +366,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 
 		// Test access to the volume from pods on different node
 		TestConcurrentAccessToSingleVolume(l.config.Framework, l.cs, l.ns.Name,
-			e2epod.NodeSelection{Name: l.config.ClientNodeName}, resource.pvc, numPods, false /* sameNode */)
+			nodeSelection, resource.pvc, numPods, false /* sameNode */)
 	})
 }
 
@@ -502,4 +526,57 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 		ginkgo.By(fmt.Sprintf("Rechecking if read from the volume in pod%d works properly", index))
 		utils.CheckReadFromPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 	}
+}
+
+// getCurrentTopologies() goes through all Nodes and returns unique driver topologies and count of Nodes per topology
+func getCurrentTopologiesNumber(cs clientset.Interface, nodes *v1.NodeList, keys []string) ([]topology, []int, error) {
+	topos := []topology{}
+	topoCount := []int{}
+
+	// TODO: scale?
+	for _, n := range nodes.Items {
+		topo := map[string]string{}
+		for _, k := range keys {
+			v, ok := n.Labels[k]
+			if ok {
+				topo[k] = v
+			}
+		}
+
+		found := false
+		for i, existingTopo := range topos {
+			if topologyEqual(existingTopo, topo) {
+				found = true
+				topoCount[i]++
+				break
+			}
+		}
+		if !found {
+			framework.Logf("found topology %v", topo)
+			topos = append(topos, topo)
+			topoCount = append(topoCount, 1)
+		}
+	}
+	return topos, topoCount, nil
+}
+
+// ensureTopologyRequirements sets nodeSelection affinity according to given topology keys for drivers that provide them
+func ensureTopologyRequirements(nodeSelection *e2epod.NodeSelection, nodes *v1.NodeList, cs clientset.Interface, topologyKeys []string, minCount int) error {
+	topologyList, topologyCount, err := getCurrentTopologiesNumber(cs, nodes, topologyKeys)
+	if err != nil {
+		return err
+	}
+	suitableTopologies := []topology{}
+	for i, topo := range topologyList {
+		if topologyCount[i] >= minCount {
+			suitableTopologies = append(suitableTopologies, topo)
+		}
+	}
+	if len(suitableTopologies) == 0 {
+		framework.Skipf("No topology with at least %d nodes found - skipping", minCount)
+	}
+	// Take the first suitable topology
+	e2epod.SetNodeAffinityTopologyRequirement(nodeSelection, suitableTopologies[0])
+
+	return nil
 }


### PR DESCRIPTION
The multi-node PV test creates a PV, starts a pod that writes data to a file on
the PV, then kills the pod and starts another with node anti-affinity to read
the data from the PV attached to a different node. This is problematic on
multi-AZ clusters: there may only be one node in a zone and for volumes that
can't be transferred among zones (AWS EBS, GCE PD, ...) the test would fail.