### PR TITLE
Update test owners

### DIFF
--- a/test/extended/builds/OWNERS
+++ b/test/extended/builds/OWNERS
@@ -1,10 +1,8 @@
 reviewers:
   - coreydaley
-  - dmage
   - gabemontero
   - adambkaplan
 approvers:
   - adambkaplan
   - gabemontero
   - coreydaley
-  - dmage

--- a/test/extended/imageapis/OWNERS
+++ b/test/extended/imageapis/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - dmage
+  - ricardomaraschini
+approvers:
+  - dmage
+  - ricardomaraschini

--- a/test/extended/images/OWNERS
+++ b/test/extended/images/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - dmage
+  - ricardomaraschini
+approvers:
+  - dmage
+  - ricardomaraschini


### PR DESCRIPTION
Remove the Image Registry team members from builds OWNERS and add OWNERS for images and imageapis tests.