### PR TITLE
Bug 1837992: images/hyperkube: install iproute

### DIFF
--- a/images/hyperkube/Dockerfile.rhel
+++ b/images/hyperkube/Dockerfile.rhel
@@ -9,6 +9,7 @@ RUN for p in vendor/k8s.io/kubernetes/cmd/kube-apiserver vendor/k8s.io/kubernete
     /tmp/build
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
+RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False iproute && yum clean all
 COPY --from=builder /tmp/build/* /usr/bin/
 LABEL io.k8s.display-name="OpenShift Kubernetes Server Commands" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \


### PR DESCRIPTION
This is so we can access the "ss" utility, which we'd like to use during apiserver startup.

Right now we use `lsof`, which doesn't detect all sockets.