### PR TITLE
allow build git/proxy e2e error msg parsing to work with multiple git…

### DIFF
--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -290,7 +290,7 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				g.By("expecting the build logs to indicate invalid proxy")
 				buildLog, err := br.LogsNoTimestamp()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(buildLog).To(o.ContainSubstring("Could not resolve proxy: invalid.proxy.redhat.com; Unknown error"))
+				o.Expect(buildLog).To(o.ContainSubstring("Could not resolve proxy: invalid.proxy.redhat.com"))
 				g.By("checking pod as well")
 				pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Get(br.BuildName+"-build", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -324,7 +324,7 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				g.By("expecting the build logs to indicate invalid proxy")
 				buildLog, err := br.LogsNoTimestamp()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(buildLog).To(o.ContainSubstring("Could not resolve proxy: invalid.proxy.redhat.com; Unknown error"))
+				o.Expect(buildLog).To(o.ContainSubstring("Could not resolve proxy: invalid.proxy.redhat.com"))
 				g.By("checking build stored in pod as well")
 				// note, only the build stored in the Pod's "BUILD" env var has the updated proxy settings; they do not
 				// get propagated to the associated build stored in etcd

--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -49,10 +49,10 @@ var _ = g.Describe("[Feature:Builds][Slow] builds should support proxies", func(
 				buildLog, err := br.Logs()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(buildLog).NotTo(o.ContainSubstring("clone"))
-				if !strings.Contains(buildLog, `unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to 127.0.0.1:3128`) {
+				if !strings.Contains(buildLog, `unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to`) {
 					fmt.Fprintf(g.GinkgoWriter, "\nbuild log:\n%s\n", buildLog)
 				}
-				o.Expect(buildLog).To(o.ContainSubstring(`unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to 127.0.0.1:3128`))
+				o.Expect(buildLog).To(o.ContainSubstring(`unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to`))
 
 				g.By("verifying the build sample-build-1 status")
 				o.Expect(br.Build.Status.Phase).Should(o.BeEquivalentTo(buildv1.BuildPhaseFailed))


### PR DESCRIPTION
… versions

Based on prototyping in https://github.com/openshift/builder/pull/99 for using the https proxy friendly versions of scl git on rhel7, some slight adjustments to the existing build proxy related e2e error message parsing is needed to account for both the base version of `git` on rhel7 and the scl version,
as the error messages changed ever slow slightly.

Don't see non-message parsing alternatives to those tests.  But of course suggestions welcome.

Of course merging this change does not mean we are committing to fully doing git https proxy support, but this should be a benign change that facilitates our testing when that work is officially taken on.

@openshift/openshift-team-developer-experience FYI

/assign @adambkaplan 