### PR TITLE
UPSTREAM: 91816: GC doesn't have to create monitors in the constructor

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector.go
@@ -76,7 +76,6 @@ type GarbageCollector struct {
 func NewGarbageCollector(
 	metadataClient metadata.Interface,
 	mapper resettableRESTMapper,
-	deletableResources map[schema.GroupVersionResource]struct{},
 	ignoredResources map[schema.GroupResource]struct{},
 	sharedInformers controller.InformerFactory,
 	informersStarted <-chan struct{},
@@ -91,7 +90,7 @@ func NewGarbageCollector(
 		attemptToOrphan:  attemptToOrphan,
 		absentOwnerCache: absentOwnerCache,
 	}
-	gb := &GraphBuilder{
+	gc.dependencyGraphBuilder = &GraphBuilder{
 		metadataClient:   metadataClient,
 		informersStarted: informersStarted,
 		restMapper:       mapper,
@@ -105,10 +104,6 @@ func NewGarbageCollector(
 		sharedInformers:  sharedInformers,
 		ignoredResources: ignoredResources,
 	}
-	if err := gb.syncMonitors(deletableResources); err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to sync all monitors: %v", err))
-	}
-	gc.dependencyGraphBuilder = gb
 
 	return gc, nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -81,12 +81,12 @@ func TestGarbageCollectorConstruction(t *testing.T) {
 	// construction will not fail.
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
-	gc, err := NewGarbageCollector(metadataClient, rm, twoResources, map[schema.GroupResource]struct{}{},
+	gc, err := NewGarbageCollector(metadataClient, rm, map[schema.GroupResource]struct{}{},
 		controller.NewInformerFactory(sharedInformers, metadataInformers), alwaysStarted)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 1, len(gc.dependencyGraphBuilder.monitors))
+	assert.Equal(t, 0, len(gc.dependencyGraphBuilder.monitors))
 
 	// Make sure resource monitor syncing creates and stops resource monitors.
 	tweakableRM.Add(schema.GroupVersionKind{Group: "tpr.io", Version: "v1", Kind: "unknown"}, nil)
@@ -198,12 +198,11 @@ func setupGC(t *testing.T, config *restclient.Config) garbageCollector {
 		t.Fatal(err)
 	}
 
-	podResource := map[schema.GroupVersionResource]struct{}{{Version: "v1", Resource: "pods"}: {}}
 	client := fake.NewSimpleClientset()
 	sharedInformers := informers.NewSharedInformerFactory(client, 0)
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
-	gc, err := NewGarbageCollector(metadataClient, &testRESTMapper{testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)}, podResource, ignoredResources, sharedInformers, alwaysStarted)
+	gc, err := NewGarbageCollector(metadataClient, &testRESTMapper{testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)}, ignoredResources, sharedInformers, alwaysStarted)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -827,13 +826,10 @@ func TestGarbageCollectorSync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	podResource := map[schema.GroupVersionResource]struct{}{
-		{Group: "", Version: "v1", Resource: "pods"}: {},
-	}
 	sharedInformers := informers.NewSharedInformerFactory(client, 0)
 	alwaysStarted := make(chan struct{})
 	close(alwaysStarted)
-	gc, err := NewGarbageCollector(metadataClient, rm, podResource, map[schema.GroupResource]struct{}{}, sharedInformers, alwaysStarted)
+	gc, err := NewGarbageCollector(metadataClient, rm, map[schema.GroupResource]struct{}{}, sharedInformers, alwaysStarted)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vendor/k8s.io/kubernetes/test/integration/garbagecollector/garbage_collector_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/garbagecollector/garbage_collector_test.go
@@ -232,7 +232,6 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 	discoveryClient := cacheddiscovery.NewMemCacheClient(clientSet.Discovery())
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
 	restMapper.Reset()
-	deletableResources := garbagecollector.GetDeletableResources(discoveryClient)
 	config := *result.ClientConfig
 	metadataClient, err := metadata.NewForConfig(&config)
 	if err != nil {
@@ -249,7 +248,6 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 	gc, err := garbagecollector.NewGarbageCollector(
 		metadataClient,
 		restMapper,
-		deletableResources,
 		garbagecollector.DefaultIgnoredResources(),
 		controller.NewInformerFactory(sharedInformers, metadataInformers),
 		alwaysStarted,


### PR DESCRIPTION
It prevents the GC from entering a slow loop (up to 1 hour) and blocking the other controllers.

Before this PR the GC used the restmapper (with the cache) in the constructor (a blocking operation) to construct its dependency graph.

In order to fill up the cache, the mapper needs to perform the full discovery which visits all API servers even if what it needs is already in the cache. The cache itself is invalidated by the KCM every 30 seconds. The GC needs to use the mapper many times (~len(deletableResources)) before it creates the graph.

When the discovery is slow (a node is down, a network is slow/broken) and takes more than 30s, creating the graph is also slow (cache invalidation) and might block the other controllers when the GC is run early in the process.

This PR moves the logic that creates the graph to the main loop (async operation) from the constructor.