### PR TITLE
Bug 1791211: test/extended/prometheus: exclude AlertmanagerReceiversNotConfigured from checking

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -199,7 +199,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 				runQueries(tests, oc, ns, execPodName, url, bearerToken)
 			})
 		})
-		g.It("should report less than two alerts in firing or pending state", func() {
+		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured", func() {
 			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 				e2e.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
 			}
@@ -210,7 +210,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 
 			tests := map[string]bool{
 				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-				`ALERTS{alertname!="Watchdog",alertstate="firing"} >= 1`: false,
+				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured",alertstate="firing"} >= 1`: false,
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 		})


### PR DESCRIPTION
This is a backport of https://github.com/openshift/origin/pull/24276 and #24465 to allow merging https://github.com/openshift/cluster-monitoring-operator/pull/614

/cc @openshift/openshift-team-monitoring 