### PR TITLE
monitor: add time to track from for a Condition

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -139,11 +139,17 @@ func (m *Monitor) Events(from, to time.Time) EventIntervals {
 		if i > 0 && events[i-1].At.After(events[i].At) {
 			fmt.Printf("ERROR: event %d out of order\n  %#v\n  %#v\n", i, events[i-1], events[i])
 		}
-		at := events[i].At
+
+		to := events[i].At
+		from := events[i].InitiatedAt
+		if from.IsZero() {
+			from = to
+		}
+
 		condition := &events[i].Condition
 		intervals = append(intervals, &EventInterval{
-			From:      at,
-			To:        at,
+			From:      from,
+			To:        to,
 			Condition: condition,
 		})
 	}

--- a/pkg/monitor/sampler_test.go
+++ b/pkg/monitor/sampler_test.go
@@ -58,13 +58,15 @@ func TestStartSampling(t *testing.T) {
 		describe = append(describe, fmt.Sprintf("%v %s", *interval.Condition, i))
 		log = append(log, fmt.Sprintf("%v", *interval.Condition))
 	}
+
+	zero := time.Time{}.String()
 	expected := []string{
-		"{2 tester dying}",
-		"{2 tester down}",
-		"{0 tester recovering}",
-		"{2 tester dying 2}",
-		"{2 tester down}",
-		"{0 tester recovering 2}",
+		fmt.Sprintf("{2 tester dying %s}", zero),
+		fmt.Sprintf("{2 tester down %s}", zero),
+		fmt.Sprintf("{0 tester recovering %s}", zero),
+		fmt.Sprintf("{2 tester dying 2 %s}", zero),
+		fmt.Sprintf("{2 tester down %s}", zero),
+		fmt.Sprintf("{0 tester recovering 2 %s}", zero),
 	}
 	if !reflect.DeepEqual(log, expected) {
 		t.Fatalf("%s", diff.ObjectReflectDiff(log, expected))

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -54,6 +54,8 @@ type Condition struct {
 
 	Locator string
 	Message string
+
+	InitiatedAt time.Time
 }
 
 type EventInterval struct {


### PR DESCRIPTION
API monitor does not keep track of when an Event started. 