### PR TITLE
Revert "must-gather: temporarily disable broken test"

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -103,9 +103,8 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 			{pluginOutputDir, "cluster-scoped-resources", "config.openshift.io", "oauths.yaml"},
 			{pluginOutputDir, "cluster-scoped-resources", "config.openshift.io", "projects.yaml"},
 			{pluginOutputDir, "cluster-scoped-resources", "config.openshift.io", "schedulers.yaml"},
-			// TODO: This got broken and we need to fix this. Disabled temporarily.
-			// {pluginOutputDir, "namespaces", "openshift-kube-apiserver", "core", "configmaps.yaml"},
-			// {pluginOutputDir, "namespaces", "openshift-kube-apiserver", "core", "secrets.yaml"},
+			{pluginOutputDir, "namespaces", "openshift-kube-apiserver", "core", "configmaps.yaml"},
+			{pluginOutputDir, "namespaces", "openshift-kube-apiserver", "core", "secrets.yaml"},
 			{pluginOutputDir, "host_service_logs", "masters", "crio_service.log"},
 			{pluginOutputDir, "host_service_logs", "masters", "kubelet_service.log"},
 		}


### PR DESCRIPTION
This reverts commit 81a4b85d92d9c0d9da38246338f91b8a70250712.

https://github.com/openshift/origin/pull/25239 nerfs a test that is important to ensure we can service our product.  this restores it.

try merging https://github.com/openshift/oc/pull/484