### PR TITLE
Bug 1809195: test/extended/prometheus: Require HTTPS for the CVO

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -232,8 +232,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 						targets.Expect(labels{"job": "kube-state-metrics"}, "up", "^https://.*/metrics$"),
 
 						// Cluster version operator
-						// TODO: require HTTPS once https://github.com/openshift/cluster-version-operator/pull/385 lands
-						targets.Expect(labels{"job": "cluster-version-operator"}, "up", "^https?://.*/metrics$"),
+						targets.Expect(labels{"job": "cluster-version-operator"}, "up", "^https://.*/metrics$"),
 					)
 				}
 

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -232,8 +232,8 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 						targets.Expect(labels{"job": "kube-state-metrics"}, "up", "^https://.*/metrics$"),
 
 						// Cluster version operator
-						// TODO: should probably be https
-						targets.Expect(labels{"job": "cluster-version-operator"}, "up", "^http://.*/metrics$"),
+						// TODO: require HTTPS once https://github.com/openshift/cluster-version-operator/pull/385 lands
+						targets.Expect(labels{"job": "cluster-version-operator"}, "up", "^https?://.*/metrics$"),
 					)
 				}
 


### PR DESCRIPTION
Now that the CVO pull request has landed, require HTTPS going forward (firming up the flexible behavior from #25134).

/hold

Until openshift/cluster-version-operator#385 actually lands.