### PR TITLE
[release-4.3] Bug 1811200: /readyz should start returning failure on shutdown initiation

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -805,7 +805,7 @@ func TestDispatchingBookmarkEventsWithConcurrentStop(t *testing.T) {
 		wg := sync.WaitGroup{}
 		wg.Add(2)
 		go func() {
-			cacher.dispatchEvent(bookmark)
+			cacher.processEvent(bookmark)
 			wg.Done()
 		}()
 


### PR DESCRIPTION
Currently, /readyz starts reporting failure after ShutdownDelayDuration
elapses. We expect /readyz to start returning failure as soon as
shutdown is initiated. This gives the load balancer a window defined by
ShutdownDelayDuration to detect that /readyz is red and stop sending
traffic to this server.