### PR TITLE
extended/router: Omit routes.json from cat command

### DIFF
--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 				if err != nil {
 					panic(err)
 				}
-				exutil.DumpPodsCommand(oc.AdminKubeClient(), ns, selector, "cat /var/lib/haproxy/router/routes.json /var/lib/haproxy/conf/haproxy.config")
+				exutil.DumpPodsCommand(oc.AdminKubeClient(), ns, selector, "cat /var/lib/haproxy/conf/haproxy.config")
 			}
 		}
 	})


### PR DESCRIPTION
Delete a reference to `routes.json`, which https://github.com/openshift/router/pull/126 deleted, when dumping router pod info.

* `test/extended/router/router.go`: Delete `routes.json` from `cat` command.