### PR TITLE
Bug 1850140: tests: extended: fix TM regression test

### DIFF
--- a/test/extended/topology_manager/resourcealign.go
+++ b/test/extended/topology_manager/resourcealign.go
@@ -260,6 +260,13 @@ var _ = g.Describe("[Serial][sig-node][Feature:TopologyManager] Configured clust
 			})
 
 			// rhbz#1813567
+			// a well-behaving TM must admit only *one* of the pods.
+			// The reference test environment is like this:
+			// 1. Two NUMA nodes
+			// 2. A SRIOV Device - with 2+ VFs - on NUMA node 1. No VFs on the other node (see below)
+			// 3. No other workload is running together with the tests (all resources available to the test)
+			// 4. The pods request are arranged in such a way that only one pod can run in aligned environment.
+			//    The simplest way to enable this is to have VFs only on one NUMA node (see above).
 			g.It("should guarantee correct allocation with concurrent creation", func() {
 				// the following assumes:
 				// 1. even split of cores between NUMA nodes. Do we know when this is not the case?
@@ -280,6 +287,12 @@ var _ = g.Describe("[Serial][sig-node][Feature:TopologyManager] Configured clust
 				// we know we fit on the node granted the systemReservedCpus are configured properly,
 				// so no need to check for enoughCoresInTheCluster
 
+				// invariants:
+				// 1. we know we have a free NUMA node (the same one with SRIOV devices attached)
+				// 2. the largest pod must fit on a NUMA node, and must leave few free cores
+				// 3. the smallest pod must fit on the free cores on the other NUMA node.
+				//
+				// keep this invariant true if you tune these values: sum(cores) <= 0.75 * system_cores
 				pps := PodParamsList{
 					{
 						Containers: []ContainerParams{{
@@ -310,9 +323,29 @@ var _ = g.Describe("[Serial][sig-node][Feature:TopologyManager] Configured clust
 
 				setNodeForPods(pods, node)
 
-				testingPods := createPods(client, testNs, pods...)
+				isNotPending := func(phase corev1.PodPhase) bool {
+					return phase == corev1.PodRunning || phase == corev1.PodFailed
+				}
+				testingPods := createPodsAndWait(client, testNs, isNotPending, pods...)
 				defer deletePods(oc, testingPods)
-				expectPodsHaveAlignedResources(testingPods, oc, deviceResourceName)
+
+				// we don't know -and better not care- about the ordering here.
+				// we only know that exactly one pod must fail for TopologyAffinityError
+				affinityErrors := 0
+				for _, testingPod := range testingPods {
+					if testingPod.Status.Phase == corev1.PodFailed && isTopologyAffinityError(testingPod) {
+						affinityErrors++
+					}
+				}
+				o.Expect(affinityErrors).To(o.Equal(1), "unexpected number of pods failed for TopologyAffinityError: %v (expected 1)", affinityErrors)
+
+				// the other pod, OTOH, must have been properly aligned
+				// we do this check later because it's more expensive.
+				for _, testingPod := range testingPods {
+					if testingPod.Status.Phase == corev1.PodRunning {
+						expectSinglePodHaveAlignedResources(testingPod, oc, deviceResourceName)
+					}
+				}
 			})
 
 		})
@@ -617,30 +650,35 @@ func deletePods(oc *exutil.CLI, pods []*corev1.Pod) {
 	}
 }
 
+func expectSinglePodHaveAlignedResources(pod *corev1.Pod, oc *exutil.CLI, deviceResourceName string) {
+	for _, cnt := range pod.Spec.Containers {
+		out, err := getAllowedCpuListForContainer(oc, pod, &cnt)
+		e2e.ExpectNoError(err)
+		envOut := makeAllowedCpuListEnv(out)
+
+		podEnv, err := getEnvironmentVariables(oc, pod, &cnt)
+		e2e.ExpectNoError(err)
+		envOut += podEnv
+
+		e2e.Logf("Full environment for pod %q container %q: %q", pod.Name, cnt.Name, envOut)
+
+		numaNodes, err := getNumaNodeCountFromContainer(oc, pod, &cnt)
+		e2e.ExpectNoError(err)
+		envInfo := testEnvInfo{
+			numaNodes:         numaNodes,
+			sriovResourceName: deviceResourceName,
+		}
+		numaRes, err := checkNUMAAlignment(oc.KubeFramework(), pod, &cnt, envOut, &envInfo)
+		e2e.ExpectNoError(err)
+		ok := numaRes.CheckAlignment()
+
+		o.Expect(ok).To(o.BeTrue(), "misaligned NUMA resources: %s", numaRes.String())
+	}
+
+}
+
 func expectPodsHaveAlignedResources(updatedPods []*corev1.Pod, oc *exutil.CLI, deviceResourceName string) {
 	for _, pod := range updatedPods {
-		for _, cnt := range pod.Spec.Containers {
-			out, err := getAllowedCpuListForContainer(oc, pod, &cnt)
-			e2e.ExpectNoError(err)
-			envOut := makeAllowedCpuListEnv(out)
-
-			podEnv, err := getEnvironmentVariables(oc, pod, &cnt)
-			e2e.ExpectNoError(err)
-			envOut += podEnv
-
-			e2e.Logf("Full environment for pod %q container %q: %q", pod.Name, cnt.Name, envOut)
-
-			numaNodes, err := getNumaNodeCountFromContainer(oc, pod, &cnt)
-			e2e.ExpectNoError(err)
-			envInfo := testEnvInfo{
-				numaNodes:         numaNodes,
-				sriovResourceName: deviceResourceName,
-			}
-			numaRes, err := checkNUMAAlignment(oc.KubeFramework(), pod, &cnt, envOut, &envInfo)
-			e2e.ExpectNoError(err)
-			ok := numaRes.CheckAlignment()
-
-			o.Expect(ok).To(o.BeTrue(), "misaligned NUMA resources: %s", numaRes.String())
-		}
+		expectSinglePodHaveAlignedResources(pod, oc, deviceResourceName)
 	}
 }

--- a/test/extended/topology_manager/resourcealign.go
+++ b/test/extended/topology_manager/resourcealign.go
@@ -61,8 +61,8 @@ var _ = g.Describe("[Serial][sig-node][Feature:TopologyManager] Configured clust
 				ns := oc.KubeFramework().Namespace.Name
 				testingPods := pps.MakeBusyboxPods(ns, deviceResourceName)
 				// we just want to run pods and check they actually go running
-				createPods(client, ns, testingPods...)
-				defer deletePods(oc, testingPods)
+				updatedPods := createPods(client, ns, testingPods...)
+				defer deletePods(oc, updatedPods)
 			},
 			// rhbz#1813397 - k8s issue83775
 			t.Entry("with single pod, single container requesting 1 core", []PodParams{

--- a/test/extended/topology_manager/utils.go
+++ b/test/extended/topology_manager/utils.go
@@ -293,7 +293,9 @@ func setNodeForPods(pods []*corev1.Pod, node *corev1.Node) {
 
 }
 
-func createPods(client clientset.Interface, namespace string, testPods ...*corev1.Pod) []*corev1.Pod {
+type podPhaseChecker func(corev1.PodPhase) bool
+
+func createPodsAndWait(client clientset.Interface, namespace string, phaseChecker podPhaseChecker, testPods ...*corev1.Pod) []*corev1.Pod {
 	updatedPods := make([]*corev1.Pod, len(testPods), len(testPods))
 	var wg sync.WaitGroup
 
@@ -305,7 +307,7 @@ func createPods(client clientset.Interface, namespace string, testPods ...*corev
 			created, err := client.CoreV1().Pods(namespace).Create(context.Background(), testPods[idx], metav1.CreateOptions{})
 			e2e.ExpectNoError(err)
 
-			err = waitForPhase(client, created.Namespace, created.Name, corev1.PodRunning, 5*time.Minute)
+			err = waitForPhase(client, created.Namespace, created.Name, phaseChecker, 5*time.Minute)
 			e2e.ExpectNoError(err)
 
 			updatedPods[idx], err = client.CoreV1().Pods(created.Namespace).Get(context.Background(), created.Name, metav1.GetOptions{})
@@ -317,14 +319,21 @@ func createPods(client clientset.Interface, namespace string, testPods ...*corev
 	return updatedPods
 }
 
-func waitForPhase(c clientset.Interface, namespace, name string, phase corev1.PodPhase, timeout time.Duration) error {
+func createPods(client clientset.Interface, namespace string, testPods ...*corev1.Pod) []*corev1.Pod {
+	isRunning := func(phase corev1.PodPhase) bool {
+		return phase == corev1.PodRunning
+	}
+	return createPodsAndWait(client, namespace, isRunning, testPods...)
+}
+
+func waitForPhase(c clientset.Interface, namespace, name string, phaseChecker podPhaseChecker, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		updatedPod, err := c.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}
 		e2e.Logf("pod %q phase %s", updatedPod.Name, updatedPod.Status.Phase)
-		if updatedPod.Status.Phase == phase {
+		if phaseChecker(updatedPod.Status.Phase) {
 			return true, nil
 		}
 		return false, nil

--- a/test/extended/topology_manager/utils.go
+++ b/test/extended/topology_manager/utils.go
@@ -296,13 +296,15 @@ func setNodeForPods(pods []*corev1.Pod, node *corev1.Node) {
 type podPhaseChecker func(corev1.PodPhase) bool
 
 func createPodsAndWait(client clientset.Interface, namespace string, phaseChecker podPhaseChecker, testPods ...*corev1.Pod) []*corev1.Pod {
-	updatedPods := make([]*corev1.Pod, len(testPods), len(testPods))
+	num := len(testPods)
+	updatedPods := make([]*corev1.Pod, num, num)
 	var wg sync.WaitGroup
 
-	for i := 0; i < len(testPods); i++ {
+	for i := 0; i < num; i++ {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
+			defer g.GinkgoRecover()
 
 			created, err := client.CoreV1().Pods(namespace).Create(context.Background(), testPods[idx], metav1.CreateOptions{})
 			e2e.ExpectNoError(err)


### PR DESCRIPTION
TL;DR: the topology manager code is correct, a specific test fails to capture this leading to false negatives

The existing regression test which wants to cover against regressions
on RHBZ#1813567 is actually doing the reverse check than it should.
We noticed after having the test run for few days on environment kindly
provided by nfvpe team.
The likely cause of why this mistake sneaked in is that I wrongly
configured the original environment on which I tried the test.

This patch fixes the issue and puts extra care in documenting and
checking the intent of the original bugzilla.

Signed-off-by: Francesco Romani <fromani@redhat.com>