### PR TITLE
e2e: topomgr: remove policy check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,6 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20200427153329-656914f816f9
 	k8s.io/kubectl v0.0.0
-	k8s.io/kubelet v0.0.0
 	k8s.io/kubernetes v1.19.0-rc.2
 	k8s.io/legacy-cloud-providers v0.0.0
 	sigs.k8s.io/yaml v1.2.0

--- a/test/extended/topology_manager/resourcealign.go
+++ b/test/extended/topology_manager/resourcealign.go
@@ -639,13 +639,6 @@ func isTopologyAffinityError(pod *corev1.Pod) bool {
 	return re.MatchString(pod.Status.Reason)
 }
 
-func deletePods(oc *exutil.CLI, pods []*corev1.Pod) {
-	client := oc.AsAdmin().KubeFramework().ClientSet
-	for _, pod := range pods {
-		e2epod.DeletePodWithWait(client, pod)
-	}
-}
-
 func expectSinglePodHaveAlignedResources(pod *corev1.Pod, oc *exutil.CLI, deviceResourceName string) {
 	for _, cnt := range pod.Spec.Containers {
 		out, err := getAllowedCpuListForContainer(oc, pod, &cnt)


### PR DESCRIPTION
When we introduced the topology manager extended tests, we added a check
to ensure that the topology manager was configured with the
`single-numa-node` policy. This because the `single-numa-node` policy
is the strictest one, so this is the simplest scenario on which we can
check the correct outcome of the allocation.

Checking other policies in the general case requires either
- complex testing code to properly detect various legal resource allocation
- accept the chance of having false negatives (test code misdetecting legal allocations)
- even a stricter coupling between test code and production code

However, we want to be able to check other policies.
The simplest possible step forward is to just remove the check for the
policy and to put on who sets the test up the responsability of
configuring the environment on such a way that test is relevant.
In other words, that could mean to over-provision the environment to
make sure the aligned allocations are possible with less strict
policies.

This change nothing for the current test scenarios, on which we set the
single-numa-node policy anyway, but makes it possible to use the
testsuite against clusters configured with the `best-effort` policy,
like it is the case when the `performance-addon-operator` is enabled
in the cluster.

Signed-off-by: Francesco Romani <fromani@redhat.com>