### PR TITLE
Bug 1728130: Bump libseccomp-golang to v0.9.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0321c461c9996ff8becdd4c3b6f3a4613d9e51cea7c042036d04ed59f7bf9860
-updated: 2020-05-20T12:43:17.595493+02:00
+hash: 58f332a15d7df757f7646a0245bd767ff7f95e6d75d9b699f22cde1cdbd9f751
+updated: 2020-05-28T11:51:25.251385012-05:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -1098,7 +1098,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/seccomp/libseccomp-golang
-  version: 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
+  version: 689e3c1541a84461afc49c1c87352a6cedf72e9c
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
 - name: github.com/sirupsen/logrus
@@ -1508,7 +1508,7 @@ imports:
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
-  version: e46c46eda5f2d5bbf60122c71895782b33d05784
+  version: d11f61f412e0f0df591679e682fddcc1ca9d74d5
   repo: https://github.com/openshift/kubernetes-apiserver.git
   subpackages:
   - pkg/admission
@@ -1863,7 +1863,7 @@ imports:
   - pkg/util/proto/testing
   - pkg/util/proto/validation
 - name: k8s.io/kubernetes
-  version: 1ccffe3ceb2c1e91822bc36495852fb72c47c1f4
+  version: b3b92b285f38984ad0b5b4d4ba6b150ac119dd2a
   repo: https://github.com/openshift/kubernetes.git
   subpackages:
   - cmd/controller-manager/app
@@ -2630,7 +2630,6 @@ imports:
   - plugin/pkg/auth/authorizer/node
   - plugin/pkg/auth/authorizer/rbac
   - plugin/pkg/auth/authorizer/rbac/bootstrappolicy
-  - staging/src/k8s.io/apimachinery/pkg/labels
   - test/e2e
   - test/e2e/apimachinery
   - test/e2e/apps

--- a/glide.yaml
+++ b/glide.yaml
@@ -482,7 +482,7 @@ import:
 - package: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - package: github.com/seccomp/libseccomp-golang
-  version: 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
+  version: v0.9.1
 - package: github.com/shurcooL/sanitized_anchor_name
   version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
 - package: github.com/spf13/afero

--- a/vendor/github.com/seccomp/libseccomp-golang/.gitignore
+++ b/vendor/github.com/seccomp/libseccomp-golang/.gitignore
@@ -1,0 +1,4 @@
+*~
+*.swp
+*.orig
+tags

--- a/vendor/github.com/seccomp/libseccomp-golang/CHANGELOG
+++ b/vendor/github.com/seccomp/libseccomp-golang/CHANGELOG
@@ -1,0 +1,17 @@
+libseccomp-golang: Releases
+===============================================================================
+https://github.com/seccomp/libseccomp-golang
+
+* Version 0.9.1 - May 21, 2019
+- Minimum supported version of libseccomp bumped to v2.2.0
+- Use Libseccomp's `seccomp_version` API to retrieve library version
+- Unconditionally set TSync attribute for filters, due to Go's heavily threaded nature
+- Fix CVE-2017-18367 - Multiple syscall arguments were incorrectly combined with logical-OR, instead of logical-AND
+- Fix a failure to build on Debian-based distributions due to CGo code
+- Fix unit test failures on 32-bit architectures
+- Improve several errors to be more verbose about their causes
+- Add support for SCMP_ACT_LOG (with libseccomp versions 2.4.x and higher), permitting syscalls but logging their execution
+- Add support for SCMP_FLTATR_CTL_LOG (with libseccomp versions 2.4.x and higher), logging not-allowed actions when they are denied
+
+* Version 0.9.0 - January 5, 2017
+- Initial tagged release

--- a/vendor/github.com/seccomp/libseccomp-golang/Makefile
+++ b/vendor/github.com/seccomp/libseccomp-golang/Makefile
@@ -1,0 +1,26 @@
+# libseccomp-golang
+
+.PHONY: all check check-build check-syntax fix-syntax vet test lint
+
+all: check-build
+
+check: vet test
+
+check-build:
+	go build
+
+check-syntax:
+	gofmt -d .
+
+fix-syntax:
+	gofmt -w .
+
+vet:
+	go vet -v
+
+test:
+	go test -v
+
+lint:
+	@$(if $(shell which golint),true,$(error "install golint and include it in your PATH"))
+	golint -set_exit_status

--- a/vendor/github.com/seccomp/libseccomp-golang/README
+++ b/vendor/github.com/seccomp/libseccomp-golang/README
@@ -24,3 +24,28 @@ please note that a Google account is not required to subscribe to the mailing
 list.
 
 	-> https://groups.google.com/d/forum/libseccomp
+
+Documentation is also available at:
+
+	-> https://godoc.org/github.com/seccomp/libseccomp-golang
+
+* Installing the package
+
+The libseccomp-golang bindings require at least Go v1.2.1 and GCC v4.8.4;
+earlier versions may yield unpredictable results.  If you meet these
+requirements you can install this package using the command below:
+
+	$ go get github.com/seccomp/libseccomp-golang
+
+* Testing the Library
+
+A number of tests and lint related recipes are provided in the Makefile, if
+you want to run the standard regression tests, you can excute the following:
+
+	$ make check
+
+In order to execute the 'make lint' recipe the 'golint' tool is needed, it
+can be found at:
+
+	-> https://github.com/golang/lint
+

--- a/vendor/github.com/seccomp/libseccomp-golang/SUBMITTING_PATCHES
+++ b/vendor/github.com/seccomp/libseccomp-golang/SUBMITTING_PATCHES
@@ -1,0 +1,112 @@
+How to Submit Patches to the libseccomp Project
+===============================================================================
+https://github.com/seccomp/libseccomp-golang
+
+This document is intended to act as a guide to help you contribute to the
+libseccomp project.  It is not perfect, and there will always be exceptions
+to the rules described here, but by following the instructions below you
+should have a much easier time getting your work merged with the upstream
+project.
+
+* Test Your Code
+
+There are two possible tests you can run to verify your code.  The first test
+is used to check the formatting and coding style of your changes, you can run
+the test with the following command:
+
+	# make check-syntax
+
+... if there are any problems with your changes a diff/patch will be shown
+which indicates the problems and how to fix them.
+
+The second possible test is used to ensure the sanity of your code changes
+and to test these changes against the included tests.  You can run the test
+with the following command:
+
+	# make check
+
+... if there are any faults or errors they will be displayed.
+
+* Generate the Patch(es)
+
+Depending on how you decided to work with the libseccomp code base and what
+tools you are using there are different ways to generate your patch(es).
+However, regardless of what tools you use, you should always generate your
+patches using the "unified" diff/patch format and the patches should always
+apply to the libseccomp source tree using the following command from the top
+directory of the libseccomp sources:
+
+	# patch -p1 < changes.patch
+
+If you are not using git, stacked git (stgit), or some other tool which can
+generate patch files for you automatically, you may find the following command
+helpful in generating patches, where "libseccomp.orig/" is the unmodified
+source code directory and "libseccomp/" is the source code directory with your
+changes:
+
+	# diff -purN libseccomp-golang.orig/ libseccomp-golang/
+
+When in doubt please generate your patch and try applying it to an unmodified
+copy of the libseccomp sources; if it fails for you, it will fail for the rest
+of us.
+
+* Explain Your Work
+
+At the top of every patch you should include a description of the problem you
+are trying to solve, how you solved it, and why you chose the solution you
+implemented.  If you are submitting a bug fix, it is also incredibly helpful
+if you can describe/include a reproducer for the problem in the description as
+well as instructions on how to test for the bug and verify that it has been
+fixed.
+
+* Sign Your Work
+
+The sign-off is a simple line at the end of the patch description, which
+certifies that you wrote it or otherwise have the right to pass it on as an
+open-source patch.  The "Developer's Certificate of Origin" pledge is taken
+from the Linux Kernel and the rules are pretty simple:
+
+	Developer's Certificate of Origin 1.1
+
+	By making a contribution to this project, I certify that:
+
+	(a) The contribution was created in whole or in part by me and I
+	    have the right to submit it under the open source license
+	    indicated in the file; or
+
+	(b) The contribution is based upon previous work that, to the best
+	    of my knowledge, is covered under an appropriate open source
+	    license and I have the right under that license to submit that
+	    work with modifications, whether created in whole or in part
+	    by me, under the same open source license (unless I am
+	    permitted to submit under a different license), as indicated
+	    in the file; or
+
+	(c) The contribution was provided directly to me by some other
+	    person who certified (a), (b) or (c) and I have not modified
+	    it.
+
+	(d) I understand and agree that this project and the contribution
+	    are public and that a record of the contribution (including all
+	    personal information I submit with it, including my sign-off) is
+	    maintained indefinitely and may be redistributed consistent with
+	    this project or the open source license(s) involved.
+
+... then you just add a line to the bottom of your patch description, with
+your real name, saying:
+
+	Signed-off-by: Random J Developer <random@developer.example.org>
+
+* Email Your Patch(es)
+
+Finally, you will need to email your patches to the mailing list so they can
+be reviewed and potentially merged into the main libseccomp-golang repository.
+When sending patches to the mailing list it is important to send your email in
+text form, no HTML mail please, and ensure that your email client does not
+mangle your patches.  It should be possible to save your raw email to disk and
+apply it directly to the libseccomp source code; if that fails then you likely
+have a problem with your email client.  When in doubt try a test first by
+sending yourself an email with your patch and attempting to apply the emailed
+patch to the libseccomp-golang repository; if it fails for you, it will fail
+for the rest of us trying to test your patch and include it in the main
+libseccomp-golang repository.

--- a/vendor/github.com/seccomp/libseccomp-golang/seccomp_test.go
+++ b/vendor/github.com/seccomp/libseccomp-golang/seccomp_test.go
@@ -12,6 +12,103 @@ import (
 
 // Type Function Tests
 
+type versionErrorTest struct {
+	err VersionError
+	str string
+}
+
+var versionStr = fmt.Sprintf("%d.%d.%d", verMajor, verMinor, verMicro)
+
+var versionErrorTests = []versionErrorTest{
+	{
+		VersionError{
+			"deadbeef",
+			"x.y.z",
+		},
+		"Libseccomp version too low: deadbeef: " +
+			"minimum supported is x.y.z: detected " + versionStr,
+	},
+	{
+		VersionError{
+			"",
+			"x.y.z",
+		},
+		"Libseccomp version too low: minimum supported is x.y.z: " +
+			"detected " + versionStr,
+	},
+	{
+		VersionError{
+			"deadbeef",
+			"",
+		},
+		"Libseccomp version too low: " +
+			"deadbeef: minimum supported is 2.2.0: " +
+			"detected " + versionStr,
+	},
+	{
+		VersionError{
+			"",
+			"",
+		},
+		"Libseccomp version too low: minimum supported is 2.2.0: " +
+			"detected " + versionStr,
+	},
+}
+
+func TestVersionError(t *testing.T) {
+	for i, test := range versionErrorTests {
+		str := test.err.Error()
+		if str != test.str {
+			t.Errorf("VersionError %d: got %q: expected %q", i, str, test.str)
+		}
+	}
+}
+
+func ApiLevelIsSupported() bool {
+	return verMajor > 2 ||
+		(verMajor == 2 && verMinor > 3) ||
+		(verMajor == 2 && verMinor == 3 && verMicro >= 3)
+}
+
+func TestGetApiLevel(t *testing.T) {
+	api, err := GetApi()
+	if !ApiLevelIsSupported() {
+		if api != 0 {
+			t.Errorf("API level returned despite lack of support: %v", api)
+		} else if err == nil {
+			t.Errorf("No error returned despite lack of API level support")
+		}
+
+		t.Skipf("Skipping test: %s", err)
+	} else if err != nil {
+		t.Errorf("Error getting API level: %s", err)
+	}
+	fmt.Printf("Got API level of %v\n", api)
+}
+
+func TestSetApiLevel(t *testing.T) {
+	var expectedApi uint
+
+	expectedApi = 1
+	err := SetApi(expectedApi)
+	if !ApiLevelIsSupported() {
+		if err == nil {
+			t.Errorf("No error returned despite lack of API level support")
+		}
+
+		t.Skipf("Skipping test: %s", err)
+	} else if err != nil {
+		t.Errorf("Error setting API level: %s", err)
+	}
+
+	api, err := GetApi()
+	if err != nil {
+		t.Errorf("Error getting API level: %s", err)
+	} else if api != expectedApi {
+		t.Errorf("Got API level %v: expected %v", api, expectedApi)
+	}
+}
+
 func TestActionSetReturnCode(t *testing.T) {
 	if ActInvalid.SetReturnCode(0x0010) != ActInvalid {
 		t.Errorf("Able to set a return code on invalid action!")
@@ -335,6 +432,38 @@ func TestFilterAttributeGettersAndSetters(t *testing.T) {
 		t.Errorf("No new privileges bit was not set correctly")
 	}
 
+	if ApiLevelIsSupported() {
+		api, err := GetApi()
+		if err != nil {
+			t.Errorf("Error getting API level: %s", err)
+		} else if api < 3 {
+			err = SetApi(3)
+			if err != nil {
+				t.Errorf("Error setting API level: %s", err)
+			}
+		}
+	}
+
+	err = filter.SetLogBit(true)
+	if err != nil {
+		if !ApiLevelIsSupported() {
+			t.Logf("Ignoring failure: %s\n", err)
+		} else {
+			t.Errorf("Error setting log bit")
+		}
+	}
+
+	log, err := filter.GetLogBit()
+	if err != nil {
+		if !ApiLevelIsSupported() {
+			t.Logf("Ignoring failure: %s\n", err)
+		} else {
+			t.Errorf("Error getting log bit")
+		}
+	} else if log != true {
+		t.Errorf("Log bit was not set correctly")
+	}
+
 	err = filter.SetBadArchAction(ActInvalid)
 	if err == nil {
 		t.Errorf("Setting bad arch action to an invalid action should error")
@@ -413,6 +542,11 @@ func TestRuleAddAndLoad(t *testing.T) {
 		t.Errorf("Error getting syscall number of setreuid: %s", err)
 	}
 
+	call3, err := GetSyscallFromName("setreuid32")
+	if err != nil {
+		t.Errorf("Error getting syscall number of setreuid32: %s", err)
+	}
+
 	uid := syscall.Getuid()
 	euid := syscall.Geteuid()
 
@@ -438,6 +572,11 @@ func TestRuleAddAndLoad(t *testing.T) {
 		t.Errorf("Error adding conditional rule: %s", err)
 	}
 
+	err = filter1.AddRuleConditional(call3, ActErrno.SetReturnCode(0x3), conditions)
+	if err != nil {
+		t.Errorf("Error adding second conditional rule: %s", err)
+	}
+
 	err = filter1.Load()
 	if err != nil {
 		t.Errorf("Error loading filter: %s", err)
@@ -451,7 +590,81 @@ func TestRuleAddAndLoad(t *testing.T) {
 
 	// Try making a Geteuid syscall that should normally succeed
 	err = syscall.Setreuid(uid, euid)
-	if err != syscall.Errno(2) {
+	if err == nil {
 		t.Errorf("Syscall should have returned error code!")
+	} else if err != syscall.Errno(2) && err != syscall.Errno(3) {
+		t.Errorf("Syscall returned incorrect error code - likely not blocked by Seccomp!")
+	}
+}
+
+func TestLogAct(t *testing.T) {
+	expectedPid := syscall.Getpid()
+
+	api, err := GetApi()
+	if err != nil {
+		if !ApiLevelIsSupported() {
+			t.Skipf("Skipping test: %s", err)
+		}
+
+		t.Errorf("Error getting API level: %s", err)
+	} else if api < 3 {
+		t.Skipf("Skipping test: API level %d is less than 3", api)
+	}
+
+	filter, err := NewFilter(ActErrno.SetReturnCode(0x0001))
+	if err != nil {
+		t.Errorf("Error creating filter: %s", err)
+	}
+	defer filter.Release()
+
+	call, err := GetSyscallFromName("getpid")
+	if err != nil {
+		t.Errorf("Error getting syscall number of getpid: %s", err)
+	}
+
+	call1, err := GetSyscallFromName("write")
+	if err != nil {
+		t.Errorf("Error getting syscall number of write: %s", err)
+	}
+
+	call2, err := GetSyscallFromName("futex")
+	if err != nil {
+		t.Errorf("Error getting syscall number of futex: %s", err)
+	}
+
+	call3, err := GetSyscallFromName("exit_group")
+	if err != nil {
+		t.Errorf("Error getting syscall number of exit_group: %s", err)
+	}
+
+	err = filter.AddRule(call, ActLog)
+	if err != nil {
+		t.Errorf("Error adding rule to log syscall: %s", err)
+	}
+
+	err = filter.AddRule(call1, ActAllow)
+	if err != nil {
+		t.Errorf("Error adding rule to allow write syscall: %s", err)
+	}
+
+	err = filter.AddRule(call2, ActAllow)
+	if err != nil {
+		t.Errorf("Error adding rule to allow futex syscall: %s", err)
+	}
+
+	err = filter.AddRule(call3, ActAllow)
+	if err != nil {
+		t.Errorf("Error adding rule to allow exit_group syscall: %s", err)
+	}
+
+	err = filter.Load()
+	if err != nil {
+		t.Errorf("Error loading filter: %s", err)
+	}
+
+	// Try making a simple syscall, it should succeed
+	pid := syscall.Getpid()
+	if pid != expectedPid {
+		t.Errorf("Syscall should have returned expected pid (%d != %d)", pid, expectedPid)
 	}
 }


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1728130

@rphillips 