### PR TITLE
UPSTREAM: <carry>: oauth-authn: add implicit audience support

### DIFF
--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/authentication/oauth/expirationvalidator_test.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/authentication/oauth/expirationvalidator_test.go
@@ -30,7 +30,7 @@ func TestAuthenticateTokenExpired(t *testing.T) {
 	)
 	fakeUserClient := userfake.NewSimpleClientset(&userv1.User{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "bar"}})
 
-	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, NewExpirationValidator())
+	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, nil, NewExpirationValidator())
 
 	for _, tokenName := range []string{"token1", "token2"} {
 		userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), tokenName)
@@ -57,7 +57,7 @@ func TestAuthenticateTokenValidated(t *testing.T) {
 	)
 	fakeUserClient := userfake.NewSimpleClientset(&userv1.User{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "bar"}})
 
-	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, NewExpirationValidator(), NewUIDValidator())
+	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, nil, NewExpirationValidator(), NewUIDValidator())
 
 	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
 	if !found {

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/authentication/oauth/tokenauthenticator_test.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/authentication/oauth/tokenauthenticator_test.go
@@ -31,7 +31,7 @@ func TestAuthenticateTokenInvalidUID(t *testing.T) {
 	)
 	fakeUserClient := userfake.NewSimpleClientset(&userv1.User{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "bar2"}})
 
-	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, NewUIDValidator())
+	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, nil, NewUIDValidator())
 
 	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
 	if found {
@@ -48,7 +48,7 @@ func TestAuthenticateTokenInvalidUID(t *testing.T) {
 func TestAuthenticateTokenNotFoundSuppressed(t *testing.T) {
 	fakeOAuthClient := oauthfake.NewSimpleClientset()
 	fakeUserClient := userfake.NewSimpleClientset()
-	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{})
+	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, nil)
 
 	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
 	if found {
@@ -68,7 +68,7 @@ func TestAuthenticateTokenOtherGetErrorSuppressed(t *testing.T) {
 		return true, nil, errors.New("get error")
 	})
 	fakeUserClient := userfake.NewSimpleClientset()
-	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{})
+	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, nil)
 
 	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
 	if found {
@@ -171,7 +171,7 @@ func TestAuthenticateTokenTimeout(t *testing.T) {
 	// add some padding to all sleep invocations to make sure we are not failing on any boundary values
 	buffer := time.Nanosecond
 
-	tokenAuthenticator := NewTokenAuthenticator(accessTokenGetter, fakeUserClient.UserV1().Users(), NoopGroupMapper{}, timeouts)
+	tokenAuthenticator := NewTokenAuthenticator(accessTokenGetter, fakeUserClient.UserV1().Users(), NoopGroupMapper{}, nil, timeouts)
 
 	go timeouts.Run(stopCh)
 

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/authenticator/config.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/authenticator/config.go
@@ -191,7 +191,7 @@ func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, er
 	// tokens that allows us to recognize human users differently than machine users.  The openAPI is always correct because we always
 	// configuration service account tokens, so we just have to create and add another authenticator.
 	// TODO make this a webhook authenticator and remove this patch.
-	tokenAuthenticators = AddOAuthServerAuthenticatorIfNeeded(tokenAuthenticators, config.ServiceAccountTokenGetter)
+	tokenAuthenticators = AddOAuthServerAuthenticatorIfNeeded(tokenAuthenticators, config.APIAudiences)
 
 	if len(tokenAuthenticators) > 0 {
 		// Union the token authenticators

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/authenticator/patch_authenticator.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/authenticator/patch_authenticator.go
@@ -8,6 +8,7 @@ import (
 	userclient "github.com/openshift/client-go/user/clientset/versioned"
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	bootstrap "github.com/openshift/library-go/pkg/authentication/bootstrapauthenticator"
+
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/group"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -17,7 +18,6 @@ import (
 	oauthvalidation "k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/oauth"
 	"k8s.io/kubernetes/openshift-kube-apiserver/authentication/oauth"
 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
-	"k8s.io/kubernetes/pkg/serviceaccount"
 )
 
 const authenticatedOAuthGroup = "system:authenticated:oauth"
@@ -26,7 +26,7 @@ const authenticatedOAuthGroup = "system:authenticated:oauth"
 // before then we should try to eliminate our direct to storage access.  It's making us do weird things.
 const defaultInformerResyncPeriod = 10 * time.Minute
 
-func AddOAuthServerAuthenticatorIfNeeded(tokenAuthenticators []authenticator.Token, serviceAccountTokenGetter serviceaccount.ServiceAccountTokenGetter) []authenticator.Token {
+func AddOAuthServerAuthenticatorIfNeeded(tokenAuthenticators []authenticator.Token, implicitAudiences authenticator.Audiences) []authenticator.Token {
 	if !enablement.IsOpenShift() {
 		return tokenAuthenticators
 	}
@@ -72,7 +72,7 @@ func AddOAuthServerAuthenticatorIfNeeded(tokenAuthenticators []authenticator.Tok
 		return nil
 	})
 	groupMapper := usercache.NewGroupCache(userInformer.User().V1().Groups())
-	oauthTokenAuthenticator := oauth.NewTokenAuthenticator(oauthClient.OauthV1().OAuthAccessTokens(), userClient.UserV1().Users(), groupMapper, validators...)
+	oauthTokenAuthenticator := oauth.NewTokenAuthenticator(oauthClient.OauthV1().OAuthAccessTokens(), userClient.UserV1().Users(), groupMapper, implicitAudiences, validators...)
 	tokenAuthenticators = append(tokenAuthenticators,
 		// if you have an OAuth bearer token, you're a human (usually)
 		group.NewTokenGroupAdder(oauthTokenAuthenticator, []string{authenticatedOAuthGroup}))


### PR DESCRIPTION
The TokenReview REST implementation expects that the authn chain returns audiences in the authn response. Authenticators that don't support audiences must return the default slice of audiences, e.g. the legacy service account authenticator does that. This PR adds that to our custom oauth authenticator.

Folliowing https://github.com/kubernetes/kubernetes/blob/master/pkg/serviceaccount/jwt.go#L283.

Compare https://github.com/kubernetes/kubernetes/pull/69582/files#r225535241.