### PR TITLE
Bug 1826071: [marketplace] Remove CSC related tests

### DIFF
--- a/test/extended/marketplace/marketplace_diffname.go
+++ b/test/extended/marketplace/marketplace_diffname.go
@@ -19,19 +19,16 @@ var _ = g.Describe("[sig-operator][Feature:Marketplace] Marketplace diff name te
 
 	var (
 		oc            = exutil.NewCLI("marketplace")
-		allNs         = "openshift-operators"
 		marketplaceNs = "openshift-marketplace"
 		resourceWait  = 60 * time.Second
 
 		opsrcYamltem = exutil.FixturePath("testdata", "marketplace", "opsrc", "02-opsrc.yaml")
-		cscYamltem   = exutil.FixturePath("testdata", "marketplace", "csc", "02-csc.yaml")
 	)
 
 	g.AfterEach(func() {
 		// Clear the resource
 		allresourcelist := [][]string{
 			{"operatorsource", "samename", marketplaceNs},
-			{"catalogsourceconfig", "samename", marketplaceNs},
 		}
 
 		for _, source := range allresourcelist {
@@ -40,7 +37,7 @@ var _ = g.Describe("[sig-operator][Feature:Marketplace] Marketplace diff name te
 		}
 	})
 
-	//OCP-25672 create a opsrc named "samename", then create a csc also named "samename"
+	//OCP-25672 create a opsrc named "samename"
 	g.It("[ocp-25672] create the samename opsrc&csc [Serial]", func() {
 
 		// Create one opsrc samename
@@ -74,15 +71,5 @@ var _ = g.Describe("[sig-operator][Feature:Marketplace] Marketplace diff name te
 			msg, _ := existResources(oc, source[0], source[1], source[2])
 			o.Expect(msg).Should(o.BeTrue())
 		}
-
-		// Create the csc samename
-		cscYaml, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", cscYamltem, "-p", "NAME=samename", fmt.Sprintf("NAMESPACE=%s", allNs), fmt.Sprintf("MARKETPLACE=%s", marketplaceNs), "PACKAGES=camel-k-marketplace-e2e-tests", "DISPLAYNAME=samename", "PUBLISHER=samename").OutputToFile("config.json")
-		err = createResources(oc, cscYaml)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		// Check the csc status
-		outMesg, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("catalogsourceconfig", "samename", "-o=jsonpath={.status.currentPhase.phase.message}", "-n", marketplaceNs).Output()
-		o.Expect(outMesg).Should(o.ContainSubstring("Deployment samename exists"))
-		outStatus, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("catalogsourceconfig", "samename", "-o=jsonpath={.status.currentPhase.phase.name}", "-n", marketplaceNs).Output()
-		o.Expect(outStatus).Should(o.ContainSubstring("Configuring"))
 	})
 })


### PR DESCRIPTION
The CatalogSourceConfig is being deprecated from Openshift 4.5.
This PR removes the CSC related tests.
Ref: operator-framework/operator-marketplace#302