### PR TITLE
Bug 1827062: UPSTREAM: 90608: Updates the fstype of Cinder volumes to be ext4 if nil

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
@@ -570,6 +570,10 @@ func (c *cinderVolumeProvisioner) Provision(selectedNode *v1.Node, allowedTopolo
 		return nil, err
 	}
 
+	if fstype == "" {
+		fstype = "ext4"
+	}
+
 	volumeMode := c.options.PVC.Spec.VolumeMode
 	if volumeMode != nil && *volumeMode == v1.PersistentVolumeBlock {
 		// Block volumes should not have any FSType


### PR DESCRIPTION
Backport of kubernetes/kubernetes#90608

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1827062