### PR TITLE
UPSTREAM: 92714: Add label selector value validation

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -45,6 +45,12 @@ func ValidateLabelSelectorRequirement(sr metav1.LabelSelectorRequirement, fldPat
 	case metav1.LabelSelectorOpIn, metav1.LabelSelectorOpNotIn:
 		if len(sr.Values) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified when `operator` is 'In' or 'NotIn'"))
+		} else {
+			for _, v := range sr.Values {
+				for _, msg := range validation.IsValidLabelValue(v) {
+					allErrs = append(allErrs, field.Invalid(fldPath, v, msg))
+				}
+			}
 		}
 	case metav1.LabelSelectorOpExists, metav1.LabelSelectorOpDoesNotExist:
 		if len(sr.Values) > 0 {


### PR DESCRIPTION
This moves validation of LabelSelector values in pod specs
to the API server, to be checked at creation time.