### PR TITLE
UPSTREAM: <carry>: apiserver: log new connections during termination

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -208,10 +208,6 @@ type Config struct {
 	// Default to 0, means never send GOAWAY. Max is 0.02 to prevent break the apiserver.
 	GoawayChance float64
 
-	// TerminationGoaway indicates that on start of termination GOAWAY frames are sent
-	// immediately (before ShutdownDelayDuration has passed) in order to speed up draining.
-	TerminationGoaway bool
-
 	// MergedResourceConfig indicates which groupVersion enabled and its resources enabled/disabled.
 	// This is composed of genericapiserver defaultAPIResourceConfig and those parsed from flags.
 	// If not specify any in flags, then genericapiserver will only enable defaultAPIResourceConfig.
@@ -761,9 +757,6 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
 	if c.SecureServing != nil && !c.SecureServing.DisableHTTP2 && c.GoawayChance > 0 {
 		handler = genericfilters.WithProbabilisticGoaway(handler, c.GoawayChance)
-	}
-	if c.TerminationGoaway {
-		handler = genericfilters.WithTerminationGoaway(handler, c.IsTerminating)
 	}
 	handler = genericapifilters.WithCacheControl(handler)
 	handler = genericfilters.WithPanicRecovery(handler, c.IsTerminating)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	gpath "path"
@@ -339,6 +340,23 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 		s.Eventf(corev1.EventTypeNormal, "TerminationMinimalShutdownDurationFinished", "The minimal shutdown duration of %v finished", s.ShutdownDelayDuration)
 	}()
 
+	lateStopCh := make(chan struct{})
+	if s.ShutdownDelayDuration > 0 {
+		go func() {
+			defer close(lateStopCh)
+
+			<-stopCh
+
+			time.Sleep(s.ShutdownDelayDuration * 8 / 10)
+		}()
+	}
+
+	s.SecureServingInfo.Listener = &terminationLoggingListener{
+		Listener:   s.SecureServingInfo.Listener,
+		stopCh:     stopCh,
+		lateStopCh: lateStopCh,
+	}
+
 	// close socket after delayed stopCh
 	err := s.NonBlockingRun(delayedStopCh)
 	if err != nil {
@@ -650,4 +668,31 @@ func (s *GenericAPIServer) Eventf(eventType, reason, messageFmt string, args ...
 	if _, err := s.eventSink.Create(e); err != nil {
 		klog.Warningf("failed to create event %s/%s: %v", e.Namespace, e.Name, err)
 	}
+}
+
+// terminationLoggingListener wraps the given listener and logs new connections
+// after the stopCh has been closed, i.e. when termination has begun.
+type terminationLoggingListener struct {
+	net.Listener
+	stopCh, lateStopCh <-chan struct{}
+}
+
+func (l *terminationLoggingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	select {
+	case <-l.lateStopCh:
+		klog.Warningf("Accepted new connection from %s very late in the graceful termination process (more than 80%% has passed), possibly a hint for a broken load balancer setup.", c.RemoteAddr().String())
+	default:
+		select {
+		case <-l.stopCh:
+			klog.V(2).Infof("Accepted new connection from %s during graceful termination.", c.RemoteAddr())
+		default:
+		}
+	}
+
+	return c, err
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -39,7 +39,6 @@ type ServerRunOptions struct {
 	MaxMutatingRequestsInFlight int
 	RequestTimeout              time.Duration
 	GoawayChance                float64
-	TerminationGoaway           bool
 	LivezGracePeriod            time.Duration
 	MinRequestTimeout           int
 	ShutdownDelayDuration       time.Duration
@@ -79,7 +78,6 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.LivezGracePeriod = s.LivezGracePeriod
 	c.RequestTimeout = s.RequestTimeout
 	c.GoawayChance = s.GoawayChance
-	c.TerminationGoaway = s.TerminationGoaway
 	c.MinRequestTimeout = s.MinRequestTimeout
 	c.ShutdownDelayDuration = s.ShutdownDelayDuration
 	c.JSONPatchMaxCopyBytes = s.JSONPatchMaxCopyBytes
@@ -195,9 +193,6 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"The client's other in-flight requests won't be affected, and the client will reconnect, likely landing on a different apiserver after going through the load balancer again. "+
 		"This argument sets the fraction of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer, should NOT enable this. "+
 		"Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.")
-
-	fs.BoolVar(&s.TerminationGoaway, "termination-goaway", s.TerminationGoaway, ""+
-		"This option speeds up draining of a terminating apiserver by sending GOAWAY frames immediately after termination has been initiated (i.e. before shutdown-delay-duration has passed).")
 
 	fs.DurationVar(&s.LivezGracePeriod, "livez-grace-period", s.LivezGracePeriod, ""+
 		"This option represents the maximum amount of time it should take for apiserver to complete its startup sequence "+

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -209,7 +209,7 @@ func RunServer(
 		defer utilruntime.HandleCrash()
 
 		var listener net.Listener
-		listener = tcpKeepAliveListener{ln.(*net.TCPListener)}
+		listener = tcpKeepAliveListener{ln}
 		if server.TLSConfig != nil {
 			listener = tls.NewListener(listener, server.TLSConfig)
 		}
@@ -235,15 +235,17 @@ func RunServer(
 //
 // Copied from Go 1.7.2 net/http/server.go
 type tcpKeepAliveListener struct {
-	*net.TCPListener
+	net.Listener
 }
 
 func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
-	tc, err := ln.AcceptTCP()
+	c, err := ln.Listener.Accept()
 	if err != nil {
 		return nil, err
 	}
-	tc.SetKeepAlive(true)
-	tc.SetKeepAlivePeriod(defaultKeepAlivePeriod)
-	return tc, nil
+	if tc, ok := c.(*net.TCPConn); ok {
+		tc.SetKeepAlive(true)
+		tc.SetKeepAlivePeriod(defaultKeepAlivePeriod)
+	}
+	return c, nil
 }


### PR DESCRIPTION
This is an alternative to https://github.com/openshift/origin/pull/25106 and https://github.com/openshift/origin/pull/25118. Instead of full http logs, we only get a remote address though. Good enough to leave it on in production code and without risk of logging oauth tokens.