### PR TITLE
Bug 1813894: Disable the addition of service ca to token secrets

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch_satoken.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch_satoken.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -14,6 +15,10 @@ var applyOpenShiftServiceServingCertCA = func(in serviceaccountcontroller.Tokens
 }
 
 func applyOpenShiftServiceServingCertCAFunc(openshiftConfigBase string, openshiftConfig map[string]interface{}) error {
+	if os.Getenv("ADD_SERVICE_SERVING_CA_TO_TOKEN_SECRETS") != "true" {
+		return nil
+	}
+
 	serviceServingCertCAFilename := getServiceServingCertCAFilename(openshiftConfig)
 	if len(serviceServingCertCAFilename) == 0 {
 		return nil

--- a/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokens_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokens_controller.go
@@ -511,7 +511,7 @@ func (e *TokensController) hasReferencedToken(serviceAccount *v1.ServiceAccount)
 func (e *TokensController) secretUpdateNeeded(secret *v1.Secret) (bool, bool, bool, bool) {
 	caData := secret.Data[v1.ServiceAccountRootCAKey]
 	needsCA := len(e.rootCA) > 0 && !bytes.Equal(caData, e.rootCA)
-	needsServiceServingCA := len(e.serviceServingCA) > 0 && bytes.Compare(secret.Data[ServiceServingCASecretKey], e.serviceServingCA) != 0
+	needsServiceServingCA := bytes.Compare(secret.Data[ServiceServingCASecretKey], e.serviceServingCA) != 0
 
 	needsNamespace := len(secret.Data[v1.ServiceAccountNamespaceKey]) == 0
 
@@ -560,7 +560,11 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *v1.ServiceAccou
 		liveSecret.Data[v1.ServiceAccountRootCAKey] = e.rootCA
 	}
 	if needsServiceServingCA {
-		liveSecret.Data[ServiceServingCASecretKey] = e.serviceServingCA
+		if len(e.serviceServingCA) > 0 {
+			liveSecret.Data[ServiceServingCASecretKey] = e.serviceServingCA
+		} else {
+			delete(liveSecret.Data, ServiceServingCASecretKey)
+		}
 	}
 	// Set the namespace
 	if needsNamespace {


### PR DESCRIPTION
Previously the serving service CA was added to token secrets by default. This commit changes the addition to be disabled by default and optionally enabled by setting `ADD_SERVICE_SERVING_CA_TO_TOKEN_SECRETS=true` in the environment.

PRs that need to merge before this one:
 - [x] https://github.com/openshift/cluster-etcd-operator/pull/344
 - [x] https://github.com/openshift/cluster-kube-apiserver-operator/pull/854
 - [x] https://github.com/openshift/cluster-kube-controller-manager-operator/pull/411
 - [x] https://github.com/openshift/cluster-kube-scheduler-operator/pull/248
 - [x] https://github.com/openshift/cluster-image-registry-operator/pull/547
 - [ ] https://github.com/openshift/cluster-samples-operator/pull/270 (more involved fix in progress)
 - [x] https://github.com/openshift/router/pull/130
 - [x] https://github.com/openshift/telemeter/pull/334