### PR TITLE
Bug 1817595: make s2i-dropcaps more reliable by not depending on a yum install to …

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -55731,7 +55731,7 @@ func testExtendedTestdataS2iDropcapsRootAccessBuildYaml() (*asset, error) {
 
 var _testExtendedTestdataS2iDropcapsRootableRubyDockerfile = []byte(`FROM centos/ruby-25-centos7:latest
 USER root
-RUN yum -y install expect
+RUN rm -f /usr/bin/ls
 RUN echo "root:redhat" | chpasswd
 USER 1001
 COPY ./adduser /usr/libexec/s2i/

--- a/test/extended/testdata/s2i-dropcaps/rootable-ruby/Dockerfile
+++ b/test/extended/testdata/s2i-dropcaps/rootable-ruby/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos/ruby-25-centos7:latest
 USER root
-RUN yum -y install expect
+RUN rm -f /usr/bin/ls
 RUN echo "root:redhat" | chpasswd
 USER 1001
 COPY ./adduser /usr/libexec/s2i/


### PR DESCRIPTION
…the centos mirrors

Pre recent 4-dev-triage and e2e flakes with the centos mirror being down

/assign @adambkaplan 
/assign @bparees 