### PR TITLE
Allow oauth token + cert fallback test to be skipped when running skew tests

### DIFF
--- a/test/extended/oauth/oauthcertfallback.go
+++ b/test/extended/oauth/oauthcertfallback.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	userv1client "github.com/openshift/client-go/user/clientset/versioned"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -32,6 +33,9 @@ var _ = g.Describe("[Feature:OAuthServer] OAuth server", func() {
 	oc := exutil.NewCLI("oauth", exutil.KubeConfigPath())
 
 	g.It("has the correct token and certificate fallback semantics", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2e.Skipf("Authenticator order changed in 4.4 to match kubernetes which precludes running this test against a skewed cluster.")
+		}
 		var (
 			// We have to generate this dynamically in order to have an invalid cert signed by a signer with the same name as the valid CA
 			invalidCert = restclient.TLSClientConfig{}


### PR DESCRIPTION
Behavior has changed between 4.3 and 4.4 ([commit]( https://github.com/openshift/origin/pull/24178/commits/7e2a82946fb8f0f96c77af908e4a4d5e9a580e22)) which precludes skew testing.
