### PR TITLE
Bug 1832641: UPSTREAM: 90823: Service load balancers should include unschedulable nodes

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/service/controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/service/controller.go
@@ -604,12 +604,6 @@ func nodeSlicesEqualForLB(x, y []*v1.Node) bool {
 
 func getNodeConditionPredicate() NodeConditionPredicate {
 	return func(node *v1.Node) bool {
-		// We add the master to the node list, but its unschedulable.  So we use this to filter
-		// the master.
-		if node.Spec.Unschedulable {
-			return false
-		}
-
 		if utilfeature.DefaultFeatureGate.Enabled(legacyNodeRoleBehaviorFeature) {
 			// As of 1.6, we will taint the master, but not necessarily mark it unschedulable.
 			// Recognize nodes labeled as master, and filter them also, as we were doing previously.

--- a/vendor/k8s.io/kubernetes/pkg/controller/service/controller_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/service/controller_test.go
@@ -490,7 +490,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 		{
 			node:         v1.Node{},
 			expectAccept: false,
-			name:         "empty",
+			name:         "nodes that are not ready are not included",
 		},
 		{
 			node: v1.Node{
@@ -501,7 +501,7 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 				},
 			},
 			expectAccept: true,
-			name:         "basic",
+			name:         "healthy nodes are included",
 		},
 		{
 			node: v1.Node{
@@ -512,8 +512,8 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 					},
 				},
 			},
-			expectAccept: false,
-			name:         "unschedulable",
+			expectAccept: true,
+			name:         "unschedulable but healthy nodes are included",
 		},
 	}
 	pred := getNodeConditionPredicate()


### PR DESCRIPTION
In 16443 a set of changes were made to enable service load balancers
for Kube 1.1 and GCP to exclude unschedulable nodes from load balancer
pools. However, Unschedulable has nothing to do with whether nodes
should host service load balancer pods - the act of preventing new
pods from landing on a node has no impact on existing workloads.

In general nodes are not special, and a user who wants to exclude
otherwise healthy nodes can use the beta service load balancer
label to exclude the node from the LB pool.

This commit removes the check for unschedulable nodes from the
LB pool.