### PR TITLE
Bug 1803190: test/extended/prometheus: temporarily disable etcdInsufficientMembers

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -58,7 +58,7 @@ var _ = g.Describe("[Feature:Prometheus][Late] Alerts", func() {
 
 		tests := map[string]bool{
 			// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-			`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|KubeAPILatencyHigh|FailingOperator",alertstate="firing"}[2h]) >= 1`: false,
+			`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|KubeAPILatencyHigh|etcdInsufficientMembers|FailingOperator",alertstate="firing"}[2h]) >= 1`: false,
 		}
 		runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 	})
@@ -291,7 +291,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 
 			tests := map[string]bool{
 				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|PrometheusRemoteWriteDesiredShards",alertstate="firing"} >= 1`: false,
+				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|PrometheusRemoteWriteDesiredShards|etcdInsufficientMembers",alertstate="firing"} >= 1`: false,
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})


### PR DESCRIPTION
In order to merge the `cluster-etcd-operator`, we need to disable `etcdInsufficientMembers` as we pivot from the old etcd-member static pod. This will be followed by the removal of the etcd-member spec from MCO and reenabling this alert.