### PR TITLE
test: Set appropriate cloud defaults even when not specified on tests

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -111,7 +111,12 @@ func newRunCommand() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return mirrorToFile(opt, func() error {
-				matchFn, err := initializeTestFramework(exutil.TestContext, opt.Provider, opt.DryRun)
+				config, err := decodeProvider(opt.Provider, opt.DryRun, true)
+				if err != nil {
+					return err
+				}
+				opt.Provider = config.ToJSONString()
+				matchFn, err := initializeTestFramework(exutil.TestContext, config, opt.DryRun)
 				if err != nil {
 					return err
 				}
@@ -173,7 +178,12 @@ func newRunUpgradeCommand() *cobra.Command {
 					}
 				}
 
-				matchFn, err := initializeTestFramework(exutil.TestContext, opt.Provider, opt.DryRun)
+				config, err := decodeProvider(opt.Provider, opt.DryRun, true)
+				if err != nil {
+					return err
+				}
+				opt.Provider = config.ToJSONString()
+				matchFn, err := initializeTestFramework(exutil.TestContext, config, opt.DryRun)
 				if err != nil {
 					return err
 				}
@@ -211,7 +221,11 @@ func newRunTestCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if _, err := initializeTestFramework(exutil.TestContext, os.Getenv("TEST_PROVIDER"), testOpt.DryRun); err != nil {
+			config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false)
+			if err != nil {
+				return err
+			}
+			if _, err := initializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
 				return err
 			}
 			exutil.TestContext.ReportDir = upgradeOpts.JUnitDir

--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -22,12 +22,7 @@ import (
 
 type TestNameMatchesFunc func(name string) bool
 
-func initializeTestFramework(context *e2e.TestContextType, provider string, dryRun bool) (TestNameMatchesFunc, error) {
-	config, err := decodeProvider(provider, dryRun)
-	if err != nil {
-		return nil, err
-	}
-
+func initializeTestFramework(context *e2e.TestContextType, config *exutilcloud.ClusterConfiguration, dryRun bool) (TestNameMatchesFunc, error) {
 	// update context with loaded config
 	context.Provider = config.ProviderName
 	context.CloudConfig = e2e.CloudConfig{
@@ -37,7 +32,7 @@ func initializeTestFramework(context *e2e.TestContextType, provider string, dryR
 		NumNodes:    config.NumNodes,
 		MultiMaster: config.MultiMaster,
 		MultiZone:   config.MultiZone,
-		ConfigFile:  config.CloudConfigFile,
+		ConfigFile:  config.ConfigFile,
 	}
 	context.AllowedNotReadyNodes = 100
 	context.MaxNodesToGather = 0
@@ -64,7 +59,7 @@ func initializeTestFramework(context *e2e.TestContextType, provider string, dryR
 	return skipFn, nil
 }
 
-func decodeProvider(provider string, dryRun bool) (*exutilcloud.ClusterConfiguration, error) {
+func decodeProvider(provider string, dryRun, discover bool) (*exutilcloud.ClusterConfiguration, error) {
 	switch provider {
 	case "":
 		if _, ok := os.LookupEnv("KUBE_SSH_USER"); ok {
@@ -99,11 +94,47 @@ func decodeProvider(provider string, dryRun bool) (*exutilcloud.ClusterConfigura
 		if len(providerInfo.Type) == 0 {
 			return nil, fmt.Errorf("provider must be a JSON object with the 'type' key")
 		}
-		config := &exutilcloud.ClusterConfiguration{
-			ProviderName: providerInfo.Type,
-		}
-		if err := json.Unmarshal([]byte(provider), config); err != nil {
+		var cloudConfig e2e.CloudConfig
+		if err := json.Unmarshal([]byte(provider), &cloudConfig); err != nil {
 			return nil, fmt.Errorf("provider must decode into the cloud config object: %v", err)
+		}
+
+		// attempt to load the default config, then overwrite with any values from the passed
+		// object that can be overriden
+		var config *exutilcloud.ClusterConfiguration
+		if discover {
+			if clientConfig, err := e2e.LoadConfig(true); err == nil {
+				config, _ = exutilcloud.LoadConfig(clientConfig)
+			}
+		}
+		if config == nil {
+			config = &exutilcloud.ClusterConfiguration{
+				ProviderName: providerInfo.Type,
+				ProjectID:    cloudConfig.ProjectID,
+				Region:       cloudConfig.Region,
+				Zone:         cloudConfig.Zone,
+				NumNodes:     cloudConfig.NumNodes,
+				MultiMaster:  cloudConfig.MultiMaster,
+				MultiZone:    cloudConfig.MultiZone,
+				ConfigFile:   cloudConfig.ConfigFile,
+			}
+		} else {
+			config.ProviderName = providerInfo.Type
+			if len(cloudConfig.ProjectID) > 0 {
+				config.ProjectID = cloudConfig.ProjectID
+			}
+			if len(cloudConfig.Region) > 0 {
+				config.Region = cloudConfig.Region
+			}
+			if len(cloudConfig.Zone) > 0 {
+				config.Zone = cloudConfig.Zone
+			}
+			if len(cloudConfig.ConfigFile) > 0 {
+				config.ConfigFile = cloudConfig.ConfigFile
+			}
+			if cloudConfig.NumNodes > 0 {
+				config.NumNodes = cloudConfig.NumNodes
+			}
 		}
 		return config, nil
 	}

--- a/test/extended/util/cloud/cloud.go
+++ b/test/extended/util/cloud/cloud.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 
@@ -15,18 +16,26 @@ import (
 )
 
 type ClusterConfiguration struct {
-	ProviderName string
+	ProviderName string `json:"type"`
 
 	// These fields chosen to match the e2e configuration we fill
-	ProjectID       string
-	Region          string
-	Zone            string
-	NumNodes        int
-	MultiMaster     bool
-	MultiZone       bool
-	CloudConfigFile string
+	ProjectID   string
+	Region      string
+	Zone        string
+	NumNodes    int
+	MultiMaster bool
+	MultiZone   bool
+	ConfigFile  string
 
 	NetworkPlugin string
+}
+
+func (c *ClusterConfiguration) ToJSONString() string {
+	out, err := json.Marshal(c)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
 }
 
 // LoadConfig uses the cluster to setup the cloud provider config.
@@ -119,7 +128,7 @@ func LoadConfig(clientConfig *rest.Config) (*ClusterConfiguration, error) {
 		if err := ioutil.WriteFile(tmpFile.Name(), data, 0600); err != nil {
 			return nil, err
 		}
-		config.CloudConfigFile = tmpFile.Name()
+		config.ConfigFile = tmpFile.Name()
 	}
 
 	return config, nil


### PR DESCRIPTION
The --provider argument for openshift-tests accepts a string (the type)
which triggers discovery, or JSON, which previously meant "use exactly
these values". However, we have more tests which depend on logic from
implicit fields (multimaster, region, zone, and number of nodes) that
we don't want to have accidentally off. This was recently triggered
when refactoring the methods in that numNodes was lost in CI, causing
certain networking tests not to run.

This commit changes openshift-tests run/run-upgrade to attempt to fill
all fields of the config even when JSON is passed to --provider by
invoking the cloud config load method, then updating provider for
the subsequent exec'd test command so that it is accurate. The run-test
command does not perform discovery, which forces the suite runner to
be accurate.

If correct, the granular network tests will not be in the skip list.