### PR TITLE
Bug 1855444: UPSTREAM: 91648: Changes to ManagedFields is not mutation for GC

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/registry/rbac/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rbac/BUILD
@@ -57,5 +57,7 @@ go_test(
         "//pkg/apis/core/helper:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/github.com/google/gofuzz:go_default_library",
     ],
 )

--- a/vendor/k8s.io/kubernetes/pkg/registry/rbac/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rbac/helpers.go
@@ -44,6 +44,7 @@ func IsOnlyMutatingGCFields(obj, old runtime.Object, equalities conversion.Equal
 	copiedMeta.SetOwnerReferences(oldMeta.GetOwnerReferences())
 	copiedMeta.SetFinalizers(oldMeta.GetFinalizers())
 	copiedMeta.SetSelfLink(oldMeta.GetSelfLink())
+	copiedMeta.SetManagedFields(oldMeta.GetManagedFields())
 
 	return equalities.DeepEqual(copied, old)
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/rbac/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rbac/helpers_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package rbac
 
 import (
+	"reflect"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
+
+	fuzz "github.com/google/gofuzz"
 )
 
 func newPod() *kapi.Pod {
@@ -50,6 +54,22 @@ func TestIsOnlyMutatingGCFields(t *testing.T) {
 			},
 			old: func() runtime.Object {
 				return newPod()
+			},
+			expected: true,
+		},
+		{
+			name: "different managedFields",
+			obj: func() runtime.Object {
+				return newPod()
+			},
+			old: func() runtime.Object {
+				obj := newPod()
+				obj.ManagedFields = []metav1.ManagedFieldsEntry{
+					{
+						Manager: "manager",
+					},
+				}
+				return obj
 			},
 			expected: true,
 		},
@@ -147,6 +167,36 @@ func TestIsOnlyMutatingGCFields(t *testing.T) {
 		actual := IsOnlyMutatingGCFields(tc.obj(), tc.old(), kapihelper.Semantic)
 		if tc.expected != actual {
 			t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, actual)
+		}
+	}
+}
+
+func TestNewMetadataFields(t *testing.T) {
+	f := fuzz.New().NilChance(0.0).NumElements(1, 1)
+	for i := 0; i < 100; i++ {
+		objMeta := metav1.ObjectMeta{}
+		f.Fuzz(&objMeta)
+		objMeta.Name = ""
+		objMeta.GenerateName = ""
+		objMeta.Namespace = ""
+		objMeta.SelfLink = ""
+		objMeta.UID = types.UID("")
+		objMeta.ResourceVersion = ""
+		objMeta.Generation = 0
+		objMeta.CreationTimestamp = metav1.Time{}
+		objMeta.DeletionTimestamp = nil
+		objMeta.DeletionGracePeriodSeconds = nil
+		objMeta.Labels = nil
+		objMeta.Annotations = nil
+		objMeta.OwnerReferences = nil
+		objMeta.Finalizers = nil
+		objMeta.ClusterName = ""
+		objMeta.ManagedFields = nil
+
+		if !reflect.DeepEqual(metav1.ObjectMeta{}, objMeta) {
+			t.Fatalf(`A new field was introduced in ObjectMeta, add the field to
+IsOnlyMutatingGCFields if necessary, and update this test:
+%#v`, objMeta)
 		}
 	}
 }


### PR DESCRIPTION
Manually cherry-picking #25261 back to 4.5, to get a head-start on 4.5 CI jobs (without waiting for the master PR to land).