### PR TITLE
watch-termination: don't log oauth tokens

### DIFF
--- a/cmd/watch-termination/main.go
+++ b/cmd/watch-termination/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -121,6 +122,12 @@ type terminationFileWriter struct {
 }
 
 func (w *terminationFileWriter) Write(bs []byte) (int, error) {
+	// temporary hack to avoid logging sensitive tokens.
+	// TODO: drop when we moved to a non-sensitive storage format
+	if strings.Contains(string(bs), "URI=\"/apis/oauth.openshift.io/v1/oauthaccesstokens/") || strings.Contains(string(bs), "URI=\"/apis/oauth.openshift.io/v1/oauthauthorizetokens/") {
+		return len(bs), nil
+	}
+
 	select {
 	case <-w.startFileLoggingCh:
 		if w.logger == nil {


### PR DESCRIPTION
We log requests of oauth tokens when log level is increased. But in the default case we don't log any requests. This PR restore the old (sub-optimal) situation, i.e. we are not worse than before.