### PR TITLE
[release-3.11] Bug 1814804: UPSTREAM: 88251: Partially fix incorrect configuration of kubepods.slice unit by kubelet

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/node_container_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/node_container_manager.go
@@ -41,10 +41,17 @@ const (
 
 //createNodeAllocatableCgroups creates Node Allocatable Cgroup when CgroupsPerQOS flag is specified as true
 func (cm *containerManagerImpl) createNodeAllocatableCgroups() error {
+	nodeAllocatable := cm.capacity
+	// Use Node Allocatable limits instead of capacity if the user requested enforcing node allocatable.
+	nc := cm.NodeConfig.NodeAllocatableConfig
+	if cm.CgroupsPerQOS && nc.EnforceNodeAllocatable.Has(kubetypes.NodeAllocatableEnforcementKey) {
+		nodeAllocatable = cm.getNodeAllocatableAbsolute()
+	}
+
 	cgroupConfig := &CgroupConfig{
 		Name: cm.cgroupRoot,
 		// The default limits for cpu shares can be very low which can lead to CPU starvation for pods.
-		ResourceParameters: getCgroupConfig(cm.capacity),
+		ResourceParameters: getCgroupConfig(nodeAllocatable),
 	}
 	if cm.cgroupManager.Exists(cgroupConfig.Name) {
 		return nil


### PR DESCRIPTION
Backports kubepods.slice fix into 3.11 for OOM related issues revolving around kubelet reservations.

Origin PR : https://github.com/openshift/origin/pull/24568
Originating 4.x BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1802687