### PR TITLE
Bug 1805821: change restart policy of command pod to RestartPolicyOnFailure

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1648,7 +1648,8 @@ func RunOneShotCommandPod(
 		}
 
 		if podHasErrored(cmdPod) {
-			return true, fmt.Errorf("the pod errored trying to run the command")
+			e2e.Logf("pod %q errored trying to run the command: %v", pod.Name, err)
+			return false, nil
 		}
 		return podHasCompleted(cmdPod), nil
 	})
@@ -1707,7 +1708,7 @@ func newCommandPod(name, image, command string, args []string, volumeMounts []co
 		},
 		Spec: corev1.PodSpec{
 			Volumes:       volumes,
-			RestartPolicy: corev1.RestartPolicyNever,
+			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Containers: []corev1.Container{
 				{
 					Name:            name,

--- a/test/extended/util/ldap.go
+++ b/test/extended/util/ldap.go
@@ -181,7 +181,7 @@ func runLDAPSearchInPod(oc *CLI, host string) (string, error) {
 	mounts, volumes := LDAPClientMounts()
 	output, errs := RunOneShotCommandPod(oc, "runonce-ldapsearch-pod", OpenLDAPTestImage, fmt.Sprintf(ldapSearchCommandFormat, host), mounts, volumes, nil, 8*time.Minute)
 	if len(errs) != 0 {
-		return output, fmt.Errorf("errours encountered trying to run ldapsearch pod: %v", errs)
+		return output, fmt.Errorf("errors encountered trying to run ldapsearch pod: %v", errs)
 	}
 	return output, nil
 }


### PR DESCRIPTION
This PR aims to cut down the CI flakes for the LDAP test.

There are a good number of failures because of connection failures due to race conditions between the LDAP client and the LDAP server. Using `RestartPolicyOnFailure` instead of `RestartPolicyNever` will make sure the pod command completes by restarting the pod in case of transient failures.

The same ldap container image is being used for both server and client. The client implementation is not under our control for the pod to be resilient to transient failures. To cover these failures restarting pod on failure seems to be a good option.