### PR TITLE
trivial change of log

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -283,7 +283,7 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 
 	// define file config source
 	if kubeCfg.StaticPodPath != "" {
-		klog.Infof("Adding pod path: %v", kubeCfg.StaticPodPath)
+		klog.Infof("Adding pod path : %v", kubeCfg.StaticPodPath)
 		config.NewSourceFile(kubeCfg.StaticPodPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(kubetypes.FileSource))
 	}
 


### PR DESCRIPTION
I was investigating e2e-gcp-upgrade failure :

https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/pr-logs/pull/24686/pull-ci-openshift-origin-master-e2e-gcp-upgrade/2825/artifacts/e2e-gcp-upgrade/

which was for porting #89055 from upstream.

I opened this PR to try out several scenarios since e2e-gcp-upgrade doesn't exist upstream.

Please keep this open.