### PR TITLE
kube-apiserver: drain HTTP/2 early during termination

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -208,6 +208,10 @@ type Config struct {
 	// Default to 0, means never send GOAWAY. Max is 0.02 to prevent break the apiserver.
 	GoawayChance float64
 
+	// TerminationGoaway indicates that on start of termination GOAWAY frames are sent
+	// immediately (before ShutdownDelayDuration has passed) in order to speed up draining.
+	TerminationGoaway bool
+
 	// MergedResourceConfig indicates which groupVersion enabled and its resources enabled/disabled.
 	// This is composed of genericapiserver defaultAPIResourceConfig and those parsed from flags.
 	// If not specify any in flags, then genericapiserver will only enable defaultAPIResourceConfig.
@@ -757,6 +761,9 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
 	if c.SecureServing != nil && !c.SecureServing.DisableHTTP2 && c.GoawayChance > 0 {
 		handler = genericfilters.WithProbabilisticGoaway(handler, c.GoawayChance)
+	}
+	if c.TerminationGoaway {
+		handler = genericfilters.WithTerminationGoaway(handler, c.IsTerminating)
 	}
 	handler = genericapifilters.WithCacheControl(handler)
 	handler = genericfilters.WithPanicRecovery(handler, c.IsTerminating)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/goaway.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/goaway.go
@@ -56,13 +56,25 @@ func WithProbabilisticGoaway(inner http.Handler, chance float64) http.Handler {
 	}
 }
 
+// WithTerminationGoaway sends a GOAWAY when isTerminating is returning true.
+func WithTerminationGoaway(inner http.Handler, isTerminating func() bool) http.Handler {
+	return &goaway{
+		handler: inner,
+		decider: GoawayDeciderFunc(
+			func(r *http.Request) bool {
+				return isTerminating()
+			},
+		),
+	}
+}
+
 // goaway send a GOAWAY to client according to decider for HTTP2 requests
 type goaway struct {
 	handler http.Handler
 	decider GoawayDecider
 }
 
-// ServeHTTP implement HTTP handler
+// ServeHTTP implements HTTP handler
 func (h *goaway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Proto == "HTTP/2.0" && h.decider.Goaway(r) {
 		// Send a GOAWAY and tear down the TCP connection when idle.
@@ -72,17 +84,21 @@ func (h *goaway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handler.ServeHTTP(w, r)
 }
 
-// probabilisticGoawayDecider send GOAWAY probabilistically according to chance
+// probabilisticGoawayDecider sends GOAWAY probabilistically according to chance
 type probabilisticGoawayDecider struct {
 	chance float64
 	next   func() float64
 }
 
-// Goaway implement GoawayDecider
+// Goaway implements GoawayDecider
 func (p *probabilisticGoawayDecider) Goaway(r *http.Request) bool {
-	if p.next() < p.chance {
-		return true
-	}
+	return p.next() < p.chance
+}
 
-	return false
+// GoawayDeciderFunc wraps a decider func as decider interface.
+type GoawayDeciderFunc func(r *http.Request) bool
+
+// GoawayDeciderFunc implements GoawayDecider
+func (f GoawayDeciderFunc) Goaway(r *http.Request) bool {
+	return f(r)
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -39,6 +39,7 @@ type ServerRunOptions struct {
 	MaxMutatingRequestsInFlight int
 	RequestTimeout              time.Duration
 	GoawayChance                float64
+	TerminationGoaway           bool
 	LivezGracePeriod            time.Duration
 	MinRequestTimeout           int
 	ShutdownDelayDuration       time.Duration
@@ -78,6 +79,7 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.LivezGracePeriod = s.LivezGracePeriod
 	c.RequestTimeout = s.RequestTimeout
 	c.GoawayChance = s.GoawayChance
+	c.TerminationGoaway = s.TerminationGoaway
 	c.MinRequestTimeout = s.MinRequestTimeout
 	c.ShutdownDelayDuration = s.ShutdownDelayDuration
 	c.JSONPatchMaxCopyBytes = s.JSONPatchMaxCopyBytes
@@ -193,6 +195,9 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"The client's other in-flight requests won't be affected, and the client will reconnect, likely landing on a different apiserver after going through the load balancer again. "+
 		"This argument sets the fraction of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer, should NOT enable this. "+
 		"Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.")
+
+	fs.BoolVar(&s.TerminationGoaway, "termination-goaway", s.TerminationGoaway, ""+
+		"This option speeds up draining of a terminating apiserver by sending GOAWAY frames immediately after termination has been initiated (i.e. before shutdown-delay-duration has passed).")
 
 	fs.DurationVar(&s.LivezGracePeriod, "livez-grace-period", s.LivezGracePeriod, ""+
 		"This option represents the maximum amount of time it should take for apiserver to complete its startup sequence "+


### PR DESCRIPTION
Picking upstream https://github.com/kubernetes/kubernetes/pull/92136.