### PR TITLE
Bug 1843407: oVirt, add oVirt as a provide to openshift tests

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -15,6 +15,9 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 	exutilcloud "github.com/openshift/origin/test/extended/util/cloud"
 
+	// Initialize ovirt as a provider
+	_ "github.com/openshift/origin/test/extended/util/ovirt"
+
 	// these are loading important global flags that we need to get and set
 	_ "k8s.io/kubernetes/test/e2e"
 	_ "k8s.io/kubernetes/test/e2e/lifecycle"

--- a/test/extended/util/ovirt/provider.go
+++ b/test/extended/util/ovirt/provider.go
@@ -1,0 +1,18 @@
+package ovirt
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func init() {
+	framework.RegisterProvider("ovirt", newProvider)
+}
+
+func newProvider() (framework.ProviderInterface, error) {
+	return &Provider{}, nil
+}
+
+// Provider is a structure to handle ovirt for e2e testing
+type Provider struct {
+	framework.NullProvider
+}


### PR DESCRIPTION
oVirt didn't get a chance to be added as a provider to Kubernetes e2e tests [1][2][3], So we need to be added to origin like IBM on [4].
This is needed for skipping tests for ovirt [5]

[1] https://github.com/kubernetes-cn/kubernetes/blob/c3bec0bae43b4c46800a13f44534ce6cd14b5f40/test/e2e/framework/providers/openstack/openstack.go
[2] https://github.com/kubernetes-cn/kubernetes/blob/c3bec0bae43b4c46800a13f44534ce6cd14b5f40/test/e2e/framework/providers/vsphere/vsphere.go
[3] https://github.com/kubernetes-cn/kubernetes/blob/c3bec0bae43b4c46800a13f44534ce6cd14b5f40/test/e2e/framework/providers/azure/azure.go
[4] https://github.com/openshift/origin/pull/24817
[5] https://github.com/openshift/origin/blob/master/cmd/openshift-tests/provider.go#L57-L63

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>