### PR TITLE
Bug 1796483: Use --kubeconfig flag for Jenkins Tests

### DIFF
--- a/test/extended/util/jenkins/ref.go
+++ b/test/extended/util/jenkins/ref.go
@@ -60,9 +60,9 @@ type Definition struct {
 // NewRef creates a jenkins reference from an OC client
 func NewRef(oc *exutil.CLI) *JenkinsRef {
 	g.By("get ip and port for jenkins service")
-	serviceIP, err := oc.Run("get").Args("svc", "jenkins", "--config", exutil.KubeConfigPath()).Template("{{.spec.clusterIP}}").Output()
+	serviceIP, err := oc.Run("get").Args("svc", "jenkins", "--kubeconfig", exutil.KubeConfigPath()).Template("{{.spec.clusterIP}}").Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
-	port, err := oc.Run("get").Args("svc", "jenkins", "--config", exutil.KubeConfigPath()).Template("{{ $x := index .spec.ports 0}}{{$x.port}}").Output()
+	port, err := oc.Run("get").Args("svc", "jenkins", "--kubeconfig", exutil.KubeConfigPath()).Template("{{ $x := index .spec.ports 0}}{{$x.port}}").Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	g.By("get token via whoami")


### PR DESCRIPTION
- Changes similar to https://github.com/openshift/origin/commit/4a31327f4aff3842812aae731adba9257e28ee54 as `--config` is deprecated and the replacement for the same is `--kubeconfig`
- https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_jenkins/1015/pull-ci-openshift-jenkins-master-e2e-aws-jenkins/756 is a failed build where we are getting the error. 
```
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_jenkins/1015/pull-ci-openshift-jenkins-master-e2e-aws-jenkins/756
```
- Updating this would allow for the Jenkins tests to be done by using the --kubeconfig flag with oc instead of --config