### PR TITLE
Bug 1826230: oc get --request-timeout: Timeout exceeded while reading body printed with -v=5

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -46693,10 +46693,10 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/request-timeout"
 # This test validates the global request-timeout option
 os::cmd::expect_success 'oc create deploymentconfig testdc --image=busybox'
-os::cmd::expect_success_and_text 'oc get dc/testdc -w --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get dc/testdc -w -v=5 --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1s' 'testdc'
 os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1' 'testdc'
-os::cmd::expect_success_and_text 'oc get pods --watch --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get pods --watch -v=5 --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 
 echo "request-timeout: ok"
 os::test::junit::declare_suite_end

--- a/test/extended/testdata/cmd/test/cmd/timeout.sh
+++ b/test/extended/testdata/cmd/test/cmd/timeout.sh
@@ -13,10 +13,10 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/request-timeout"
 # This test validates the global request-timeout option
 os::cmd::expect_success 'oc create deploymentconfig testdc --image=busybox'
-os::cmd::expect_success_and_text 'oc get dc/testdc -w --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get dc/testdc -w -v=5 --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1s' 'testdc'
 os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1' 'testdc'
-os::cmd::expect_success_and_text 'oc get pods --watch --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get pods --watch -v=5 --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 
 echo "request-timeout: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Expected "Timeout exceeded while reading body" error message is printed with -v=5.
Without the error message, both --watch oc get commands unexpectedly fail.