### PR TITLE
image: add ImageTag to etcd test

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -185,6 +185,7 @@ var openshiftEtcdStorageData = map[schema.GroupVersionResource]etcddata.StorageD
 // TODO fix for real GVK.
 var kindWhiteList = sets.NewString(
 	"ImageStreamTag",
+	"ImageTag",
 	"UserIdentityMapping",
 	// these are now served using CRDs
 	"ClusterResourceQuota",


### PR DESCRIPTION
This should address following failure:

```
fail [github.com/openshift/origin/test/extended/etcd/etcd_test_runner.go:72]: test failed:
no test data for image.openshift.io/v1, Kind=ImageTag.  Please add a test for your new type to etcdStorageData.
etcd data does not match the types we saw:
in etcd data but not seen:
[]
seen but not in etcd data:
[
	image.openshift.io/v1, Resource=imagetags
```

Found by @smarterclayton in https://testgrid.k8s.io/redhat-openshift-ocp-release-4.4-informing#release-openshift-ocp-installer-e2e-metal-serial-4.4

Question: Why was this test not failing before and we only found this on metal?

/cc @bparees 
/cc @adambkaplan 