### PR TITLE
test: Ensure the upgrade test LB remains available

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -96,7 +96,10 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	// Hit it once before considering ourselves ready
 	ginkgo.By("hitting pods through the service's LoadBalancer")
 	timeout := service.LoadBalancerLagTimeoutAWS
-	service.TestReachableHTTP(tcpIngressIP, svcPort, timeout)
+	// require five passing requests to continue (in case the SLB becomes available and then degrades)
+	for i := 0; i < 5; i++ {
+		service.TestReachableHTTP(tcpIngressIP, svcPort, timeout)
+	}
 
 	t.jig = jig
 	t.tcpService = tcpService


### PR DESCRIPTION
In some tests we are seeing the LB become ready, then start failing again. Try for five successes to reduce the chance that ELB is stable when we start the upgrade.

Example: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/19275 and the failures at the beginning of the upgrade (before anything starts)