### PR TITLE
Bug 1874079: Do not harcode arch for fedora container image

### DIFF
--- a/test/extended/csrapprover/csrapprover.go
+++ b/test/extended/csrapprover/csrapprover.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 		// the /config/master API port+endpoint is only visible from inside the cluster
 		// (-> we need to create a pod to try to reach it) and contains the token
 		// of the node-bootstrapper SA, so no random pods should be able to see it
-		pod, err := exutil.NewPodExecutor(oc, "get-bootstrap-creds", "quay.io/fedora/fedora:32-x86_64")
+		pod, err := exutil.NewPodExecutor(oc, "get-bootstrap-creds", "registry.fedoraproject.org/fedora:32")
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// get the API server URL, mutate to internal API (use infra.Status.APIServerURLInternal) once API is bumped


### PR DESCRIPTION
This test was failing on non-x86 images because of the hardcoded
architecture

Fixes #25275 

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>