### PR TITLE
Bug 1845778: [release-3.11] kubelet: block non-forwarded packets from crossing the localhost boundary

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_network.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_network.go
@@ -117,6 +117,22 @@ func (kl *Kubelet) syncNetworkUtil() {
 		glog.Errorf("Failed to ensure rule to drop packet marked by %v in %v chain %v: %v", KubeMarkDropChain, utiliptables.TableFilter, KubeFirewallChain, err)
 		return
 	}
+
+	// drop all non-local packets to localhost if they're not part of an existing
+	// forwarded connection. See #90259
+	if !kl.iptClient.IsIpv6() { // ipv6 doesn't have this issue
+		if _, err := kl.iptClient.EnsureRule(utiliptables.Append, utiliptables.TableFilter, KubeFirewallChain,
+			"-m", "comment", "--comment", "block incoming localnet connections",
+			"--dst", "127.0.0.0/8",
+			"!", "--src", "127.0.0.0/8",
+			"-m", "conntrack",
+			"!", "--ctstate", "RELATED,ESTABLISHED,DNAT",
+			"-j", "DROP"); err != nil {
+			glog.Errorf("Failed to ensure rule to drop invalid localhost packets in %v chain %v: %v", utiliptables.TableFilter, KubeFirewallChain, err)
+			return
+		}
+	}
+
 	if _, err := kl.iptClient.EnsureRule(utiliptables.Prepend, utiliptables.TableFilter, utiliptables.ChainOutput, "-j", string(KubeFirewallChain)); err != nil {
 		glog.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", utiliptables.TableFilter, utiliptables.ChainOutput, KubeFirewallChain, err)
 		return


### PR DESCRIPTION
This is a release-3.11 cherry-pick of https://github.com/openshift/origin/pull/25141