### PR TITLE
Bug 1835042: UPSTREAM: 91066: tweak exec-probe log statement to be more concise

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/prober/prober.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/prober/prober.go
@@ -163,7 +163,7 @@ func buildHeader(headerList []v1.HTTPHeader) http.Header {
 func (pb *prober) runProbe(probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (probe.Result, string, error) {
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	if p.Exec != nil {
-		klog.V(4).Infof("Exec-Probe Pod: %v, Container: %v, Command: %v", pod, container, p.Exec.Command)
+		klog.V(4).Infof("Exec-Probe Pod: %v, Container: %v, Command: %v", pod.Name, container.Name, p.Exec.Command)
 		command := kubecontainer.ExpandContainerCommandOnlyStatic(p.Exec.Command, container.Env)
 		return pb.exec.Probe(pb.newExecInContainer(container, containerID, command, timeout))
 	}


### PR DESCRIPTION
Fixes the log message for kubelet exec-probe log messages

ref: https://github.com/kubernetes/kubernetes/pull/91066

/assign @sjenning 