### PR TITLE
test/extended: exclude ovnkube master/node metrics endpoints from secure test

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -257,6 +257,8 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			// job="crio" - https://issues.redhat.com/browse/MON-1034 + https://issues.redhat.com/browse/OCPNODE-321
 			// job="sdn" - https://bugzilla.redhat.com/show_bug.cgi?id=1809205
 			// job="multus-admission-controller-monitor-service" - https://bugzilla.redhat.com/show_bug.cgi?id=1809204
+			// job="ovnkube-master" - https://issues.redhat.com/browse/SDN-912
+			// job="ovnkube-node" - https://issues.redhat.com/browse/SDN-912
 			// Exclude list should be reduced to 0
 			exclude := map[string]bool{
 				"cco-metrics":              true,
@@ -265,6 +267,8 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 				"crio":                     true,
 				"sdn":                      true,
 				"multus-admission-controller-monitor-service": true,
+				"ovnkube-master": true,
+				"ovnkube-node":   true,
 			}
 
 			pattern := regexp.MustCompile("^https://.*")


### PR DESCRIPTION
Fix will be tracked in https://issues.redhat.com/browse/SDN-912

@knobunc @fepan 