### PR TITLE
Bug 1803163: UPSTREAM: 65357: Allow more fields at root of CRD schema if status is enabled

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -832,32 +832,71 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			name: "root type without status",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					Type: "object",
+					Type: "string",
 				},
 			},
 			statusEnabled: false,
 			wantError:     false,
 		},
 		{
-			name: "root type with status",
+			name: "root type having invalid value, with status",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					Type: "object",
+					Type: "string",
 				},
 			},
 			statusEnabled: true,
 			wantError:     true,
 		},
 		{
-			name: "properties, required and description with status",
+			name: "non-allowed root field with status",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					AnyOf: []apiextensions.JSONSchemaProps{
+						{
+							Description: "First schema",
+						},
+						{
+							Description: "Second schema",
+						},
+					},
+				},
+			},
+			statusEnabled: true,
+			wantError:     true,
+		},
+		{
+			name: "all allowed fields at the root of the schema with status",
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Description:      "This is a description",
+					Type:             "object",
+					Format:           "date-time",
+					Title:            "This is a title",
+					Maximum:          float64Ptr(10),
+					ExclusiveMaximum: true,
+					Minimum:          float64Ptr(5),
+					ExclusiveMinimum: true,
+					MaxLength:        int64Ptr(10),
+					MinLength:        int64Ptr(5),
+					Pattern:          "^[a-z]$",
+					MaxItems:         int64Ptr(10),
+					MinItems:         int64Ptr(5),
+					MultipleOf:       float64Ptr(3),
+					Required:         []string{"spec", "status"},
+					Items: &apiextensions.JSONSchemaPropsOrArray{
+						Schema: &apiextensions.JSONSchemaProps{
+							Description: "This is a schema nested under Items",
+						},
+					},
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"spec":   {},
 						"status": {},
 					},
-					Required:    []string{"spec", "status"},
-					Description: "This is a description",
+					ExternalDocs: &apiextensions.ExternalDocumentation{
+						Description: "This is an external documentation description",
+					},
+					Example: &example,
 				},
 			},
 			statusEnabled: true,
@@ -874,4 +913,14 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+var example = apiextensions.JSON(`"This is an example"`)
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}
+
+func int64Ptr(f int64) *int64 {
+	return &f
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -321,7 +321,7 @@ func TestScaleSubresource(t *testing.T) {
 	}
 }
 
-func TestValidationSchema(t *testing.T) {
+func TestValidationSchemaWithStatus(t *testing.T) {
 	stopCh, config, err := testserver.StartDefaultServer()
 	if err != nil {
 		t.Fatal(err)
@@ -344,7 +344,7 @@ func TestValidationSchema(t *testing.T) {
 	}
 	_, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err == nil {
-		t.Fatalf(`unexpected non-error, expected: must only have "properties" or "required" at the root if the status subresource is enabled`)
+		t.Fatalf(`unexpected non-error, expected: must not have "additionalProperties" at the root of the schema if the status subresource is enabled`)
 	}
 
 	// make sure we are not restricting fields to properties even in subschemas


### PR DESCRIPTION
This PR is a cherrypick from the upstream PR: https://github.com/kubernetes/kubernetes/pull/65357

We're specifically requesting this change be cherrypicked back to release-3.11 as it currently prevents a single set of CRD resources being compatible with OpenShift 3.11 whilst also being considered 'structural' in OpenShift 4.x (and newer Kubernetes versions).

Without this patch, users will see errors like:

```
Error from server (Invalid): error when creating "cert-manager-openshift-v0.13.0.yaml": CustomResourceDefinition.apiextensions.k8s.io "certificaterequests.cert-manager.io" is invalid: spec.validation.openAPIV3Schema: Invalid value: apiextensions.JSONSchemaProps{ID:""

...

ensions.JSONSchemaDefinitions(nil), ExternalDocs:(*apiextensions.ExternalDocumentation)(nil), Example:(*apiextensions.JSON)(nil)}: must only have "properties", "required" or "description" at the root if the status subresource is enabled
```

when installing CRDs that enable the `status` resource that (correctly) specify `type: object` at the root of their CRD schema.

See also: https://github.com/jetstack/cert-manager/issues/2200

This patch applied clean from the upstream PR. This is my first contribution to `origin` so please let me know if I need to make any changes to how I've submitted this 😄 

/assign @sttts 
