### PR TITLE
[WIP] Backport Kube e2e Image Override Patches

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/create.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/create.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
+        imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // LoadFromManifests loads .yaml or .json manifest files and returns
@@ -300,6 +301,20 @@ func (f *Framework) PatchNamespace(item *string) {
 	}
 }
 
+// PatchContainerImages replaces the specified Container Registry with a custom
+// one provided via the KUBE_TEST_REPO_LIST env variable
+func PatchContainerImages(containers []v1.Container) error {
+       var err error
+       for i, c := range containers {
+               containers[i].Image, err = imageutils.ReplaceRegistryInImageURL(c.Image)
+               if err != nil {
+                       return err
+               }
+       }
+
+       return nil
+}
+
 func (f *Framework) patchItemRecursively(item interface{}) error {
 	switch item := item.(type) {
 	case *rbac.Subject:
@@ -350,8 +365,20 @@ func (f *Framework) patchItemRecursively(item interface{}) error {
 		f.PatchNamespace(&item.ObjectMeta.Namespace)
 	case *apps.StatefulSet:
 		f.PatchNamespace(&item.ObjectMeta.Namespace)
+               if err := PatchContainerImages(item.Spec.Template.Spec.Containers); err != nil {
+                       return err
+               }
+               if err := PatchContainerImages(item.Spec.Template.Spec.InitContainers); err != nil {
+                       return err
+               }
 	case *apps.DaemonSet:
 		f.PatchNamespace(&item.ObjectMeta.Namespace)
+               if err := PatchContainerImages(item.Spec.Template.Spec.Containers); err != nil {
+                       return err
+               }
+               if err := PatchContainerImages(item.Spec.Template.Spec.InitContainers); err != nil {
+                       return err
+               }
 	default:
 		return errors.Errorf("missing support for patching item of type %T", item)
 	}

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/ingress/ingress_utils.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/ingress/ingress_utils.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/manifest"
 	testutils "k8s.io/kubernetes/test/utils"
+        imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
 )
@@ -925,7 +926,7 @@ func generateBacksideHTTPSDeploymentSpec() *apps.Deployment {
 					Containers: []v1.Container{
 						{
 							Name:  "echoheaders-https",
-							Image: "k8s.gcr.io/echoserver:1.10",
+							Image: imageutils.GetE2EImage(imageutils.EchoServer),
 							Ports: []v1.ContainerPort{{
 								ContainerPort: 8443,
 								Name:          "echo-443",

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/utils/utils.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/utils/utils.go
@@ -338,7 +338,7 @@ func StartExternalProvisioner(c clientset.Interface, ns string, externalPluginNa
 			Containers: []v1.Container{
 				{
 					Name:  "nfs-provisioner",
-					Image: "quay.io/kubernetes_incubator/nfs-provisioner:v2.2.0-k8s1.12",
+					Image: imageutils.GetE2EImage(imageutils.NFSProvisioner),
 					SecurityContext: &v1.SecurityContext{
 						Capabilities: &v1.Capabilities{
 							Add: []v1.Capability{"DAC_READ_SEARCH"},

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/providers/gce"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+        imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
@@ -1128,7 +1129,7 @@ func startGlusterDpServerPod(c clientset.Interface, ns string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "glusterdynamic-provisioner",
-					Image: "docker.io/humblec/glusterdynamic-provisioner:v1.0",
+					Image: imageutils.GetE2EImage(imageutils.GlusterDynamicProvisioner),
 					Args: []string{
 						"-config=" + "/etc/heketi/heketi.json",
 					},

--- a/vendor/k8s.io/kubernetes/test/utils/image/BUILD
+++ b/vendor/k8s.io/kubernetes/test/utils/image/BUILD
@@ -1,9 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -25,4 +22,10 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["manifest_test.go"],
+    embed = [":go_default_library"],
 )

--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
@@ -29,6 +29,7 @@ import (
 type RegistryList struct {
 	DockerLibraryRegistry string `yaml:"dockerLibraryRegistry"`
 	E2eRegistry           string `yaml:"e2eRegistry"`
+	E2eVolumeRegistry           string `yaml:"e2eVolumeRegistry"`
 	EtcdRegistry          string `yaml:"etcdRegistry"`
 	GcRegistry            string `yaml:"gcRegistry"`
         GcrReleaseRegistry      string `yaml:"gcrReleaseRegistry"`
@@ -64,12 +65,13 @@ func initReg() RegistryList {
 	registry := RegistryList{
 		DockerLibraryRegistry: "docker.io/library",
 		E2eRegistry:           "gcr.io/kubernetes-e2e-test-images",
+		E2eVolumeRegistry:     "gcr.io/kubernetes-e2e-test-images/volume",
 		EtcdRegistry:          "quay.io/coreos",
 		GcRegistry:            "k8s.gcr.io",
-                GcrReleaseRegistry:      "gcr.io/gke-release",
+                GcrReleaseRegistry:    "gcr.io/gke-release",
 		PrivateRegistry:       "gcr.io/k8s-authenticated-test",
 		SampleRegistry:        "gcr.io/google-samples",
-                QuayK8sCSI:              "quay.io/k8scsi",
+                QuayK8sCSI:            "quay.io/k8scsi",
 	}
 	repoList := os.Getenv("KUBE_TEST_REPO_LIST")
 	if repoList == "" {
@@ -92,6 +94,8 @@ var (
 	registry              = initReg()
 	dockerLibraryRegistry = registry.DockerLibraryRegistry
 	e2eRegistry           = registry.E2eRegistry
+	e2eVolumeRegistry     = registry.E2eVolumeRegistry
+
 	etcdRegistry          = registry.EtcdRegistry
 	gcRegistry            = registry.GcRegistry
         gcrReleaseRegistry      = registry.GcrReleaseRegistry
@@ -245,10 +249,10 @@ func initImageConfigs() map[int]Config {
 	configs[ResourceController] = Config{e2eRegistry, "resource-consumer/controller", "1.0"}
 	configs[ServeHostname] = Config{e2eRegistry, "serve-hostname", "1.1"}
 	configs[TestWebserver] = Config{e2eRegistry, "test-webserver", "1.0"}
-	configs[VolumeNFSServer] = Config{e2eRegistry, "volume/nfs", "1.0"}
-	configs[VolumeISCSIServer] = Config{e2eRegistry, "volume/iscsi", "1.0"}
-	configs[VolumeGlusterServer] = Config{e2eRegistry, "volume/gluster", "1.0"}
-	configs[VolumeRBDServer] = Config{e2eRegistry, "volume/rbd", "1.0.1"}
+	configs[VolumeNFSServer] = Config{e2eVolumeRegistry, "nfs", "1.0"}
+	configs[VolumeISCSIServer] = Config{e2eVolumeRegistry, "iscsi", "1.0"}
+	configs[VolumeGlusterServer] = Config{e2eVolumeRegistry, "gluster", "1.0"}
+	configs[VolumeRBDServer] = Config{e2eVolumeRegistry, "rbd", "1.0.1"}
 	return configs
 }
 
@@ -286,6 +290,8 @@ func ReplaceRegistryInImageURL(imageURL string) (string, error) {
 	switch registryAndUser {
 	case "gcr.io/kubernetes-e2e-test-images":
 		registryAndUser = e2eRegistry
+	case "gcr.io/kubernetes-e2e-test-images/volume":
+		registryAndUser = e2eVolumeRegistry
 	case "k8s.gcr.io":
 		registryAndUser = gcRegistry
 	case "gcr.io/k8s-authenticated-test":

--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
@@ -28,6 +28,7 @@ import (
 // RegistryList holds public and private image registries
 type RegistryList struct {
 	DockerLibraryRegistry string `yaml:"dockerLibraryRegistry"`
+	DockerGluster           string `yaml:"dockerGluster"`
 	E2eRegistry           string `yaml:"e2eRegistry"`
 	E2eVolumeRegistry           string `yaml:"e2eVolumeRegistry"`
 	EtcdRegistry          string `yaml:"etcdRegistry"`
@@ -64,6 +65,7 @@ func (i *Config) SetVersion(version string) {
 func initReg() RegistryList {
 	registry := RegistryList{
 		DockerLibraryRegistry: "docker.io/library",
+		DockerGluster:           "docker.io/gluster",
 		E2eRegistry:           "gcr.io/kubernetes-e2e-test-images",
 		E2eVolumeRegistry:     "gcr.io/kubernetes-e2e-test-images/volume",
 		EtcdRegistry:          "quay.io/coreos",
@@ -72,6 +74,7 @@ func initReg() RegistryList {
 		PrivateRegistry:       "gcr.io/k8s-authenticated-test",
 		SampleRegistry:        "gcr.io/google-samples",
                 QuayK8sCSI:            "quay.io/k8scsi",
+		QuayIncubator:           "quay.io/kubernetes_incubator",
 	}
 	repoList := os.Getenv("KUBE_TEST_REPO_LIST")
 	if repoList == "" {
@@ -93,13 +96,14 @@ func initReg() RegistryList {
 var (
 	registry              = initReg()
 	dockerLibraryRegistry = registry.DockerLibraryRegistry
+	dockerGluster           = registry.DockerGluster
 	e2eRegistry           = registry.E2eRegistry
 	e2eVolumeRegistry     = registry.E2eVolumeRegistry
-
 	etcdRegistry          = registry.EtcdRegistry
 	gcRegistry            = registry.GcRegistry
         gcrReleaseRegistry      = registry.GcrReleaseRegistry
         quayK8sCSI              = registry.QuayK8sCSI
+	quayIncubator           = registry.QuayIncubator
 	// PrivateRegistry is an image repository that requires authentication
 	PrivateRegistry = registry.PrivateRegistry
 	sampleRegistry  = registry.SampleRegistry
@@ -139,6 +143,8 @@ const (
 	Fakegitserver
 	// GBFrontend image
 	GBFrontend
+	// GlusterDynamicProvisioner image
+	GlusterDynamicProvisioner
 	// GBRedisSlave image
 	GBRedisSlave
 	// Hostexec image
@@ -167,6 +173,8 @@ const (
 	Netexec
 	// Nettest image
 	Nettest
+	// NFSProvisioner image
+	NFSProvisioner
 	// Nginx image
 	Nginx
 	// NginxNew image
@@ -221,6 +229,7 @@ func initImageConfigs() map[int]Config {
 	configs[Etcd] = Config{etcdRegistry, "etcd", "v3.3.10"}
 	configs[Fakegitserver] = Config{e2eRegistry, "fakegitserver", "1.0"}
 	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
+	configs[GlusterDynamicProvisioner] = Config{dockerGluster, "glusterdynamic-provisioner", "v1.0"}
 	configs[GBRedisSlave] = Config{sampleRegistry, "gb-redisslave", "v3"}
 	configs[Hostexec] = Config{e2eRegistry, "hostexec", "1.1"}
 	configs[IpcUtils] = Config{e2eRegistry, "ipc-utils", "1.0"}
@@ -235,6 +244,7 @@ func initImageConfigs() map[int]Config {
 	configs[Net] = Config{e2eRegistry, "net", "1.0"}
 	configs[Netexec] = Config{e2eRegistry, "netexec", "1.1"}
 	configs[Nettest] = Config{e2eRegistry, "nettest", "1.0"}
+	configs[NFSProvisioner] = Config{quayIncubator, "nfs-provisioner", "v2.2.0-k8s1.12"}
 	configs[Nginx] = Config{dockerLibraryRegistry, "nginx", "1.14-alpine"}
 	configs[NginxNew] = Config{dockerLibraryRegistry, "nginx", "1.15-alpine"}
 	configs[Nonewprivs] = Config{e2eRegistry, "nonewprivs", "1.0"}


### PR DESCRIPTION
To test s390x in the CI pipeline, we need to provide s390x builds of the e2e test containers and configure origin to pull them instead of the default x86_64 containers.

The following patches implement functionality to override the default e2e test container images that will be pulled:

https://github.com/kubernetes/kubernetes/commit/302e9d9f6b2c510ef70314784592521f39ff9637#diff-d511d08b2cdc3d78d9e75c3c131ed2ce
https://github.com/kubernetes/kubernetes/commit/2dab911ac296ae7c94e1191ce3aa37bbdfd974a8#diff-d511d08b2cdc3d78d9e75c3c131ed2ce

This pull request is a partial backport of these patches, which will allow the CI pipeline to pull s390x versions of the testing containers.  This is a temporary patch to origin until  these features can be backported upstream in kubernetes, at which point the origin/vendor/k8s.io/kubernetes package can be bumped and this patch can be dropped.
