### PR TITLE
Bug 1814282: Storage e2es leaving namespaces/pods around

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/pod/delete.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/pod/delete.go
@@ -35,10 +35,15 @@ const (
 	PodDeleteTimeout = 5 * time.Minute
 )
 
-// DeletePodOrFail deletes the pod of the specified namespace and name.
+// DeletePodOrFail deletes the pod of the specified namespace and name. Resilient to the pod
+// not existing.
 func DeletePodOrFail(c clientset.Interface, ns, name string) {
 	ginkgo.By(fmt.Sprintf("Deleting pod %s in namespace %s", name, ns))
 	err := c.CoreV1().Pods(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return
+	}
+
 	expectNoError(err, "failed to delete pod %s in namespace %s", name, ns)
 }
 

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -268,7 +268,7 @@ OUTER:
 
 // WaitForNamespacesDeleted waits for the namespaces to be deleted.
 func WaitForNamespacesDeleted(c clientset.Interface, namespaces []string, timeout time.Duration) error {
-	ginkgo.By("Waiting for namespaces to vanish")
+	ginkgo.By(fmt.Sprintf("Waiting for namespaces %+v to vanish", namespaces))
 	nsMap := map[string]bool{}
 	for _, ns := range namespaces {
 		nsMap[ns] = true

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/csi.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/csi.go
@@ -208,7 +208,6 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.Per
 	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
 	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
 	cleanupFunc := func() {
-		framework.RemoveCleanupAction(h.cleanupHandle)
 		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
 		// Delete the primary namespace but its okay to fail here because this namespace will
 		// also be deleted by framework.Aftereach hook
@@ -220,6 +219,12 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.Per
 
 		ginkgo.By(fmt.Sprintf("deleting the driver namespace: %s", ns2))
 		tryFunc(deleteNamespaceFunc(f.ClientSet, ns2, framework.DefaultNamespaceDeletionTimeout))
+		// cleanup function has already ran and hence we don't need to run it again.
+		// We do this as very last action because in-case defer(or AfterEach) races
+		// with AfterSuite and test routine gets killed then this block still
+		// runs in AfterSuite
+		framework.RemoveCleanupAction(h.cleanupHandle)
+
 	}
 	h.cleanupHandle = framework.AddCleanupAction(cleanupFunc)
 
@@ -371,7 +376,6 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
 	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
 	cleanupFunc := func() {
-		framework.RemoveCleanupAction(m.cleanupHandle)
 		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
 		// Delete the primary namespace but its okay to fail here because this namespace will
 		// also be deleted by framework.Aftereach hook
@@ -382,6 +386,12 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 		tryFunc(cancelLogging)
 		ginkgo.By(fmt.Sprintf("deleting the driver namespace: %s", ns2))
 		tryFunc(deleteNamespaceFunc(f.ClientSet, ns2, framework.DefaultNamespaceDeletionTimeout))
+		// cleanup function has already ran and hence we don't need to run it again.
+		// We do this as very last action because in-case defer(or AfterEach) races
+		// with AfterSuite and test routine gets killed then this block still
+		// runs in AfterSuite
+		framework.RemoveCleanupAction(m.cleanupHandle)
+
 	}
 
 	m.cleanupHandle = framework.AddCleanupAction(cleanupFunc)
@@ -515,7 +525,6 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
 	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
 	cleanupFunc := func() {
-		framework.RemoveCleanupAction(g.cleanupHandle)
 		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
 		// Delete the primary namespace but its okay to fail here because this namespace will
 		// also be deleted by framework.Aftereach hook
@@ -527,6 +536,12 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 
 		ginkgo.By(fmt.Sprintf("deleting the driver namespace: %s", ns2))
 		tryFunc(deleteNamespaceFunc(f.ClientSet, ns2, framework.DefaultNamespaceDeletionTimeout))
+		// cleanup function has already ran and hence we don't need to run it again.
+		// We do this as very last action because in-case defer(or AfterEach) races
+		// with AfterSuite and test routine gets killed then this block still
+		// runs in AfterSuite
+		framework.RemoveCleanupAction(g.cleanupHandle)
+
 	}
 	g.cleanupHandle = framework.AddCleanupAction(cleanupFunc)
 

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/csi.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/csi.go
@@ -71,6 +71,7 @@ const (
 type hostpathCSIDriver struct {
 	driverInfo       testsuites.DriverInfo
 	manifests        []string
+	cleanupHandle    framework.CleanupActionHandle
 	volumeAttributes []map[string]string
 }
 
@@ -167,8 +168,13 @@ func (h *hostpathCSIDriver) GetSnapshotClass(config *testsuites.PerTestConfig) *
 }
 
 func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
+	// Create secondary namespace which will be used for creating driver
+	driverNamespace := utils.CreateDriverNamespace(f)
+	ns2 := driverNamespace.Name
+	ns1 := f.Namespace.Name
+
 	ginkgo.By(fmt.Sprintf("deploying %s driver", h.driverInfo.Name))
-	cancelLogging := testsuites.StartPodLogs(f)
+	cancelLogging := testsuites.StartPodLogs(f, driverNamespace)
 	cs := f.ClientSet
 
 	// The hostpath CSI driver only works when everything runs on the same node.
@@ -179,6 +185,7 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.Per
 		Prefix:              "hostpath",
 		Framework:           f,
 		ClientNodeSelection: e2epod.NodeSelection{Name: node.Name},
+		DriverNamespace:     driverNamespace,
 	}
 
 	o := utils.PatchCSIOptions{
@@ -190,19 +197,33 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.Per
 		SnapshotterContainerName: "csi-snapshotter",
 		NodeName:                 node.Name,
 	}
-	cleanup, err := utils.CreateFromManifests(config.Framework, func(item interface{}) error {
+	cleanup, err := utils.CreateFromManifests(config.Framework, driverNamespace, func(item interface{}) error {
 		return utils.PatchCSIDeployment(config.Framework, o, item)
-	},
-		h.manifests...)
+	}, h.manifests...)
+
 	if err != nil {
 		framework.Failf("deploying %s driver: %v", h.driverInfo.Name, err)
 	}
 
-	return config, func() {
-		ginkgo.By(fmt.Sprintf("uninstalling %s driver", h.driverInfo.Name))
-		cleanup()
-		cancelLogging()
+	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
+	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
+	cleanupFunc := func() {
+		framework.RemoveCleanupAction(h.cleanupHandle)
+		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
+		// Delete the primary namespace but its okay to fail here because this namespace will
+		// also be deleted by framework.Aftereach hook
+		tryFunc(deleteNamespaceFunc(f.ClientSet, ns1, framework.DefaultNamespaceDeletionTimeout))
+
+		ginkgo.By("uninstalling csi mock driver")
+		tryFunc(cleanup)
+		tryFunc(cancelLogging)
+
+		ginkgo.By(fmt.Sprintf("deleting the driver namespace: %s", ns2))
+		tryFunc(deleteNamespaceFunc(f.ClientSet, ns2, framework.DefaultNamespaceDeletionTimeout))
 	}
+	h.cleanupHandle = framework.AddCleanupAction(cleanupFunc)
+
+	return config, cleanupFunc
 }
 
 // mockCSI
@@ -213,6 +234,7 @@ type mockCSIDriver struct {
 	attachable          bool
 	attachLimit         int
 	enableNodeExpansion bool
+	cleanupHandle       framework.CleanupActionHandle
 }
 
 // CSIMockDriverOpts defines options used for csi driver
@@ -291,8 +313,13 @@ func (m *mockCSIDriver) GetDynamicProvisionStorageClass(config *testsuites.PerTe
 }
 
 func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
+	// Create secondary namespace which will be used for creating driver
+	driverNamespace := utils.CreateDriverNamespace(f)
+	ns2 := driverNamespace.Name
+	ns1 := f.Namespace.Name
+
 	ginkgo.By("deploying csi mock driver")
-	cancelLogging := testsuites.StartPodLogs(f)
+	cancelLogging := testsuites.StartPodLogs(f, driverNamespace)
 	cs := f.ClientSet
 
 	// pods should be scheduled on the node
@@ -303,6 +330,7 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 		Prefix:              "mock",
 		Framework:           f,
 		ClientNodeSelection: e2epod.NodeSelection{Name: node.Name},
+		DriverNamespace:     driverNamespace,
 	}
 
 	containerArgs := []string{"--name=csi-mock-" + f.UniqueName}
@@ -332,24 +360,38 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 			storagev1.VolumeLifecycleEphemeral,
 		},
 	}
-	cleanup, err := utils.CreateFromManifests(f, func(item interface{}) error {
+	cleanup, err := utils.CreateFromManifests(f, driverNamespace, func(item interface{}) error {
 		return utils.PatchCSIDeployment(f, o, item)
-	},
-		m.manifests...)
+	}, m.manifests...)
+
 	if err != nil {
 		framework.Failf("deploying csi mock driver: %v", err)
 	}
 
-	return config, func() {
+	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
+	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
+	cleanupFunc := func() {
+		framework.RemoveCleanupAction(m.cleanupHandle)
+		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
+		// Delete the primary namespace but its okay to fail here because this namespace will
+		// also be deleted by framework.Aftereach hook
+		tryFunc(deleteNamespaceFunc(f.ClientSet, ns1, framework.DefaultNamespaceDeletionTimeout))
+
 		ginkgo.By("uninstalling csi mock driver")
-		cleanup()
-		cancelLogging()
+		tryFunc(cleanup)
+		tryFunc(cancelLogging)
+		ginkgo.By(fmt.Sprintf("deleting the driver namespace: %s", ns2))
+		tryFunc(deleteNamespaceFunc(f.ClientSet, ns2, framework.DefaultNamespaceDeletionTimeout))
 	}
+
+	m.cleanupHandle = framework.AddCleanupAction(cleanupFunc)
+	return config, cleanupFunc
 }
 
 // gce-pd
 type gcePDCSIDriver struct {
-	driverInfo testsuites.DriverInfo
+	driverInfo    testsuites.DriverInfo
+	cleanupHandle framework.CleanupActionHandle
 }
 
 var _ testsuites.TestDriver = &gcePDCSIDriver{}
@@ -433,7 +475,12 @@ func (g *gcePDCSIDriver) GetSnapshotClass(config *testsuites.PerTestConfig) *uns
 
 func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
 	ginkgo.By("deploying csi gce-pd driver")
-	cancelLogging := testsuites.StartPodLogs(f)
+	// Create secondary namespace which will be used for creating driver
+	driverNamespace := utils.CreateDriverNamespace(f)
+	ns2 := driverNamespace.Name
+	ns1 := f.Namespace.Name
+
+	cancelLogging := testsuites.StartPodLogs(f, driverNamespace)
 	// It would be safer to rename the gcePD driver, but that
 	// hasn't been done before either and attempts to do so now led to
 	// errors during driver registration, therefore it is disabled
@@ -446,7 +493,7 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 	// 	DriverContainerName:      "gce-driver",
 	// 	ProvisionerContainerName: "csi-external-provisioner",
 	// }
-	createGCESecrets(f.ClientSet, f.Namespace.Name)
+	createGCESecrets(f.ClientSet, ns2)
 
 	manifests := []string{
 		"test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml",
@@ -456,7 +503,7 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 		"test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml",
 	}
 
-	cleanup, err := utils.CreateFromManifests(f, nil, manifests...)
+	cleanup, err := utils.CreateFromManifests(f, driverNamespace, nil, manifests...)
 	if err != nil {
 		framework.Failf("deploying csi gce-pd driver: %v", err)
 	}
@@ -465,15 +512,30 @@ func (g *gcePDCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTes
 		framework.Failf("waiting for csi driver node registration on: %v", err)
 	}
 
+	// Cleanup CSI driver and namespaces. This function needs to be idempotent and can be
+	// concurrently called from defer (or AfterEach) and AfterSuite action hooks.
+	cleanupFunc := func() {
+		framework.RemoveCleanupAction(g.cleanupHandle)
+		ginkgo.By(fmt.Sprintf("deleting the test namespace: %s", ns1))
+		// Delete the primary namespace but its okay to fail here because this namespace will
+		// also be deleted by framework.Aftereach hook
+		tryFunc(deleteNamespaceFunc(f.ClientSet, ns1, framework.DefaultNamespaceDeletionTimeout))
+
+		ginkgo.By("uninstalling csi mock driver")
+		tryFunc(cleanup)
+		tryFunc(cancelLogging)
+
+		ginkgo.By(fmt.Sprintf("deleting the driver namespace: %s", ns2))
+		tryFunc(deleteNamespaceFunc(f.ClientSet, ns2, framework.DefaultNamespaceDeletionTimeout))
+	}
+	g.cleanupHandle = framework.AddCleanupAction(cleanupFunc)
+
 	return &testsuites.PerTestConfig{
-			Driver:    g,
-			Prefix:    "gcepd",
-			Framework: f,
-		}, func() {
-			ginkgo.By("uninstalling gce-pd driver")
-			cleanup()
-			cancelLogging()
-		}
+		Driver:          g,
+		Prefix:          "gcepd",
+		Framework:       f,
+		DriverNamespace: driverNamespace,
+	}, cleanupFunc
 }
 
 func waitForCSIDriverRegistrationOnAllNodes(driverName string, cs clientset.Interface) error {
@@ -508,4 +570,31 @@ func waitForCSIDriverRegistrationOnNode(nodeName string, driverName string, cs c
 		return fmt.Errorf("error waiting for CSI driver %s registration on node %s: %v", driverName, nodeName, waitErr)
 	}
 	return nil
+}
+
+func deleteNamespaceFunc(cs clientset.Interface, ns string, timeout time.Duration) func() {
+	return func() {
+		err := cs.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			framework.Logf("error deleting namespace %s: %v", ns, err)
+		}
+		err = framework.WaitForNamespacesDeleted(cs, []string{ns}, timeout)
+		if err != nil {
+			framework.Logf("error deleting namespace %s: %v", ns, err)
+		}
+	}
+}
+
+func tryFunc(f func()) error {
+	var err error
+	if f == nil {
+		return nil
+	}
+	defer func() {
+		if recoverError := recover(); recoverError != nil {
+			err = fmt.Errorf("%v", recoverError)
+		}
+	}()
+	f()
+	return err
 }

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/external/external.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/external/external.go
@@ -297,7 +297,7 @@ func (d *driverDefinition) GetDynamicProvisionStorageClass(config *testsuites.Pe
 		framework.ExpectNoError(err, "load storage class from %s", d.StorageClass.FromFile)
 		framework.ExpectEqual(len(items), 1, "exactly one item from %s", d.StorageClass.FromFile)
 
-		err = utils.PatchItems(f, items...)
+		err = utils.PatchItems(f, f.Namespace, items...)
 		framework.ExpectNoError(err, "patch items")
 
 		sc, ok = items[0].(*storagev1.StorageClass)

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/base.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/base.go
@@ -511,10 +511,11 @@ func getSnapshot(claimName string, ns, snapshotClassName string) *unstructured.U
 //
 // The output goes to log files (when using --report-dir, as in the
 // CI) or the output stream (otherwise).
-func StartPodLogs(f *framework.Framework) func() {
+func StartPodLogs(f *framework.Framework, driverNamespace *v1.Namespace) func() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cs := f.ClientSet
-	ns := f.Namespace
+
+	ns := driverNamespace.Name
 
 	to := podlogs.LogOutput{
 		StatusWriter: ginkgo.GinkgoWriter,
@@ -532,13 +533,13 @@ func StartPodLogs(f *framework.Framework) func() {
 		to.LogPathPrefix = framework.TestContext.ReportDir + "/" +
 			reg.ReplaceAllString(test.FullTestText, "_") + "/"
 	}
-	podlogs.CopyAllLogs(ctx, cs, ns.Name, to)
+	podlogs.CopyAllLogs(ctx, cs, ns, to)
 
 	// pod events are something that the framework already collects itself
 	// after a failed test. Logging them live is only useful for interactive
 	// debugging, not when we collect reports.
 	if framework.TestContext.ReportDir == "" {
-		podlogs.WatchPods(ctx, cs, ns.Name, ginkgo.GinkgoWriter)
+		podlogs.WatchPods(ctx, cs, ns, ginkgo.GinkgoWriter)
 	}
 
 	return cancel

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/testdriver.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/testdriver.go
@@ -215,6 +215,9 @@ type PerTestConfig struct {
 	// the configuration that then has to be used to run tests.
 	// The values above are ignored for such tests.
 	ServerConfig *volume.TestConfig
+
+	// Some drivers run in their own namespace
+	DriverNamespace *v1.Namespace
 }
 
 // GetUniqueDriverName returns unique driver name that can be used parallelly in tests


### PR DESCRIPTION
Backport of:

1. https://github.com/kubernetes/kubernetes/pull/90773
2. https://github.com/kubernetes/kubernetes/pull/91221
3. https://github.com/kubernetes/kubernetes/pull/91689

This fixes issues that were caused by CSI driver being deleted before pod that was using could be deleted and hence such pods were left in "terminating" state.  This PR fixes that bug by causing CSI driver to be installed in different namespace. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1814282

There are still some issues around snapshot e2es leaving namespaces in terminating state. But those are not e2e bugs but are actual bugs in snapshot controller etc - this is being tracked https://bugzilla.redhat.com/show_bug.cgi?id=1848633

