### PR TITLE
Bug 1813428: Restore globally-writeable /etc/passwd in tests image

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -9,7 +9,8 @@ FROM registry.svc.ci.openshift.org/ocp/4.2:cli
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
-    git config --system user.email test@test.com
+    git config --system user.email test@test.com && \
+    chmod g+w /etc/passwd
 LABEL io.k8s.display-name="OpenShift End-to-End Tests" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,tests,e2e"


### PR DESCRIPTION
This reverts commit 33a6115867f59fc479dba6ca009de3492632c114.

This is required for our CI infrastructure to use SSH correctly
until we have completely moved CI to 4.x infrastructure (where
/etc/passwd becomes dynamic). This broke the disruptive test
suite and etcd recovery, and blocks a number of other tests being
added.

The issue is not a CVE.