### PR TITLE
fixes panic in openshift-test cmd

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -329,7 +329,6 @@ var _ = g.Describe("[cli] oc explain", func() {
 	defer g.GinkgoRecover()
 
 	oc := exutil.NewCLI("oc-explain", exutil.KubeConfigPath())
-	crdClient := apiextensionsclientset.NewForConfigOrDie(oc.AdminConfig())
 
 	g.It("should contain spec+status for builtinTypes", func() {
 		for _, bt := range builtinTypes {
@@ -341,6 +340,7 @@ var _ = g.Describe("[cli] oc explain", func() {
 	g.It("should contain proper spec+status for CRDs", func() {
 		for _, ct := range crdTypes {
 			e2e.Logf("Checking %s...", ct)
+			crdClient := apiextensionsclientset.NewForConfigOrDie(oc.AdminConfig())
 			o.Expect(verifyCRDSpecStatusExplain(oc, crdClient, ct)).NotTo(o.HaveOccurred())
 		}
 	})


### PR DESCRIPTION
This PR fixes the following panic when running `openshift-tests run openshift/conformance/serial --dry-run `

```                                                                                                                                                                  
goroutine 1 [running, locked to thread]:                                                                                                                                                                                                                                                                            
runtime/debug.Stack(0x6d, 0xc0038c58c0, 0x2a0)                                                                                                                                                                                                                                                                      
        /usr/local/go/src/runtime/debug/stack.go:24 +0x9d                                                                                                                                                                                                                                                           
github.com/openshift/origin/test/extended/util.FatalErr(0x567ff20, 0xc0039910e0)                                                                                                                                                                                                                                    
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/client.go:643 +0x26                                                                                                                                                                  
github.com/openshift/origin/test/extended/util.(*CLI).AdminConfig(0xc0039bf000, 0xa)                                                                                                                                                                                                                                
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/client.go:443 +0x65                                                                                                                                                                  
github.com/openshift/origin/test/extended/cli.glob..func4()                                                                                                                                                                                                                                                         
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/cli/explain.go:332 +0x9e                                                                                                                                                                  
github.com/openshift/origin/vendor/github.com/onsi/ginkgo/internal/suite.(*Suite).PushContainerNode(0xc0002914f0, 0x5f44669, 0x10, 0x61d5558, 0x0, 0x9918b62, 0x80, 0x148, 0xc0039e33b0, 0x8c)                                                                                                                      
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:144 +0x158                                                                                                                                        
github.com/openshift/origin/vendor/github.com/onsi/ginkgo.Describe(0x5f44669, 0x10, 0x61d5558, 0xc0038a8d01)                                                                                                                                                                                                        
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:293 +0xaa                                                                                                                                                   
github.com/openshift/origin/test/extended/cli.init()                                                                                                                                                                                                                                                                
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/cli/explain.go:328 +0xb5                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
Jan 22 09:43:29.262: FAIL: open : no such file or directory                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
Full Stack Trace                                                                                                                                                                                                                                                                                                    
github.com/openshift/origin/test/extended/util.FatalErr(0x567ff20, 0xc0039910e0)                                                                                                                                                                                                                                    
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/client.go:644 +0x118                                                                                                                                                                 
github.com/openshift/origin/test/extended/util.(*CLI).AdminConfig(0xc0039bf000, 0xa)                                                                                                                                                                                                                                
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/client.go:443 +0x65                                                                                                                                                                  
github.com/openshift/origin/test/extended/cli.glob..func4()                                                                                                                                                                                                                                                         
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/cli/explain.go:332 +0x9e                                                                                                                                                                  
github.com/openshift/origin/test/extended/cli.init()                                                                                                                                                                                                                                                                
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/cli/explain.go:328 +0xb5                                                                                                                                                                  
Jan 22 09:43:30.652: INFO: Could not get network operator configuration: not adding any plugin-specific skips                                                                                                                                                                                                       
W0122 09:43:30.770256   88003 test_context.go:410] Unable to find in-cluster config, using default host : http://127.0.0.1:8080            
```