### PR TITLE
Bug 1835371: router/metrics: Fix haproxy_server_max_sessions test

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -236,7 +236,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 				}
 
 				maxSessionsInvariant := func(v []float64) bool {
-					return len(v) >= 2 && v[0] > 0 && v[1] > 0
+					return len(v) == 1 && v[0] > 0
 				}
 
 				updatedMetrics, err := refreshMetrics()
@@ -245,7 +245,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 					return false, err
 				}
 
-				if len(findGaugesWithLabels(updatedMetrics["haproxy_server_up"], serverLabels)) < 2 {
+				if len(findGaugesWithLabels(updatedMetrics["haproxy_server_up"], serverLabels)) != 1 {
 					e2e.Logf("haproxy_server_up: %v", findGaugesWithLabels(updatedMetrics["haproxy_server_up"], serverLabels))
 					g.By("sending traffic to a weighted route")
 					return false, expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", host), "weighted.metrics.example.com", http.StatusOK, times, proxyProtocol)

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -186,7 +186,6 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			o.Expect(findGaugesWithLabels(metrics["haproxy_backend_up"], routeLabels)).To(o.Equal([]float64{1}))
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_bytes_in_total"], serverLabels)).To(o.ConsistOf(o.BeNumerically(">=", 0), o.BeNumerically(">=", 0)))
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_bytes_out_total"], serverLabels)).To(o.ConsistOf(o.BeNumerically(">=", 0), o.BeNumerically(">=", 0)))
-			o.Expect(findGaugesWithLabels(metrics["haproxy_server_max_sessions"], serverLabels)).To(o.ConsistOf(o.BeNumerically(">", 0), o.BeNumerically(">", 0)))
 
 			// generic metrics
 			o.Expect(findGaugesWithLabels(metrics["haproxy_up"], nil)).To(o.Equal([]float64{1}))
@@ -219,6 +218,73 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(findGaugesWithLabels(updatedMetrics["haproxy_backend_connections_total"], routeLabels)[0]).To(o.BeNumerically(">=", findGaugesWithLabels(metrics["haproxy_backend_connections_total"], routeLabels)[0]))
 			o.Expect(findGaugesWithLabels(updatedMetrics["haproxy_server_bytes_in_total"], serverLabels)[0]).To(o.BeNumerically(">=", findGaugesWithLabels(metrics["haproxy_server_bytes_in_total"], serverLabels)[0]))
+
+			// haxproxy_server_max_sessions needs to be
+			// greater than zero over two successive
+			// scrapes once the first scrape shows an
+			// increase in total connections.
+			err = wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
+				refreshMetrics := func() (map[string]*dto.MetricFamily, error) {
+					startTime := time.Now()
+					results, err := getBearerTokenURLViaPod(ns, execPodName, fmt.Sprintf("http://%s:%d/metrics", host, metricsPort), bearerToken)
+					if err != nil {
+						return nil, err
+					}
+					metrics, err := p.TextToMetricFamilies(bytes.NewBufferString(results))
+					e2e.Logf("metrics refresh completed in %s", time.Now().Sub(startTime).Round(time.Second).String())
+					return metrics, err
+				}
+
+				maxSessionsInvariant := func(v []float64) bool {
+					return len(v) >= 2 && v[0] > 0 && v[1] > 0
+				}
+
+				updatedMetrics, err := refreshMetrics()
+				if err != nil {
+					e2e.Logf("refresh metrics error: %v", err)
+					return false, err
+				}
+
+				if len(findGaugesWithLabels(updatedMetrics["haproxy_server_up"], serverLabels)) < 2 {
+					e2e.Logf("haproxy_server_up: %v", findGaugesWithLabels(updatedMetrics["haproxy_server_up"], serverLabels))
+					g.By("sending traffic to a weighted route")
+					return false, expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", host), "weighted.metrics.example.com", http.StatusOK, times, proxyProtocol)
+				}
+
+				if findGaugesWithLabels(updatedMetrics["haproxy_backend_connections_total"], routeLabels)[0] < float64(times) {
+					e2e.Logf("haproxy_backend_connections_total: %+v", findGaugesWithLabels(updatedMetrics["haproxy_backend_connections_total"], routeLabels)[0])
+					g.By("sending traffic to a weighted route")
+					return false, expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", host), "weighted.metrics.example.com", http.StatusOK, times, proxyProtocol)
+				}
+
+				if !maxSessionsInvariant(findGaugesWithLabels(updatedMetrics["haproxy_server_max_sessions"], serverLabels)) {
+					e2e.Logf("scrape 0: max_sessions invariant not held, got: %+v", findGaugesWithLabels(updatedMetrics["haproxy_server_max_sessions"], serverLabels))
+					g.By("sending traffic to a weighted route")
+					return false, expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", host), "weighted.metrics.example.com", http.StatusOK, times, proxyProtocol)
+				}
+
+				updatedMetrics, err = refreshMetrics()
+				if err != nil {
+					e2e.Logf("refresh metrics error: %v", err)
+					return false, err
+				}
+				if !maxSessionsInvariant(findGaugesWithLabels(updatedMetrics["haproxy_server_max_sessions"], serverLabels)) {
+					e2e.Logf("scrape 1: max_sessions invariant not held, got: %+v", findGaugesWithLabels(updatedMetrics["haproxy_server_max_sessions"], serverLabels))
+					return false, nil
+				}
+
+				updatedMetrics, err = refreshMetrics()
+				if err != nil {
+					e2e.Logf("refresh metrics error: %v", err)
+					return false, err
+				}
+				success := maxSessionsInvariant(findGaugesWithLabels(updatedMetrics["haproxy_server_max_sessions"], serverLabels))
+				if !success {
+					e2e.Logf("scrape 2: max_sessions invariant not held, got: %+v", findGaugesWithLabels(updatedMetrics["haproxy_server_max_sessions"], serverLabels))
+				}
+				return success, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
 		g.It("should expose the profiling endpoints", func() {


### PR DESCRIPTION
This assertion currently flakes a lot. (I believe) the flake occurs
when the router reloads and the GET for the latest metrics reads
zero's because there has been no updates.

It may be better to mark this test as serial. This commit retries the
assertion as opposed to dealing with it as a one-shot.

The expectation is that haxproxy_server_max_sessions needs to be
greater than zero over two successive scrapes once the first scrape
shows an increase. However, this assertion can still fail depending on
when the metrics are refreshed and when the router reloads, which is
every 5s. In my testing I have seen this to be more resilient but
there are periods when running the full openshift/conformance tests
that this continues to fail.