### PR TITLE
Bug 1800343: fix projects when watching with selector

### DIFF
--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -117,7 +117,8 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 		return nil, err
 	}
 
-	watcher := projectauth.NewUserProjectWatcher(userInfo, allowedNamespaces, s.projectCache, s.authCache, includeAllExistingProjects)
+	m := projectutil.MatchProject(apihelpers.InternalListOptionsToSelectors(options))
+	watcher := projectauth.NewUserProjectWatcher(userInfo, allowedNamespaces, s.projectCache, s.authCache, includeAllExistingProjects, m)
 	s.authCache.AddWatcher(watcher)
 
 	go watcher.Watch()


### PR DESCRIPTION
Backport of https://github.com/openshift/origin/pull/21167.

Filters events for projects on membership-change for a user based on a
field or label selector provided by a consumer of project events.