### PR TITLE
Bug: Cockroach  2.1.11 operator was removed

### DIFF
--- a/test/extended/testdata/olm/cockroachdb-subscription.yaml
+++ b/test/extended/testdata/olm/cockroachdb-subscription.yaml
@@ -14,7 +14,7 @@ objects:
     name: cockroachdb
     source: "${SOURCENAME}"
     sourceNamespace: "${SOURCENAMESPACE}"
-    startingCSV: cockroachdb.v2.1.11
+    startingCSV: cockroachdb.v3.0.7
 parameters:
 - name: NAME
 - name: NAMESPACE


### PR DESCRIPTION
This commit updates an olm e2e test that ensures operator subscription
works. The test currently relies on an external repository of operator
metadata to generate that subscription. An update removed the 2.1.11
version from the current update graph, so this test is broken. As a
temporary solution, updating the test to point to the latest available
version. In the future, this test should either ship its own manifests
(so that it is not dependent on an external content souce) or be
removed entirely.