### PR TITLE
Re-enable skipped conformance tests for IBM Cloud

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -265,7 +265,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed": "should be submitted and removed [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [k8s.io] [sig-node] Pods Extended [k8s.io] Pod Container Status should never report success for a pending container": "should never report success for a pending container [Skipped:ibmcloud] [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [k8s.io] [sig-node] Pods Extended [k8s.io] Pod Container Status should never report success for a pending container": "should never report success for a pending container [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be set on Pods with matching resource requests and limits for memory and cpu [Conformance]": "should be set on Pods with matching resource requests and limits for memory and cpu [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -251,15 +251,6 @@ var (
 			// Currently ibm-master-proxy-static and imbcloud-block-storage-plugin tolerate all taints
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1825027
 			`\[Feature:Platform\] Managed cluster should ensure control plane operators do not make themselves unevictable`,
-
-			// Prometheus is not reporting router metrics
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1825029
-			`\[Feature:Prometheus\]\[Conformance\] Prometheus when installed on the cluster should provide ingress metrics`,
-			`\[Conformance\]\[Area:Networking\]\[Feature:Router\] The HAProxy router should enable openshift-monitoring to pull metrics`,
-
-			// Test does not allow enough time for the pods to be created before deleting them
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1825372
-			`Pod Container Status should never report success for a pending container`,
 		},
 		"[sig-node]": {
 			`\[NodeConformance\]`,


### PR DESCRIPTION
Re-enabling selected tests now that associated bugs have been fixed and are in the Red Hat OpenShift on IBM Cloud v4.3 builds.
```
[Feature:Prometheus][Conformance] Prometheus when installed on the cluster should provide ingress metrics
[Conformance][Area:Networking][Feature:Router] The HAProxy router should enable openshift-monitoring to pull metrics
[k8s.io] [sig-node] Pods Extended [k8s.io] Pod Container Status should never report success for a pending container
```