### PR TITLE
test: Allow CSI tests to access fixtures pre run

### DIFF
--- a/cmd/openshift-tests/csi.go
+++ b/cmd/openshift-tests/csi.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openshift/origin/test/extended/csi"
-
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/storage/external"
+
+	"github.com/openshift/origin/test/extended/csi"
 )
 
 const (

--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -137,8 +137,15 @@ var staticSuites = []*ginkgo.TestSuite{
 	{
 		Name: "openshift/csi",
 		Description: templates.LongDesc(`
-		Run tests for an installed CSI driver. TEST_CSI_DRIVER_FILES env. variable must be set and it must be a comma separated list of CSI driver definition files.
-        See https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/external/README.md for required format of the files.
+		Run tests for an CSI driver. Set the TEST_INSTALL_CSI_DRIVERS environment variable to the name of the driver to load.
+		For example, TEST_INSTALL_CSI_DRIVERS=aws-ebs will test the AWS EBS CSI driver. To change the location of the images,
+		specify IMAGE_FORMAT=myregistry.com/myrepository/${component}:4.5 where ${component} will be substituted with the
+		names of required CSI component images:
+
+			csi-external-attacher, csi-external-provisioner, csi-external-resizer,
+			csi-external-snapshotter, csi-node-driver-registrar, csi-livenessprobe
+
+		See https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/external/README.md for required format of the files.
 		`),
 		Matches: func(name string) bool {
 			return strings.Contains(name, "External Storage [Driver:") && !strings.Contains(name, "[Disruptive]")

--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -38,9 +38,14 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcloud.C
 	context.MaxNodesToGather = 0
 	reale2e.SetViperConfig(os.Getenv("VIPERCONFIG"))
 
-	if err := initCSITests(dryRun); err != nil {
+	// allow the CSI tests to access test data, but only briefly
+	// TODO: ideally CSI would not use any of these test methods
+	var err error
+	exutil.WithCleanup(func() { err = initCSITests(dryRun) })
+	if err != nil {
 		return nil, err
 	}
+
 	if err := exutil.InitTest(dryRun); err != nil {
 		return nil, err
 	}

--- a/test/extended/csi/install.go
+++ b/test/extended/csi/install.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	csiBasePath         = "test/extended/testdata/csi"
-	defaultImageFormat  = "registry.svc.ci.openshift.org/origin/4.3:${component}"
+	defaultImageFormat  = "registry.svc.ci.openshift.org/origin/4.5:${component}"
 	imageFormatVariable = "IMAGE_FORMAT"
 )
 

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -156,7 +156,10 @@ func WithCleanup(fn func()) {
 	fixtureDir, init := fixtureDirectory()
 	if init {
 		os.Setenv("OS_TEST_FIXTURE_DIR", fixtureDir)
-		defer os.RemoveAll(fixtureDir)
+		defer func() {
+			os.Setenv("OS_TEST_FIXTURE_DIR", "")
+			os.RemoveAll(fixtureDir)
+		}()
 	}
 
 	fn()


### PR DESCRIPTION
As a special exemption, allow CSI tests to access oc and fixtures
before a test starts. In the future this should be refactored so
that a different clearly auditable set of methods is invoked.