### PR TITLE
Enable verification for machineconfig CRDs

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -98,13 +98,11 @@ var (
 		// {Group: "monitoring.coreos.com", Version: "v1", Resource: "prometheusrules"},
 		// {Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors"},
 
-		// FIXME
-		// {Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "containerruntimeconfigs"},
-		// {Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "controllerconfigs"},
-		// {Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "kubeletconfigs"},
-		// {Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "machineconfigpools"},
-		// {Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "machineconfigs"},
-		// {Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "mcoconfigs"},
+		{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "containerruntimeconfigs"},
+		{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "controllerconfigs"},
+		{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "kubeletconfigs"},
+		{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "machineconfigpools"},
+		{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "machineconfigs"},
 
 		{Group: "operator.openshift.io", Version: "v1alpha1", Resource: "imagecontentsourcepolicies"},
 


### PR DESCRIPTION
Now with https://github.com/openshift/machine-config-operator/pull/1485
oc explain is working for *.machineconfiguration CRDs. Also remove
"mcoconfigs" as it does not seem to exist anywhere.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>