### PR TITLE
Copy the kubeconfig into container with proper name

### DIFF
--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -74,7 +74,7 @@ var _ = g.Describe("[Suite:openshift/oauth][Serial] ldap group sync", func() {
 		err = pod.CopyFromHost(ldapCAPath, remoteTmp)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = pod.CopyFromHost(testutil.KubeConfigPath(), remoteTmp)
+		err = pod.CopyFromHost(testutil.KubeConfigPath(), path.Join(remoteTmp, kubeConfigFileName))
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		groupSyncScriptPath := path.Join(tmpDir, "groupsync.sh")


### PR DESCRIPTION
The test is expecting kubeconfig file in the following path, hence even while copying it should refer to the kubeConfigFileName `path.Join(remoteTmp, kubeConfigFileName)`. This will allow tests to have different name for the kubeconfig file