### PR TITLE
WIP: Bug 1843183: test/e2e/upgrade: Split update testing into per-hop cases

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -234,8 +234,6 @@ func getUpgradeContext(c configv1client.Interface, upgradeImage string) (*upgrad
 	return upgCtx, nil
 }
 
-var errControlledAbort = fmt.Errorf("beginning abort")
-
 func clusterUpgrade(c configv1client.Interface, dc dynamic.Interface, config *rest.Config, version upgrades.VersionContext) error {
 	fmt.Fprintf(os.Stderr, "\n\n\n")
 	defer func() { fmt.Fprintf(os.Stderr, "\n\n\n") }()


### PR DESCRIPTION
"Cluster should remain functional during upgrade" is a big bucket, and it's hard to figure out what's going on when it fails based on just the test-case.  This commit pulls the setup steps out into their own case (which is unlikely to fail, but still).  And it puts each hop in its own case, including the source and target version.

FIXME: break out major/minor so we can aggregate in Sippy, etc.