### PR TITLE
[MON-831] check if metrics cardinality isn't exploding

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -236,7 +236,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPod.Name, metav1.NewDeleteOptions(1)) }()
 
 			tests := map[string]bool{
-				`sum(rate(prometheus_tsdb_head_series_created_total[1m]))>0`: false,
+				`sum(rate(prometheus_tsdb_head_series_created_total[1m]))>10`: false,
 			}
 			cfg := config{
 				maxAttempts:      100,


### PR DESCRIPTION
another attempt to add cardinality test as in https://github.com/openshift/origin/pull/24074

As part of this added a bigger failure threshold as the cardinality should be messured only at the end of the cluster boostraping when all pod creation is fully done.

/cc @LiliC



Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>