### PR TITLE
fix unstable case to check resource status

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -157,7 +157,7 @@ var _ = g.Describe("[sig-operator] an end user use OLM", func() {
 
 	var (
 		oc           = exutil.NewCLI("olm-23440", exutil.KubeConfigPath())
-		operatorWait = 120 * time.Second
+		operatorWait = 150 * time.Second
 
 		buildPruningBaseDir = exutil.FixturePath("testdata", "olm")
 		operatorGroup       = filepath.Join(buildPruningBaseDir, "operatorgroup.yaml")
@@ -177,9 +177,10 @@ var _ = g.Describe("[sig-operator] an end user use OLM", func() {
 		err := wait.Poll(10*time.Second, operatorWait, func() (bool, error) {
 			output, err := oc.AsAdmin().Run("get").Args("-n", oc.Namespace(), "csv", "etcdoperator.v0.9.4", "-o=jsonpath={.status.phase}").Output()
 			if err != nil {
-				e2e.Failf("Failed to deploy etcdoperator.v0.9.4, error:%v", err)
-				return false, err
+				e2e.Logf("Failed to check etcdoperator.v0.9.4, error:%v, try next round", err)
+				return false, nil
 			}
+			e2e.Logf("the output is %s", output)
 			if strings.Contains(output, "Succeeded") {
 				return true, nil
 			}


### PR DESCRIPTION
@jianzhangbjz could you please help review the PR? thanks
```console
I0312 14:29:11.289935   20276 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0312 14:29:13.964047   20278 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with catalogsources at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/2/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]"

started: (0/3/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with subscriptions at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/4/11) "[Feature:Platform] an end user use OLM [Top Level] [Feature:Platform] an end user use OLM can subscribe to the etcd operator [Suite:openshift/conformance/parallel]"

started: (0/5/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with operatorgroups at version v1 [Suite:openshift/conformance/parallel]"

started: (0/6/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [Suite:openshift/conformance/parallel]"

started: (0/7/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with installplans at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/8/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with packagemanifests at version v1 [Suite:openshift/conformance/parallel]"

started: (0/9/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with clusterserviceversions at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/10/11) "[Feature:Platform] an end user use OLM [Top Level] [Feature:Platform] an end user use OLM Report Upgradeable in OLM ClusterOperators status [Suite:openshift/conformance/parallel]"

passed: (16s) 2020-03-12T06:29:30 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with catalogsources at version v1alpha1 [Suite:openshift/conformance/parallel]"

passed: (16.1s) 2020-03-12T06:29:30 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [Suite:openshift/conformance/parallel]"

passed: (16.9s) 2020-03-12T06:29:30 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with installplans at version v1alpha1 [Suite:openshift/conformance/parallel]"

passed: (17s) 2020-03-12T06:29:30 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with clusterserviceversions at version v1alpha1 [Suite:openshift/conformance/parallel]"

passed: (18.6s) 2020-03-12T06:29:32 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with subscriptions at version v1alpha1 [Suite:openshift/conformance/parallel]"

passed: (18.9s) 2020-03-12T06:29:32 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with operatorgroups at version v1 [Suite:openshift/conformance/parallel]"

passed: (20.3s) 2020-03-12T06:29:34 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should be installed with packagemanifests at version v1 [Suite:openshift/conformance/parallel]"

passed: (20.5s) 2020-03-12T06:29:34 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]"

passed: (26.7s) 2020-03-12T06:29:40 "[Feature:Platform] an end user use OLM [Top Level] [Feature:Platform] an end user use OLM Report Upgradeable in OLM ClusterOperators status [Suite:openshift/conformance/parallel]"

passed: (42.6s) 2020-03-12T06:29:56 "[Feature:Platform] an end user use OLM [Top Level] [Feature:Platform] an end user use OLM can subscribe to the etcd operator [Suite:openshift/conformance/parallel]"

started: (0/11/11) "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should [Serial] olm version should contain the source commit id [Suite:openshift/conformance/serial]"

passed: (19.2s) 2020-03-12T06:30:15 "[Feature:Platform] OLM should [Top Level] [Feature:Platform] OLM should [Serial] olm version should contain the source commit id [Suite:openshift/conformance/serial]"

11 pass, 0 skip (1m2s)
```