### PR TITLE
[release-4.4] Bug 1826033: Ignore ImagePruningDisabled alert

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -58,7 +58,8 @@ var _ = g.Describe("[Feature:Prometheus][Late] Alerts", func() {
 
 		tests := map[string]bool{
 			// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-			`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|KubeAPILatencyHigh|FailingOperator",alertstate="firing"}[2h]) >= 1`: false,
+			// Bug 1826033: Image pruner installs itself as suspended by default, firing an alert
+			`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|KubeAPILatencyHigh|FailingOperator|ImagePruningDisabled",alertstate="firing"}[2h]) >= 1`: false,
 		}
 		runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 	})
@@ -291,7 +292,8 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 
 			tests := map[string]bool{
 				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|PrometheusRemoteWriteDesiredShards",alertstate="firing"} >= 1`: false,
+				// Bug 1826033: Image pruner installs itself as suspended by default, firing an alert
+				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|PrometheusRemoteWriteDesiredShards|ImagePruningDisabled",alertstate="firing"} >= 1`: false,
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})


### PR DESCRIPTION
In 4.4 the automatic image pruner is initially disabled. Cluster admins are responsible for enabling it day 2. An alert is fired if the image pruner is disabled.

Note that in 4.5 the automatic image pruner is enabled on new clusters.