### PR TITLE
Bug 1822514: tests: split API availability monitor into kube and OpenShift

### DIFF
--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -40,7 +40,10 @@ func Start(ctx context.Context) (*Monitor, error) {
 		return nil, err
 	}
 
-	if err := StartAPIMonitoring(ctx, m, clusterConfig, 5*time.Second); err != nil {
+	if err := StartKubeAPIMonitoring(ctx, m, clusterConfig, 5*time.Second); err != nil {
+		return nil, err
+	}
+	if err := StartOpenShiftAPIMonitoring(ctx, m, clusterConfig, 5*time.Second); err != nil {
 		return nil, err
 	}
 	startPodMonitoring(ctx, m, client)
@@ -52,14 +55,10 @@ func Start(ctx context.Context) (*Monitor, error) {
 	return m, nil
 }
 
-func StartAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
+func StartKubeAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
 	pollingConfig := *clusterConfig
 	pollingConfig.Timeout = timeout
 	pollingClient, err := clientcorev1.NewForConfig(&pollingConfig)
-	if err != nil {
-		return err
-	}
-	openshiftPollingClient, err := clientimagev1.NewForConfig(&pollingConfig)
 	if err != nil {
 		return err
 	}
@@ -88,10 +87,20 @@ func StartAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Con
 			Message: fmt.Sprintf("Kube API is not responding to GET requests"),
 		}),
 	)
+	return nil
+}
+
+func StartOpenShiftAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
+	pollingConfig := *clusterConfig
+	pollingConfig.Timeout = timeout
+	pollingClient, err := clientimagev1.NewForConfig(&pollingConfig)
+	if err != nil {
+		return err
+	}
 
 	m.AddSampler(
 		StartSampling(ctx, m, time.Second, func(previous bool) (condition *Condition, next bool) {
-			_, err := openshiftPollingClient.ImageStreams("openshift-apiserver").Get(ctx, "missing", metav1.GetOptions{})
+			_, err := pollingClient.ImageStreams("openshift-apiserver").Get(ctx, "missing", metav1.GetOptions{})
 			if !errors.IsUnexpectedServerError(err) && errors.IsNotFound(err) {
 				err = nil
 			}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -34,7 +34,8 @@ import (
 
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
-		&controlplane.AvailableTest{},
+		&controlplane.KubeAvailableTest{},
+		&controlplane.OpenShiftAvailableTest{},
 		&frontends.AvailableTest{},
 		&service.UpgradeTest{},
 		&upgrades.SecretUpgradeTest{},


### PR DESCRIPTION
The OpenShift APIs are technically very different from the Kube ones. To make triaging easier, this PR splits them into two monitors.