### PR TITLE
Bug 1833387: Extend timeout for operator rollout test

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	operatorWait = 1 * time.Minute
+	operatorWait = 5 * time.Minute
 	cvoWait      = 5 * time.Minute
 )
 


### PR DESCRIPTION
A number of reasons related to the changes in configmaps and secrets result in a new kube-apiserver revision. The reason for a new deployment is highly non-deterministic and the deployment can be rolled out at any time. Also the time it takes for kube-apiserver deployment to complete rollout highly varies. Having so many varying factors and difficulty in finding the root cause, It is fairly a hard problem to increase test resilience. 

The best shot here is to reduce the CI failure rate is to increase the test timeout. My understanding from previous observations is that it takes roughly 5-8mins for kube-apiserver deployment to complete. Accordingly changing the time the test wait time hoping for the best case scenario.