### PR TITLE
UPSTREAM: 89164: Fix data race issue in unit test

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -793,7 +793,7 @@ func TestDispatchingBookmarkEventsWithConcurrentStop(t *testing.T) {
 		wg := sync.WaitGroup{}
 		wg.Add(2)
 		go func() {
-			cacher.dispatchEvent(bookmark)
+			cacher.processEvent(bookmark)
 			wg.Done()
 		}()
 


### PR DESCRIPTION
clean pick.

`TestDispatchingBookmarkEventsWithConcurrentStop` must use `processEvent` instead of `dispatchEvent` to avoid data race conditions with `Cacher.watchersBuffer`.