### PR TITLE
Bug 1814357: Fix another nil reference when accessing un-migrated platform status

### DIFF
--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType:
 				// supported
 			default:
-				g.Skip(fmt.Sprintf("BZ 1772125 -- not verified on platform type %q", infra.Status.PlatformStatus.Type))
+				g.Skip(fmt.Sprintf("BZ 1772125 -- not verified on platform type %q", platformType))
 			}
 
 			defer func() {


### PR DESCRIPTION
Another nil reference fix for a crash when accessing an infrastructure status field that
hasn't been migrated.