### PR TITLE
test/extended/prometheus: do not fail when info alert is firing

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -291,7 +291,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 
 			tests := map[string]bool{
 				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|PrometheusRemoteWriteDesiredShards",alertstate="firing"} >= 1`: false,
+				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|PrometheusRemoteWriteDesiredShards",alertstate="firing",severity!="info"} >= 1`: false,
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})


### PR DESCRIPTION
In 4.5 we will ship inhibition of `info` alerts so there is no point of checking if such alerts are firing.

Hold until `master` points to `release-4.5` and not `release-4.4`
/hold

/cc @LiliC @s-urbaniak @brancz 