### PR TITLE
UPSTREAM: 90118: Respect NodeName in pause pod config

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/scheduling/predicates.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/scheduling/predicates.go
@@ -837,6 +837,7 @@ func initPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 			Tolerations:                   conf.Tolerations,
 			PriorityClassName:             conf.PriorityClassName,
 			TerminationGracePeriodSeconds: &gracePeriod,
+			NodeName:                      conf.NodeName,
 		},
 	}
 	// TODO: setting the Pod's nodeAffinity instead of setting .spec.nodeName works around the


### PR DESCRIPTION
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1731263