### PR TITLE
Check if prometheus-operator is reporting metrics

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -219,8 +219,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 					targets.Expect(labels{"job": "kubelet"}, "up", "^https://.*/metrics$"),
 					targets.Expect(labels{"job": "kubelet"}, "up", "^https://.*/metrics/cadvisor$"),
 					targets.Expect(labels{"job": "node-exporter"}, "up", "^https://.*/metrics$"),
-					// FIXME(paulfantom): uncomment after https://github.com/openshift/cluster-monitoring-operator/pull/722 is merged
-					// targets.Expect(labels{"job": "prometheus-operator"}, "up", "^https://.*/metrics$"),
+					targets.Expect(labels{"job": "prometheus-operator"}, "up", "^https://.*/metrics$"),
 					targets.Expect(labels{"job": "alertmanager-main"}, "up", "^https://.*/metrics$"),
 					targets.Expect(labels{"job": "crio"}, "up", "^http://.*/metrics$"),
 				)


### PR DESCRIPTION
Revert https://github.com/openshift/origin/pull/24780 as https://github.com/openshift/cluster-monitoring-operator/pull/722 is already merged.

Possibly improve checking for firing alerts by inverting query logic. If it works, then e2e tests should fail as there is `TargetDown` alert firing due to https://bugzilla.redhat.com/show_bug.cgi?id=1818772

/cc @lilic 
