### PR TITLE
Bug 1763340: ingress: targetPortForService: Use port name only

### DIFF
--- a/pkg/route/controller/ingress/ingress.go
+++ b/pkg/route/controller/ingress/ingress.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -357,7 +357,7 @@ func (c *Controller) sync(key queueKey) error {
 	}
 
 	ingress, err := c.ingressLister.Ingresses(key.namespace).Get(key.name)
-	if errors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {
@@ -441,7 +441,7 @@ func (c *Controller) sync(key queueKey) error {
 
 	// purge any previously managed routes
 	for _, route := range old {
-		if err := c.client.Routes(route.Namespace).Delete(route.Name, nil); err != nil && !errors.IsNotFound(err) {
+		if err := c.client.Routes(route.Namespace).Delete(route.Name, nil); err != nil && !kerrors.IsNotFound(err) {
 			errs = append(errs, err)
 		}
 	}
@@ -671,7 +671,7 @@ func createRouteWithName(client routeclient.RoutesGetter, ingress *extensionsv1b
 
 		// if we aren't generating names (or if we got any other type of error)
 		// return right away
-		if len(base) == 0 || !errors.IsAlreadyExists(err) {
+		if len(base) == 0 || !kerrors.IsAlreadyExists(err) {
 			return err
 		}
 		lastErr = err

--- a/pkg/route/controller/ingress/ingress_test.go
+++ b/pkg/route/controller/ingress/ingress_test.go
@@ -224,6 +224,20 @@ func TestController_stabilizeAfterCreate(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ingress-endpoint-3",
+				Namespace: "test",
+			},
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{
+					{
+						Port:       80,
+						TargetPort: intstr.FromString("tcp-8080"),
+					},
+				},
+			},
+		},
 	}}
 
 	var names []string
@@ -582,6 +596,40 @@ func TestController_sync(t *testing.T) {
 			args: queueKey{namespace: "test", name: "1"},
 		},
 		{
+			name: "ignores incomplete ingress - service does not exist",
+			fields: fields{
+				i: &ingressLister{Items: []*extensionsv1beta1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "1",
+							Namespace: "test",
+						},
+						Spec: extensionsv1beta1.IngressSpec{
+							Rules: []extensionsv1beta1.IngressRule{
+								{
+									Host: "test.com",
+									IngressRuleValue: extensionsv1beta1.IngressRuleValue{
+										HTTP: &extensionsv1beta1.HTTPIngressRuleValue{
+											Paths: []extensionsv1beta1.HTTPIngressPath{
+												{
+													Path: "/", Backend: extensionsv1beta1.IngressBackend{
+														ServiceName: "service-3",
+														ServicePort: intstr.FromInt(80),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+				r: &routeLister{},
+			},
+			args: queueKey{namespace: "test", name: "1"},
+		},
+		{
 			name: "create route",
 			fields: fields{
 				i: &ingressLister{Items: []*extensionsv1beta1.Ingress{
@@ -635,7 +683,7 @@ func TestController_sync(t *testing.T) {
 							Name: "service-1",
 						},
 						Port: &routev1.RoutePort{
-							TargetPort: intstr.FromInt(8080),
+							TargetPort: intstr.FromString("http"),
 						},
 					},
 				},
@@ -652,7 +700,61 @@ func TestController_sync(t *testing.T) {
 							Name: "service-1",
 						},
 						Port: &routev1.RoutePort{
-							TargetPort: intstr.FromInt(8080),
+							TargetPort: intstr.FromString("http"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "create route - targetPort string, service port with name",
+			fields: fields{
+				i: &ingressLister{Items: []*extensionsv1beta1.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "1",
+							Namespace: "test",
+						},
+						Spec: extensionsv1beta1.IngressSpec{
+							Rules: []extensionsv1beta1.IngressRule{
+								{
+									Host: "test.com",
+									IngressRuleValue: extensionsv1beta1.IngressRuleValue{
+										HTTP: &extensionsv1beta1.HTTPIngressRuleValue{
+											Paths: []extensionsv1beta1.HTTPIngressPath{
+												{
+													Path: "/", Backend: extensionsv1beta1.IngressBackend{
+														ServiceName: "service-2",
+														ServicePort: intstr.FromInt(80),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+				r: &routeLister{},
+			},
+			args:        queueKey{namespace: "test", name: "1"},
+			wantExpects: []queueKey{{namespace: "test", name: "1"}},
+			wantCreates: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "<generated>",
+						Namespace:       "test",
+						OwnerReferences: []metav1.OwnerReference{{APIVersion: "extensions/v1beta1", Kind: "Ingress", Name: "1", Controller: &boolTrue}},
+					},
+					Spec: routev1.RouteSpec{
+						Host: "test.com",
+						Path: "/",
+						To: routev1.RouteTargetReference{
+							Name: "service-2",
+						},
+						Port: &routev1.RoutePort{
+							TargetPort: intstr.FromString("80-tcp"),
 						},
 					},
 				},
@@ -761,7 +863,7 @@ func TestController_sync(t *testing.T) {
 			wantPatches: []clientgotesting.PatchActionImpl{
 				{
 					Name:  "1-abcdef",
-					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":8080}}}]`),
+					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":"http"}}}]`),
 				},
 			},
 		},
@@ -809,7 +911,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 						},
@@ -863,7 +965,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 						},
@@ -947,7 +1049,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 						},
@@ -1008,7 +1110,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 							TLS: &routev1.TLSConfig{
@@ -1025,7 +1127,7 @@ func TestController_sync(t *testing.T) {
 			wantPatches: []clientgotesting.PatchActionImpl{
 				{
 					Name:  "1-abcdef",
-					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":8080}}}]`),
+					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":"http"}}}]`),
 				},
 			},
 		},
@@ -1076,7 +1178,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 						},
@@ -1087,7 +1189,7 @@ func TestController_sync(t *testing.T) {
 			wantPatches: []clientgotesting.PatchActionImpl{
 				{
 					Name:  "1-abcdef",
-					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":8080},"tls":{"termination":"edge","certificate":"cert","key":"key","insecureEdgeTerminationPolicy":"Redirect"}}}]`),
+					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":"http"},"tls":{"termination":"edge","certificate":"cert","key":"key","insecureEdgeTerminationPolicy":"Redirect"}}}]`),
 				},
 			},
 		},
@@ -1138,7 +1240,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 							TLS: &routev1.TLSConfig{
@@ -1154,7 +1256,7 @@ func TestController_sync(t *testing.T) {
 			wantPatches: []clientgotesting.PatchActionImpl{
 				{
 					Name:  "1-abcdef",
-					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":8080},"tls":{"termination":"edge","certificate":"cert","key":"key2"}}}]`),
+					Patch: []byte(`[{"op":"replace","path":"/spec","value":{"host":"test.com","path":"/","to":{"kind":"","name":"service-1","weight":null},"port":{"targetPort":"http"},"tls":{"termination":"edge","certificate":"cert","key":"key2"}}}]`),
 				},
 			},
 		},
@@ -1205,7 +1307,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 							TLS: &routev1.TLSConfig{
@@ -1267,7 +1369,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 							TLS: &routev1.TLSConfig{
@@ -1329,7 +1431,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 							TLS: &routev1.TLSConfig{
@@ -1390,7 +1492,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 							TLS: &routev1.TLSConfig{
@@ -1457,7 +1559,7 @@ func TestController_sync(t *testing.T) {
 								Name: "service-1",
 							},
 							Port: &routev1.RoutePort{
-								TargetPort: intstr.FromInt(8080),
+								TargetPort: intstr.FromString("http"),
 							},
 							WildcardPolicy: routev1.WildcardPolicyNone,
 							TLS: &routev1.TLSConfig{
@@ -1568,10 +1670,10 @@ func TestController_sync(t *testing.T) {
 
 			for i := range tt.wantCreates {
 				if i > len(actions)-1 {
-					t.Fatalf("Controller.sync() unexpected actions: %#v", kc.Actions())
+					t.Fatalf("Controller.sync() unexpected action[%d]: %#v", i, tt.wantCreates[i])
 				}
 				if actions[i].GetVerb() != "create" {
-					t.Fatalf("Controller.sync() unexpected actions: %#v", kc.Actions())
+					t.Fatalf("Controller.sync() unexpected action[%d]: %#v", i, tt.wantCreates[i])
 				}
 				action := actions[i].(clientgotesting.CreateAction)
 				if action.GetNamespace() != tt.args.namespace {

--- a/pkg/route/controller/ingress/ingress_test.go
+++ b/pkg/route/controller/ingress/ingress_test.go
@@ -6,7 +6,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,7 +50,7 @@ func (r *nsRouteLister) Get(name string) (*routev1.Route, error) {
 			return s, nil
 		}
 	}
-	return nil, errors.NewNotFound(schema.GroupResource{}, name)
+	return nil, kerrors.NewNotFound(schema.GroupResource{}, name)
 }
 
 type ingressLister struct {
@@ -79,7 +79,7 @@ func (r *nsIngressLister) Get(name string) (*extensionsv1beta1.Ingress, error) {
 			return s, nil
 		}
 	}
-	return nil, errors.NewNotFound(schema.GroupResource{}, name)
+	return nil, kerrors.NewNotFound(schema.GroupResource{}, name)
 }
 
 type serviceLister struct {
@@ -112,7 +112,7 @@ func (r *nsServiceLister) Get(name string) (*v1.Service, error) {
 			return s, nil
 		}
 	}
-	return nil, errors.NewNotFound(schema.GroupResource{}, name)
+	return nil, kerrors.NewNotFound(schema.GroupResource{}, name)
 }
 
 type secretLister struct {
@@ -141,7 +141,7 @@ func (r *nsSecretLister) Get(name string) (*v1.Secret, error) {
 			return s, nil
 		}
 	}
-	return nil, errors.NewNotFound(schema.GroupResource{}, name)
+	return nil, kerrors.NewNotFound(schema.GroupResource{}, name)
 }
 
 const complexIngress = `


### PR DESCRIPTION
When translating the port specified by an Ingress to the target port for a Route, use the port name rather than the number, or omit the target port if it has no name.

An Ingress resource specifies a Service and a port on that Service whereas a Route resource specifies a Service and a target port on the corresponding Endpoints resource.  The ports on the Endpoints resource and the ports on the Service resources have matching names but may have different numbers. Therefore, when mapping an Ingress and Service to a Route and a target port for the Endpoints resource, we cannot use port numbers; we must use names or omit the target port entirely.

It is safe to omit the target port if it does not have a name because a Service port must have a name if the Service has more than one port; therefore if a port is nameless, it must be the only port; and omitting the target port in the Route spec means that every port (or in this case, the only port) on the Endpoints resource is targeted.

* `pkg/route/ingress/ingress.go` (`targetPortForService`): Add an error return value.  Return an error if the Ingress references a Service or port that cannot be found.  Otherwise, return the Service port's name as the target port, or return nil if the port has no name.
(`newRouteForIngress`, `routeMatchesIngress`): Update to check the error value from `targetPortForService` and to handle a nil target port (which means the Route should have a null port specification).
* `pkg/route/ingress/ingress_test.go` (`TestController_stabilizeAfterCreate`):
Add test case with a nameless port.
(`TestController_sync`): Add a test case where the Ingress references a Service that does not exist.  Add a test case where the Ingress specifies a port by number.  Update test cases to expect port names in Route port specifications.  Update the failure messages for unexpected actions to print the actions.

Co-authored-by: derkoe <christian.koeberl@gmail.com>