### PR TITLE
DO NOT MERGE: Test a speculative Ginkgo patch

### DIFF
--- a/vendor/github.com/onsi/ginkgo/internal/codelocation/code_location.go
+++ b/vendor/github.com/onsi/ginkgo/internal/codelocation/code_location.go
@@ -3,7 +3,6 @@ package codelocation
 import (
 	"regexp"
 	"runtime"
-	"runtime/debug"
 	"strings"
 
 	"github.com/onsi/ginkgo/types"
@@ -11,8 +10,8 @@ import (
 
 func New(skip int) types.CodeLocation {
 	_, file, line, _ := runtime.Caller(skip + 1)
-	stackTrace := PruneStack(string(debug.Stack()), skip)
-	return types.CodeLocation{FileName: file, LineNumber: line, FullStackTrace: stackTrace}
+	//stackTrace := PruneStack(string(debug.Stack()), skip)
+	return types.CodeLocation{FileName: file, LineNumber: line /*FullStackTrace: stackTrace*/}
 }
 
 func PruneStack(fullStackTrace string, skip int) string {


### PR DESCRIPTION
Ginkgo invokes runtime.Debug which is extremely expensive. Test whether
we actually need this (cuts start time of openshift-tests from 1.2s to 0.3s).