### PR TITLE
Remove dumpLogs for nonexistent DC - Jenkins e2e

### DIFF
--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -238,8 +238,6 @@ var _ = g.Describe("[sig-builds][Feature:Builds][sig-devex][Feature:Jenkins][Slo
 						exutil.DumpBuilds(oc)
 						exutil.DumpBuildLogs("ruby", oc)
 						exutil.DumpDeploymentLogs("mongodb", 1, oc)
-						exutil.DumpDeploymentLogs("jenkins-second-deployment", 1, oc)
-						exutil.DumpDeploymentLogs("jenkins-second-deployment", 2, oc)
 					}
 					br.AssertSuccess()
 


### PR DESCRIPTION
- jenkins-second-deployment is no longer created by the jenkins-client-plugin e2e tests
- We are trying to DumpDeploymentLogs for a non-existent/non-expected deploymentConfig

Removing the DumpDeploymentLogs for `jenkins-second-deployment`