### PR TITLE
UPSTREAM: 89055: Remove wait.Until for running Kubelet Bootstrap

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kubelet/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubelet/app/server.go
@@ -1125,9 +1125,7 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 
 func startKubelet(k kubelet.Bootstrap, podCfg *config.PodConfig, kubeCfg *kubeletconfiginternal.KubeletConfiguration, kubeDeps *kubelet.Dependencies, enableCAdvisorJSONEndpoints, enableServer bool) {
 	// start the kubelet
-	go wait.Until(func() {
-		k.Run(podCfg.Updates())
-	}, 0, wait.NeverStop)
+	go k.Run(podCfg.Updates())
 
 	// start the kubelet server
 	if enableServer {


### PR DESCRIPTION
As @liggitt outlined in #88779 (comment) , there are two options in preventing multiple parallel Run goroutines.

This PR adopts option #1.