### PR TITLE
Split verify-commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ check: | build verify
 #
 # Example:
 #   make verify
+# TODO: remove verify-upstream-commits when CI is switched over
 verify: build
 	# build-tests task has been disabled until we can determine why memory usage is so high
 	{ \
@@ -96,6 +97,9 @@ verify: build
 	}
 .PHONY: verify
 
+verify-commits:
+	hack/verify-upstream-commits.sh
+.PHONY: verify-commits
 
 # Update all generated artifacts.
 #


### PR DESCRIPTION
The check is meant to be overridden for rebases, it's easier and more reliable to do in a separate job. Needs to go in 2 PR so nothing sneaks in between until the CI is switched over and we can't merge a new CI check before it is in the repo.

/cc @sttts @marun 