### PR TITLE
Bug 1814357: Fix nil reference when accessing un-migrated platform status

### DIFF
--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -44,9 +44,14 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		g.It("should set Forwarded headers appropriately", func() {
 			o.Expect(infra).NotTo(o.BeNil())
 
-			if !(infra.Status.PlatformStatus.Type == configv1.AWSPlatformType ||
-				infra.Status.PlatformStatus.Type == configv1.AzurePlatformType ||
-				infra.Status.PlatformStatus.Type == configv1.GCPPlatformType) {
+			platformType := infra.Status.Platform
+			if infra.Status.PlatformStatus != nil {
+				platformType = infra.Status.PlatformStatus.Type
+			}
+			switch platformType {
+			case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType:
+				// supported
+			default:
 				g.Skip(fmt.Sprintf("BZ 1772125 -- not verified on platform type %q", infra.Status.PlatformStatus.Type))
 			}
 
@@ -111,7 +116,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			g.By(fmt.Sprintf("inspecting the echoed headers"))
 			ffHeader := req.Header.Get("X-Forwarded-For")
 
-			switch infra.Status.PlatformStatus.Type {
+			switch platformType {
 			case configv1.AWSPlatformType:
 				// On AWS we can only assert that we
 				// get an X-Forwarded-For header; we

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -47,7 +47,11 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get("cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		proxyProtocol = infra.Status.PlatformStatus.Type == configv1.AWSPlatformType
+		platformType := infra.Status.Platform
+		if infra.Status.PlatformStatus != nil {
+			platformType = infra.Status.PlatformStatus.Type
+		}
+		proxyProtocol = platformType == configv1.AWSPlatformType
 
 		// This test needs to make assertions against a single router pod, so all access
 		// to the router should happen through a single endpoint.


### PR DESCRIPTION
Fix nil reference crashes when accessing an infrastructure status field that
hasn't been migrated.