### PR TITLE
Bug 1833387: test/extended/operators/operators: Don't worry about Progressing ClusterOperator

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -274,7 +274,6 @@ func surprisingConditions(co objx.Map) ([]configv1.ClusterOperatorStatusConditio
 	for _, conditionType := range []configv1.ClusterStatusConditionType{
 		configv1.OperatorAvailable,
 		configv1.OperatorDegraded,
-		configv1.OperatorProgressing,
 	} {
 		cond := condition(co, string(conditionType))
 		if len(cond) == 0 {


### PR DESCRIPTION
We've been failing this test on `Progressing=True` since 6300a87622 (#22058).  But the installer [only cares about `ClusterVersion` `Available=True`][1], which means some operators who have leveled (as far as the cluster-version operator is concerned) may still have `Progressing=True` when the installer declares success.  We aren't too concerned about that as long as operators are available and not degraded, so stop worrying about it in this test.  This avoids failures [like][2]:

```
[sig-arch][Early] Managed cluster should start all core operators [Suite:openshift/conformance/parallel]

fail [github.com/openshift/origin/test/extended/operators/operators.go:159]: May  8 13:27:58.992: Some cluster operators never became ready: kube-apiserver (Progressing=True NodeInstaller: NodeInstallerProgressing: 1 nodes are at revision 5; 2 nodes are at revision 7)
```

although such failures rarely killed the job, because the cluster was happy enough by the time the "start all core operators" test was rerun to detect "flakes" at the end of the suite.

[1]: https://github.com/openshift/installer/blob/aecb9201459e3e92f12344e78aaaf03b6550fde7/cmd/openshift-install/create.go#L382-L384
[2]: https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.5/1040