### PR TITLE
Bug 1835786: UPSTREAM: 90414: bugfix: initcontainer wasn't considered when calculate resource request

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/resource_allocation.go
+++ b/vendor/k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/resource_allocation.go
@@ -124,6 +124,7 @@ func calculateResourceAllocatableRequest(nodeInfo *schedulernodeinfo.NodeInfo, p
 
 // calculatePodResourceRequest returns the total non-zero requests. If Overhead is defined for the pod and the
 // PodOverhead feature is enabled, the Overhead is added to the result.
+// podResourceRequest = max(sum(podSpec.Containers), podSpec.InitContainers) + overHead
 func calculatePodResourceRequest(pod *v1.Pod, resource v1.ResourceName) int64 {
 	var podRequest int64
 	for i := range pod.Spec.Containers {
@@ -132,11 +133,20 @@ func calculatePodResourceRequest(pod *v1.Pod, resource v1.ResourceName) int64 {
 		podRequest += value
 	}
 
+	for i := range pod.Spec.InitContainers {
+		initContainer := &pod.Spec.InitContainers[i]
+		value := priorityutil.GetNonzeroRequestForResource(resource, &initContainer.Resources.Requests)
+		if podRequest < value {
+			podRequest = value
+		}
+	}
+
 	// If Overhead is being utilized, add to the total requests for the pod
 	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) {
 		if quantity, found := pod.Spec.Overhead[resource]; found {
 			podRequest += quantity.Value()
 		}
 	}
+
 	return podRequest
 }

--- a/vendor/k8s.io/kubernetes/pkg/scheduler/nodeinfo/node_info.go
+++ b/vendor/k8s.io/kubernetes/pkg/scheduler/nodeinfo/node_info.go
@@ -555,6 +555,7 @@ func (n *NodeInfo) RemovePod(pod *v1.Pod) error {
 	return fmt.Errorf("no corresponding pod %s in pods of node %s", pod.Name, n.node.Name)
 }
 
+// resourceRequest = max(sum(podSpec.Containers), podSpec.InitContainers) + overHead
 func calculateResource(pod *v1.Pod) (res Resource, non0CPU int64, non0Mem int64) {
 	resPtr := &res
 	for _, c := range pod.Spec.Containers {
@@ -564,6 +565,18 @@ func calculateResource(pod *v1.Pod) (res Resource, non0CPU int64, non0Mem int64)
 		non0CPU += non0CPUReq
 		non0Mem += non0MemReq
 		// No non-zero resources for GPUs or opaque resources.
+	}
+
+	for _, ic := range pod.Spec.InitContainers {
+		resPtr.SetMaxResource(ic.Resources.Requests)
+		non0CPUReq, non0MemReq := priorityutil.GetNonzeroRequests(&ic.Resources.Requests)
+		if non0CPU < non0CPUReq {
+			non0CPU = non0CPUReq
+		}
+
+		if non0Mem < non0MemReq {
+			non0Mem = non0MemReq
+		}
 	}
 
 	// If Overhead is being utilized, add to the total requests for the pod

--- a/vendor/k8s.io/kubernetes/pkg/scheduler/nodeinfo/node_info_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/scheduler/nodeinfo/node_info_test.go
@@ -608,6 +608,46 @@ func TestNodeInfoAddPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "node_info_cache_test",
+				Name:      "test-3",
+				UID:       types.UID("test-3"),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU: resource.MustParse("200m"),
+							},
+						},
+						Ports: []v1.ContainerPort{
+							{
+								HostIP:   "127.0.0.1",
+								HostPort: 8080,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("500m"),
+								v1.ResourceMemory: resource.MustParse("200Mi"),
+							},
+						},
+					},
+				},
+				NodeName: nodeName,
+				Overhead: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("500m"),
+					v1.ResourceMemory: resource.MustParse("500"),
+				},
+			},
+		},
 	}
 	expected := &NodeInfo{
 		node: &v1.Node{
@@ -616,15 +656,15 @@ func TestNodeInfoAddPod(t *testing.T) {
 			},
 		},
 		requestedResource: &Resource{
-			MilliCPU:         1300,
-			Memory:           1000,
+			MilliCPU:         2300,
+			Memory:           209716700, //1500 + 200MB in initContainers
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
 		nonzeroRequest: &Resource{
-			MilliCPU:         1300,
-			Memory:           209716200, //200MB + 1000 specified in requests/overhead
+			MilliCPU:         2300,
+			Memory:           419431900, //200MB(initContainers) + 200MB(default memory value) + 1500 specified in requests/overhead
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
@@ -689,6 +729,46 @@ func TestNodeInfoAddPod(t *testing.T) {
 									HostIP:   "127.0.0.1",
 									HostPort: 8080,
 									Protocol: "TCP",
+								},
+							},
+						},
+					},
+					NodeName: nodeName,
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("500m"),
+						v1.ResourceMemory: resource.MustParse("500"),
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "node_info_cache_test",
+					Name:      "test-3",
+					UID:       types.UID("test-3"),
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("200m"),
+								},
+							},
+							Ports: []v1.ContainerPort{
+								{
+									HostIP:   "127.0.0.1",
+									HostPort: 8080,
+									Protocol: "TCP",
+								},
+							},
+						},
+					},
+					InitContainers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("500m"),
+									v1.ResourceMemory: resource.MustParse("200Mi"),
 								},
 							},
 						},


### PR DESCRIPTION
Backports https://github.com/openshift/origin/pull/24977 to 4.4

Take initcontainers into account when calculating resource requests

ref: https://github.com/kubernetes/kubernetes/pull/89222
ref: https://github.com/kubernetes/kubernetes/pull/90378