### PR TITLE
Bug 1845549: manually patch scc/restricted and scc/anyuid for conformamce tests

### DIFF
--- a/test/extended/conformance-k8s.sh
+++ b/test/extended/conformance-k8s.sh
@@ -64,8 +64,7 @@ os::log::info "Running Kubernetes conformance suite for ${version}"
 # Execute OpenShift prerequisites
 # Disable container security
 oc adm policy add-scc-to-group privileged system:authenticated system:serviceaccounts
-oc adm policy remove-scc-from-group restricted system:authenticated
-oc adm policy remove-scc-from-group anyuid system:cluster-admins
+oc adm policy add-scc-to-group anyuid system:authenticated system:serviceaccounts
 # Mark the master nodes as unschedulable so tests ignore them
 oc get nodes -o name -l 'node-role.kubernetes.io/master' | xargs -L1 oc adm cordon
 unschedulable="$( ( oc get nodes -o name -l 'node-role.kubernetes.io/master'; ) | wc -l )"


### PR DESCRIPTION
Since recent changes to SCC which in the long term will be managed by
kas-o oc currently modifies rolebindings when assigning SCC to or
removing from user/group. This PR modifies our conformance test such
that the OpenShift specific restrictions are removed from SCC.

/assign @mfojtik @stlaz 