### PR TITLE
test: Allow the e2e log to be sequentially written to

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -251,7 +251,7 @@ func mirrorToFile(opt *testginkgo.Options, fn func() error) error {
 		return fn()
 	}
 
-	f, err := os.OpenFile(opt.OutFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0640)
+	f, err := os.OpenFile(opt.OutFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Common scenario is running openshift-tests multiple times in a row
for different suites.