### PR TITLE
add scc forbidden error debug around scl image pod creation

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -294,7 +294,7 @@ func (c *CLI) CreateProject() string {
 }
 
 func (c *CLI) DebugSCCForbidden() {
-	sccList, err := c.AsAdmin().AdminSecurityClient().SecurityV1().SecurityContextConstraints().List(metav1.ListOptions{})
+	sccList, err := c.AsAdmin().AdminSecurityClient().SecurityV1().SecurityContextConstraints().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		framework.Logf("error trying to dump SCC for failure debug: %s", err.Error())
 		return


### PR DESCRIPTION
See https://github.com/openshift/cluster-samples-operator/pull/242#issuecomment-599706504 and https://bugzilla.redhat.com/show_bug.cgi?id=1817099 around missing SCC / forbidden errors on pod creates of SCL images 

/assign @adambkaplan 
 @deads2k  FYI