### PR TITLE
UPSTREAM: <carry>: logs a user-agent that uses /healthz endpoint

### DIFF
--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/log_healthz.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/log_healthz.go
@@ -1,0 +1,29 @@
+package openshiftkubeapiserver
+
+import (
+	"k8s.io/klog"
+	"net/http"
+	"strings"
+
+	"k8s.io/apiserver/pkg/server/healthz"
+)
+
+// LogRequestToHealthz logs a user-agent that uses /healthz endpoint
+var LogRequestToHealthz healthz.HealthChecker = &logRequestToHealthz{}
+
+type logRequestToHealthz struct {}
+
+func (l *logRequestToHealthz) Name() string {
+	return "logRequestToHealthz"
+}
+
+func (l *logRequestToHealthz) Check(r *http.Request) error {
+	userAgent := r.Header.Get("User-Agent")
+
+	// it seems that kubelet identifies itself as "kube-probe/1.18+",
+	if len(userAgent) > 0 && !strings.Contains(userAgent, "kube-probe") {
+		klog.V(2).Infof("User-Agent:%q called %q path", userAgent, r.URL.Path)
+	}
+
+	return nil
+}

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -43,6 +43,9 @@ func NewOpenShiftKubeAPIServerConfigPatch(kubeAPIServerConfig *kubecontrolplanev
 			return err
 		}
 
+		// add a custom checker that allow us to see what else is using /healhtz endpoint in the system.
+		genericConfig.HealthzChecks = append(genericConfig.HealthzChecks, LogRequestToHealthz)
+
 		// AUTHORIZER
 		genericConfig.RequestInfoResolver = apiserverconfig.OpenshiftRequestInfoResolver()
 		// END AUTHORIZER


### PR DESCRIPTION
Allow us to see what else is using /healhtz endpoint in the system. We think that only kubelet should actually use it. Hopeful it will help us to prevent issues like https://bugzilla.redhat.com/show_bug.cgi?id=1844387