### PR TITLE
wires the egress proxy to the kube-aggregator 

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -363,6 +363,7 @@ func (s *APIAggregator) AddAPIService(apiService *v1.APIService) error {
 		proxyCurrentCertKeyContent: s.proxyCurrentCertKeyContent,
 		proxyTransport:             s.proxyTransport,
 		serviceResolver:            s.serviceResolver,
+		egressSelector:             s.egressSelector,
 	}
 	proxyHandler.updateAPIService(apiService)
 	if s.openAPIAggregationController != nil {


### PR DESCRIPTION
brings back the egress proxy configuration to the kube-aggregator lost during previous backporting.

it requires backporting at least to 4.5 and 4.4