### PR TITLE
pkg/test/ginkgo: Add 'weight' property to JUnit <testcase>

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -332,8 +332,14 @@ func (opt *Options) Run(args []string) error {
 	}
 
 	if len(opt.JUnitDir) > 0 {
-		if err := writeJUnitReport("junit_e2e", "openshift-tests", tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
-			fmt.Fprintf(opt.Out, "error: Unable to write e2e JUnit results: %v", err)
+		data, err := renderJUnitReport("openshift-tests", tests, duration, syntheticTestResults...)
+		if err == nil {
+			path := filepath.Join(opt.JUnitDir, fmt.Sprintf("junit_e2e_%s.xml", time.Now().UTC().Format("20060102-150405")))
+			fmt.Fprintf(opt.Out, "Writing JUnit report to %s\n\n", path)
+			err = ioutil.WriteFile(path, data, 0640)
+		}
+		if err != nil {
+			fmt.Fprintf(opt.ErrOut, "error: Unable to write e2e JUnit results: %v", err)
 		}
 	}
 

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -290,6 +290,14 @@ func (opt *Options) Run(args []string) error {
 				FailureOutput: &FailureOutput{
 					Output: fmt.Sprintf("%d error level events were detected during this test run:\n\n%s", errorCount, errBuf.String()),
 				},
+				Properties: &JUnitProperties{
+					Properties: []JUnitProperty{
+						{
+							Name:  "weight",
+							Value: "informer",
+						},
+					},
+				},
 			})
 		}
 
@@ -300,7 +308,9 @@ func (opt *Options) Run(args []string) error {
 	if fail > 0 && fail <= suite.MaximumAllowedFlakes {
 		var retries []*testCase
 		for _, test := range failing {
-			retries = append(retries, test.Retry())
+			retry := test.Retry()
+			test.retries = append(test.retries, retry)
+			retries = append(retries, retry)
 			if len(retries) > suite.MaximumAllowedFlakes {
 				break
 			}

--- a/pkg/test/ginkgo/junit_test.go
+++ b/pkg/test/ginkgo/junit_test.go
@@ -58,6 +58,14 @@ func Test_renderJUnitReport(t *testing.T) {
 			Message: "the additional widget exploded",
 			Output:  "bing! bang! boom!",
 		},
+		Properties: &JUnitProperties{
+			Properties: []JUnitProperty{
+				{
+					Name:  "weight",
+					Value: "informer",
+				},
+			},
+		},
 	}
 
 	data, err := renderJUnitReport("openshift-tests", tests, 4*time.Second, additionalResult)
@@ -65,7 +73,7 @@ func Test_renderJUnitReport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `<testsuite name="openshift-tests" tests="3" skipped="0" failures="2" time="4"><properties><property name="TestVersion" value="unknown"></property></properties><testcase name="Testing a failure" time="0"><failure>the main widget exploded</failure><system-out>the main widget exploded</system-out></testcase><testcase name="Testing a success" time="0"></testcase><testcase name="Additional testing" time="3"><failure message="the additional widget exploded">bing! bang! boom!</failure><system-out>system out bla, bla, bla</system-out></testcase></testsuite>`
+	expected := `<testsuite name="openshift-tests" tests="3" skipped="0" failures="2" time="4"><properties><property name="TestVersion" value="unknown"></property></properties><testcase name="Testing a failure" time="0"><failure>the main widget exploded</failure><system-out>the main widget exploded</system-out><properties><property name="weight" value="failure"></property></properties></testcase><testcase name="Testing a success" time="0"></testcase><testcase name="Additional testing" time="3"><failure message="the additional widget exploded">bing! bang! boom!</failure><system-out>system out bla, bla, bla</system-out><properties><property name="weight" value="informer"></property></properties></testcase></testsuite>`
 	if string(data) != expected {
 		t.Fatalf("unexpected report:\n\n%s\n\nexpected:\n\n%s", string(data), expected)
 	}

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -29,6 +29,7 @@ type testCase struct {
 	success  bool
 	failed   bool
 	skipped  bool
+	retries  []*testCase
 
 	previous *testCase
 }


### PR DESCRIPTION
This lays the groundwork for having the job-detail page rank failing-case severity.  `failure` cases are the most important, and users who are frustrated by their tests not passing should focus on resolving those issues.  `flake` cases did not sink this particular run, but should be addressed in the absence of `failure` cases to help drive down sporadic stability issues.  `informer` cases do not need to be "fixed", but might provide some context that helps understand cluster health or root causes of failure and flake cases.