### PR TITLE
Bug 1761043: provides a temporal fix to improve CRD publishing e2e tests in an HA setup

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apimachinery/crd_publish_openapi.go
@@ -479,7 +479,13 @@ func setupCRD(f *framework.Framework, schema []byte, groupSuffix string, version
 	return setupCRDAndVerifySchema(f, schema, expect, groupSuffix, versions...)
 }
 
-func setupCRDAndVerifySchema(f *framework.Framework, schema, expect []byte, groupSuffix string, versions ...string) (*crd.TestCrd, error) {
+func setupCRDAndVerifySchema(f *framework.Framework, schema, expect []byte, groupSuffix string, versions ...string) (tCRD *crd.TestCrd, err error) {
+	defer func() {
+		if err != nil {
+			framework.Logf("sleeping 45 seconds before running the actual tests, we hope that during all API servers converge during that window, see %q for more", "https://github.com/kubernetes/kubernetes/pull/90452")
+			time.Sleep(time.Second * 45)
+		}
+	}()
 	group := fmt.Sprintf("%s-test-%s.example.com", f.BaseName, groupSuffix)
 	if len(versions) == 0 {
 		return nil, fmt.Errorf("require at least one version for CRD")
@@ -492,7 +498,7 @@ func setupCRDAndVerifySchema(f *framework.Framework, schema, expect []byte, grou
 		}
 	}
 
-	crd, err := crd.CreateMultiVersionTestCRD(f, group, func(crd *apiextensionsv1.CustomResourceDefinition) {
+	tCRD, err = crd.CreateMultiVersionTestCRD(f, group, func(crd *apiextensionsv1.CustomResourceDefinition) {
 		var apiVersions []apiextensionsv1.CustomResourceDefinitionVersion
 		for i, version := range versions {
 			version := apiextensionsv1.CustomResourceDefinitionVersion{
@@ -521,12 +527,12 @@ func setupCRDAndVerifySchema(f *framework.Framework, schema, expect []byte, grou
 		return nil, fmt.Errorf("failed to create CRD: %v", err)
 	}
 
-	for _, v := range crd.Crd.Spec.Versions {
-		if err := waitForDefinition(f.ClientSet, definitionName(crd, v.Name), expect); err != nil {
+	for _, v := range tCRD.Crd.Spec.Versions {
+		if err := waitForDefinition(f.ClientSet, definitionName(tCRD, v.Name), expect); err != nil {
 			return nil, fmt.Errorf("%v", err)
 		}
 	}
-	return crd, nil
+	return tCRD, nil
 }
 
 func cleanupCRD(f *framework.Framework, crd *crd.TestCrd) error {


### PR DESCRIPTION
a temporal fix that will be replaced by https://github.com/kubernetes/kubernetes/pull/90452 in the future.