### PR TITLE
Bug 1796895: Don't use annotation in openshift/csi test suite

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -141,7 +141,7 @@ var staticSuites = []*ginkgo.TestSuite{
         See https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/external/README.md for required format of the files.
 		`),
 		Matches: func(name string) bool {
-			return strings.Contains(name, "[Suite:openshift/csi") && !strings.Contains(name, "[Disruptive]")
+			return strings.Contains(name, "External Storage [Driver:") && !strings.Contains(name, "[Disruptive]")
 		},
 	},
 	{

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -216,9 +216,6 @@ var (
 		"[Suite:openshift/test-cmd]": {
 			`\[Suite:openshift/test-cmd\]`,
 		},
-		"[Suite:openshift/csi]": {
-			`External Storage \[Driver:`,
-		},
 	}
 
 	// labelExcludes temporarily block tests out of a specific suite


### PR DESCRIPTION
**Summary**: 

In df6f5bd we added annotated tests to bindata. However, CSI tests are not part of the generated bindata because CSI drivers can be installed on-demand  (e.g., by an operator). 

This is particularly problematic when a partner wants to [certify their CSI driver](https://github.com/openshift/enhancements/pull/162). 

This PR changes the `openshift/csi` test suite filter by matching the test name directly, instead of adding an annotation and them matching the annotation.

**More info**:

I came up with a few possible solutions to solve this:

a) Change the upstream testing framework to allow for adding annotations to test names. I expect some pushback on this, since it seems too specific.

b) Dynamically add annotations to CSI tests **only**. This wouldn't revert df6f5bd, it would only affect CSI tests.

c) Skip adding the annotation to the test name. This is what I did in this PR.

@smarterclayton what do you think?

CC @openshift/storage 

