### PR TITLE
add kubepodcrashlooping to list of ignored alerts

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -64,7 +64,9 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 
 		tests := map[string]bool{
 			// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-			`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|KubeAPILatencyHigh",alertstate="firing",severity!="info"}[2h]) >= 1`: false,
+			// TODO: remove KubePodCrashLooping subtraction logic once https://bugzilla.redhat.com/show_bug.cgi?id=1842002
+			// is fixed, but for now we are ignoring KubePodCrashLooping alerts in the openshift-kube-controller-manager namespace.
+			`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|KubeAPILatencyHigh",alertstate="firing",severity!="info"}[2h]) - count_over_time(ALERTS{alertname="KubePodCrashLooping",namespace="openshift-kube-controller-manager",alertstate="firing",severity!="info"}[2h]) >= 1`: false,
 		}
 		helper.RunQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 	})


### PR DESCRIPTION
this is only being added temporarily until
https://bugzilla.redhat.com/show_bug.cgi?id=1842002 is resolved,
after which this PR must be reverted.