### PR TITLE
test/e2e/upgrade/service: Use 10m timeout for TestReachableHTTPWithMinSuccessCount

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -96,7 +96,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 
 	// Hit it once before considering ourselves ready
 	ginkgo.By("hitting pods through the service's LoadBalancer")
-	timeout := service.LoadBalancerLagTimeoutAWS
+	timeout := 10 * time.Minute
 	// require thirty seconds of passing requests to continue (in case the SLB becomes available and then degrades)
 	TestReachableHTTPWithMinSuccessCount(tcpIngressIP, svcPort, 30, timeout)
 


### PR DESCRIPTION
Instead of assuming that the AWS default applies to all providers, as we've done since we carried the upstream code in 9732d0124d (#24471).  This catches our copied-and-tweaked code up with upstream logic like that has switched on provider since kubernetes/kubernetes@46b89464fd (kubernetes/kubernetes#20959).