### PR TITLE
Bug 1790825: fix test flake in operators test

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -210,6 +210,10 @@ var _ = g.Describe("[sig-operator] an end user use OLM", func() {
 		output, err := oc.Run("get").Args("deployments", "-n", oc.Namespace()).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(output).To(o.ContainSubstring("etcd"))
+
+		// clean up so that it doesn't emit an alert when namespace is deleted
+		_, err = oc.AsAdmin().Run("delete").Args("-n", oc.Namespace(), "csv", "etcdoperator.v0.9.4").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	// OCP-24829 - Report `Upgradeable` in OLM ClusterOperators status


### PR DESCRIPTION
When the namespace is deleted, the operatorgroup can be removed
before the csv, which can cause the csv to flip to failed.

there is an alert that fires when the csv flips to failed, which
can cause the monitoring test ensuring no alerts fired to fail

