### PR TITLE
Bug 1809195: test/extended/prometheus: During transition, allow HTTP(S) for CVO

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -232,8 +232,8 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 						targets.Expect(labels{"job": "kube-state-metrics"}, "up", "^https://.*/metrics$"),
 
 						// Cluster version operator
-						// TODO: should probably be https
-						targets.Expect(labels{"job": "cluster-version-operator"}, "up", "^http://.*/metrics$"),
+						// TODO: require HTTPS once https://github.com/openshift/cluster-version-operator/pull/385 lands
+						targets.Expect(labels{"job": "cluster-version-operator"}, "up", "^https?://.*/metrics$"),
 					)
 				}
 


### PR DESCRIPTION
Currently the master CVO serves only HTTP.  There is a pull request in flight (openshift/cluster-version-operator#385) to declare an HTTPS target in the ServiceMonitor.  Allowing both, as I'm doing in this commit, will allow us to land this test-suite change now.  Then we can land the CVO pull request.  And then we can drop the '?' to require HTTPS going forward.