### PR TITLE
[test/extended] Remove oc run --attach/--stdin which can't be dry-run flagged

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -34580,8 +34580,6 @@ os::test::junit::declare_suite_start "cmd/run"
 # This test validates the value of --image for oc run
 os::cmd::expect_success_and_text 'oc create deploymentconfig newdcforimage --image=validimagevalue' 'deploymentconfig.apps.openshift.io/newdcforimage created'
 os::cmd::expect_failure_and_text 'oc run newdcforimage2 --image="InvalidImageValue0192"' 'error: Invalid image name "InvalidImageValue0192": invalid reference format'
-os::cmd::expect_failure_and_text 'oc run test1 --image=busybox --attach --dry-run' "dry-run can't be used with attached containers options"
-os::cmd::expect_failure_and_text 'oc run test1 --image=busybox --stdin --dry-run' "dry-run can't be used with attached containers options"
 echo "oc run: ok"
 os::test::junit::declare_suite_end
 `)

--- a/test/extended/testdata/cmd/test/cmd/run.sh
+++ b/test/extended/testdata/cmd/test/cmd/run.sh
@@ -6,7 +6,5 @@ os::test::junit::declare_suite_start "cmd/run"
 # This test validates the value of --image for oc run
 os::cmd::expect_success_and_text 'oc create deploymentconfig newdcforimage --image=validimagevalue' 'deploymentconfig.apps.openshift.io/newdcforimage created'
 os::cmd::expect_failure_and_text 'oc run newdcforimage2 --image="InvalidImageValue0192"' 'error: Invalid image name "InvalidImageValue0192": invalid reference format'
-os::cmd::expect_failure_and_text 'oc run test1 --image=busybox --attach --dry-run' "dry-run can't be used with attached containers options"
-os::cmd::expect_failure_and_text 'oc run test1 --image=busybox --stdin --dry-run' "dry-run can't be used with attached containers options"
 echo "oc run: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
```
$ oc run test1 --image=busybox --attach --dry-run
W0330 11:00:22.611725   19620 helpers.go:535] --dry-run is deprecated and can be replaced with --dry-run=client.
error: --dry-run=[server|client] can't be used with attached containers options (--attach, --stdin, or --tty)
See 'oc run -h' for help and examples
```
```
$ oc run test1 --image=busybox --stdin --dry-run
W0330 11:00:40.067325   19646 helpers.go:535] --dry-run is deprecated and can be replaced with --dry-run=client.
error: --dry-run=[server|client] can't be used with attached containers options (--attach, --stdin, or --tty)
See 'oc run -h' for help and examples
```