### PR TITLE
Bug 1806408: Ensure upgrade tests verify application disruption

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -27,26 +27,42 @@ var upgradeSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return strings.Contains(name, "[Feature:ClusterUpgrade]") && strings.Contains(name, "[Suite:openshift]")
 		},
-
 		Init: func(opt map[string]string) error {
-			for k, v := range opt {
-				switch k {
-				case "abort-at":
-					if err := upgrade.SetUpgradeAbortAt(v); err != nil {
-						return err
-					}
-				case "disrupt-reboot":
-					if err := upgrade.SetUpgradeDisruptReboot(v); err != nil {
-						return err
-					}
-				default:
-					return fmt.Errorf("unrecognized upgrade option: %s", k)
-				}
-			}
-			return filterUpgrade(upgrade.AllTests(), func(name string) bool { return true })
+			return upgradeInitArguments(opt, func(string) bool { return true })
 		},
-		TestTimeout: 120 * time.Minute,
+		TestTimeout: 240 * time.Minute,
 	},
+	{
+		Name: "platform",
+		Description: templates.LongDesc(`
+		Run only the tests that verify the platform remains available.
+		`),
+		Matches: func(name string) bool {
+			return strings.Contains(name, "[Feature:ClusterUpgrade]") && strings.Contains(name, "[Suite:openshift]")
+		},
+		Init: func(opt map[string]string) error {
+			return upgradeInitArguments(opt, func(name string) bool { return name == "control-plane-available" })
+		},
+		TestTimeout: 240 * time.Minute,
+	},
+}
+
+func upgradeInitArguments(opt map[string]string, filterFn func(name string) bool) error {
+	for k, v := range opt {
+		switch k {
+		case "abort-at":
+			if err := upgrade.SetUpgradeAbortAt(v); err != nil {
+				return err
+			}
+		case "disrupt-reboot":
+			if err := upgrade.SetUpgradeDisruptReboot(v); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unrecognized upgrade option: %s", k)
+		}
+	}
+	return filterUpgrade(upgrade.AllTests(), filterFn)
 }
 
 type UpgradeOptions struct {

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -49,6 +49,18 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("creating a TCP service " + serviceName + " with type=LoadBalancer in namespace " + ns.Name)
 	tcpService := jig.CreateTCPServiceOrFail(ns.Name, func(s *v1.Service) {
 		s.Spec.Type = v1.ServiceTypeLoadBalancer
+		if s.Annotations == nil {
+			s.Annotations = make(map[string]string)
+		}
+		// We tune the LB checks to match the longest intervals available so that interactions between
+		// upgrading components and the service are more obvious.
+		// - AWS allows configuration, default is 70s (6 failed with 10s interval in 1.17) set to match GCP
+		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"] = "8"
+		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold"] = "3"
+		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold"] = "2"
+		// - Azure is hardcoded to 15s (2 failed with 5s interval in 1.17) and is sufficient
+		// - GCP has a non-configurable interval of 32s (3 failed health checks with 8s interval in 1.17)
+		//   - thus pods need to stay up for > 32s, so pod shutdown period will will be 45s
 	})
 	tcpService = jig.WaitForLoadBalancerOrFail(ns.Name, tcpService.Name, service.LoadBalancerLagTimeoutAWS)
 	jig.SanityCheckService(tcpService, v1.ServiceTypeLoadBalancer)
@@ -59,13 +71,15 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 
 	ginkgo.By("creating RC to be part of service " + serviceName)
 	rc := jig.RunOrFail(ns.Name, func(rc *v1.ReplicationController) {
-		// ensure the pod waits long enough for most LBs to take it out of rotation
-		minute := int64(60)
+		// ensure the pod waits long enough for most LBs to take it out of rotation, which has to be
+		// longer than the LB failed health check interval
 		rc.Spec.Template.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
 			PreStop: &v1.Handler{
-				Exec: &v1.ExecAction{Command: []string{"sleep", "30"}},
+				Exec: &v1.ExecAction{Command: []string{"sleep", "45"}},
 			},
 		}
+		// ensure the pod is not forcibly deleted at 30s, but waits longer than the graceful sleep
+		minute := int64(60)
 		rc.Spec.Template.Spec.TerminationGracePeriodSeconds = &minute
 
 		jig.AddRCAntiAffinity(rc)

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -32,8 +32,10 @@ type UpgradeTest struct {
 	tcpService *v1.Service
 }
 
-// Name returns the tracking name of the test.
-func (UpgradeTest) Name() string { return "k8s-service-upgrade" }
+func (UpgradeTest) Name() string { return "k8s-service-lb-available" }
+func (UpgradeTest) DisplayName() string {
+	return "Application behind service load balancer with PDB is not disrupted"
+}
 
 func shouldTestPDBs() bool { return true }
 

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -92,7 +92,10 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	// Hit it once before considering ourselves ready
 	ginkgo.By("hitting pods through the service's LoadBalancer")
 	timeout := service.LoadBalancerLagTimeoutAWS
-	jig.TestReachableHTTP(tcpIngressIP, svcPort, timeout)
+	// require five passing requests to continue (in case the SLB becomes available and then degrades)
+	for i := 0; i < 5; i++ {
+		jig.TestReachableHTTP(tcpIngressIP, svcPort, timeout)
+	}
 
 	t.jig = jig
 	t.tcpService = tcpService

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -102,6 +102,8 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	m := monitor.NewMonitorWithInterval(1 * time.Second)
 	err = startEndpointMonitoring(ctx, m, t.tcpService, r)
 	o.Expect(err).NotTo(o.HaveOccurred(), "unable to monitor API")
+
+	start := time.Now()
 	m.StartSampling(ctx)
 
 	// wait to ensure API is still up after the test ends
@@ -109,6 +111,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	ginkgo.By("waiting for any post disruption failures")
 	time.Sleep(15 * time.Second)
 	cancel()
+	end := time.Now()
 
 	var duration time.Duration
 	var describe []string
@@ -122,7 +125,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			duration += i
 		}
 	}
-	if duration > 60*time.Second {
+	if float64(duration)/float64(end.Sub(start)) > 0.02 {
 		framework.Failf("Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
 	} else if duration > 0 {
 		disruption.Flakef(f, "Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -127,23 +126,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	cancel()
 	end := time.Now()
 
-	var duration time.Duration
-	var describe []string
-	for _, interval := range m.Events(time.Time{}, time.Time{}) {
-		describe = append(describe, interval.String())
-		i := interval.To.Sub(interval.From)
-		if i < time.Second {
-			i = time.Second
-		}
-		if interval.Condition.Level > monitor.Info {
-			duration += i
-		}
-	}
-	if float64(duration)/float64(end.Sub(start)) > 0.02 {
-		framework.Failf("Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
-	} else if duration > 0 {
-		disruption.Flakef(f, "Service was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
-	}
+	disruption.ExpectNoDisruption(f, 0.02, end.Sub(start), m.Events(time.Time{}, time.Time{}), "Service was unreachable during disruption")
 
 	// verify finalizer behavior
 	defer func() {

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -30,11 +30,13 @@ import (
 	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
+	"github.com/openshift/origin/test/extended/util/disruption/frontends"
 )
 
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
 		&controlplane.AvailableTest{},
+		&frontends.AvailableTest{},
 		&service.UpgradeTest{},
 		&upgrades.SecretUpgradeTest{},
 		&apps.ReplicaSetUpgradeTest{},

--- a/test/extended/operators/cluster.go
+++ b/test/extended/operators/cluster.go
@@ -81,6 +81,9 @@ var _ = g.Describe("[Feature:Platform] Managed cluster should", func() {
 		ns := make(map[string]struct{})
 		for _, pod := range podsWithProblems {
 			delete(lastPending, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+			if strings.HasPrefix(pod.Name, "samename-") {
+				continue
+			}
 			if _, ok := ns[pod.Namespace]; !ok {
 				e2e.DumpEventsInNamespace(func(opts metav1.ListOptions, ns string) (*corev1.EventList, error) {
 					return c.CoreV1().Events(ns).List(opts)

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -17,8 +17,8 @@ import (
 type AvailableTest struct {
 }
 
-// Name returns the tracking name of the test.
-func (AvailableTest) Name() string { return "control-plane-upgrade" }
+func (AvailableTest) Name() string        { return "control-plane-available" }
+func (AvailableTest) DisplayName() string { return "Kubernetes and OpenShift APIs remain available" }
 
 // Setup does nothing
 func (t *AvailableTest) Setup(f *framework.Framework) {

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -55,7 +55,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 			duration += i
 		}
 	}
-	if float64(duration)/float64(end.Sub(start)) > 0.04 {
+	if float64(duration)/float64(end.Sub(start)) > 0.08 {
 		framework.Failf("API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
 	} else if duration > 0 {
 		disruption.Flakef(f, "API was unreachable during upgrade for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 	"k8s.io/kubernetes/test/utils/junit"
+
+	"github.com/openshift/origin/pkg/monitor"
 )
 
 // testWithDisplayName is implemented by tests that want more descriptive test names
@@ -202,4 +204,27 @@ func createTestFrameworks(tests []upgrades.Test) map[string]*framework.Framework
 		}
 	}
 	return testFrameworks
+}
+
+// ExpectNoDisruption fails if the sum of the duration of all events exceeds tolerate as a fraction ([0-1]) of total, reports a
+// disruption flake if any disruption occurs, and uses reason to prefix the message. I.e. tolerate 0.1 of 10m total will fail
+// if the sum of the intervals is greater than 1m, or report a flake if any interval is found.
+func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Duration, events monitor.EventIntervals, reason string) {
+	var duration time.Duration
+	var describe []string
+	for _, interval := range events {
+		describe = append(describe, interval.String())
+		i := interval.To.Sub(interval.From)
+		if i < time.Second {
+			i = time.Second
+		}
+		if interval.Condition.Level > monitor.Info {
+			duration += i
+		}
+	}
+	if percent := float64(duration) / float64(total); percent > tolerate {
+		framework.Failf("%s for at least %s of %s (%0.0f%%):\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
+	} else if duration > 0 {
+		Flakef(f, "%s for at least %s of %s (%0.0f%%):\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
+	}
 }

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -124,9 +124,7 @@ func (cma *chaosMonkeyAdapter) Test(sem *chaosmonkey.Semaphore) {
 		cma.testReport.Skipped = "skipping test " + cma.test.Name()
 		return
 	}
-	fmt.Printf("DEBUG: starting test\n")
 	cma.framework.BeforeEach()
-	fmt.Printf("DEBUG: starting test, setup\n")
 	cma.test.Setup(cma.framework)
 	defer cma.test.Teardown(cma.framework)
 	ready()

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -21,6 +21,12 @@ import (
 	"k8s.io/kubernetes/test/utils/junit"
 )
 
+// testWithDisplayName is implemented by tests that want more descriptive test names
+// than Name() (which must be namespace safe) allows.
+type testWithDisplayName interface {
+	DisplayName() string
+}
+
 // flakeSummary is a test summary type that allows upgrades to report violations
 // without failing the upgrade test.
 type flakeSummary string
@@ -65,8 +71,12 @@ func runChaosmonkey(
 ) {
 	testFrameworks := createTestFrameworks(tests)
 	for _, t := range tests {
+		displayName := t.Name()
+		if dn, ok := t.(testWithDisplayName); ok {
+			displayName = dn.DisplayName()
+		}
 		testCase := &junit.TestCase{
-			Name:      t.Name(),
+			Name:      displayName,
 			Classname: "disruption_tests",
 		}
 		testSuite.TestCases = append(testSuite.TestCases, testCase)

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -101,23 +100,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	var duration time.Duration
-	var describe []string
-	for _, interval := range m.Events(time.Time{}, time.Time{}) {
-		describe = append(describe, interval.String())
-		i := interval.To.Sub(interval.From)
-		if i < time.Second {
-			i = time.Second
-		}
-		if interval.Condition.Level > monitor.Info {
-			duration += i
-		}
-	}
-	if float64(duration)/float64(end.Sub(start)) > 0.15 {
-		framework.Failf("Frontends were unreachable during disruption for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
-	} else if duration > 0 {
-		disruption.Flakef(f, "Frontends were unreachable during disruption for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
-	}
+	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.Events(time.Time{}, time.Time{}), "Frontends were unreachable during disruption")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -1,0 +1,236 @@
+package frontends
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+
+	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/test/extended/util/disruption"
+)
+
+// AvailableTest tests that route frontends are available before, during, and
+// after a cluster upgrade.
+type AvailableTest struct {
+	frontends []Frontend
+}
+
+type Frontend struct {
+	Namespace string
+	Name      string
+	URL       string
+	Path      string
+
+	Expect string
+}
+
+func (AvailableTest) Name() string { return "frontend-ingress-available" }
+func (AvailableTest) DisplayName() string {
+	return "Cluster frontend ingress remain available"
+}
+
+// Setup finds the routes the platform exposes by default
+func (t *AvailableTest) Setup(f *framework.Framework) {
+	t.frontends = []Frontend{
+		{Namespace: "openshift-authentication", Name: "oauth-openshift", Path: "/healthz", Expect: "ok"},
+		{Namespace: "openshift-console", Name: "console", Expect: "Red Hat OpenShift Container Platform"},
+	}
+	config, err := framework.LoadConfig()
+	framework.ExpectNoError(err)
+	client, err := routeclientset.NewForConfig(config)
+	framework.ExpectNoError(err)
+	for i, frontend := range t.frontends {
+		route, err := client.RouteV1().Routes(frontend.Namespace).Get(frontend.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		for _, ingress := range route.Status.Ingress {
+			if len(ingress.Host) > 0 {
+				t.frontends[i].URL = fmt.Sprintf("https://%s", ingress.Host)
+
+				break
+			}
+		}
+		if len(t.frontends[i].URL) == 0 {
+			framework.Failf("route %s/%s has no ingress host: %#v", route.Namespace, route.Name, route.Status.Ingress)
+		}
+	}
+}
+
+// Test runs a connectivity check to the service.
+func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	client, err := framework.LoadClientset()
+	framework.ExpectNoError(err)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	newBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1beta1().Events("")})
+	r := newBroadcaster.NewRecorder(scheme.Scheme, "openshift.io/frontends-available-test")
+	newBroadcaster.StartRecordingToSink(stopCh)
+
+	ginkgo.By("continuously hitting infrastructure through the router")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m := monitor.NewMonitorWithInterval(1 * time.Second)
+	for _, frontend := range t.frontends {
+		err = startEndpointMonitoring(ctx, m, frontend, r)
+		framework.ExpectNoError(err, "unable to monitor route")
+	}
+
+	start := time.Now()
+	m.StartSampling(ctx)
+
+	// wait to ensure API is still up after the test ends
+	<-done
+	ginkgo.By("waiting for any post disruption failures")
+	time.Sleep(15 * time.Second)
+	cancel()
+	end := time.Now()
+
+	var duration time.Duration
+	var describe []string
+	for _, interval := range m.Events(time.Time{}, time.Time{}) {
+		describe = append(describe, interval.String())
+		i := interval.To.Sub(interval.From)
+		if i < time.Second {
+			i = time.Second
+		}
+		if interval.Condition.Level > monitor.Info {
+			duration += i
+		}
+	}
+	if float64(duration)/float64(end.Sub(start)) > 0.15 {
+		framework.Failf("Frontends were unreachable during disruption for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
+	} else if duration > 0 {
+		disruption.Flakef(f, "Frontends were unreachable during disruption for at least %s:\n\n%s", duration.Truncate(time.Second), strings.Join(describe, "\n"))
+	}
+}
+
+// Teardown cleans up any remaining resources.
+func (t *AvailableTest) Teardown(f *framework.Framework) {
+	// rely on the namespace deletion to clean up everything
+}
+
+func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, frontend Frontend, r events.EventRecorder) error {
+	// this client reuses connections and detects abrupt breaks
+	continuousClient, err := rest.UnversionedRESTClientFor(&rest.Config{
+		Host:    frontend.URL,
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 15 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 15 * time.Second,
+			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+		},
+		ContentConfig: rest.ContentConfig{
+			NegotiatedSerializer: scheme.Codecs,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	m.AddSampler(
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+			data, err := continuousClient.Get().AbsPath(frontend.Path).DoRaw()
+			if err == nil && !bytes.Contains(data, []byte(frontend.Expect)) {
+				err = fmt.Errorf("route returned success but did not contain the correct body contents: %q", string(data))
+			}
+			switch {
+			case err == nil && !previous:
+				condition = &monitor.Condition{
+					Level:   monitor.Info,
+					Locator: locateRoute(frontend.Namespace, frontend.Name),
+					Message: "Route started responding to GET requests on reused connections",
+				}
+			case err != nil && previous:
+				framework.Logf("Route %s is unreachable on reused connections: %v", frontend.Name, err)
+				r.Eventf(&v1.ObjectReference{Kind: "Route", Namespace: "kube-system", Name: frontend.Name}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on reused connections")
+				condition = &monitor.Condition{
+					Level:   monitor.Error,
+					Locator: locateRoute(frontend.Namespace, frontend.Name),
+					Message: "Route stopped responding to GET requests on reused connections",
+				}
+			case err != nil:
+				framework.Logf("Route %s is unreachable on reused connections: %v", frontend.Name, err)
+			}
+			return condition, err == nil
+		}).ConditionWhenFailing(&monitor.Condition{
+			Level:   monitor.Error,
+			Locator: locateRoute(frontend.Namespace, frontend.Name),
+			Message: "Route is not responding to GET requests on reused connections",
+		}),
+	)
+
+	// this client creates fresh connections and detects failure to establish connections
+	client, err := rest.UnversionedRESTClientFor(&rest.Config{
+		Host:    frontend.URL,
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   15 * time.Second,
+				KeepAlive: -1,
+			}).Dial,
+			TLSHandshakeTimeout: 15 * time.Second,
+			IdleConnTimeout:     15 * time.Second,
+			DisableKeepAlives:   true,
+			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+		},
+		ContentConfig: rest.ContentConfig{
+			NegotiatedSerializer: scheme.Codecs,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	m.AddSampler(
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+			data, err := client.Get().AbsPath(frontend.Path).DoRaw()
+			if err == nil && !bytes.Contains(data, []byte(frontend.Expect)) {
+				err = fmt.Errorf("route returned success but did not contain the correct body contents: %q", string(data))
+			}
+			switch {
+			case err == nil && !previous:
+				condition = &monitor.Condition{
+					Level:   monitor.Info,
+					Locator: locateRoute(frontend.Namespace, frontend.Name),
+					Message: "Route started responding to GET requests over new connections",
+				}
+			case err != nil && previous:
+				framework.Logf("Route %s is unreachable on new connections: %v", frontend.Name, err)
+				r.Eventf(&v1.ObjectReference{Kind: "Route", Namespace: "kube-system", Name: frontend.Name}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on new connections")
+				condition = &monitor.Condition{
+					Level:   monitor.Error,
+					Locator: locateRoute(frontend.Namespace, frontend.Name),
+					Message: "Route stopped responding to GET requests over new connections",
+				}
+			case err != nil:
+				framework.Logf("Route %s is unreachable on new connections: %v", frontend.Name, err)
+			}
+			return condition, err == nil
+		}).ConditionWhenFailing(&monitor.Condition{
+			Level:   monitor.Error,
+			Locator: locateRoute(frontend.Namespace, frontend.Name),
+			Message: "Route is not responding to GET requests over new connections",
+		}),
+	)
+	return nil
+}
+
+func locateRoute(ns, name string) string {
+	return fmt.Sprintf("ns/%s route/%s", ns, name)
+}


### PR DESCRIPTION
Backport a number of changes from 4.4 that ensured we reported the correct
behavior while upgrading.