### PR TITLE
Bug 1835845: Metrics test for router should allow backend metrics

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -176,8 +176,10 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			// route specific metrics from server and backend
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_http_responses_total"], serverLabels.With("code", "2xx"))).To(o.ConsistOf(o.BeNumerically(">", 0), o.BeNumerically(">", 0)))
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_http_responses_total"], serverLabels.With("code", "5xx"))).To(o.Equal([]float64{0, 0}))
-			// only server returns response counts
-			o.Expect(findGaugesWithLabels(metrics["haproxy_backend_http_responses_total"], routeLabels.With("code", "2xx"))).To(o.HaveLen(0))
+			// backends will start returning response counts in https://github.com/openshift/router/pull/132
+			if arr := findGaugesWithLabels(metrics["haproxy_backend_http_responses_total"], routeLabels.With("code", "2xx")); len(arr) == 0 {
+				e2e.Logf("waiting for https://github.com/openshift/router/pull/132 to merge before this will be removed")
+			}
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_connections_total"], serverLabels)).To(o.ConsistOf(o.BeNumerically(">=", 0), o.BeNumerically(">=", 0)))
 			o.Expect(findGaugesWithLabels(metrics["haproxy_backend_connections_total"], routeLabels)).To(o.ConsistOf(o.BeNumerically(">=", times)))
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_up"], serverLabels)).To(o.Equal([]float64{1, 1}))


### PR DESCRIPTION
The new metrics backend exposed metrics were explicitly checked to
not return - we will weaken that test in anticipation of the other
PR being merged.

Prerequisite for https://github.com/openshift/router/pull/132