### PR TITLE
bug 1779303: UPSTREAM: 87242: SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run - set resource requests as well

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/scheduling/predicates.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/scheduling/predicates.go
@@ -154,7 +154,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		verifyResult(cs, podsNeededForSaturation, 1, ns)
 	})
 
-	// This test verifies we don't allow scheduling of pods in a way that sum of local ephemeral storage limits of pods is greater than machines capacity.
+	// This test verifies we don't allow scheduling of pods in a way that sum of local ephemeral storage resource requests of pods is greater than machines capacity.
 	// It assumes that cluster add-on pods stay stable and cannot be run in parallel with any other test that touches Nodes or Pods.
 	// It is so because we need to have precise control on what's running in the cluster.
 	ginkgo.It("validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]", func() {
@@ -224,6 +224,9 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 				Limits: v1.ResourceList{
 					v1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralStoragePerPod, "DecimalSI"),
 				},
+				Requests: v1.ResourceList{
+					v1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralStoragePerPod, "DecimalSI"),
+				},
 			},
 		}
 		WaitForSchedulerAfterAction(f, createPausePodAction(f, conf), ns, podName, false)
@@ -231,7 +234,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 	})
 
 	// This test verifies we don't allow scheduling of pods in a way that sum of
-	// limits of pods is greater than machines capacity.
+	// resource requests of pods is greater than machines capacity.
 	// It assumes that cluster add-on pods stay stable and cannot be run in parallel
 	// with any other test that touches Nodes or Pods.
 	// It is so because we need to have precise control on what's running in the cluster.
@@ -244,7 +247,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 	/*
 		Release : v1.9
 		Testname: Scheduler, resource limits
-		Description: Scheduling Pods MUST fail if the resource limits exceed Machine capacity.
+		Description: Scheduling Pods MUST fail if the resource requests exceed Machine capacity.
 	*/
 	framework.ConformanceIt("validates resource limits of pods that are allowed to run ", func() {
 		WaitForStableCluster(cs, masterNodes)
@@ -338,6 +341,9 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 			Labels: map[string]string{"name": "additional"},
 			Resources: &v1.ResourceRequirements{
 				Limits: v1.ResourceList{
+					v1.ResourceCPU: *resource.NewMilliQuantity(nodeMaxAllocatable*5/10, "DecimalSI"),
+				},
+				Requests: v1.ResourceList{
 					v1.ResourceCPU: *resource.NewMilliQuantity(nodeMaxAllocatable*5/10, "DecimalSI"),
 				},
 			},


### PR DESCRIPTION
Backporting https://github.com/kubernetes/kubernetes/pull/87242