### PR TITLE
Decrease number of replicas in StatefulSet e2e

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/apps/statefulset.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/statefulset.go
@@ -100,7 +100,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		ginkgo.It("should provide basic identity", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			e2epv.SkipIfNoDefaultStorageClass(c)
-			*(ss.Spec.Replicas) = 3
+			*(ss.Spec.Replicas) = 2
 			e2esset.PauseNewPods(ss)
 
 			_, err := c.AppsV1().StatefulSets(ns).Create(ss)
@@ -260,7 +260,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		ginkgo.It("should perform rolling updates and roll backs of template modifications with PVCs", func() {
 			ginkgo.By("Creating a new StatefulSet with PVCs")
 			e2epv.SkipIfNoDefaultStorageClass(c)
-			*(ss.Spec.Replicas) = 3
+			*(ss.Spec.Replicas) = 2
 			rollbackTest(c, ns, ss)
 		})
 


### PR DESCRIPTION
Many Azure flakes happen in these 2 tests:

```
[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity

[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications with PVCs
```

Looking at the logs from 2 flakes we can see that both tests timeout after 15 minutes. The majority of this time is spent creating and restarting StatefulSets. 

For instance, consider these 2 jobs:

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.3/562
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.3/561

**Saturating the StatefulSet after creating it (waiting for all pods to be Running and Ready)**: 6-8 minutes.
**Restarting StatefulSet (and waiting for all pods again)**: 6-7 minutes.

Looking deeply we can see that both tests create StatefulSets with 3 replicas. This seems unnecessary, and decreasing this number to 2 sped up the tests in a few minutes.

While more investigation needs to be done, I'd like to verify if this change decreases the number of flakes we've seen in Azure.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1781579
CC @openshift/storage 