### PR TITLE
Bug 1796715: Add a service upgrade test that verifies availability

### DIFF
--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -40,7 +40,7 @@ func Start(ctx context.Context) (*Monitor, error) {
 		return nil, err
 	}
 
-	if err := startAPIMonitoring(ctx, m, clusterConfig); err != nil {
+	if err := StartAPIMonitoring(ctx, m, clusterConfig, 5*time.Second); err != nil {
 		return nil, err
 	}
 	startPodMonitoring(ctx, m, client)
@@ -52,9 +52,9 @@ func Start(ctx context.Context) (*Monitor, error) {
 	return m, nil
 }
 
-func startAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
+func StartAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
 	pollingConfig := *clusterConfig
-	pollingConfig.Timeout = 3 * time.Second
+	pollingConfig.Timeout = timeout
 	pollingClient, err := clientcorev1.NewForConfig(&pollingConfig)
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ func startAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Con
 				condition = &Condition{
 					Level:   Info,
 					Locator: "openshift-apiserver",
-					Message: fmt.Sprintf("OpenShift API started failing: %v", err),
+					Message: fmt.Sprintf("OpenShift API stopped responding to GET requests: %v", err),
 				}
 			}
 			return condition, err == nil

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -21,8 +21,14 @@ type Monitor struct {
 
 // NewMonitor creates a monitor with the default sampling interval.
 func NewMonitor() *Monitor {
+	return NewMonitorWithInterval(15 * time.Second)
+}
+
+// NewMonitorWithInterval creates a monitor that samples at the provided
+// interval.
+func NewMonitorWithInterval(interval time.Duration) *Monitor {
 	return &Monitor{
-		interval: 15 * time.Second,
+		interval: interval,
 	}
 }
 

--- a/pkg/monitor/sampler_test.go
+++ b/pkg/monitor/sampler_test.go
@@ -1,0 +1,77 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestStartSampling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := NewMonitorWithInterval(5 * time.Millisecond)
+
+	doneCh := make(chan struct{})
+	var count int
+	m.AddSampler(StartSampling(ctx, m, 21*time.Millisecond, func(previous bool) (condition *Condition, next bool) {
+		defer func() { count++ }()
+		switch {
+		case count <= 5:
+			return nil, true
+		case count == 6:
+			return &Condition{Level: Error, Locator: "tester", Message: "dying"}, false
+		case count == 7:
+			return &Condition{Level: Info, Locator: "tester", Message: "recovering"}, true
+		case count <= 12:
+			return nil, true
+		case count == 13:
+			return &Condition{Level: Error, Locator: "tester", Message: "dying 2"}, false
+		case count <= 16:
+			return nil, false
+		case count == 17:
+			return &Condition{Level: Info, Locator: "tester", Message: "recovering 2"}, true
+		case count <= 20:
+			return nil, true
+		default:
+			doneCh <- struct{}{}
+			return nil, true
+		}
+	}).ConditionWhenFailing(&Condition{
+		Level:   Error,
+		Locator: "tester",
+		Message: "down",
+	}))
+
+	m.StartSampling(ctx)
+	<-doneCh
+	cancel()
+
+	var describe []string
+	var log []string
+	events := m.Events(time.Time{}, time.Time{})
+	for _, interval := range events {
+		i := interval.To.Sub(interval.From)
+		describe = append(describe, fmt.Sprintf("%v %s", *interval.Condition, i))
+		log = append(log, fmt.Sprintf("%v", *interval.Condition))
+	}
+	expected := []string{
+		"{2 tester dying}",
+		"{2 tester down}",
+		"{0 tester recovering}",
+		"{2 tester dying 2}",
+		"{2 tester down}",
+		"{0 tester recovering 2}",
+	}
+	if !reflect.DeepEqual(log, expected) {
+		t.Fatalf("%s", diff.ObjectReflectDiff(log, expected))
+	}
+	if events[4].To.Sub(events[4].From) < 2*events[1].To.Sub(events[1].From) {
+		t.Fatalf("last condition should be at least 2x first condition length:\n%s", strings.Join(describe, "\n"))
+	} else {
+		t.Logf("%s", strings.Join(describe, "\n"))
+	}
+}

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -67,7 +67,11 @@ func (i *EventInterval) String() string {
 	if i.From.Equal(i.To) {
 		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 	}
-	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(i.To.Sub(i.From)/time.Second))+"s", eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
+	duration := i.To.Sub(i.From)
+	if duration < time.Second {
+		return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Millisecond))+"ms", eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
+	}
+	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Second))+"s", eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 }
 
 type EventIntervals []*EventInterval

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -1,0 +1,255 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/service"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+
+	"github.com/openshift/origin/pkg/monitor"
+)
+
+// UpgradeTest tests that a service is available before, during, and
+// after a cluster upgrade.
+type UpgradeTest struct {
+	jig        *service.TestJig
+	tcpService *v1.Service
+}
+
+// Name returns the tracking name of the test.
+func (UpgradeTest) Name() string { return "k8s-service-upgrade" }
+
+func shouldTestPDBs() bool { return true }
+
+// Setup creates a service with a load balancer and makes sure it's reachable.
+func (t *UpgradeTest) Setup(f *framework.Framework) {
+	serviceName := "service-test"
+	jig := service.NewTestJig(f.ClientSet, f.Namespace.Name, serviceName)
+
+	ns := f.Namespace
+	cs := f.ClientSet
+
+	ginkgo.By("creating a TCP service " + serviceName + " with type=LoadBalancer in namespace " + ns.Name)
+	tcpService, err := jig.CreateTCPService(func(s *v1.Service) {
+		s.Spec.Type = v1.ServiceTypeLoadBalancer
+	})
+	framework.ExpectNoError(err)
+	tcpService, err = jig.WaitForLoadBalancer(service.GetServiceLoadBalancerCreationTimeout(cs))
+	framework.ExpectNoError(err)
+
+	// Get info to hit it with
+	tcpIngressIP := service.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0])
+	svcPort := int(tcpService.Spec.Ports[0].Port)
+
+	ginkgo.By("creating RC to be part of service " + serviceName)
+	rc, err := jig.Run(func(rc *v1.ReplicationController) {
+		// ensure the pod waits long enough for most LBs to take it out of rotation
+		minute := int64(60)
+		rc.Spec.Template.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
+			PreStop: &v1.Handler{
+				Exec: &v1.ExecAction{Command: []string{"sleep", "30"}},
+			},
+		}
+		rc.Spec.Template.Spec.TerminationGracePeriodSeconds = &minute
+
+		jig.AddRCAntiAffinity(rc)
+	})
+	framework.ExpectNoError(err)
+
+	if shouldTestPDBs() {
+		ginkgo.By("creating a PodDisruptionBudget to cover the ReplicationController")
+		_, err = jig.CreatePDB(rc)
+		framework.ExpectNoError(err)
+	}
+
+	// Hit it once before considering ourselves ready
+	ginkgo.By("hitting pods through the service's LoadBalancer")
+	timeout := service.LoadBalancerLagTimeoutAWS
+	service.TestReachableHTTP(tcpIngressIP, svcPort, timeout)
+
+	t.jig = jig
+	t.tcpService = tcpService
+}
+
+// Test runs a connectivity check to the service.
+func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	client, err := framework.LoadClientset()
+	framework.ExpectNoError(err)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	newBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1beta1().Events("")})
+	r := newBroadcaster.NewRecorder(scheme.Scheme, "openshift.io/upgrade-test-service")
+	newBroadcaster.StartRecordingToSink(stopCh)
+
+	ginkgo.By("continuously hitting pods through the service's LoadBalancer")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m := monitor.NewMonitorWithInterval(1 * time.Second)
+	err = startEndpointMonitoring(ctx, m, t.tcpService, r)
+	framework.ExpectNoError(err, "unable to monitor API")
+	m.StartSampling(ctx)
+
+	// wait to ensure API is still up after the test ends
+	<-done
+	ginkgo.By("waiting for any post disruption failures")
+	time.Sleep(15 * time.Second)
+	cancel()
+
+	var duration time.Duration
+	var describe []string
+	for _, interval := range m.Events(time.Time{}, time.Time{}) {
+		describe = append(describe, interval.String())
+		i := interval.To.Sub(interval.From)
+		if i < time.Second {
+			i = time.Second
+		}
+		if interval.Condition.Level > monitor.Info {
+			duration += i
+		}
+	}
+	if duration > 2*time.Second {
+		framework.Failf("Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
+	} else if duration > 0 {
+		framework.Logf("Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
+	}
+
+	// verify finalizer behavior
+	defer func() {
+		ginkgo.By("Check that service can be deleted with finalizer")
+		service.WaitForServiceDeletedWithFinalizer(t.jig.Client, t.tcpService.Namespace, t.tcpService.Name)
+	}()
+	ginkgo.By("Check that finalizer is present on loadBalancer type service")
+	service.WaitForServiceUpdatedWithFinalizer(t.jig.Client, t.tcpService.Namespace, t.tcpService.Name, true)
+}
+
+// Teardown cleans up any remaining resources.
+func (t *UpgradeTest) Teardown(f *framework.Framework) {
+	// rely on the namespace deletion to clean up everything
+}
+
+func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Service, r events.EventRecorder) error {
+	tcpIngressIP := service.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
+	svcPort := int(svc.Spec.Ports[0].Port)
+
+	// this client reuses connections and detects abrupt breaks
+	continuousClient, err := rest.UnversionedRESTClientFor(&rest.Config{
+		Host:    fmt.Sprintf("http://%s", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort))),
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 15 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 15 * time.Second,
+		},
+		ContentConfig: rest.ContentConfig{
+			NegotiatedSerializer: runtime.NewSimpleNegotiatedSerializer(scheme.Codecs.SupportedMediaTypes()[0]),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	m.AddSampler(
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+			data, err := continuousClient.Get().AbsPath("echo").Param("msg", "Hello").DoRaw()
+			if err == nil && !bytes.Contains(data, []byte("Hello")) {
+				err = fmt.Errorf("service returned success but did not contain the correct body contents: %q", string(data))
+			}
+			switch {
+			case err == nil && !previous:
+				condition = &monitor.Condition{
+					Level:   monitor.Info,
+					Locator: locateService(svc),
+					Message: "Service started responding to GET requests on reused connections",
+				}
+			case err != nil && previous:
+				framework.Logf("Service %s is unreachable on reused connections: %v", svc.Name, err)
+				r.Eventf(&v1.ObjectReference{Kind: "Service", Namespace: "kube-system", Name: "service-upgrade-test"}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on reused connections")
+				condition = &monitor.Condition{
+					Level:   monitor.Error,
+					Locator: locateService(svc),
+					Message: "Service stopped responding to GET requests on reused connections",
+				}
+			case err != nil:
+				framework.Logf("Service %s is unreachable on reused connections: %v", svc.Name, err)
+			}
+			return condition, err == nil
+		}).ConditionWhenFailing(&monitor.Condition{
+			Level:   monitor.Error,
+			Locator: locateService(svc),
+			Message: "Service is not responding to GET requests on reused connections",
+		}),
+	)
+
+	// this client creates fresh connections and detects failure to establish connections
+	client, err := rest.UnversionedRESTClientFor(&rest.Config{
+		Host:    fmt.Sprintf("http://%s", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort))),
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   15 * time.Second,
+				KeepAlive: -1,
+			}).Dial,
+			TLSHandshakeTimeout: 15 * time.Second,
+			IdleConnTimeout:     15 * time.Second,
+			DisableKeepAlives:   true,
+		},
+		ContentConfig: rest.ContentConfig{
+			NegotiatedSerializer: runtime.NewSimpleNegotiatedSerializer(scheme.Codecs.SupportedMediaTypes()[0]),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	m.AddSampler(
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+			data, err := client.Get().AbsPath("echo").Param("msg", "Hello").DoRaw()
+			if err == nil && !bytes.Contains(data, []byte("Hello")) {
+				err = fmt.Errorf("service returned success but did not contain the correct body contents: %q", string(data))
+			}
+			switch {
+			case err == nil && !previous:
+				condition = &monitor.Condition{
+					Level:   monitor.Info,
+					Locator: locateService(svc),
+					Message: "Service started responding to GET requests over new connections",
+				}
+			case err != nil && previous:
+				framework.Logf("Service %s is unreachable on new connections: %v", svc.Name, err)
+				r.Eventf(&v1.ObjectReference{Kind: "Service", Namespace: "kube-system", Name: "service-upgrade-test"}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on new connections")
+				condition = &monitor.Condition{
+					Level:   monitor.Error,
+					Locator: locateService(svc),
+					Message: "Service stopped responding to GET requests over new connections",
+				}
+			case err != nil:
+				framework.Logf("Service %s is unreachable on new connections: %v", svc.Name, err)
+			}
+			return condition, err == nil
+		}).ConditionWhenFailing(&monitor.Condition{
+			Level:   monitor.Error,
+			Locator: locateService(svc),
+			Message: "Service is not responding to GET requests over new connections",
+		}),
+	)
+	return nil
+}
+
+func locateService(svc *v1.Service) string {
+	return fmt.Sprintf("ns/%s svc/%s", svc.Namespace, svc.Name)
+}

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/upgrades"
 
 	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/test/extended/util/disruption"
 )
 
 // UpgradeTest tests that a service is available before, during, and
@@ -123,10 +124,10 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			duration += i
 		}
 	}
-	if duration > 2*time.Second {
+	if duration > 60*time.Second {
 		framework.Failf("Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
 	} else if duration > 0 {
-		framework.Logf("Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
+		disruption.Flakef(f, "Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
 	}
 
 	// verify finalizer behavior

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -27,10 +27,12 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/util/disruption"
+	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 )
 
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
+		&controlplane.AvailableTest{},
 		&service.UpgradeTest{},
 		&upgrades.SecretUpgradeTest{},
 		&apps.ReplicaSetUpgradeTest{},
@@ -38,14 +40,7 @@ func AllTests() []upgrades.Test {
 		&apps.DeploymentUpgradeTest{},
 		&apps.JobUpgradeTest{},
 		&upgrades.ConfigMapUpgradeTest{},
-		// &upgrades.HPAUpgradeTest{},
-		//&storage.PersistentVolumeUpgradeTest{},
 		&apps.DaemonSetUpgradeTest{},
-		// &upgrades.IngressUpgradeTest{},
-		// &upgrades.AppArmorUpgradeTest{},
-		// &upgrades.MySqlUpgradeTest{},
-		// &upgrades.EtcdUpgradeTest{},
-		// &upgrades.CassandraUpgradeTest{},
 	}
 }
 

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -25,12 +25,13 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/util/disruption"
 )
 
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
-		&upgrades.ServiceUpgradeTest{},
+		&service.UpgradeTest{},
 		&upgrades.SecretUpgradeTest{},
 		&apps.ReplicaSetUpgradeTest{},
 		&apps.StatefulSetUpgradeTest{},
@@ -240,7 +241,10 @@ func clusterUpgrade(c configv1client.Interface, dc dynamic.Interface, config *re
 
 	if version.NodeImage == "[pause]" {
 		framework.Logf("Running a dry-run upgrade test")
-		time.Sleep(2 * time.Minute)
+		wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+			framework.Logf("Waiting ...")
+			return false, nil
+		})
 		return nil
 	}
 

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/upgrades"
 
 	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/test/extended/util/disruption"
 )
 
 // AvailableTest tests that the control plane remains is available
@@ -51,10 +52,10 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 			duration += i
 		}
 	}
-	if duration > 30*time.Second {
+	if duration > 120*time.Second {
 		framework.Failf("API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
 	} else if duration > 0 {
-		framework.Logf("API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
+		disruption.Flakef(f, "API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
 	}
 }
 

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -1,0 +1,63 @@
+package controlplane
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+
+	"github.com/openshift/origin/pkg/monitor"
+)
+
+// AvailableTest tests that the control plane remains is available
+// before and after a cluster upgrade.
+type AvailableTest struct {
+}
+
+// Name returns the tracking name of the test.
+func (AvailableTest) Name() string { return "control-plane-upgrade" }
+
+// Setup does nothing
+func (t *AvailableTest) Setup(f *framework.Framework) {
+}
+
+// Test runs a connectivity check to the core APIs.
+func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	config, err := framework.LoadConfig()
+	framework.ExpectNoError(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m := monitor.NewMonitorWithInterval(time.Second)
+	err = monitor.StartAPIMonitoring(ctx, m, config, 15*time.Second)
+	framework.ExpectNoError(err, "unable to monitor API")
+	m.StartSampling(ctx)
+
+	// wait to ensure API is still up after the test ends
+	<-done
+	time.Sleep(15 * time.Second)
+	cancel()
+
+	var duration time.Duration
+	var describe []string
+	for _, interval := range m.Events(time.Time{}, time.Time{}) {
+		describe = append(describe, interval.String())
+		i := interval.To.Sub(interval.From)
+		if i < time.Second {
+			i = time.Second
+		}
+		if interval.Condition.Level > monitor.Info {
+			duration += i
+		}
+	}
+	if duration > 30*time.Second {
+		framework.Failf("API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
+	} else if duration > 0 {
+		framework.Logf("API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
+	}
+}
+
+// Teardown cleans up any remaining resources.
+func (t *AvailableTest) Teardown(f *framework.Framework) {
+}

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -104,7 +104,6 @@ func (cma *chaosMonkeyAdapter) Test(sem *chaosmonkey.Semaphore) {
 		})
 	}
 	defer finalizeTest(start, cma.testReport)
-	defer g.GinkgoRecover()
 	defer ready()
 	if skippable, ok := cma.test.(upgrades.Skippable); ok && skippable.Skip(cma.UpgradeContext) {
 		g.By("skipping test " + cma.test.Name())


### PR DESCRIPTION
The upstream upgrade test doesn't correctly test for disruption of the backend during upgrade - it only tests that the service is not available for more than 2 minutes at a time.

This is obviously not a good test of whether a service maintains availability during upgrade. Take the core structure and use the monitor and polling behavior of the apiserver which is much more effective.