### PR TITLE
Bug 1842650: All NetworkPolicy tests currently being skipped on openshift-sdn

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -56,12 +56,20 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcloud.C
 
 	// given the configuration we have loaded, skip tests that our provider should exclude
 	// or our network plugin should exclude
-	skipProvider := fmt.Sprintf("[Skipped:%s", config.ProviderName)
-	skipNetworkPlugin := fmt.Sprintf("[Skipped:Network/%s", config.NetworkPlugin)
-	skipFn := func(name string) bool {
-		return !strings.Contains(name, skipProvider) && !strings.Contains(name, skipNetworkPlugin)
+	var skips []string
+	skips = append(skips, fmt.Sprintf("[Skipped:%s]", config.ProviderName))
+	for _, id := range config.NetworkPluginIDs {
+		skips = append(skips, fmt.Sprintf("[Skipped:Network/%s]", id))
 	}
-	return skipFn, nil
+	matchFn := func(name string) bool {
+		for _, skip := range skips {
+			if strings.Contains(name, skip) {
+				return false
+			}
+		}
+		return true
+	}
+	return matchFn, nil
 }
 
 func decodeProvider(provider string, dryRun, discover bool) (*exutilcloud.ClusterConfiguration, error) {

--- a/test/extended/util/cloud/cloud.go
+++ b/test/extended/util/cloud/cloud.go
@@ -13,6 +13,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	"github.com/openshift/origin/test/extended/util/azure"
 )
 
@@ -28,7 +29,7 @@ type ClusterConfiguration struct {
 	MultiZone   bool
 	ConfigFile  string
 
-	NetworkPlugin string
+	NetworkPluginIDs []string
 }
 
 func (c *ClusterConfiguration) ToJSONString() string {
@@ -47,17 +48,24 @@ func LoadConfig(clientConfig *rest.Config) (*ClusterConfiguration, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := configclient.NewForConfig(clientConfig)
+	configClient, err := configclient.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	operatorClient, err := operatorclient.NewForConfig(clientConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	var networkPlugin string
-	if networkConfig, err := client.ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{}); err == nil {
-		networkPlugin = networkConfig.Spec.NetworkType
+	var networkPluginIDs []string
+	if networkConfig, err := operatorClient.OperatorV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{}); err == nil {
+		networkPluginIDs = append(networkPluginIDs, string(networkConfig.Spec.DefaultNetwork.Type))
+		if networkConfig.Spec.DefaultNetwork.OpenShiftSDNConfig != nil && networkConfig.Spec.DefaultNetwork.OpenShiftSDNConfig.Mode != "" {
+			networkPluginIDs = append(networkPluginIDs, string(networkConfig.Spec.DefaultNetwork.Type)+"/"+string(networkConfig.Spec.DefaultNetwork.OpenShiftSDNConfig.Mode))
+		}
 	}
 
-	infra, err := client.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +75,7 @@ func LoadConfig(clientConfig *rest.Config) (*ClusterConfiguration, error) {
 	}
 	if p.Type == configv1.NonePlatformType {
 		return &ClusterConfiguration{
-			NetworkPlugin: networkPlugin,
+			NetworkPluginIDs: networkPluginIDs,
 		}, nil
 	}
 
@@ -91,9 +99,9 @@ func LoadConfig(clientConfig *rest.Config) (*ClusterConfiguration, error) {
 	}
 
 	config := &ClusterConfiguration{
-		MultiMaster:   len(masters.Items) > 1,
-		MultiZone:     zones.Len() > 1,
-		NetworkPlugin: networkPlugin,
+		MultiMaster:      len(masters.Items) > 1,
+		MultiZone:        zones.Len() > 1,
+		NetworkPluginIDs: networkPluginIDs,
 	}
 	if zones.Len() > 0 {
 		config.Zone = zones.List()[0]


### PR DESCRIPTION
The old code allowed annotating tests as both "`[Skipped:Network/OpenShiftSDN]`" ("Skip on OpenShiftSDN") and "`[Skipped:Network/OpenShiftSDN/Multitenant]`" ("Skip on OpenShiftSDN in
Multitenant mode"). But the current code lost that distinction and ended up skipping the "only skip in Multitenant mode" tests even in NetworkPolicy mode (meaning we were always skipping the NetworkPolicy tests on openshift-sdn).

/assign @smarterclayton 