### PR TITLE
Bug 1793340: Revert "images/tests: Globally-writeable /etc/passwd"

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -9,8 +9,7 @@ FROM registry.svc.ci.openshift.org/ocp/4.2:cli
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
-    git config --system user.email test@test.com && \
-    chmod g+w /etc/passwd
+    git config --system user.email test@test.com
 LABEL io.k8s.display-name="OpenShift End-to-End Tests" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,tests,e2e"


### PR DESCRIPTION
This reverts commit ca35cd633a46d2156ef598e827ce230391684926, #22592.

As described in that commit message, the access was broadened to allow `ssh` from containers launched from the tests image.  But since openshift/release@7baa9f2e44 (openshift/release#6854) landed, we no longer need to SSH from those containers.  Restore the usual access restrictions to address [CVE-2019-19347][1].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1793287