### PR TITLE
Flaky Network Granular Check

### DIFF
--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -126,6 +126,12 @@ var (
 
 			// TODO(node): test works when run alone, but not in the suite in CI
 			`\[Feature:HPA\] Horizontal pod autoscaling \(scale resource: CPU\) \[sig-autoscaling\] ReplicationController light Should scale from 1 pod to 2 pods`,
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1794714
+			`\[sig-network\] Networking Granular Checks: Services should function for node-Service`,
+			`\[sig-network\] Networking Granular Checks: Services should function for pod-Service`,
+			`\[sig-network\] Networking Granular Checks: Services should function for endpoint-Service`,
+,
 		},
 		// tests that must be run without competition
 		"[Serial]": {


### PR DESCRIPTION
This test is frequently failing for all platforms: https://search.svc.ci.openshift.org/?search=failed%3A+.*Networking+Granular+Checks%3A+Services+should+function+for+node-Service%3A+http&maxAge=336h&context=2&type=all#

The issue is being tracked here: https://bugzilla.redhat.com/show_bug.cgi?id=1794714
but until that is resolved, tests are continuing to fail.