### PR TITLE
DO NOT MERGE: Add fake metrics report for configured signals

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/eviction/eviction_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/eviction/eviction_manager.go
@@ -183,6 +183,10 @@ func (m *managerImpl) Start(diskInfoProvider DiskInfoProvider, podFunc ActivePod
 			}
 		}
 	}
+	// report all configured signals at zero
+	for _, t := range m.config.Thresholds {
+		metrics.Evictions.WithLabelValues(string(t.Signal)).Add(0)
+	}
 	// start the eviction manager monitoring
 	go func() {
 		for {


### PR DESCRIPTION
We aren't reporting any eviction metrics, try priming the counter
with zero for each threshold type just to see.