### PR TITLE
pkg/test/ginkgo: Include flake retries in JUnit

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -300,7 +300,9 @@ func (opt *Options) Run(args []string) error {
 	if fail > 0 && fail <= suite.MaximumAllowedFlakes {
 		var retries []*testCase
 		for _, test := range failing {
-			retries = append(retries, test.Retry())
+			retry := test.Retry()
+			retries = append(retries, retry)
+			tests = append(tests, retry)
 			if len(retries) > suite.MaximumAllowedFlakes {
 				break
 			}


### PR DESCRIPTION
The upstream JUnit lens learned how to dedup repeated tests and distinguish flakes in kubernetes/test-infra#16992.  Include our retries in the output to take advantage of that new UX.