### PR TITLE
e2e: Add other client-authn methods to token request test

### DIFF
--- a/test/extended/oauth/client_secret.go
+++ b/test/extended/oauth/client_secret.go
@@ -1,20 +1,26 @@
 package oauth
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/test/e2e/framework"
 )
+
+const authzTokenName string = "oauth-client-with-plus-with-more-than-thirty-two-characters-in-this-very-long-name"
 
 var _ = g.Describe("[sig-auth][Feature:OAuthServer]", func() {
 	defer g.GinkgoRecover()
@@ -36,7 +42,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			oc.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthclients"), oauthClient)
 
-			g.By("create synthetic identity, user, and binding")
+			g.By("create synthetic user")
 
 			user, err := oc.AdminUserClient().UserV1().Users().Create(ctx, &userv1.User{
 				TypeMeta: metav1.TypeMeta{},
@@ -48,50 +54,90 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			oc.AddResourceToDelete(userv1.GroupVersion.WithResource("users"), user)
 
-			oauthAuthorizeToken, err := oc.AdminOauthClient().OauthV1().OAuthAuthorizeTokens().Create(ctx, &oauthv1.OAuthAuthorizeToken{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "oauth-client-with-plus-with-more-than-thirty-two-characters-in-this-very-long-name",
-				},
-				ClientName:          oauthClient.Name,
-				ExpiresIn:           100000000,
-				RedirectURI:         "https://www.google.com",
-				Scopes:              []string{"user:full"},
-				UserName:            user.Name,
-				UserUID:             string(user.UID),
-				CodeChallenge:       "",
-				CodeChallengeMethod: "",
-			}, metav1.CreateOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
-			oc.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthauthorizetokens"), oauthAuthorizeToken)
-
-			g.By("querying for a token")
 			oauthRoute, err := oc.AdminRouteClient().RouteV1().Routes("openshift-authentication").Get(ctx, "oauth-openshift", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			tokenPost, err := http.NewRequest("POST", "https://"+oauthRoute.Status.Ingress[0].Host+"/oauth/token?"+
-				"grant_type=authorization_code&"+
-				"code=oauth-client-with-plus-with-more-than-thirty-two-characters-in-this-very-long-name&"+
-				"client_id=oauth-client-with-plus&"+
-				"client_secret=secret%2Bwith%2Bplus",
-				nil)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			requestDump, err := httputil.DumpRequest(tokenPost, true)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			framework.Logf("%v", string(requestDump))
+			for _, createTokenReq := range []func(string) *http.Request{
+				queryClientAuthRequest,
+				bodyClientAuthRequest,
+				headerClientAuthRequest,
+			} {
+				g.By("create synthetic authz token")
+				oauthAuthorizeToken, err := oc.AdminOauthClient().OauthV1().OAuthAuthorizeTokens().Create(ctx, &oauthv1.OAuthAuthorizeToken{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: authzTokenName,
+					},
+					ClientName:          oauthClient.Name,
+					ExpiresIn:           100000000,
+					RedirectURI:         "https://www.google.com",
+					Scopes:              []string{"user:full"},
+					UserName:            user.Name,
+					UserUID:             string(user.UID),
+					CodeChallenge:       "",
+					CodeChallengeMethod: "",
+				}, metav1.CreateOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				oc.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthauthorizetokens"), oauthAuthorizeToken)
 
-			// we don't really care if this URL is safe
-			tr := &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				g.By("querying for a token")
+
+				tokenReq := createTokenReq(oauthRoute.Status.Ingress[0].Host)
+				tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				requestDump, err := httputil.DumpRequest(tokenReq, true)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				framework.Logf("%v", string(requestDump))
+
+				// we don't really care if this URL is safe
+				tr := &http.Transport{
+					Proxy:           http.ProxyFromEnvironment,
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				}
+				client := &http.Client{Transport: tr}
+
+				tokenResponse, err := client.Do(tokenReq)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				response, err := httputil.DumpResponse(tokenResponse, true)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				framework.Logf("%v", string(response))
+				o.Expect(tokenResponse.StatusCode).To(o.Equal(http.StatusOK))
 			}
-			client := &http.Client{Transport: tr}
-
-			tokenResponse, err := client.Do(tokenPost)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			response, err := httputil.DumpResponse(tokenResponse, true)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			framework.Logf("%v", string(response))
-			o.Expect(tokenResponse.StatusCode).To(o.Equal(http.StatusOK))
 		})
 	})
 })
+
+func queryClientAuthRequest(host string) *http.Request {
+	req, err := http.NewRequest("POST", "https://"+host+"/oauth/token?"+
+		"grant_type=authorization_code&"+
+		"code="+authzTokenName+"&"+
+		"client_id=oauth-client-with-plus&"+
+		"client_secret=secret%2Bwith%2Bplus",
+		nil)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return req
+}
+
+func bodyClientAuthRequest(host string) *http.Request {
+	req, err := http.NewRequest("POST", "https://"+host+"/oauth/token",
+		bytes.NewBufferString("grant_type=authorization_code&"+
+			"code="+authzTokenName+"&"+
+			"client_id=oauth-client-with-plus&"+
+			"client_secret=secret%2Bwith%2Bplus",
+		),
+	)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return req
+}
+
+func headerClientAuthRequest(host string) *http.Request {
+	req, err := http.NewRequest("POST", "https://"+host+"/oauth/token",
+		bytes.NewBufferString("grant_type=authorization_code&"+
+			"code="+authzTokenName,
+		),
+	)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("oauth-client-with-plus:secret+with+plus"))))
+	return req
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/openshift/origin/pull/24984

/assign @deads2k 