### PR TITLE
[release-3.11] Bug 1855852: Backport HAProxy report all backend metrics

### DIFF
--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -487,10 +487,7 @@ func (e *Exporter) collectMetrics(metrics chan<- prometheus.Metric) {
 	for _, m := range e.frontendMetrics {
 		m.Collect(metrics)
 	}
-	for i, m := range e.backendMetrics {
-		if _, ok := e.reducedBackendExports[i]; !e.serverLimited && !ok {
-			continue
-		}
+	for _, m := range e.backendMetrics {
 		m.Collect(metrics)
 	}
 	if !e.serverLimited {

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -150,8 +150,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			// route specific metrics from server and backend
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_http_responses_total"], serverLabels.With("code", "2xx"))).To(o.ConsistOf(o.BeNumerically(">", 0), o.BeNumerically(">", 0)))
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_http_responses_total"], serverLabels.With("code", "5xx"))).To(o.Equal([]float64{0, 0}))
-			// only server returns response counts
-			o.Expect(findGaugesWithLabels(metrics["haproxy_backend_http_responses_total"], routeLabels.With("code", "2xx"))).To(o.HaveLen(0))
+			o.Expect(findGaugesWithLabels(metrics["haproxy_backend_http_responses_total"], routeLabels.With("code", "2xx"))).ToNot(o.BeZero())
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_connections_total"], serverLabels)).To(o.ConsistOf(o.BeNumerically(">=", 0), o.BeNumerically(">=", 0)))
 			o.Expect(findGaugesWithLabels(metrics["haproxy_backend_connections_total"], routeLabels)).To(o.ConsistOf(o.BeNumerically(">=", times)))
 			o.Expect(findGaugesWithLabels(metrics["haproxy_server_up"], serverLabels)).To(o.Equal([]float64{1, 1}))


### PR DESCRIPTION
This is the 3.11.z backport of https://github.com/openshift/router/pull/132
---

When no servers are exposed, backend metrics are needed to see
how many requests are making it to a service. If we don't report
them users can't see when no pods are up (a crashlooping service
for instance would have no metrics at all because no pods are
ready). Always report all backend metrics. Increases cardinality
by O(routes), but prometheus is a lot faster now.