### PR TITLE
Bug 1838730: UPSTREAM: 91642: Adjust Azure e2e binding mode

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/in_tree.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/in_tree.go
@@ -1580,8 +1580,9 @@ func (a *azureDiskDriver) GetDynamicProvisionStorageClass(config *testsuites.Per
 	}
 	ns := config.Framework.Namespace.Name
 	suffix := fmt.Sprintf("%s-sc", a.driverInfo.Name)
+	delayedBinding := storagev1.VolumeBindingWaitForFirstConsumer
 
-	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+	return testsuites.GetStorageClass(provisioner, parameters, &delayedBinding, ns, suffix)
 }
 
 func (a *azureDiskDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {


### PR DESCRIPTION
Backport of https://github.com/kubernetes/kubernetes/pull/91642 .

**What this PR does / why we need it**:
Adjusts the Azure e2e binding mode from the default (Immediate) to WaitForFirstConsumer. This change also updates the Azure StorageClass to mirror the AWS and GCE ones.