### PR TITLE
Bug 1824423: Revert "UPSTREAM: <drop>: Increate timeout in volume expansion test"

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -94,11 +94,6 @@ const (
 	// minutes by slow docker pulls or something else.
 	PodStartShortTimeout = 2 * time.Minute
 
-	// PodStartAfterResizeTimeout is same as `PodStartTimeout`, but longer to better
-	// tolerate attaching a volume that is still being modified in the cloud.
-	// Use it when starting a pod with a volume that has been recently resized in the cloud.
-	PodStartAfterResizeTimeout = 10 * time.Minute
-
 	// PodDeleteTimeout is how long to wait for a pod to be deleted.
 	PodDeleteTimeout = 5 * time.Minute
 

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/volume_expand.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/volume_expand.go
@@ -203,7 +203,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 			l.resource.Pvc = npvc
 
 			ginkgo.By("Creating a new pod with same volume")
-			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{l.resource.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil, l.config.ClientNodeSelection, framework.PodStartAfterResizeTimeout)
+			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{l.resource.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil, l.config.ClientNodeSelection, framework.PodStartTimeout)
 			defer func() {
 				err = e2epod.DeletePodWithWait(f.ClientSet, l.pod2)
 				framework.ExpectNoError(err, "while cleaning up pod before exiting resizing test")


### PR DESCRIPTION
This reverts commit 648d8f84875920df4a6509ec4c1677859117968a.

Currently the flake happens around twice a day. That's probably not caused by the patch itself, but we should drop it anyways because it hasn't improved the situation.
