### PR TITLE
Bug 1848921: Add start build to the created pipeline

### DIFF
--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -389,6 +389,7 @@ var _ = g.Describe("[Feature:Builds][Feature:Jenkins][Slow] openshift pipeline b
 				g.By(fmt.Sprintf("calling oc new-app -f %q", origPipelinePath))
 				err := oc.Run("new-app").Args("-f", origPipelinePath).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
+				exutil.StartBuild(oc, "sample-pipeline")
 
 				g.By("verify job is in jenkins")
 				_, err = j.WaitForContent("", 200, 30*time.Second, "job/%s/job/%s-sample-pipeline/", oc.Namespace(), oc.Namespace())


### PR DESCRIPTION
Add start build to the created pipeline as for 4.2+ it doesn't start automatically
The build never starts, the test cannot get the url.