### PR TITLE
test: Allow more control plane disruption for multi upgrade releases

### DIFF
--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -55,7 +55,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 			duration += i
 		}
 	}
-	if float64(duration)/float64(end.Sub(start)) > 0.04 {
+	if float64(duration)/float64(end.Sub(start)) > 0.08 {
 		framework.Failf("API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
 	} else if duration > 0 {
 		disruption.Flakef(f, "API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))


### PR DESCRIPTION
When running sequential updates, the control plane appears to take
more disruption than can be currently tolerated. Bump the limit for
now until we identify the root cause of the disruption.