### PR TITLE
Bug 1821945: Ensure the server FQIN is stored and searched in lowercase (vsphere)

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/vsphere/credentialmanager.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/vsphere/credentialmanager.go
@@ -77,6 +77,8 @@ func (secretCredentialManager *SecretCredentialManager) GetCredential(server str
 		klog.Warningf("secret %q not found in namespace %q", secretCredentialManager.SecretName, secretCredentialManager.SecretNamespace)
 	}
 
+	// Converting server FQIN to lowercase to consolidate with config parsing approach
+	server = strings.ToLower(server)
 	credential, found := secretCredentialManager.Cache.GetCredential(server)
 	if !found {
 		klog.Errorf("credentials not found for server %q", server)


### PR DESCRIPTION
PR: https://github.com/kubernetes/kubernetes/pull/90796
Scrapped issue with details: https://github.com/kubernetes/kubernetes/issues/90795