### PR TITLE
Bug 1722672: UPSTREAM: 82027: Enabled reading config files for vsphere e2e tests

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/test_context.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/test_context.go
@@ -336,7 +336,7 @@ func RegisterClusterFlags(flags *flag.FlagSet) {
 	flags.StringVar(&cloudConfig.MasterTag, "master-tag", "", "Network tags used on master instances. Valid only for gce, gke")
 
 	flags.StringVar(&cloudConfig.ClusterTag, "cluster-tag", "", "Tag used to identify resources.  Only required if provider is aws.")
-	flags.StringVar(&cloudConfig.ConfigFile, "cloud-config-file", "", "Cloud config file.  Only required if provider is azure.")
+	flags.StringVar(&cloudConfig.ConfigFile, "cloud-config-file", "", "Cloud config file.  Only required if provider is azure or vsphere.")
 	flags.IntVar(&TestContext.MinStartupPods, "minStartupPods", 0, "The number of pods which we need to see in 'Running' state with a 'Ready' condition of true, before we try running tests. This is useful in any cluster which needs some base pod-based services running before it can be used.")
 	flags.DurationVar(&TestContext.SystemPodsStartupTimeout, "system-pods-startup-timeout", 10*time.Minute, "Timeout for waiting for all system pods to be running before starting tests.")
 	flags.DurationVar(&TestContext.NodeSchedulableTimeout, "node-schedulable-timeout", 30*time.Minute, "Timeout for waiting for all nodes to be schedulable.")

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/vsphere/config.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/vsphere/config.go
@@ -98,7 +98,10 @@ func GetVSphereInstances() (map[string]*VSphere, error) {
 
 func getConfig() (*ConfigFile, error) {
 	if confFileLocation == "" {
-		return nil, fmt.Errorf("Env variable 'VSPHERE_CONF_FILE' is not set.")
+		if framework.TestContext.CloudConfig.ConfigFile == "" {
+			return nil, fmt.Errorf("Env variable 'VSPHERE_CONF_FILE' is not set, and no config-file specified")
+		}
+		confFileLocation = framework.TestContext.CloudConfig.ConfigFile
 	}
 	confFile, err := os.Open(confFileLocation)
 	if err != nil {


### PR DESCRIPTION
This backports https://github.com/kubernetes/kubernetes/pull/82027 to origin.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Enables the ability to pass vsphere configuration files for e2e tests outside of an environment variable.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```