### PR TITLE
tools/commitchecker: fix base commit in CI

### DIFF
--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -16,5 +16,5 @@ fi
 os::util::ensure::built_binary_exists 'commitchecker'
 
 os::test::junit::declare_suite_start "verify/upstream-commits"
-os::cmd::expect_success "commitchecker"
+os::cmd::expect_success "commitchecker --start ${PULL_BASE_SHA:-master}"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
The upstream commit message pattern is the following:

```
^UPSTREAM: (revert: )?(([\w\.-]+\/[\w-\.-]+)?: )?(\d+:|<carry>:|<drop>:)
```

Yet, we merged PRs with commit without the first column. Reason was that the commit range was wrong with `master..HEAD` as `master` pointed to the merge commit of the PR into origin/master.