### PR TITLE
Bug 1829225: Increase waiting time for namespace deletion in project test

### DIFF
--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -317,7 +317,7 @@ func waitForOnlyDelete(projectName string, w watch.Interface) {
 				}
 				g.Fail(fmt.Sprintf("got unexpected project %v", project.Name))
 
-			case <-time.After(30 * time.Second):
+			case <-time.After(time.Minute):
 				g.Fail(fmt.Sprintf("timeout: %v", projectName))
 			}
 		}


### PR DESCRIPTION
The waitForOnlyDelete() waits only 30s for the project being deleted.
The e2e logs shows that in ~18% of e2e tests, the deletion takes longer
than 30s, presumably because of GC cleaning up the namespace.

In those cases, the cleanup takes 35-40s.