### PR TITLE
integration: fix TestOadmPodNetwork for CI changes

### DIFF
--- a/test/integration/sdn_test.go
+++ b/test/integration/sdn_test.go
@@ -10,6 +10,7 @@ import (
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	restclient "k8s.io/client-go/rest"
 
+	"github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/network"
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	networkclient "github.com/openshift/origin/pkg/network/generated/internalclientset/typed/network/internalversion"
@@ -72,6 +73,13 @@ func TestOadmPodNetwork(t *testing.T) {
 	}
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.NetworkConfig.NetworkPluginName = network.MultiTenantPluginName
+	// Set the cluster and service networks to something invalid since it doesn't
+	// matter for this test but they need to not conflict with the local networks
+	masterConfig.NetworkConfig.ClusterNetworks = []config.ClusterNetworkEntry{{
+		CIDR:             "0.1.0.0/16",
+		HostSubnetLength: 8,
+	}}
+	masterConfig.NetworkConfig.ServiceNetworkCIDR = "0.2.0.0/16"
 	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {
 		t.Fatalf("error starting server: %v", err)


### PR DESCRIPTION
In the new CI cluster, test-integration gets run in a pod in a cluster
using the default OCP IP ranges, which broke TestOadmPodNetwork
because that test brings up enough of openshift-sdn that it complains
when it sees that eth0 has an IP inside the range it was planning to
use.

The test doesn't actually allocate any IPs, so it doesn't matter what
ranges the master is configured to use, so just set it to something
invalid so it's guaranteed to not overlap no matter what.