### PR TITLE
[release-3.11] Bug 1772594: Make DNS querying more efficient by querying once per dns name

### DIFF
--- a/pkg/network/common/dns_test.go
+++ b/pkg/network/common/dns_test.go
@@ -189,7 +189,7 @@ func TestUpdateDNS(t *testing.T) {
 		dns.HandleFunc(test.domainName, serverFn)
 		defer dns.HandleRemove(test.domainName)
 
-		err, _ = n.updateOne(test.domainName)
+		_, err = n.updateOne(test.domainName)
 		if test.expectFailure && err == nil {
 			t.Fatalf("Test case: %s failed, expected failure but got success", test.testCase)
 		} else if !test.expectFailure && err != nil {

--- a/pkg/network/common/egress_dns.go
+++ b/pkg/network/common/egress_dns.go
@@ -5,10 +5,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
 	networkapi "github.com/openshift/api/network/v1"
-
 	ktypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type EgressDNSUpdate struct {
@@ -16,11 +17,15 @@ type EgressDNSUpdate struct {
 	Namespace string
 }
 
+type EgressDNSUpdates []EgressDNSUpdate
+
 type EgressDNS struct {
 	// Protects pdMap/namespaces operations
 	lock sync.Mutex
-	// Holds Egress DNS entries for each policy
-	pdMap map[ktypes.UID]*DNS
+	// holds DNS entries globally
+	dns *DNS
+	// this map holds which DNS names are in what policy objects
+	dnsNamesToPolicies map[string]sets.String
 	// Maintain namespaces for each policy to avoid querying etcd in syncEgressDNSPolicyRules()
 	namespaces map[ktypes.UID]string
 
@@ -28,66 +33,81 @@ type EgressDNS struct {
 	added chan bool
 
 	// Report changes when there are dns updates
-	Updates chan EgressDNSUpdate
+	Updates chan EgressDNSUpdates
 }
 
-func NewEgressDNS() *EgressDNS {
-	return &EgressDNS{
-		pdMap:      map[ktypes.UID]*DNS{},
-		namespaces: map[ktypes.UID]string{},
-		added:      make(chan bool),
-		Updates:    make(chan EgressDNSUpdate),
-	}
-}
-
-func (e *EgressDNS) Add(policy networkapi.EgressNetworkPolicy) {
+func NewEgressDNS() (*EgressDNS, error) {
 	dnsInfo, err := NewDNS("/etc/resolv.conf")
 	if err != nil {
 		utilruntime.HandleError(err)
+		return nil, err
 	}
+	return &EgressDNS{
+		dns:                dnsInfo,
+		dnsNamesToPolicies: map[string]sets.String{},
+		namespaces:         map[ktypes.UID]string{},
+		added:              make(chan bool),
+		Updates:            make(chan EgressDNSUpdates),
+	}, nil
+}
+
+func (e *EgressDNS) Add(policy networkapi.EgressNetworkPolicy) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
 
 	for _, rule := range policy.Spec.Egress {
 		if len(rule.To.DNSName) > 0 {
-			if err := dnsInfo.Add(rule.To.DNSName); err != nil {
-				utilruntime.HandleError(err)
+			if _, exists := e.dnsNamesToPolicies[rule.To.DNSName]; !exists {
+				e.dnsNamesToPolicies[rule.To.DNSName] = sets.NewString(string(policy.UID))
+				//only call Add if the dnsName doesn't exist in the dnsNamesToPolicies
+				if err := e.dns.Add(rule.To.DNSName); err != nil {
+					utilruntime.HandleError(err)
+				}
+				e.signalAdded()
+			} else {
+				e.dnsNamesToPolicies[rule.To.DNSName].Insert(string(policy.UID))
 			}
 		}
 	}
-
-	if dnsInfo.Size() > 0 {
-		e.lock.Lock()
-		defer e.lock.Unlock()
-
-		e.pdMap[policy.UID] = dnsInfo
-		e.namespaces[policy.UID] = policy.Namespace
-		e.signalAdded()
-	}
+	e.namespaces[policy.UID] = policy.Namespace
 }
 
 func (e *EgressDNS) Delete(policy networkapi.EgressNetworkPolicy) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
+	//delete the entry from the dnsNames to UIDs map for each rule in the policy
+	//if the slice is empty at this point, delete the entry from the dns object too
+	//also remove the policy entry from the namespaces map.
+	for _, rule := range policy.Spec.Egress {
+		if len(rule.To.DNSName) > 0 {
+			if uids, ok := e.dnsNamesToPolicies[rule.To.DNSName]; ok {
+				uids.Delete(string(policy.UID))
+				if uids.Len() == 0 {
+					e.dns.Delete(rule.To.DNSName)
+					delete(e.dnsNamesToPolicies, rule.To.DNSName)
+				} else {
+					e.dnsNamesToPolicies[rule.To.DNSName] = uids
+				}
+			}
+		}
+	}
 
-	if _, ok := e.pdMap[policy.UID]; ok {
-		delete(e.pdMap, policy.UID)
+	if _, ok := e.namespaces[policy.UID]; ok {
 		delete(e.namespaces, policy.UID)
 	}
 }
 
-func (e *EgressDNS) Update(policyUID ktypes.UID) (error, bool) {
+func (e *EgressDNS) Update(dns string) (bool, error) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
-	if dnsInfo, ok := e.pdMap[policyUID]; ok {
-		return dnsInfo.Update()
-	}
-	return nil, false
+	return e.dns.Update(dns)
 }
 
 func (e *EgressDNS) Sync() {
 	var duration time.Duration
 	for {
-		tm, policyUID, policyNamespace, ok := e.GetMinQueryTime()
+		tm, dnsName, updates, ok := e.GetNextQueryTime()
 		if !ok {
 			duration = 30 * time.Minute
 		} else {
@@ -96,13 +116,13 @@ func (e *EgressDNS) Sync() {
 				// Item needs to wait for this duration before it can be processed
 				duration = tm.Sub(now)
 			} else {
-				err, changed := e.Update(policyUID)
+				changed, err := e.Update(dnsName)
 				if err != nil {
 					utilruntime.HandleError(err)
 				}
 
 				if changed {
-					e.Updates <- EgressDNSUpdate{policyUID, policyNamespace}
+					e.Updates <- updates
 				}
 				continue
 			}
@@ -116,44 +136,35 @@ func (e *EgressDNS) Sync() {
 	}
 }
 
-func (e *EgressDNS) GetMinQueryTime() (time.Time, ktypes.UID, string, bool) {
+func (e *EgressDNS) GetNextQueryTime() (time.Time, string, []EgressDNSUpdate, bool) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-
-	timeSet := false
-	var minTime time.Time
-	var uid ktypes.UID
-
-	for policyUID, dnsInfo := range e.pdMap {
-		tm, ok := dnsInfo.GetMinQueryTime()
-		if !ok {
-			continue
-		}
-
-		if (timeSet == false) || tm.Before(minTime) {
-			timeSet = true
-			minTime = tm
-			uid = policyUID
-		}
+	policyUpdates := make([]EgressDNSUpdate, 0)
+	tm, dnsName, timeSet := e.dns.GetNextQueryTime()
+	if !timeSet {
+		return tm, dnsName, nil, timeSet
 	}
 
-	return minTime, uid, e.namespaces[uid], timeSet
+	if uids, exists := e.dnsNamesToPolicies[dnsName]; exists {
+		for uid := range uids {
+			policyUpdates = append(policyUpdates, EgressDNSUpdate{ktypes.UID(uid), e.namespaces[ktypes.UID(uid)]})
+		}
+	} else {
+		glog.V(5).Infof("Didn't find any entry for dns name: %s in the dns map.", dnsName)
+	}
+	return tm, dnsName, policyUpdates, timeSet
 }
 
-func (e *EgressDNS) GetIPs(policy networkapi.EgressNetworkPolicy, dnsName string) []net.IP {
+func (e *EgressDNS) GetIPs(dnsName string) []net.IP {
 	e.lock.Lock()
 	defer e.lock.Unlock()
+	return e.dns.Get(dnsName).ips
 
-	dnsInfo, ok := e.pdMap[policy.UID]
-	if !ok {
-		return []net.IP{}
-	}
-	return dnsInfo.Get(dnsName).ips
 }
 
-func (e *EgressDNS) GetNetCIDRs(policy networkapi.EgressNetworkPolicy, dnsName string) []net.IPNet {
+func (e *EgressDNS) GetNetCIDRs(dnsName string) []net.IPNet {
 	cidrs := []net.IPNet{}
-	for _, ip := range e.GetIPs(policy, dnsName) {
+	for _, ip := range e.GetIPs(dnsName) {
 		// IPv4 CIDR
 		cidrs = append(cidrs, net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)})
 	}

--- a/pkg/network/node/egress_network_policy.go
+++ b/pkg/network/node/egress_network_policy.go
@@ -119,19 +119,20 @@ func (plugin *OsdnNode) syncEgressDNSPolicyRules() {
 
 	for {
 		policyUpdates := <-plugin.egressDNS.Updates
-		glog.V(5).Infof("Egress dns sync: updating policy: %v", policyUpdates.UID)
+		for _, policyUpdate := range policyUpdates {
+			glog.V(5).Infof("Egress dns sync: updating policy: %v", policyUpdate.UID)
+			vnid, err := plugin.policy.GetVNID(policyUpdate.Namespace)
+			if err != nil {
+				glog.Warningf("Could not find netid for namespace %q: %v", policyUpdate.Namespace, err)
+				continue
+			}
 
-		vnid, err := plugin.policy.GetVNID(policyUpdates.Namespace)
-		if err != nil {
-			glog.Warningf("Could not find netid for namespace %q: %v", policyUpdates.Namespace, err)
-			continue
+			func() {
+				plugin.egressPoliciesLock.Lock()
+				defer plugin.egressPoliciesLock.Unlock()
+
+				plugin.updateEgressNetworkPolicyRules(vnid)
+			}()
 		}
-
-		func() {
-			plugin.egressPoliciesLock.Lock()
-			defer plugin.egressPoliciesLock.Unlock()
-
-			plugin.updateEgressNetworkPolicyRules(vnid)
-		}()
 	}
 }

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -171,6 +171,11 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		masqBit = uint32(*c.MasqueradeBit)
 	}
 
+	egressDNS, err := common.NewEgressDNS()
+	if err != nil {
+		return nil, err
+	}
+
 	plugin := &OsdnNode{
 		policy:             policy,
 		kClient:            c.KClient,
@@ -185,7 +190,7 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		mtu:                c.MTU,
 		masqueradeBit:      masqBit,
 		egressPolicies:     make(map[uint32][]networkapi.EgressNetworkPolicy),
-		egressDNS:          common.NewEgressDNS(),
+		egressDNS:          egressDNS,
 		kubeInformers:      c.KubeInformers,
 		networkInformers:   c.NetworkInformers,
 		egressIP:           newEgressIPWatcher(oc, c.SelfIP, c.MasqueradeBit),

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -517,7 +517,7 @@ func (oc *ovsController) UpdateEgressNetworkPolicyRules(policies []networkapi.Eg
 			if len(rule.To.CIDRSelector) > 0 {
 				selectors = append(selectors, rule.To.CIDRSelector)
 			} else if len(rule.To.DNSName) > 0 {
-				ips := egressDNS.GetIPs(policies[0], rule.To.DNSName)
+				ips := egressDNS.GetIPs(rule.To.DNSName)
 				for _, ip := range ips {
 					selectors = append(selectors, ip.String())
 				}

--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -67,12 +67,16 @@ type OsdnProxy struct {
 // Called by higher layers to create the proxy plugin instance; only used by nodes
 func New(pluginName string, networkClient networkclient.Interface, kClient kclientset.Interface,
 	networkInformers networkinformers.SharedInformerFactory) (*OsdnProxy, error) {
+	egressDNS, err := common.NewEgressDNS()
+	if err != nil {
+		return nil, err
+	}
 	return &OsdnProxy{
 		kClient:          kClient,
 		networkClient:    networkClient,
 		networkInformers: networkInformers,
 		ids:              make(map[string]uint32),
-		egressDNS:        common.NewEgressDNS(),
+		egressDNS:        egressDNS,
 		firewall:         make(map[string]*proxyFirewallItem),
 		allEndpoints:     make(map[ktypes.UID]*proxyEndpoints),
 	}, nil
@@ -197,7 +201,7 @@ func (proxy *OsdnProxy) updateEgressNetworkPolicy(policy networkapi.EgressNetwor
 			}
 			firewall = append(firewall, firewallItem{rule.Type, cidr})
 		} else if len(rule.To.DNSName) > 0 {
-			cidrs := proxy.egressDNS.GetNetCIDRs(policy, rule.To.DNSName)
+			cidrs := proxy.egressDNS.GetNetCIDRs(rule.To.DNSName)
 			for _, cidr := range cidrs {
 				firewall = append(firewall, firewallItem{rule.Type, &cidr})
 			}
@@ -376,24 +380,26 @@ func (proxy *OsdnProxy) syncEgressDNSProxyFirewall() {
 
 	for {
 		policyUpdates := <-proxy.egressDNS.Updates
-		glog.V(5).Infof("Egress dns sync: update proxy firewall for policy: %v", policyUpdates.UID)
+		for _, policyUpdate := range policyUpdates {
+			glog.V(5).Infof("Egress dns sync: update proxy firewall for policy: %v", policyUpdate.UID)
 
-		policy, ok := getPolicy(policyUpdates.UID, policies)
-		if !ok {
-			policies, err = proxy.networkClient.Network().EgressNetworkPolicies(kapi.NamespaceAll).List(metav1.ListOptions{})
-			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("Failed to update proxy firewall for policy: %v, Could not get EgressNetworkPolicies: %v", policyUpdates.UID, err))
-				continue
-			}
-
-			policy, ok = getPolicy(policyUpdates.UID, policies)
+			policy, ok := getPolicy(policyUpdate.UID, policies)
 			if !ok {
-				glog.Warningf("Unable to update proxy firewall for policy: %v, policy not found", policyUpdates.UID)
-				continue
-			}
-		}
+				policies, err = proxy.networkClient.Network().EgressNetworkPolicies(kapi.NamespaceAll).List(metav1.ListOptions{})
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("Failed to update proxy firewall for policy: %v, Could not get EgressNetworkPolicies: %v", policyUpdate.UID, err))
+					continue
+				}
 
-		proxy.updateEgressNetworkPolicyLocked(policy)
+				policy, ok = getPolicy(policyUpdate.UID, policies)
+				if !ok {
+					glog.Warningf("Unable to update proxy firewall for policy: %v, policy not found", policyUpdate.UID)
+					continue
+				}
+			}
+
+			proxy.updateEgressNetworkPolicyLocked(policy)
+		}
 	}
 }
 


### PR DESCRIPTION
Refactor the datastructures to query DNS names more efficiently as
the same DNS name may appear across multiple policies.