### PR TITLE
Bug 1873961: e2e/apiserver: check for LateConnections+NonGracefulTermination events

### DIFF
--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -1,0 +1,63 @@
+package apiserver
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLI("terminating-kube-apiserver")
+
+	g.It("kubelet terminates kube-apiserver gracefully", func() {
+		t := g.GinkgoT()
+
+		client, err := kubernetes.NewForConfig(oc.AdminConfig())
+		if err != nil {
+			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
+		}
+
+		evs, err := client.CoreV1().Events("openshift-kube-apiserver").List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
+		}
+
+		for _, ev := range evs.Items {
+			if ev.Reason != "NonGracefulTermination" {
+				continue
+			}
+
+			t.Errorf("kube-apiserver reports a non-graceful termination: %#v. Probably kubelet or CRI-O is not giving the time to cleanly shut down. This can lead to connection refused and network I/O timeout errors in other components.", ev)
+		}
+	})
+
+	g.It("API LBs follow /readyz of kube-apiserver and stop sending requests", func() {
+		t := g.GinkgoT()
+
+		client, err := kubernetes.NewForConfig(oc.AdminConfig())
+		if err != nil {
+			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
+		}
+
+		evs, err := client.CoreV1().Events("openshift-kube-apiserver").List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
+		}
+
+		for _, ev := range evs.Items {
+			if ev.Reason != "LateConnections" {
+				continue
+			}
+
+			t.Errorf("API LBs send requests to kube-apiserver far too late in termination process, probably due to broken LB configuration: %#v. This can lead to connection refused and network I/O timeout errors in other components.", ev)
+		}
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -521,6 +521,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-api-machinery][Feature:APIServer] authenticated browser should get a 200 from /": "authenticated browser should get a 200 from / [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and stop sending requests": "API LBs follow /readyz of kube-apiserver and stop sending requests [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-api-machinery][Feature:APIServer][Late] kubelet terminates kube-apiserver gracefully": "kubelet terminates kube-apiserver gracefully [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-api-machinery][Feature:Audit] Basic audit should audit API calls": "should audit API calls [Disabled:SpecialConfig] [Suite:openshift]",
 
 	"[Top Level] [sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces": "should control resource limits across namespaces [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
These are produced by kube-apiserver when
- non-localhost clients connect in the last 20% of the termination period. This is a strong hint that the LBs are misconfigured or misbehaving => LateConnections
- the kube-apiserver is not cleanly terminating, but e.g. is receiving a SIGKILL instead of an early SIGTERM => NonGracefulTermination