### PR TITLE
Bug 1811020: Fix count of failures in JUnit output

### DIFF
--- a/pkg/test/ginkgo/junit.go
+++ b/pkg/test/ginkgo/junit.go
@@ -145,7 +145,7 @@ func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, du
 				},
 			})
 		case test.success:
-			s.NumFailed++
+			s.NumTests++
 			s.TestCases = append(s.TestCases, &JUnitTestCase{
 				Name:     test.name,
 				Duration: test.duration.Seconds(),


### PR DESCRIPTION
Don't count success as a failure. Looks like copy-paste "typo".