### PR TITLE
Make new-app related tests more resilient to changes to deployment by default

### DIFF
--- a/test/extended/builds/service.go
+++ b/test/extended/builds/service.go
@@ -4,6 +4,10 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	kapierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kdeployutil "k8s.io/kubernetes/test/e2e/framework/deployment"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -38,8 +42,17 @@ RUN curl -vvv hello-openshift:8080
 				err := oc.Run("new-app").Args("docker.io/openshift/hello-openshift").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "hello-openshift", 1, true, oc)
-				o.Expect(err).NotTo(o.HaveOccurred())
+				deploy, derr := oc.KubeClient().AppsV1().Deployments(oc.Namespace()).Get("hello-openshift", metav1.GetOptions{})
+				if kapierrs.IsNotFound(derr) {
+					// if deployment is not there we're working with old new-app producing deployment configs
+					err := exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "hello-openshift", 1, true, oc)
+					o.Expect(err).NotTo(o.HaveOccurred())
+				} else {
+					// if present - wait for deployment
+					o.Expect(derr).NotTo(o.HaveOccurred())
+					err := kdeployutil.WaitForDeploymentComplete(oc.KubeClient(), deploy)
+					o.Expect(err).NotTo(o.HaveOccurred())
+				}
 
 				err = exutil.WaitForEndpoint(oc.KubeFramework().ClientSet, oc.Namespace(), "hello-openshift")
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/testdata/cmd/test/cmd/env.sh
+++ b/test/extended/testdata/cmd/test/cmd/env.sh
@@ -4,32 +4,32 @@ trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/set-env"
 # This test validates the value of --image for oc run
-os::cmd::expect_success 'oc new-app node'
-os::cmd::expect_failure_and_text 'oc set env dc/node' 'error: at least one environment variable must be provided'
-os::cmd::expect_success_and_text 'oc set env dc/node key=value' 'deploymentconfig.apps.openshift.io/node updated'
-os::cmd::expect_success_and_text 'oc set env dc/node --list' 'deploymentconfigs/node, container node'
-os::cmd::expect_success_and_text 'oc set env dc --all --containers="node" key-' 'deploymentconfig.apps.openshift.io/node updated'
-os::cmd::expect_failure_and_text 'oc set env dc --all --containers="node"' 'error: at least one environment variable must be provided'
-os::cmd::expect_failure_and_not_text 'oc set env --from=secret/mysecret dc/node' 'error: at least one environment variable must be provided'
-os::cmd::expect_failure_and_text 'oc set env dc/node test#abc=1234' 'environment variable test#abc=1234 is invalid, a valid environment variable name must consist of alphabetic characters'
+os::cmd::expect_success 'oc create deploymentconfig testdc --image=busybox'
+os::cmd::expect_failure_and_text 'oc set env dc/testdc' 'error: at least one environment variable must be provided'
+os::cmd::expect_success_and_text 'oc set env dc/testdc key=value' 'deploymentconfig.apps.openshift.io/testdc updated'
+os::cmd::expect_success_and_text 'oc set env dc/testdc --list' 'deploymentconfigs/testdc, container default-container'
+os::cmd::expect_success_and_text 'oc set env dc --all --containers="default-container" key-' 'deploymentconfig.apps.openshift.io/testdc updated'
+os::cmd::expect_failure_and_text 'oc set env dc --all --containers="default-container"' 'error: at least one environment variable must be provided'
+os::cmd::expect_failure_and_not_text 'oc set env --from=secret/mysecret dc/testdc' 'error: at least one environment variable must be provided'
+os::cmd::expect_failure_and_text 'oc set env dc/testdc test#abc=1234' 'environment variable test#abc=1234 is invalid, a valid environment variable name must consist of alphabetic characters'
 
 # ensure deleting a var through --env does not result in an error message
-os::cmd::expect_success_and_text 'oc set env dc/node key=value' 'deploymentconfig.apps.openshift.io/node updated'
-os::cmd::expect_success_and_text 'oc set env dc/node dots.in.a.key=dots.in.a.value' 'deploymentconfig.apps.openshift.io/node updated'
-os::cmd::expect_success_and_text 'oc set env dc --all --containers="node" --env=key-' 'deploymentconfig.apps.openshift.io/node updated'
+os::cmd::expect_success_and_text 'oc set env dc/testdc key=value' 'deploymentconfig.apps.openshift.io/testdc updated'
+os::cmd::expect_success_and_text 'oc set env dc/testdc dots.in.a.key=dots.in.a.value' 'deploymentconfig.apps.openshift.io/testdc updated'
+os::cmd::expect_success_and_text 'oc set env dc --all --containers="default-container" --env=key-' 'deploymentconfig.apps.openshift.io/testdc updated'
 # ensure deleting a var through --env actually deletes the env var
-os::cmd::expect_success_and_not_text "oc get dc/node -o jsonpath='{ .spec.template.spec.containers[?(@.name==\"node\")].env }'" 'name\:key'
-os::cmd::expect_success_and_text "oc get dc/node -o jsonpath='{ .spec.template.spec.containers[?(@.name==\"node\")].env }'" 'name\:dots.in.a.key'
-os::cmd::expect_success_and_text 'oc set env dc --all --containers="node" --env=dots.in.a.key-' 'deploymentconfig.apps.openshift.io/node updated'
-os::cmd::expect_success_and_not_text "oc get dc/node -o jsonpath='{ .spec.template.spec.containers[?(@.name==\"node\")].env }'" 'name\:dots.in.a.key'
+os::cmd::expect_success_and_not_text "oc get dc/testdc -o jsonpath='{ .spec.template.spec.containers[?(@.name==\"default-container\")].env }'" 'name\:key'
+os::cmd::expect_success_and_text "oc get dc/testdc -o jsonpath='{ .spec.template.spec.containers[?(@.name==\"default-container\")].env }'" 'name\:dots.in.a.key'
+os::cmd::expect_success_and_text 'oc set env dc --all --containers="default-container" --env=dots.in.a.key-' 'deploymentconfig.apps.openshift.io/testdc updated'
+os::cmd::expect_success_and_not_text "oc get dc/testdc -o jsonpath='{ .spec.template.spec.containers[?(@.name==\"default-container\")].env }'" 'name\:dots.in.a.key'
 
 # check that env vars are not split at commas
-os::cmd::expect_success_and_text 'oc set env -o yaml dc/node PASS=x,y=z' 'value: x,y=z'
-os::cmd::expect_success_and_text 'oc set env -o yaml dc/node --env PASS=x,y=z' 'value: x,y=z'
+os::cmd::expect_success_and_text 'oc set env -o yaml dc/testdc PASS=x,y=z' 'value: x,y=z'
+os::cmd::expect_success_and_text 'oc set env -o yaml dc/testdc --env PASS=x,y=z' 'value: x,y=z'
 # warning is printed when --env has comma in it
-os::cmd::expect_success_and_text 'oc set env dc/node --env PASS=x,y=z' 'no longer accepts comma-separated list'
+os::cmd::expect_success_and_text 'oc set env dc/testdc --env PASS=x,y=z' 'no longer accepts comma-separated list'
 # warning is not printed for variables passed as positional arguments
-os::cmd::expect_success_and_not_text 'oc set env dc/node PASS=x,y=z' 'no longer accepts comma-separated list'
+os::cmd::expect_success_and_not_text 'oc set env dc/testdc PASS=x,y=z' 'no longer accepts comma-separated list'
 
 # create a build-config object with the JenkinsPipeline strategy
 os::cmd::expect_success 'oc process -p NAMESPACE=openshift -f ${TEST_DATA}/jenkins/jenkins-ephemeral-template.json | oc create -f -'

--- a/test/extended/testdata/cmd/test/cmd/printer.sh
+++ b/test/extended/testdata/cmd/test/cmd/printer.sh
@@ -11,14 +11,12 @@ os::cmd::expect_success_and_not_text 'oc get is' 'imagestream.image.openshift.io
 
 # Test that resource printer includes namespaces for buildconfigs with custom strategies
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/application-template-custombuild.json'
-os::cmd::expect_success_and_text 'oc new-app ruby-helloworld-sample' 'deploymentconfig.apps.openshift.io "frontend" created'
+os::cmd::expect_success_and_text 'oc new-app ruby-helloworld-sample' 'deployment.*.apps.* "frontend" created'
 os::cmd::expect_success_and_text 'oc get all --all-namespaces' 'cmd-printer[\ ]+buildconfig.build.openshift.io\/ruby\-sample\-build'
 
 # Test that infos printer supports all outputFormat options
-os::cmd::expect_success_and_text 'oc new-app node -o yaml | oc set env -f - MYVAR=value' 'deploymentconfig.apps.openshift.io/node updated'
-# FIXME: what to do with this?
-# os::cmd::expect_success 'oc new-app node -o yaml | oc set env -f - MYVAR=value -o custom-colums="NAME:.metadata.name"'
-os::cmd::expect_success_and_text 'oc new-app node -o yaml | oc set env -f - MYVAR=value -o yaml' 'apiVersion: apps.openshift.io/v1'
-os::cmd::expect_success_and_text 'oc new-app node -o yaml | oc set env -f - MYVAR=value -o json' '"apiVersion": "apps.openshift.io/v1"'
+os::cmd::expect_success_and_text 'oc new-app node --dry-run -o yaml | oc set env --local -f - MYVAR=value' 'deployment.*.apps.*/node updated'
+os::cmd::expect_success_and_text 'oc new-app node --dry-run -o yaml | oc set env --local -f - MYVAR=value -o yaml' 'apiVersion: apps.*/v1'
+os::cmd::expect_success_and_text 'oc new-app node --dry-run -o yaml | oc set env --local -f - MYVAR=value -o json' '"apiVersion": "apps.*/v1"'
 echo "resource printer: ok"
 os::test::junit::declare_suite_end

--- a/test/extended/testdata/cmd/test/cmd/timeout.sh
+++ b/test/extended/testdata/cmd/test/cmd/timeout.sh
@@ -12,10 +12,10 @@ trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/request-timeout"
 # This test validates the global request-timeout option
-os::cmd::expect_success_and_text 'oc new-app node' 'Success'
-os::cmd::expect_success_and_text 'oc get dc node -w --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
-os::cmd::expect_success_and_text 'oc get dc node --request-timeout=1s' 'node'
-os::cmd::expect_success_and_text 'oc get dc node --request-timeout=1' 'node'
+os::cmd::expect_success 'oc create deploymentconfig testdc --image=busybox'
+os::cmd::expect_success_and_text 'oc get dc/testdc -w --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1s' 'testdc'
+os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1' 'testdc'
 os::cmd::expect_success_and_text 'oc get pods --watch --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 
 echo "request-timeout: ok"

--- a/test/extended/testdata/cmd/test/cmd/triggers.sh
+++ b/test/extended/testdata/cmd/test/cmd/triggers.sh
@@ -18,7 +18,6 @@ os::test::junit::declare_suite_start "cmd/triggers"
 
 os::cmd::expect_success 'oc new-app centos/ruby-25-centos7~https://github.com/openshift/ruby-hello-world.git'
 os::cmd::expect_success 'oc get bc/ruby-hello-world'
-os::cmd::expect_success 'oc get dc/ruby-hello-world'
 
 os::cmd::expect_success "oc new-build --name=scratch --docker-image=scratch --dockerfile='FROM scratch'"
 
@@ -94,32 +93,33 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/triggers/deploymentconfigs"
 ## Deployment configs
 
+os::cmd::expect_success 'oc create deploymentconfig testdc --image=busybox'
+
 # error conditions
-os::cmd::expect_failure_and_text 'oc set triggers dc/ruby-hello-world --from-github' 'deployment configs do not support GitHub web hooks'
-os::cmd::expect_failure_and_text 'oc set triggers dc/ruby-hello-world --from-webhook' 'deployment configs do not support web hooks'
-os::cmd::expect_failure_and_text 'oc set triggers dc/ruby-hello-world --from-gitlab' 'deployment configs do not support GitLab web hooks'
-os::cmd::expect_failure_and_text 'oc set triggers dc/ruby-hello-world --from-bitbucket' 'deployment configs do not support Bitbucket web hooks'
-os::cmd::expect_failure_and_text 'oc set triggers dc/ruby-hello-world --from-image=test:latest' 'you must specify --containers when setting --from-image'
-os::cmd::expect_failure_and_text 'oc set triggers dc/ruby-hello-world --from-image=test:latest --containers=other' 'not all container names exist: other \(accepts: ruby-hello-world\)'
+os::cmd::expect_failure_and_text 'oc set triggers dc/testdc --from-github' 'deployment configs do not support GitHub web hooks'
+os::cmd::expect_failure_and_text 'oc set triggers dc/testdc --from-webhook' 'deployment configs do not support web hooks'
+os::cmd::expect_failure_and_text 'oc set triggers dc/testdc --from-gitlab' 'deployment configs do not support GitLab web hooks'
+os::cmd::expect_failure_and_text 'oc set triggers dc/testdc --from-bitbucket' 'deployment configs do not support Bitbucket web hooks'
+os::cmd::expect_failure_and_text 'oc set triggers dc/testdc --from-image=test:latest' 'you must specify --containers when setting --from-image'
+os::cmd::expect_failure_and_text 'oc set triggers dc/testdc --from-image=test:latest --containers=other' 'not all container names exist: other \(accepts: default-container\)'
 # print
-os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world' 'config.*true'
-os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world' 'image.*ruby-hello-world:latest \(ruby-hello-world\).*true'
-os::cmd::expect_success_and_not_text 'oc set triggers dc/ruby-hello-world' 'webhook|github|gitlab|bitbucket'
-os::cmd::expect_success_and_not_text 'oc set triggers dc/ruby-hello-world' 'gitlab'
-os::cmd::expect_success_and_not_text 'oc set triggers dc/ruby-hello-world' 'bitbucket'
+os::cmd::expect_success_and_text 'oc set triggers dc/testdc' 'config.*true'
+os::cmd::expect_success_and_not_text 'oc set triggers dc/testdc' 'webhook|github|gitlab|bitbucket'
+os::cmd::expect_success_and_not_text 'oc set triggers dc/testdc' 'gitlab'
+os::cmd::expect_success_and_not_text 'oc set triggers dc/testdc' 'bitbucket'
 # remove all
-os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world --remove-all' 'updated'
-os::cmd::expect_success_and_not_text 'oc set triggers dc/ruby-hello-world' 'webhook|github|image|gitlab|bitbucket'
-os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world' 'config.*false'
+os::cmd::expect_success_and_text 'oc set triggers dc/testdc --remove-all' 'updated'
+os::cmd::expect_success_and_not_text 'oc set triggers dc/testdc' 'webhook|github|image|gitlab|bitbucket'
+os::cmd::expect_success_and_text 'oc set triggers dc/testdc' 'config.*false'
 # auto
-os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world --auto' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world' 'config.*true'
-os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world --from-image=ruby-hello-world:latest -c ruby-hello-world' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world' 'image.*ruby-hello-world:latest \(ruby-hello-world\).*true'
+os::cmd::expect_success_and_text 'oc set triggers dc/testdc --auto' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers dc/testdc' 'config.*true'
+os::cmd::expect_success_and_text 'oc set triggers dc/testdc --from-image=ruby-hello-world:latest -c default-container' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers dc/testdc' 'image.*ruby-hello-world:latest \(default-container\).*true'
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/triggers/annotations"
-## Deployment configs
+## Deployment
 
 os::cmd::expect_success 'oc create deployment test --image=busybox'
 

--- a/test/extended/util/deploymentconfigs.go
+++ b/test/extended/util/deploymentconfigs.go
@@ -1,13 +1,101 @@
 package util
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	appsv1clienttyped "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	"github.com/openshift/library-go/pkg/apps/appsutil"
 )
+
+// WaitForDeploymentConfig waits for a DeploymentConfig to complete transition
+// to a given version and report minimum availability.
+func WaitForDeploymentConfig(kc kubernetes.Interface, dcClient appsv1clienttyped.DeploymentConfigsGetter, namespace, name string, version int64, enforceNotProgressing bool, cli *CLI) error {
+	e2e.Logf("waiting for deploymentconfig %s/%s to be available with version %d\n", namespace, name, version)
+	var dc *appsv1.DeploymentConfig
+
+	start := time.Now()
+	err := wait.Poll(time.Second, 15*time.Minute, func() (done bool, err error) {
+		dc, err = dcClient.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// TODO re-enable this check once @mfojtik introduces a test that ensures we'll only ever get
+		// exactly one deployment triggered.
+		/*
+			if dc.Status.LatestVersion > version {
+				return false, fmt.Errorf("latestVersion %d passed %d", dc.Status.LatestVersion, version)
+			}
+		*/
+		if dc.Status.LatestVersion < version {
+			return false, nil
+		}
+
+		var progressing, available *appsv1.DeploymentCondition
+		for i, condition := range dc.Status.Conditions {
+			switch condition.Type {
+			case appsv1.DeploymentProgressing:
+				progressing = &dc.Status.Conditions[i]
+
+			case appsv1.DeploymentAvailable:
+				available = &dc.Status.Conditions[i]
+			}
+		}
+
+		if enforceNotProgressing {
+			if progressing != nil && progressing.Status == corev1.ConditionFalse {
+				return false, fmt.Errorf("not progressing")
+			}
+		}
+
+		if progressing != nil &&
+			progressing.Status == corev1.ConditionTrue &&
+			progressing.Reason == appsutil.NewRcAvailableReason &&
+			available != nil &&
+			available.Status == corev1.ConditionTrue {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		e2e.Logf("got error %q when waiting for deploymentconfig %s/%s to be available with version %d\n", err, namespace, name, version)
+		cli.Run("get").Args("dc", dc.Name, "-o", "yaml").Execute()
+
+		DumpDeploymentLogs(name, version, cli)
+		DumpApplicationPodLogs(name, cli)
+
+		return err
+	}
+
+	requirement, err := labels.NewRequirement(appsutil.DeploymentLabel, selection.Equals, []string{appsutil.LatestDeploymentNameForConfigAndVersion(
+		dc.Name, dc.Status.LatestVersion)})
+	if err != nil {
+		return err
+	}
+
+	podnames, err := GetPodNamesByFilter(kc.CoreV1().Pods(namespace), labels.NewSelector().Add(*requirement), func(corev1.Pod) bool { return true })
+	if err != nil {
+		return err
+	}
+
+	e2e.Logf("deploymentconfig %s/%s available after %s\npods: %s\n", namespace, name, time.Now().Sub(start), strings.Join(podnames, ", "))
+
+	return nil
+}
 
 // RemoveDeploymentConfigs deletes the given DeploymentConfigs in a namespace
 func RemoveDeploymentConfigs(oc *CLI, dcs ...string) error {
@@ -44,4 +132,39 @@ func RemoveDeploymentConfigs(oc *CLI, dcs ...string) error {
 	}
 
 	return nil
+}
+
+func GetDeploymentConfigPods(oc *CLI, dcName string, version int64) (*corev1.PodList, error) {
+	return oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).List(metav1.ListOptions{LabelSelector: ParseLabelsOrDie(fmt.Sprintf("%s=%s-%d",
+		appsv1.DeployerPodForDeploymentLabel, dcName, version)).String()})
+}
+
+func GetApplicationPods(oc *CLI, dcName string) (*corev1.PodList, error) {
+	return oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).List(metav1.ListOptions{LabelSelector: ParseLabelsOrDie(fmt.Sprintf("deploymentconfig=%s", dcName)).String()})
+}
+
+// DumpDeploymentLogs will dump the latest deployment logs for a DeploymentConfig for debug purposes
+func DumpDeploymentLogs(dcName string, version int64, oc *CLI) {
+	e2e.Logf("Dumping deployment logs for deploymentconfig %q\n", dcName)
+
+	pods, err := GetDeploymentConfigPods(oc, dcName, version)
+	if err != nil {
+		e2e.Logf("Unable to retrieve pods for deploymentconfig %q: %v\n", dcName, err)
+		return
+	}
+
+	DumpPodLogs(pods.Items, oc)
+}
+
+// DumpApplicationPodLogs will dump the latest application logs for a DeploymentConfig for debug purposes
+func DumpApplicationPodLogs(dcName string, oc *CLI) {
+	e2e.Logf("Dumping application logs for deploymentconfig %q\n", dcName)
+
+	pods, err := GetApplicationPods(oc, dcName)
+	if err != nil {
+		e2e.Logf("Unable to retrieve pods for deploymentconfig %q: %v\n", dcName, err)
+		return
+	}
+
+	DumpPodLogs(pods.Items, oc)
 }


### PR DESCRIPTION
https://github.com/openshift/oc/pull/355 is switching `oc new-app` to produce deployments instead of deployment configs by default. There will be a new flag `--as-deployment-config` to provide backwards compatiblity. 
This change requires our tests to be more resilient expecting the outcome. This PR either changes tests to explicitly create DC where possible or expects either deployment or DC. 

/assign @mfojtik 