### PR TITLE
apiserver: verbosity 3 on termination and watch-termination binary

### DIFF
--- a/cmd/watch-termination/main.go
+++ b/cmd/watch-termination/main.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+)
+
+func main() {
+	terminationLog := flag.String("termination-log-file", "", "Write logs after SIGTERM to this file (in addition to stderr)")
+	terminationLock := flag.String("termination-touch-file", "", "Touch this file on SIGTERM and delete on termination")
+
+	flag.Parse()
+	args := flag.CommandLine.Args()
+
+	if len(args) == 0 {
+		fmt.Println("Missing command line")
+		os.Exit(1)
+	}
+
+	// use special tee-like writer when termination log is set
+	termCh := make(chan struct{})
+	var stderr io.Writer = os.Stderr
+	if len(*terminationLog) > 0 {
+		stderr = &terminationFileWriter{
+			Writer:             os.Stderr,
+			fn:                 *terminationLog,
+			startFileLoggingCh: termCh,
+		}
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = stderr
+
+	// forward SIGTERM and SIGINT to child
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for s := range sigCh {
+			fmt.Fprintf(stderr, "Received signal %s\n", s)
+
+			if len(*terminationLock) > 0 {
+				fmt.Fprintln(stderr, "Touching", *terminationLock)
+				if err := touch(*terminationLock); err != nil {
+					fmt.Fprintln(stderr, fmt.Errorf("error touching %s: %v", *terminationLock, err))
+					// keep going
+				}
+			}
+
+			select {
+			case <-termCh:
+			default:
+				close(termCh)
+			}
+			cmd.Process.Signal(s)
+		}
+	}()
+
+	fmt.Printf("Launching %v\n", cmd)
+	rc := 0
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); !ok {
+			rc = exitError.ExitCode()
+		} else {
+			fmt.Fprintf(stderr, "Failed to launch %s: %v\n", args[0], err)
+			os.Exit(255)
+		}
+	}
+
+	// remove signal handling
+	signal.Stop(sigCh)
+	close(sigCh)
+	wg.Wait()
+
+	if len(*terminationLock) > 0 {
+		os.Remove(*terminationLock)
+	}
+
+	fmt.Fprintf(stderr, "Exit code %d\n", rc)
+	os.Exit(rc)
+}
+
+// terminationFileWriter forwards everything to the embedded writer. When
+// startFileLoggingCh is closed, everything is appended to the given file name
+// in addition.
+type terminationFileWriter struct {
+	io.Writer
+	fn                 string
+	startFileLoggingCh <-chan struct{}
+
+	f *os.File
+}
+
+func (w *terminationFileWriter) Write(bs []byte) (int, error) {
+	select {
+	case <-w.startFileLoggingCh:
+		if w.f == nil {
+			f, err := os.OpenFile(w.fn, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				log.Fatal(err)
+			}
+			w.f = f
+			fmt.Println("Starting logging to", w.fn)
+		}
+		if n, err := w.f.Write(bs); err != nil {
+			return n, err
+		} else if n != len(bs) {
+			return n, io.ErrShortWrite
+		}
+	default:
+	}
+
+	return w.Writer.Write(bs)
+}
+
+func touch(fn string) error {
+	_, err := os.Stat(fn)
+	if os.IsNotExist(err) {
+		file, err := os.Create(fn)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		return nil
+	}
+
+	currentTime := time.Now().Local()
+	return os.Chtimes(fn, currentTime, currentTime)
+}

--- a/images/hyperkube/Dockerfile.rhel
+++ b/images/hyperkube/Dockerfile.rhel
@@ -2,10 +2,10 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 WORKDIR /go/src/github.com/openshift/origin
 COPY . .
 RUN for p in vendor/k8s.io/kubernetes/cmd/kube-apiserver vendor/k8s.io/kubernetes/cmd/kube-controller-manager \
-    vendor/k8s.io/kubernetes/cmd/kube-scheduler vendor/k8s.io/kubernetes/cmd/kubelet; do make build WHAT=$p; done && \
+    vendor/k8s.io/kubernetes/cmd/kube-scheduler vendor/k8s.io/kubernetes/cmd/kubelet cmd/watch-termination; do make build WHAT=$p; done && \
     mkdir -p /tmp/build && \
     cp images/hyperkube/hyperkube /tmp/build && \
-    cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/{kube-apiserver,kube-controller-manager,kube-scheduler,kubelet} \
+    cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/{kube-apiserver,kube-controller-manager,kube-scheduler,kubelet,watch-termination} \
     /tmp/build
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base

--- a/vendor/k8s.io/kubernetes/cmd/controller-manager/app/serve.go
+++ b/vendor/k8s.io/kubernetes/cmd/controller-manager/app/serve.go
@@ -48,7 +48,7 @@ func BuildHandlerChain(apiHandler http.Handler, authorizationInfo *apiserver.Aut
 	}
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericapifilters.WithCacheControl(handler)
-	handler = genericfilters.WithPanicRecovery(handler)
+	handler = genericfilters.WithPanicRecovery(handler, nil)
 
 	return handler
 }

--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
@@ -268,7 +268,7 @@ func buildHandlerChain(handler http.Handler, authn authenticator.Request, authz 
 	handler = genericapifilters.WithAuthentication(handler, authn, failedHandler, nil)
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericapifilters.WithCacheControl(handler)
-	handler = genericfilters.WithPanicRecovery(handler)
+	handler = genericfilters.WithPanicRecovery(handler, nil)
 
 	return handler
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/server/insecure_handler.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/server/insecure_handler.go
@@ -42,7 +42,7 @@ func BuildInsecureHandlerChain(apiHandler http.Handler, c *server.Config) http.H
 	handler = genericfilters.WithWaitGroup(handler, c.LongRunningFunc, c.HandlerChainWaitGroup)
 	handler = genericapifilters.WithRequestInfo(handler, server.NewRequestInfoResolver(c))
 	handler = genericapifilters.WithCacheControl(handler)
-	handler = genericfilters.WithPanicRecovery(handler)
+	handler = genericfilters.WithPanicRecovery(handler, nil)
 
 	return handler
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/server/server.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/server/server.go
@@ -898,7 +898,7 @@ var statusesNoTracePred = httplog.StatusIsNot(
 
 // ServeHTTP responds to HTTP requests on the Kubelet.
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	handler := httplog.WithLogging(s.restfulCont, statusesNoTracePred)
+	handler := httplog.WithLogging(s.restfulCont, statusesNoTracePred, nil)
 
 	// monitor http requests
 	var serverType string

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -228,6 +228,9 @@ type Config struct {
 	// EquivalentResourceRegistry provides information about resources equivalent to a given resource,
 	// and the kind associated with a given resource. As resources are installed, they are registered here.
 	EquivalentResourceRegistry runtime.EquivalentResourceRegistry
+
+	// A func that returns whether the server is terminating. This can be nil.
+	IsTerminating func() bool
 }
 
 // EventSink allows to create events.
@@ -756,7 +759,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 		handler = genericfilters.WithProbabilisticGoaway(handler, c.GoawayChance)
 	}
 	handler = genericapifilters.WithCacheControl(handler)
-	handler = genericfilters.WithPanicRecovery(handler)
+	handler = genericfilters.WithPanicRecovery(handler, c.IsTerminating)
 	return handler
 }
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -87,7 +87,7 @@ func TestTimeout(t *testing.T) {
 		}), func(w http.ResponseWriter, req *http.Request, err interface{}) {
 			gotPanic <- err
 			http.Error(w, "This request caused apiserver to panic. Look in the logs for details.", http.StatusInternalServerError)
-		}),
+		}, nil),
 	)
 	defer ts.Close()
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/wrap.go
@@ -26,7 +26,7 @@ import (
 )
 
 // WithPanicRecovery wraps an http Handler to recover and log panics (except in the special case of http.ErrAbortHandler panics, which suppress logging).
-func WithPanicRecovery(handler http.Handler) http.Handler {
+func WithPanicRecovery(handler http.Handler, isTerminating func() bool) http.Handler {
 	return withPanicRecovery(handler, func(w http.ResponseWriter, req *http.Request, err interface{}) {
 		if err == http.ErrAbortHandler {
 			// honor the http.ErrAbortHandler sentinel panic value:
@@ -37,11 +37,11 @@ func WithPanicRecovery(handler http.Handler) http.Handler {
 		}
 		http.Error(w, "This request caused apiserver to panic. Look in the logs for details.", http.StatusInternalServerError)
 		klog.Errorf("apiserver panic'd on %v %v", req.Method, req.RequestURI)
-	})
+	}, isTerminating)
 }
 
-func withPanicRecovery(handler http.Handler, crashHandler func(http.ResponseWriter, *http.Request, interface{})) http.Handler {
-	handler = httplog.WithLogging(handler, httplog.DefaultStacktracePred)
+func withPanicRecovery(handler http.Handler, crashHandler func(http.ResponseWriter, *http.Request, interface{}), isTerminating func() bool) http.Handler {
+	handler = httplog.WithLogging(handler, httplog.DefaultStacktracePred, isTerminating)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer runtime.HandleCrash(func(err interface{}) {
 			crashHandler(w, req, err)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
@@ -63,7 +63,7 @@ func TestWithLogging(t *testing.T) {
 	}
 	var handler http.Handler
 	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	handler = WithLogging(WithLogging(handler, DefaultStacktracePred), DefaultStacktracePred)
+	handler = WithLogging(WithLogging(handler, DefaultStacktracePred, nil), DefaultStacktracePred, nil)
 
 	func() {
 		defer func() {
@@ -92,7 +92,7 @@ func TestLogOf(t *testing.T) {
 			}
 		})
 		if makeLogger {
-			handler = WithLogging(handler, DefaultStacktracePred)
+			handler = WithLogging(handler, DefaultStacktracePred, nil)
 			want = "*httplog.respLogger"
 		} else {
 			want = "*httplog.passthroughLogger"
@@ -120,7 +120,7 @@ func TestUnlogged(t *testing.T) {
 			}
 		})
 		if makeLogger {
-			handler = WithLogging(handler, DefaultStacktracePred)
+			handler = WithLogging(handler, DefaultStacktracePred, nil)
 		}
 
 		handler.ServeHTTP(origWriter, req)

--- a/vendor/k8s.io/kubernetes/test/integration/framework/test_server.go
+++ b/vendor/k8s.io/kubernetes/test/integration/framework/test_server.go
@@ -114,7 +114,7 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 	if err != nil {
 		t.Fatal(err)
 	}
-	kubeAPIServerConfig, _, _, _, err := app.CreateKubeAPIServerConfig(completedOptions, tunneler, proxyTransport)
+	kubeAPIServerConfig, _, _, _, err := app.CreateKubeAPIServerConfig(completedOptions, tunneler, proxyTransport, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This should give us insights into requests late in the termination phase. We still won't see those coming after termination. But as we wait 70s anyway to terminate, a request coming into after 20+ seconds (without our current LB configuration) is suspicious.

Note: this needs a fix to actually see logs after SIGTERM. Working on this.