### PR TITLE
test/etcd: wait for default service account to be avaiable

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -13,6 +13,15 @@ import (
 
 	kapiv1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	discocache "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/dynamic"
+	kclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
+	etcddata "k8s.io/kubernetes/test/integration/etcd"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -21,13 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	discocache "k8s.io/client-go/discovery/cached"
-	"k8s.io/client-go/dynamic"
-	kclientset "k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
-	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
-	etcddata "k8s.io/kubernetes/test/integration/etcd"
 
 	etcdv3 "go.etcd.io/etcd/clientv3"
 )
@@ -263,6 +265,10 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, kubeConfig *restclient.Config, e
 			t.Fatalf("error deleting test namespace: %#v", err)
 		}
 	}()
+
+	if err := exutil.WaitForServiceAccount(kubeClient.CoreV1().ServiceAccounts(testNamespace), "default"); err != nil {
+		t.Fatalf("error waiting for the default service account: %v", err)
+	}
 
 	etcdStorageData := etcddata.GetEtcdStorageData()
 


### PR DESCRIPTION
Fixes following flaky test:

```
[sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial] [Suite:openshift/conformance/serial] expand_less	1m6s
fail [github.com/openshift/origin/test/extended/etcd/etcd_test_runner.go:80]: test failed:
failed to create stub for /v1, Kind=Pod: &errors.StatusError{ErrStatus:v1.Status{TypeMeta:v1.TypeMeta{Kind:"Status", APIVersion:"v1"}, ListMeta:v1.ListMeta{SelfLink:"", ResourceVersion:"", Continue:"", RemainingItemCount:(*int64)(nil)}, Status:"Failure", Message:"pods \"pod1\" is forbidden: error looking up service account etcdstoragepathtestnamespace/default: serviceaccount \"default\" not found", Reason:"Forbidden", Details:(*v1.StatusDetails)(0xc003328960), Code:403}}
```