### PR TITLE
Bug 1835931: Fix panic in test code

### DIFF
--- a/test/extended/dr/common.go
+++ b/test/extended/dr/common.go
@@ -77,7 +77,9 @@ func constructEtcdConnectionString(masters []string) string {
 				break
 			}
 		}
-		etcdDNSName := strings.Split(entry, "=")[1]
+		entries := strings.Split(entry, "=")
+		o.Expect(entries).To(o.HaveLen(2))
+		etcdDNSName := entries[1]
 		o.Expect(etcdDNSName).NotTo(o.BeEmpty())
 		etcdConnectionString = fmt.Sprintf("%setcd-member-%s=https://%s:2380,", etcdConnectionString, master, etcdDNSName)
 	}


### PR DESCRIPTION
Fix out of bounds access which causes intermittent test panics.