### PR TITLE
disable broken jenkins test

### DIFF
--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -217,6 +217,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][sig-devex][Feature:Jenkins][Slo
 	g.Context("jenkins-client-plugin tests", func() {
 
 		g.It("using the ephemeral template", func() {
+			g.Skip("skipping because second deployment does not exist")
 			defer cleanup(jenkinsEphemeralTemplatePath)
 			setupJenkins(jenkinsEphemeralTemplatePath)
 


### PR DESCRIPTION
this test consistently fails because the pipeline references a second deployment which does not exist.
