### PR TITLE
DO NOT MERGE: Prioritize certain kubelet pod status updates over others

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/config/config.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/config/config.go
@@ -457,6 +457,7 @@ func checkAndUpdatePod(existing, ref *v1.Pod) (needUpdate, needReconcile, needGr
 		if !reflect.DeepEqual(existing.Status, ref.Status) {
 			// Pod with changed pod status needs reconcile, because kubelet should
 			// be the source of truth of pod status.
+			existing.ResourceVersion = ref.ResourceVersion
 			existing.Status = ref.Status
 			needReconcile = true
 		}
@@ -467,6 +468,7 @@ func checkAndUpdatePod(existing, ref *v1.Pod) (needUpdate, needReconcile, needGr
 	// internal annotation, there is no need to update.
 	ref.Annotations[kubetypes.ConfigFirstSeenAnnotationKey] = existing.Annotations[kubetypes.ConfigFirstSeenAnnotationKey]
 
+	existing.ResourceVersion = ref.ResourceVersion
 	existing.Spec = ref.Spec
 	existing.Labels = ref.Labels
 	existing.DeletionTimestamp = ref.DeletionTimestamp

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -1742,8 +1742,7 @@ func (kl *Kubelet) getPodsToSync() []*v1.Pod {
 // 1.  stopping the associated pod worker asynchronously
 // 2.  signaling to kill the pod by sending on the podKillingCh channel
 //
-// deletePod returns an error if not all sources are ready or the pod is not
-// found in the runtime cache.
+// deletePod returns an error if not all sources are ready.
 func (kl *Kubelet) deletePod(pod *v1.Pod) error {
 	if pod == nil {
 		return fmt.Errorf("deletePod does not allow nil pod")
@@ -1763,7 +1762,7 @@ func (kl *Kubelet) deletePod(pod *v1.Pod) error {
 	}
 	runningPod := kubecontainer.Pods(runningPods).FindPod("", pod.UID)
 	if runningPod.IsEmpty() {
-		return fmt.Errorf("pod not found")
+		return nil
 	}
 	podPair := kubecontainer.PodPair{APIPod: pod, RunningPod: &runningPod}
 

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_pods.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_pods.go
@@ -1402,6 +1402,7 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 			s.HostIP = hostIP.String()
 			if kubecontainer.IsHostNetworkPod(pod) && s.PodIP == "" {
 				s.PodIP = hostIP.String()
+				s.PodIPs = []v1.PodIP{{IP: s.PodIP}}
 			}
 		}
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_pods.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_pods.go
@@ -1415,16 +1415,15 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 // alter the kubelet state at all.
 func (kl *Kubelet) convertStatusToAPIStatus(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *v1.PodStatus {
 	var apiPodStatus v1.PodStatus
-	apiPodStatus.PodIPs = make([]v1.PodIP, 0, len(podStatus.IPs))
-	for _, ip := range podStatus.IPs {
-		apiPodStatus.PodIPs = append(apiPodStatus.PodIPs, v1.PodIP{
-			IP: ip,
-		})
-	}
 
-	if len(apiPodStatus.PodIPs) > 0 {
+	if len(podStatus.IPs) > 0 {
+		apiPodStatus.PodIPs = make([]v1.PodIP, 0, len(podStatus.IPs))
+		for _, ip := range podStatus.IPs {
+			apiPodStatus.PodIPs = append(apiPodStatus.PodIPs, v1.PodIP{IP: ip})
+		}
 		apiPodStatus.PodIP = apiPodStatus.PodIPs[0].IP
 	}
+
 	// set status for Pods created on versions of kube older than 1.6
 	apiPodStatus.QOSClass = v1qos.GetPodQOS(pod)
 

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/metrics/metrics.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/metrics/metrics.go
@@ -37,6 +37,7 @@ const (
 	KubeletSubsystem                     = "kubelet"
 	NodeNameKey                          = "node_name"
 	NodeLabelKey                         = "node"
+	PodStatusSyncDurationKey             = "pod_status_sync_duration_seconds"
 	PodWorkerDurationKey                 = "pod_worker_duration_seconds"
 	PodStartDurationKey                  = "pod_start_duration_seconds"
 	CgroupManagerOperationsKey           = "cgroup_manager_duration_seconds"
@@ -110,6 +111,18 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+
+	// PodStatusSyncDuration is a Histogram that tracks the duration (in seconds) in takes from the time a pod
+	// status is generated to the time it is synced with the apiserver.
+	PodStatusSyncDuration = metrics.NewSummary(
+		&metrics.SummaryOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodStatusSyncDurationKey,
+			Help:           "Duration in seconds to sync a pod status update. Measures time from detection to write.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
 	// PodWorkerDuration is a Histogram that tracks the duration (in seconds) in takes to sync a single pod.
 	// Broken down by the operation type.
 	PodWorkerDuration = metrics.NewHistogramVec(
@@ -504,6 +517,7 @@ func Register(containerCache kubecontainer.RuntimeCache, collectors ...metrics.S
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(NodeName)
 		legacyregistry.MustRegister(PodWorkerDuration)
+		legacyregistry.MustRegister(PodStatusSyncDuration)
 		legacyregistry.MustRegister(PodStartDuration)
 		legacyregistry.MustRegister(CgroupManagerDuration)
 		legacyregistry.MustRegister(PodWorkerStartDuration)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/metrics/metrics.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/metrics/metrics.go
@@ -114,13 +114,14 @@ var (
 
 	// PodStatusSyncDuration is a Histogram that tracks the duration (in seconds) in takes from the time a pod
 	// status is generated to the time it is synced with the apiserver.
-	PodStatusSyncDuration = metrics.NewSummary(
+	PodStatusSyncDuration = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
 			Subsystem:      KubeletSubsystem,
 			Name:           PodStatusSyncDurationKey,
 			Help:           "Duration in seconds to sync a pod status update. Measures time from detection to write.",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{"priority"},
 	)
 
 	// PodWorkerDuration is a Histogram that tracks the duration (in seconds) in takes to sync a single pod.


### PR DESCRIPTION
The kubelet status report loop is single threaded and periodically clears
all pending updates in a batch. Add a simple prioritization mechanism that
puts pod termination (success or failed) updates at the front of the queue
and pod readiness changes right behind it, followed by other types of pod
status change. This attempts to reduce end user visible latency around core
pod operations at the expense of adding latency to some less impactful
updates.