### PR TITLE
DO NOT MERGE: Avoid a live read from the kubelet for better performance

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/config/config.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/config/config.go
@@ -457,6 +457,7 @@ func checkAndUpdatePod(existing, ref *v1.Pod) (needUpdate, needReconcile, needGr
 		if !reflect.DeepEqual(existing.Status, ref.Status) {
 			// Pod with changed pod status needs reconcile, because kubelet should
 			// be the source of truth of pod status.
+			existing.ResourceVersion = ref.ResourceVersion
 			existing.Status = ref.Status
 			needReconcile = true
 		}
@@ -467,6 +468,7 @@ func checkAndUpdatePod(existing, ref *v1.Pod) (needUpdate, needReconcile, needGr
 	// internal annotation, there is no need to update.
 	ref.Annotations[kubetypes.ConfigFirstSeenAnnotationKey] = existing.Annotations[kubetypes.ConfigFirstSeenAnnotationKey]
 
+	existing.ResourceVersion = ref.ResourceVersion
 	existing.Spec = ref.Spec
 	existing.Labels = ref.Labels
 	existing.DeletionTimestamp = ref.DeletionTimestamp

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/metrics/metrics.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/metrics/metrics.go
@@ -37,6 +37,7 @@ const (
 	KubeletSubsystem                     = "kubelet"
 	NodeNameKey                          = "node_name"
 	NodeLabelKey                         = "node"
+	PodStatusSyncDurationKey             = "pod_status_sync_duration_seconds"
 	PodWorkerDurationKey                 = "pod_worker_duration_seconds"
 	PodStartDurationKey                  = "pod_start_duration_seconds"
 	CgroupManagerOperationsKey           = "cgroup_manager_duration_seconds"
@@ -110,6 +111,18 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+
+	// PodStatusSyncDuration is a Histogram that tracks the duration (in seconds) in takes from the time a pod
+	// status is generated to the time it is synced with the apiserver.
+	PodStatusSyncDuration = metrics.NewSummary(
+		&metrics.SummaryOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodStatusSyncDurationKey,
+			Help:           "Duration in seconds to sync a pod status update. Measures time from detection to write.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
 	// PodWorkerDuration is a Histogram that tracks the duration (in seconds) in takes to sync a single pod.
 	// Broken down by the operation type.
 	PodWorkerDuration = metrics.NewHistogramVec(
@@ -504,6 +517,7 @@ func Register(containerCache kubecontainer.RuntimeCache, collectors ...metrics.S
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(NodeName)
 		legacyregistry.MustRegister(PodWorkerDuration)
+		legacyregistry.MustRegister(PodStatusSyncDuration)
 		legacyregistry.MustRegister(PodStartDuration)
 		legacyregistry.MustRegister(CgroupManagerDuration)
 		legacyregistry.MustRegister(PodWorkerStartDuration)


### PR DESCRIPTION
The kubelet owns the status of a pod except for condition injection.
The current code does a live read and then executes a versionless patch,
which cannot not prevent changes from another client from being lost, only
reduces their frequency (another client can execute a PATCH of status in between when the kubelet calls GET and PATCH).

Instead of performing a live read for each patch, attempt to find the
current status from a "last-write" cache in the status manager, or
the pod manager, or perform a live read. This should eliminate almost
all live reads and should better expose any incorrectness around clients
that assume their writes to pod status won't be lost.