### PR TITLE
Eliminate use of tags to determine OS_GIT_VERSION

### DIFF
--- a/hack/lib/build/version.sh
+++ b/hack/lib/build/version.sh
@@ -37,32 +37,14 @@ function os::build::version::git_vars() {
 				OS_GIT_TREE_STATE="dirty"
 			fi
 		fi
-		# Use git describe to find the version based on annotated tags.
-		if [[ -n ${OS_GIT_VERSION-} ]] || OS_GIT_VERSION=$("${git[@]}" describe --long --tags --abbrev=7 --match 'v[0-9]*' "${OS_GIT_COMMIT}^{commit}" 2>/dev/null); then
-			# Try to match the "git describe" output to a regex to try to extract
-			# the "major" and "minor" versions and whether this is the exact tagged
-			# version or whether the tree is between two tagged versions.
-			if [[ "${OS_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(\.[0-9]+)*([-].*)?$ ]]; then
-				OS_GIT_MAJOR=${BASH_REMATCH[1]}
-				OS_GIT_MINOR=${BASH_REMATCH[2]}
-				OS_GIT_PATCH=${BASH_REMATCH[3]}
-				if [[ -n "${BASH_REMATCH[5]}" ]]; then
-					OS_GIT_MINOR+="+"
-				fi
-			fi
 
-			# This translates the "git describe" to an actual semver.org
-			# compatible semantic version that looks something like this:
-			#   v1.1.0-alpha.0.6+84c76d1-345
-			OS_GIT_VERSION=$(echo "${OS_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{7,40\}\)$/\+\2-\1/")
-			# If this is an exact tag, remove the last segment.
-			OS_GIT_VERSION=$(echo "${OS_GIT_VERSION}" | sed "s/-0$//")
-			if [[ "${OS_GIT_TREE_STATE}" == "dirty" ]]; then
-				# git describe --dirty only considers changes to existing files, but
-				# that is problematic since new untracked .go files affect the build,
-				# so use our idea of "dirty" from git status instead.
-				OS_GIT_VERSION+="-dirty"
-			fi
+		OS_GIT_MAJOR='4'
+		OS_GIT_MINOR='0'
+		OS_GIT_PATCH='0'
+		OS_GIT_VERSION="v${OS_GIT_MAJOR}.${OS_GIT_MINOR}.${OS_GIT_PATCH}+${OS_GIT_COMMIT}"
+
+		if [[ "${OS_GIT_TREE_STATE}" == "dirty" ]]; then
+			OS_GIT_VERSION+="-dirty"
 		fi
 	fi
 


### PR DESCRIPTION
The reliance on tags to determine OS_GIT_VERSION means that
origin/ose needed to be treated as snowflakes. To allow
us to use pure fast-forwading, version information should
be supplied at build time instead of being detected through
tags.