### PR TITLE
Bug 1807990: UPSTREAM: 88663: update kube-controller-manager and kube-scheduler to match kube-apiserver defaults

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/options/options_test.go
+++ b/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/options/options_test.go
@@ -61,6 +61,7 @@ func TestDefaultFlags(t *testing.T) {
 			},
 			Debugging: &cmoptions.DebuggingOptions{
 				DebuggingConfiguration: &componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           true,
 					EnableContentionProfiling: false,
 				},
 			},
@@ -192,6 +193,7 @@ func TestAddFlags(t *testing.T) {
 			},
 			Debugging: &cmoptions.DebuggingOptions{
 				DebuggingConfiguration: &componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           false,
 					EnableContentionProfiling: true,
 				},
 			},

--- a/vendor/k8s.io/kubernetes/cmd/controller-manager/app/options/debugging.go
+++ b/vendor/k8s.io/kubernetes/cmd/controller-manager/app/options/debugging.go
@@ -27,6 +27,16 @@ type DebuggingOptions struct {
 	*componentbaseconfig.DebuggingConfiguration
 }
 
+// RecommendedDebuggingOptions returns the currently recommended debugging options.  These are subject to change
+// between releases as we add options and decide which features should be exposed or not by default.
+func RecommendedDebuggingOptions() *DebuggingOptions {
+	return &DebuggingOptions{
+		DebuggingConfiguration: &componentbaseconfig.DebuggingConfiguration{
+			EnableProfiling: true, // profile debugging is cheap to have exposed and standard on kube binaries
+		},
+	}
+}
+
 // AddFlags adds flags related to debugging for controller manager to the specified FlagSet.
 func (o *DebuggingOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {

--- a/vendor/k8s.io/kubernetes/cmd/controller-manager/app/options/generic.go
+++ b/vendor/k8s.io/kubernetes/cmd/controller-manager/app/options/generic.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	cliflag "k8s.io/component-base/cli/flag"
-	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/kubernetes/pkg/client/leaderelectionconfig"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
@@ -39,9 +38,7 @@ type GenericControllerManagerConfigurationOptions struct {
 func NewGenericControllerManagerConfigurationOptions(cfg *kubectrlmgrconfig.GenericControllerManagerConfiguration) *GenericControllerManagerConfigurationOptions {
 	o := &GenericControllerManagerConfigurationOptions{
 		GenericControllerManagerConfiguration: cfg,
-		Debugging: &DebuggingOptions{
-			DebuggingConfiguration: &componentbaseconfig.DebuggingConfiguration{},
-		},
+		Debugging:                             RecommendedDebuggingOptions(),
 	}
 
 	return o

--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/options/options.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/options/options.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	cliflag "k8s.io/component-base/cli/flag"
 	componentbaseconfig "k8s.io/component-base/config"
+	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/klog"
 	kubeschedulerconfigv1alpha1 "k8s.io/kube-scheduler/config/v1alpha1"
 	schedulerappconfig "k8s.io/kubernetes/cmd/kube-scheduler/app/config"
@@ -130,6 +131,8 @@ func splitHostIntPort(s string) (string, int, error) {
 
 func newDefaultComponentConfig() (*kubeschedulerconfig.KubeSchedulerConfiguration, error) {
 	cfgv1alpha1 := kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration{}
+	cfgv1alpha1.DebuggingConfiguration = *configv1alpha1.NewRecommendedDebuggingConfiguration()
+
 	kubeschedulerscheme.Scheme.Default(&cfgv1alpha1)
 	cfg := kubeschedulerconfig.KubeSchedulerConfiguration{}
 	if err := kubeschedulerscheme.Scheme.Convert(&cfgv1alpha1, &cfg, nil); err != nil {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go
@@ -72,3 +72,26 @@ func RecommendedDefaultClientConnectionConfiguration(obj *ClientConnectionConfig
 		obj.Burst = 100
 	}
 }
+
+// RecommendedDebuggingConfiguration defaults profiling and debugging configuration.
+// This will set the recommended default
+// values, but they may be subject to change between API versions. This function
+// is intentionally not registered in the scheme as a "normal" `SetDefaults_Foo`
+// function to allow consumers of this type to set whatever defaults for their
+// embedded configs. Forcing consumers to use these defaults would be problematic
+// as defaulting in the scheme is done as part of the conversion, and there would
+// be no easy way to opt-out. Instead, if you want to use this defaulting method
+// run it in your wrapper struct of this type in its `SetDefaults_` method.
+func RecommendedDebuggingConfiguration(obj *DebuggingConfiguration) {
+	if obj.EnableProfiling == nil {
+		obj.EnableProfiling = utilpointer.BoolPtr(true) // profile debugging is cheap to have exposed and standard on kube binaries
+	}
+}
+
+// NewRecommendedDebuggingConfiguration returns the current recommended DebuggingConfiguration.
+// This may change between releases as recommendations shift.
+func NewRecommendedDebuggingConfiguration() *DebuggingConfiguration {
+	ret := &DebuggingConfiguration{}
+	RecommendedDebuggingConfiguration(ret)
+	return ret
+}


### PR DESCRIPTION
Clean pick with the exception that the variable in `vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/options/options.go` changed from `versionedCfg` to `cfgv1alpha1`. 

/assign @deads2k 