### PR TITLE
Bug 1827863: [Feature:Platform][Smoke] Managed cluster should ensure pods use downstream images from our release image with proper ImagePullPolicy [Suite:openshift/conformance/parallel] timing out 

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -96,6 +96,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return strings.Contains(name, "[sig-imageregistry]") && !strings.Contains(name, "[Local]")
 		},
+		TestTimeout: 20 * time.Minute,
 	},
 	{
 		Name: "openshift/image-ecosystem",


### PR DESCRIPTION
Increased default timeout on image-registry up to 20 min