### PR TITLE
Bug 1765220: Fix pod startup reattach/kill loop

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -222,6 +222,14 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 	// eg, "table=120, priority=100, reg0=${tenant_id}, actions=output:${ovs_port_1},output:${ovs_port_2}"
 	otx.AddFlow("table=120, priority=0, actions=drop")
 
+	return otx.Commit()
+}
+
+// Perform the final step of SDN setup; this is done after everything else, so if the SDN
+// pod is killed partway through setup, then when it is restarted, oc.AlreadySetUp() will
+// fail and we'll destroy and recreate the bridge again.
+func (oc *ovsController) FinishSetupOVS() error {
+	otx := oc.ovs.NewTransaction()
 	// Table 253: rule version note
 	otx.AddFlow("table=%d, actions=note:%s", ruleVersionTable, oc.getVersionNote())
 

--- a/pkg/network/node/runtime.go
+++ b/pkg/network/node/runtime.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	kubeletapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	kruntimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
@@ -64,7 +65,7 @@ func (node *OsdnNode) getPodSandboxID(filter *kruntimeapi.PodSandboxFilter) (str
 	return podSandboxList[0].Id, nil
 }
 
-func (node *OsdnNode) getPodSandboxes() (map[string]*kruntimeapi.PodSandbox, error) {
+func (node *OsdnNode) getSDNPodSandboxes() (map[string]*kruntimeapi.PodSandbox, error) {
 	runtimeService, err := node.getRuntimeService()
 	if err != nil {
 		return nil, err
@@ -79,6 +80,16 @@ func (node *OsdnNode) getPodSandboxes() (map[string]*kruntimeapi.PodSandbox, err
 
 	podSandboxMap := make(map[string]*kruntimeapi.PodSandbox)
 	for _, sandbox := range podSandboxList {
+		status, err := runtimeService.PodSandboxStatus(getPodKey(sandbox.Metadata.Namespace, sandbox.Metadata.Name))
+		if err != nil {
+			glog.Warningf("Could not get status of pod %s/%s: %v", sandbox.Metadata.Namespace, sandbox.Metadata.Name, err)
+			continue
+		}
+		if status.Linux.Namespaces.Options.Network == kruntimeapi.NamespaceMode_NODE {
+			glog.V(4).Infof("Ignoring pod %s/%s which is hostNetwork", sandbox.Metadata.Namespace, sandbox.Metadata.Name)
+			continue
+		}
+		glog.V(4).Infof("Found existing pod %s/%s", sandbox.Metadata.Namespace, sandbox.Metadata.Name)
 		podSandboxMap[getPodKey(sandbox.Metadata.Namespace, sandbox.Metadata.Name)] = sandbox
 	}
 	return podSandboxMap, nil


### PR DESCRIPTION
We should kill every (non-hostNetwork) sandbox that we can't reattach
to OVS, but previously we were only killing "every (non-hostNetwork)
sandbox that we knew was previously attached to OVS that we couldn't
reattach to OVS".

This is a backport of https://github.com/openshift/sdn/pull/58 and https://github.com/openshift/sdn/pull/52 for 3.11.