### PR TITLE
Bug 1816302: UPSTREAM: 88505: Honor status.podIP over status.podIPs, node.spec.podCIDR over node.spec.podCIDRs

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/apis/core/v1/conversion.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/core/v1/conversion.go
@@ -253,9 +253,13 @@ func Convert_v1_PodStatus_To_core_PodStatus(in *v1.PodStatus, out *core.PodStatu
 		return err
 	}
 
-	// If both fields (v1.PodIPs and v1.PodIP) are provided, then test v1.PodIP == v1.PodIPs[0]
+	// If both fields (v1.PodIPs and v1.PodIP) are provided and differ, then PodIP is authoritative for compatibility with older kubelets
 	if (len(in.PodIP) > 0 && len(in.PodIPs) > 0) && (in.PodIP != in.PodIPs[0].IP) {
-		return fmt.Errorf("conversion Error: v1.PodIP(%v) != v1.PodIPs[0](%v)", in.PodIP, in.PodIPs[0].IP)
+		out.PodIPs = []core.PodIP{
+			{
+				IP: in.PodIP,
+			},
+		}
 	}
 	// at the this point, autoConvert copied v1.PodIPs -> core.PodIPs
 	// if v1.PodIPs was empty but v1.PodIP is not, then set core.PodIPs[0] with v1.PodIP
@@ -321,9 +325,9 @@ func Convert_v1_NodeSpec_To_core_NodeSpec(in *v1.NodeSpec, out *core.NodeSpec, s
 	if err := autoConvert_v1_NodeSpec_To_core_NodeSpec(in, out, s); err != nil {
 		return err
 	}
-	// If both fields (v1.PodCIDRs and v1.PodCIDR) are provided, then test v1.PodCIDR == v1.PodCIDRs[0]
+	// If both fields (v1.PodCIDRs and v1.PodCIDR) are provided and differ, then PodCIDR is authoritative for compatibility with older clients
 	if (len(in.PodCIDR) > 0 && len(in.PodCIDRs) > 0) && (in.PodCIDR != in.PodCIDRs[0]) {
-		return fmt.Errorf("conversion Error: v1.PodCIDR(%v) != v1.CIDRs[0](%v)", in.PodCIDR, in.PodCIDRs[0])
+		out.PodCIDRs = []string{in.PodCIDR}
 	}
 
 	// at the this point, autoConvert copied v1.PodCIDRs -> core.PodCIDRs

--- a/vendor/k8s.io/kubernetes/pkg/apis/core/v1/conversion_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/core/v1/conversion_test.go
@@ -396,16 +396,60 @@ func Test_core_PodStatus_to_v1_PodStatus(t *testing.T) {
 	}
 }
 func Test_v1_PodStatus_to_core_PodStatus(t *testing.T) {
-	// fail
-	v1FailTestInputs := []v1.PodStatus{
+	asymmetricInputs := []struct {
+		name string
+		in   v1.PodStatus
+		out  core.PodStatus
+	}{
 		{
-			PodIP: "1.1.2.1", // fail becaue PodIP != PodIPs[0]
-			PodIPs: []v1.PodIP{
-				{IP: "1.1.1.1"},
-				{IP: "2.2.2.2"},
+			name: "mismatched podIP",
+			in: v1.PodStatus{
+				PodIP: "1.1.2.1", // Older field takes precedence for compatibility with patch by older clients
+				PodIPs: []v1.PodIP{
+					{IP: "1.1.1.1"},
+					{IP: "2.2.2.2"},
+				},
+			},
+			out: core.PodStatus{
+				PodIPs: []core.PodIP{
+					{IP: "1.1.2.1"},
+				},
+			},
+		},
+		{
+			name: "matching podIP",
+			in: v1.PodStatus{
+				PodIP: "1.1.1.1",
+				PodIPs: []v1.PodIP{
+					{IP: "1.1.1.1"},
+					{IP: "2.2.2.2"},
+				},
+			},
+			out: core.PodStatus{
+				PodIPs: []core.PodIP{
+					{IP: "1.1.1.1"},
+					{IP: "2.2.2.2"},
+				},
+			},
+		},
+		{
+			name: "empty podIP",
+			in: v1.PodStatus{
+				PodIP: "",
+				PodIPs: []v1.PodIP{
+					{IP: "1.1.1.1"},
+					{IP: "2.2.2.2"},
+				},
+			},
+			out: core.PodStatus{
+				PodIPs: []core.PodIP{
+					{IP: "1.1.1.1"},
+					{IP: "2.2.2.2"},
+				},
 			},
 		},
 	}
+
 	// success
 	v1TestInputs := []v1.PodStatus{
 		// only Primary IP Provided
@@ -449,12 +493,18 @@ func Test_v1_PodStatus_to_core_PodStatus(t *testing.T) {
 			},
 		},
 	}
-	// run failed cases
-	for i, failedTest := range v1FailTestInputs {
+
+	// run asymmetric cases
+	for _, tc := range asymmetricInputs {
+		testInput := tc.in
+
 		corePodStatus := core.PodStatus{}
 		// convert..
-		if err := corev1.Convert_v1_PodStatus_To_core_PodStatus(&failedTest, &corePodStatus, nil); err == nil {
-			t.Errorf("%v: Convert v1.PodStatus to core.PodStatus should have failed for input %+v", i, failedTest)
+		if err := corev1.Convert_v1_PodStatus_To_core_PodStatus(&testInput, &corePodStatus, nil); err != nil {
+			t.Errorf("%s: Convert v1.PodStatus to core.PodStatus failed with error:%v for input %+v", tc.name, err.Error(), testInput)
+		}
+		if !reflect.DeepEqual(corePodStatus, tc.out) {
+			t.Errorf("%s: expected %#v, got %#v", tc.name, tc.out.PodIPs, corePodStatus.PodIPs)
 		}
 	}
 
@@ -539,10 +589,40 @@ func Test_core_NodeSpec_to_v1_NodeSpec(t *testing.T) {
 }
 
 func Test_v1_NodeSpec_to_core_NodeSpec(t *testing.T) {
-	failInputs := []v1.NodeSpec{
-		{ // fail PodCIDRs[0] != PodCIDR
-			PodCIDR:  "10.0.0.0/24",
-			PodCIDRs: []string{"10.0.1.0/24", "ace:cab:deca::/8"},
+	asymmetricInputs := []struct {
+		name string
+		in   v1.NodeSpec
+		out  core.NodeSpec
+	}{
+		{
+			name: "mismatched podCIDR",
+			in: v1.NodeSpec{
+				PodCIDR:  "10.0.0.0/24",
+				PodCIDRs: []string{"10.0.1.0/24", "ace:cab:deca::/8"},
+			},
+			out: core.NodeSpec{
+				PodCIDRs: []string{"10.0.0.0/24"},
+			},
+		},
+		{
+			name: "unset podCIDR",
+			in: v1.NodeSpec{
+				PodCIDR:  "",
+				PodCIDRs: []string{"10.0.1.0/24", "ace:cab:deca::/8"},
+			},
+			out: core.NodeSpec{
+				PodCIDRs: []string{"10.0.1.0/24", "ace:cab:deca::/8"},
+			},
+		},
+		{
+			name: "matching podCIDR",
+			in: v1.NodeSpec{
+				PodCIDR:  "10.0.1.0/24",
+				PodCIDRs: []string{"10.0.1.0/24", "ace:cab:deca::/8"},
+			},
+			out: core.NodeSpec{
+				PodCIDRs: []string{"10.0.1.0/24", "ace:cab:deca::/8"},
+			},
 		},
 	}
 
@@ -589,11 +669,17 @@ func Test_v1_NodeSpec_to_core_NodeSpec(t *testing.T) {
 		},
 	}
 
-	// fail cases
-	for i, failInput := range failInputs {
+	// run asymmetric cases
+	for _, tc := range asymmetricInputs {
+		testInput := tc.in
+
 		coreNodeSpec := core.NodeSpec{}
-		if err := corev1.Convert_v1_NodeSpec_To_core_NodeSpec(&failInput, &coreNodeSpec, nil); err == nil {
-			t.Errorf("%v: Convert v1.NodeSpec to core.NodeSpec failed. Expected an error when coreNodeSpec.PodCIDR != coreNodeSpec.PodCIDRs[0]", i)
+		// convert..
+		if err := corev1.Convert_v1_NodeSpec_To_core_NodeSpec(&testInput, &coreNodeSpec, nil); err != nil {
+			t.Errorf("%s: Convert v1.NodeSpec to core.NodeSpec failed with error:%v for input %+v", tc.name, err.Error(), testInput)
+		}
+		if !reflect.DeepEqual(coreNodeSpec, tc.out) {
+			t.Errorf("%s: expected %#v, got %#v", tc.name, tc.out.PodCIDRs, coreNodeSpec.PodCIDRs)
 		}
 	}
 


### PR DESCRIPTION
`pod.status.podIPs` was introduced in kube 1.16 with the requirement that if `podIP` and `podIPs` are both set, they must match. This means that when a kube 1.14 / OCP 4.2 kubelet tries to change the `podIP` of a pod on a kube 1.16 / OCP 4.3 apiserver, it will fail because it didn't also try to change `podIPs`:

```
Mar 23 18:04:42 ip-10-0-163-3 hyperkube[1938]: W0323 18:04:42.769863    1938
status_manager.go:519] Failed to update status for pod "kube-apiserver-operator-
5d7c58bbb4-27mww_openshift-kube-apiserver-operator(93729130-6d20-11ea-
a89d-0a193a986132)": failed to patch status "..." for pod
"openshift-kube-apiserver-operator"/"kube-apiserver-operator-5d7c58bbb4-27mww":
conversion Error: v1.PodIP(10.129.0.65) != v1.PodIPs[0](10.129.0.41)
```

eg, specifically, if during a 4.2 to 4.3 upgrade, the apiserver pods are updated to 4.3, and then another pod gets restarted on a node that is still running a 4.2 kubelet, and upon being restarted it has a different IP then it did before, then it will get stuck.

This seems like something we should have hit sooner and I'm not sure why we didn't. (Possibly we used to end up always reassigning the pod its old IP again in this case, but some recent sdn/multus fix changed that?)

Upstream discussion: https://github.com/kubernetes/kubernetes/pull/88505

This will need to be backported to 4.4 and 4.3.