### PR TITLE
Bug 1841035: Add volumesnapshotclass to default RBAC test

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -62,6 +62,9 @@ const (
 	legacyTemplateGroup = ""
 	legacyUserGroup     = ""
 	legacyOauthGroup    = ""
+
+	// Provided as CRD via cluster-csi-snapshot-controller-operator
+	snapshotGroup = "snapshot.storage.k8s.io"
 )
 
 // Do not change any of these lists without approval from the auth and master teams
@@ -110,6 +113,7 @@ var (
 			rbacv1helpers.NewRule("get", "list").Groups(authzGroup, legacyAuthzGroup).Resources("clusterroles").RuleOrDie(),
 			rbacv1helpers.NewRule(read...).Groups(rbacGroup).Resources("clusterroles").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "list").Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch").Groups(snapshotGroup).Resources("volumesnapshotclasses").RuleOrDie(),
 			rbacv1helpers.NewRule("list", "watch").Groups(projectGroup, legacyProjectGroup).Resources("projects").RuleOrDie(),
 
 			// These custom resources are used to extend console functionality


### PR DESCRIPTION
Authenticated user will get capability to read VolumeSnapshotClasses [soon](https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/39). The test must be updated before the actual RBAC change is merged, so CI works both before the update and after.

The test tolerates 15 extra RBAC rules, so it's going to pass, only write this to stdout:

```
Jun 17 10:07:55.555: INFO: test data for system:authenticated has too many unnecessary permissions:
{APIGroups:["snapshot.storage.k8s.io"], Resources:["volumesnapshotclasses"], Verbs:["get" "list" "watch"]}
```

This resolves when cluster-csi-snapshot-controller-operator [actually includes the new RBAC rules](https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/39).

/assign @deads2k 