### PR TITLE
Bug 1845434: router/grpc-interop: switch to WaitForPodRunningSlow

### DIFF
--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -22,11 +22,11 @@ import (
 const (
 	// gRPCInteropTestTimeout is the timeout value for the
 	// internal tests.
-	gRPCInteropTestTimeout = 2 * time.Minute
+	gRPCInteropTestTimeout = 5 * time.Minute
 
 	// gRPCInteropTestCaseIterations is the number of times each gRPC
 	// interop test case should be invoked.
-	gRPCInteropTestCaseIterations = 5
+	gRPCInteropTestCaseIterations = 2
 )
 
 var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			g.By(fmt.Sprintf("creating test fixture from a config file %q", configPath))
 			err := oc.Run("new-app").Args("-f", configPath).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			e2e.ExpectNoError(oc.KubeFramework().WaitForPodRunning("grpc-interop"))
+			e2e.ExpectNoError(oc.KubeFramework().WaitForPodRunningSlow("grpc-interop"))
 
 			g.By("Discovering the set of supported test cases")
 			ns := oc.KubeFramework().Namespace.Name


### PR DESCRIPTION
The builder pod is taking a long time to complete in CI. In local
testing (i.e., on a quiescent cluster) it takes between 45s-60s to
complete. In CI this is taking much longer so switching to
WaitForPodRunningSlow which has a longer timeout (currently 15m).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1845434
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1845646