### PR TITLE
test: When the scanner fails print the error

### DIFF
--- a/test/extended/etcd/etcd_test_runner.go
+++ b/test/extended/etcd/etcd_test_runner.go
@@ -39,8 +39,9 @@ var _ = g.Describe("[sig-api-machinery] API data in etcd", func() {
 		o.Expect(cmd.Start()).NotTo(o.HaveOccurred())
 
 		scanner := bufio.NewScanner(stdOut)
-		o.Expect(scanner.Scan()).To(o.BeTrue())
+		scan := scanner.Scan()
 		o.Expect(scanner.Err()).NotTo(o.HaveOccurred())
+		o.Expect(scan).To(o.BeTrue())
 		output := scanner.Text()
 
 		port := strings.TrimSuffix(strings.TrimPrefix(output, "Forwarding from 127.0.0.1:"), " -> 2379")


### PR DESCRIPTION
Otherwise it's hard to debug.

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/24739/pull-ci-openshift-origin-master-e2e-aws-serial/13256