### PR TITLE
Bug 1825354: test/extended/router: Disable HTTP/2 tests

### DIFF
--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -51,6 +51,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should pass the gRPC interoperability tests", func() {
+			g.Skip("disabled for https://bugzilla.redhat.com/show_bug.cgi?id=1825354")
 			g.By(fmt.Sprintf("creating test fixture from a config file %q", configPath))
 			err := oc.Run("new-app").Args("-f", configPath).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -58,6 +58,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should pass the h2spec conformance tests", func() {
+			g.Skip("disabled for https://bugzilla.redhat.com/show_bug.cgi?id=1825354")
 			g.By(fmt.Sprintf("creating routes from a config file %q", configPath))
 			routerImage, err := exutil.FindRouterImage(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
Disable router tests that test or rely on HTTP/2 on the frontend.

We are disabling HTTP/2 on the frontend to prevent issues with connection coalescing that break the OAuth flow.

* `test/extended/router/grpc-interop.go`:
* `test/extended/router/h2spec.go`: Skip the tests.


----

@ironcladlou, @danehans