### PR TITLE
Cleanup the authserver artifacts

### DIFF
--- a/test/extended/oauth/oauth_ldap.go
+++ b/test/extended/oauth/oauth_ldap.go
@@ -83,7 +83,7 @@ var _ = g.Describe("[Suite:openshift/oauth] LDAP IDP", func() {
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		// Deploy an OAuth server
-		tokenOpts, _, err := oauthutil.DeployOAuthServer(oc, []osinv1.IdentityProvider{
+		tokenOpts, cleanup, err := oauthutil.DeployOAuthServer(oc, []osinv1.IdentityProvider{
 			{
 				Name:            providerName,
 				UseAsChallenger: true,
@@ -92,6 +92,7 @@ var _ = g.Describe("[Suite:openshift/oauth] LDAP IDP", func() {
 				Provider:        *ldapProvider,
 			},
 		}, []corev1.ConfigMap{caConfigMap}, nil)
+		defer cleanup()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("configuring LDAP users")


### PR DESCRIPTION
Cleanup the artifacts created by authserver, due to these leftover clusterrolebindings other serial tests ran on the same environments failed, hence this cleanup is required.