### PR TITLE
test: Broaden check for base images that are RHEL8

### DIFF
--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -139,8 +139,8 @@ var _ = Describe("[sig-arch] Managed cluster", func() {
 						e2e.Logf("unable to run command:%v with error: %v", commands, err)
 						continue
 					}
-					e2e.Logf("Image relase info:%s", result)
-					if !strings.Contains(result, "Red Hat Enterprise Linux Server") {
+					e2e.Logf("Image release info: %s", result)
+					if !strings.Contains(result, "Red Hat Enterprise Linux") {
 						invalidPodContainerDownstreamImages.Insert(fmt.Sprintf("%s/%s invalid downstream image!", pod.Name, containerName))
 					}
 				}


### PR DESCRIPTION
The UBI8 image has the following string in /etc/redhat-release

    Red Hat Enterprise Linux ...

and thus fails this test. We accept both UBI/RHEL 7/8 images and
so we loosen the test here.