### PR TITLE
UPSTREAM: <carry>: Bug 1850149: Include / prefix in the instance ID output

### DIFF
--- a/deps.diff
+++ b/deps.diff
@@ -1,0 +1,5 @@
+diff --no-dereference -N -r current/vendor/k8s.io/legacy-cloud-providers/openstack/openstack_instances.go updated/vendor/k8s.io/legacy-cloud-providers/openstack/openstack_instances.go
+260c260
+< 		return "/" + md.UUID, nil
+---
+> 		return md.UUID, nil

--- a/vendor/k8s.io/legacy-cloud-providers/openstack/openstack_instances.go
+++ b/vendor/k8s.io/legacy-cloud-providers/openstack/openstack_instances.go
@@ -257,7 +257,7 @@ func (i *Instances) InstanceID(ctx context.Context, name types.NodeName) (string
 	}
 	localName := types.NodeName(md.Name)
 	if localName == name {
-		return md.UUID, nil
+		return "/" + md.UUID, nil
 	}
 
 	srv, err := getServerByName(i.compute, name)


### PR DESCRIPTION
When we want to read instance ID from the metadata service, cloud provider doesn't include "/" prefix, which is required for successful parsing of provider ID later.
This commit adds the missing "/" prefix to the output.