### PR TITLE
Write an event when the server is ready to serve

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -395,6 +395,8 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 			close(auditStopCh)
 			return err
 		}
+
+		s.Eventf(corev1.EventTypeNormal, "ReadyToServeRequest", "The server has started and is ready to serve request(s)")
 	}
 
 	// Now that listener have bound successfully, it is the


### PR DESCRIPTION
Write an event to indicate that the kube-apiserver has bound to a port and is ready to serve request(s). This will come in handy to debug issues n perf testing, we can time when the apiserver stops serving and comes back up again and ready to serve during a roll out.