### PR TITLE
switch to regexp to validate git proxy error message across multiple …

### DIFF
--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -2,7 +2,7 @@ package builds
 
 import (
 	"fmt"
-	"strings"
+	"regexp"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -49,10 +49,12 @@ var _ = g.Describe("[Feature:Builds][Slow] builds should support proxies", func(
 				buildLog, err := br.Logs()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(buildLog).NotTo(o.ContainSubstring("clone"))
-				if !strings.Contains(buildLog, `unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to`) {
+				matched, err := regexp.MatchString(`unable to access.*.ruby-hello.*.Failed.*.connect.*.127`, buildLog)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				if !matched {
 					fmt.Fprintf(g.GinkgoWriter, "\nbuild log:\n%s\n", buildLog)
 				}
-				o.Expect(buildLog).To(o.ContainSubstring(`unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to`))
+				o.Expect(matched).To(o.BeTrue())
 
 				g.By("verifying the build sample-build-1 status")
 				o.Expect(br.Build.Status.Phase).Should(o.BeEquivalentTo(buildv1.BuildPhaseFailed))


### PR DESCRIPTION
…versions of git

So the last builds run of https://github.com/openshift/builder/pull/99 (https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_builder/99/pull-ci-openshift-builder-master-e2e-aws-builds/481) had a slightly different error message than the first time we saw the error message change at https://github.com/openshift/builder/pull/99#issuecomment-583125482

As a result the recently merged https://github.com/openshift/origin/pull/24520 did not cut it.

I've got an update here that switches to regexp and confirms the key elements that should work with multiple git versions (hopefully)

@openshift/openshift-team-developer-experience FYI
/assign @adambkaplan 