### PR TITLE
test: Allow sequential upgrades to be passed to upgrade test

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -106,6 +106,8 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	m := monitor.NewMonitorWithInterval(1 * time.Second)
 	err = startEndpointMonitoring(ctx, m, t.tcpService, r)
 	framework.ExpectNoError(err, "unable to monitor API")
+
+	start := time.Now()
 	m.StartSampling(ctx)
 
 	// wait to ensure API is still up after the test ends
@@ -113,6 +115,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	ginkgo.By("waiting for any post disruption failures")
 	time.Sleep(15 * time.Second)
 	cancel()
+	end := time.Now()
 
 	var duration time.Duration
 	var describe []string
@@ -126,7 +129,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			duration += i
 		}
 	}
-	if duration > 60*time.Second {
+	if float64(duration)/float64(end.Sub(start)) > 0.02 {
 		framework.Failf("Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
 	} else if duration > 0 {
 		disruption.Flakef(f, "Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -32,8 +32,10 @@ type UpgradeTest struct {
 	tcpService *v1.Service
 }
 
-// Name returns the tracking name of the test.
-func (UpgradeTest) Name() string { return "k8s-service-upgrade" }
+func (UpgradeTest) Name() string { return "k8s-service-lb-available" }
+func (UpgradeTest) DisplayName() string {
+	return "Application behind service load balancer with PDB is not disrupted"
+}
 
 func shouldTestPDBs() bool { return true }
 

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +62,8 @@ func SetTests(tests []upgrades.Test) {
 	upgradeTests = tests
 }
 
-// SetToImage sets the image that will be upgraded to.
+// SetToImage sets the image that will be upgraded to. This may be a comma delimited list
+// of sequential upgrade attempts.
 func SetToImage(image string) {
 	upgradeToImage = image
 }
@@ -116,7 +118,7 @@ var _ = g.Describe("[Disruptive]", func() {
 			client := configv1client.NewForConfigOrDie(config)
 			dynamicClient := dynamic.NewForConfigOrDie(config)
 
-			upgCtx, err := getUpgradeContext(client, "", upgradeToImage)
+			upgCtx, err := getUpgradeContext(client, upgradeToImage)
 			framework.ExpectNoError(err, "determining what to upgrade to version=%s image=%s", "", upgradeToImage)
 
 			disruption.Run(
@@ -128,7 +130,9 @@ var _ = g.Describe("[Disruptive]", func() {
 				},
 				upgradeTests,
 				func() {
-					framework.ExpectNoError(clusterUpgrade(client, dynamicClient, config, upgCtx.Versions[1]), "during upgrade")
+					for i := 1; i < len(upgCtx.Versions); i++ {
+						framework.ExpectNoError(clusterUpgrade(client, dynamicClient, config, upgCtx.Versions[i]), fmt.Sprintf("during upgrade to %s", upgCtx.Versions[i].NodeImage))
+					}
 				},
 			)
 		})
@@ -151,8 +155,8 @@ func latestCompleted(history []configv1.UpdateHistory) (*configv1.Update, bool) 
 	return nil, false
 }
 
-func getUpgradeContext(c configv1client.Interface, upgradeTarget, upgradeImage string) (*upgrades.UpgradeContext, error) {
-	if upgradeTarget == "[pause]" {
+func getUpgradeContext(c configv1client.Interface, upgradeImage string) (*upgrades.UpgradeContext, error) {
+	if upgradeImage == "[pause]" {
 		return &upgrades.UpgradeContext{
 			Versions: []upgrades.VersionContext{
 				{Version: *version.MustParseSemantic("0.0.1"), NodeImage: "[pause]"},
@@ -206,24 +210,23 @@ func getUpgradeContext(c configv1client.Interface, upgradeTarget, upgradeImage s
 		},
 	}
 
-	if len(upgradeTarget) == 0 && len(upgradeImage) == 0 {
+	if len(upgradeImage) == 0 {
 		return upgCtx, nil
 	}
 
-	if (len(upgradeImage) > 0 && upgradeImage == current.Image) || (len(upgradeTarget) > 0 && upgradeTarget == current.Version) {
+	upgradeImages := strings.Split(upgradeImage, ",")
+	if (len(upgradeImages[0]) > 0 && upgradeImages[0] == current.Image) || (len(upgradeImages[0]) > 0 && upgradeImages[0] == current.Version) {
 		return nil, fmt.Errorf("cluster is already at version %s", versionString(*current))
 	}
-
-	var next upgrades.VersionContext
-	next.NodeImage = upgradeImage
-	if len(upgradeTarget) > 0 {
-		nextVer, err := version.ParseSemantic(upgradeTarget)
-		if err != nil {
-			return nil, err
+	for _, upgradeImage := range upgradeImages {
+		var next upgrades.VersionContext
+		if nextVer, err := version.ParseSemantic(upgradeImage); err == nil {
+			next.Version = *nextVer
+		} else {
+			next.NodeImage = upgradeImage
 		}
-		next.Version = *nextVer
+		upgCtx.Versions = append(upgCtx.Versions, next)
 	}
-	upgCtx.Versions = append(upgCtx.Versions, next)
 
 	return upgCtx, nil
 }

--- a/test/extended/operators/cluster.go
+++ b/test/extended/operators/cluster.go
@@ -81,6 +81,9 @@ var _ = g.Describe("[Feature:Platform] Managed cluster should", func() {
 		ns := make(map[string]struct{})
 		for _, pod := range podsWithProblems {
 			delete(lastPending, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+			if strings.HasPrefix(pod.Name, "samename-") {
+				continue
+			}
 			if _, ok := ns[pod.Namespace]; !ok {
 				e2e.DumpAllNamespaceInfo(c, pod.Namespace)
 				ns[pod.Namespace] = struct{}{}

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -17,8 +17,8 @@ import (
 type AvailableTest struct {
 }
 
-// Name returns the tracking name of the test.
-func (AvailableTest) Name() string { return "control-plane-upgrade" }
+func (AvailableTest) Name() string        { return "control-plane-available" }
+func (AvailableTest) DisplayName() string { return "Kubernetes and OpenShift APIs remain available" }
 
 // Setup does nothing
 func (t *AvailableTest) Setup(f *framework.Framework) {

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -124,9 +124,7 @@ func (cma *chaosMonkeyAdapter) Test(sem *chaosmonkey.Semaphore) {
 		cma.testReport.Skipped = "skipping test " + cma.test.Name()
 		return
 	}
-	fmt.Printf("DEBUG: starting test\n")
 	cma.framework.BeforeEach()
-	fmt.Printf("DEBUG: starting test, setup\n")
 	cma.test.Setup(cma.framework)
 	defer cma.test.Teardown(cma.framework)
 	ready()

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -21,6 +21,12 @@ import (
 	"k8s.io/kubernetes/test/utils/junit"
 )
 
+// testWithDisplayName is implemented by tests that want more descriptive test names
+// than Name() (which must be namespace safe) allows.
+type testWithDisplayName interface {
+	DisplayName() string
+}
+
 // flakeSummary is a test summary type that allows upgrades to report violations
 // without failing the upgrade test.
 type flakeSummary string
@@ -65,8 +71,12 @@ func runChaosmonkey(
 ) {
 	testFrameworks := createTestFrameworks(tests)
 	for _, t := range tests {
+		displayName := t.Name()
+		if dn, ok := t.(testWithDisplayName); ok {
+			displayName = dn.DisplayName()
+		}
 		testCase := &junit.TestCase{
-			Name:      t.Name(),
+			Name:      displayName,
 			Classname: "disruption_tests",
 		}
 		testSuite.TestCases = append(testSuite.TestCases, testCase)


### PR DESCRIPTION
Upgrade test now accepts comma-delimited images or versions in
`openshift-tests run-upgrade --image A,B`. This simplifies bulk testing of
upgrades and will allow us to test existing upgrade paths.

This will allow us to test upgrades over multiple releases more easily
and allows us to avoid testing at ecah upgrade interval.

Will be used in 4.4 to test multiple input upgrades.