### PR TITLE
Bug 1798282: DROP: Avoid unnecessary calls to the cloud provider

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/service/controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/service/controller.go
@@ -42,7 +42,6 @@ import (
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 	"k8s.io/klog"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
 const (
@@ -311,10 +310,6 @@ func (s *Controller) syncLoadBalancerIfNeeded(service *v1.Service, key string) (
 	var err error
 
 	if !wantsLoadBalancer(service) || needsCleanup(service) {
-		if v1helper.LoadBalancerStatusEqual(previousStatus, &v1.LoadBalancerStatus{}) {
-			return op, nil
-		}
-		klog.V(3).Infof("Getting load balancer for service %s", key)
 		// Delete the load balancer if service no longer wants one, or if service needs cleanup.
 		op = deleteLoadBalancer
 		newStatus = &v1.LoadBalancerStatus{}


### PR DESCRIPTION
Drop UPSTREAM: 63926, which causes deletion of "LoadBalancer"-type services to get stuck.

#19742 added the carry in order to reduce unnecessary cloud-provider API calls, but it is no longer needed and causes problems with recent changes to the clean-up logic for services with type "LoadBalancer".

At the time the PR was written, the service controller added every newly created service to its work queue, which was also used for update and delete events.  When a worker for this queue subsequently processed the service, it would check if the service needed an external load-balancer, and if not, it would then check if a load balancer existed for the service (in case the service had been added to the queue by an update that changed its type from "LoadBalancer", in which case any previously provisioned load-balancer would need to be deleted).  To perform this check, the worker would make a `GetLoadBalancer` API call using the cloud provider.

#19742 added a check to skip the `GetLoadBalancer` call if the service's status indicated that it had no associated load-balancer, which should always be the case for a newly created service if its type is not "LoadBalancer".

Later, upstream commit https://github.com/kubernetes/kubernetes/pull/78262/commits/aa3f81d657c1d4b7c789352af7179c08508adc3c modified the service controller's logic to add a newly created service to the work queue only if its type were "LoadBalancer", thereby obviating the need for the check that #19742 had added. The upstream commit also modified the service controller's load-balancer clean-up logic, and the check that #19742 added breaks this new logic.

* `vendor/k8s.io/kubernetes/pkg/controller/service/controller.go` (`syncLoadBalancerIfNeeded`): Delete check for empty load balancer status.