### PR TITLE
[release-3.11] Bug 1745898: handle pod updates correctly in networkpolicy

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -700,7 +700,6 @@ func (np *networkPolicyPlugin) refreshNetworkPolicies(refreshFor refreshForType)
 				((refreshFor == refreshForPods) && npp.watchesPods) {
 				if np.updateNetworkPolicy(npns, &npp.policy) {
 					changed = true
-					break
 				}
 			}
 		}


### PR DESCRIPTION
currently if there are two network policies in a namespace that match an
incoming pod refreshNetworkPolicies() will only call updateNetworkPolicy()
on one of them. UpdateNetworkPolicy calls parseNetworkPolicy which updates
the network policy object.

removing the break in refreshNetworkPolicies() will cause
updateNetworkPolicy() to be run against all changed networkpolicies which
will ensure that all changed policies get successfully updated.

also updated the unit tests to expose this issue, so that this issue won't
be exposed again.


4.5BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1816394
4.4BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1816392
4.3BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1816390
4.2BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1816389
4.1BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1816388
3.11BZ:https://bugzilla.redhat.com/show_bug.cgi?id=1745898