### PR TITLE
patch net/http2 library to fix the graceful shutdown of HTTP2 connections

### DIFF
--- a/images/hyperkube/4d8de76-1.13.patch
+++ b/images/hyperkube/4d8de76-1.13.patch
@@ -1,0 +1,154 @@
+diff --git a/src/net/http/export_test.go b/src/net/http/export_test.go
+index e5c06a8903..0357b5137f 100644
+--- a/src/net/http/export_test.go
++++ b/src/net/http/export_test.go
+@@ -268,6 +268,17 @@ func (s *Server) ExportAllConnsIdle() bool {
+ 	return true
+ }
+ 
++func (s *Server) ExportAllConnsByState() map[ConnState]int {
++	states := map[ConnState]int{}
++	s.mu.Lock()
++	defer s.mu.Unlock()
++	for c := range s.activeConn {
++		st, _ := c.getState()
++		states[st] += 1
++	}
++	return states
++}
++
+ func (r *Request) WithT(t *testing.T) *Request {
+ 	return r.WithContext(context.WithValue(r.Context(), tLogKey{}, t.Logf))
+ }
+diff --git a/src/net/http/serve_test.go b/src/net/http/serve_test.go
+index 90f112b2ee..c082f21e2f 100644
+--- a/src/net/http/serve_test.go
++++ b/src/net/http/serve_test.go
+@@ -5542,19 +5542,26 @@ func TestServerSetKeepAlivesEnabledClosesConns(t *testing.T) {
+ 	}
+ }
+ 
+-func TestServerShutdown_h1(t *testing.T) { testServerShutdown(t, h1Mode) }
+-func TestServerShutdown_h2(t *testing.T) { testServerShutdown(t, h2Mode) }
++func TestServerShutdown_h1(t *testing.T) {
++	testServerShutdown(t, h1Mode)
++}
++func TestServerShutdown_h2(t *testing.T) {
++	testServerShutdown(t, h2Mode)
++}
+ 
+ func testServerShutdown(t *testing.T, h2 bool) {
+ 	setParallel(t)
+ 	defer afterTest(t)
+ 	var doShutdown func() // set later
++	var doStateCount func()
+ 	var shutdownRes = make(chan error, 1)
++	var statesRes = make(chan map[ConnState]int, 1)
+ 	var gotOnShutdown = make(chan struct{}, 1)
+ 	handler := HandlerFunc(func(w ResponseWriter, r *Request) {
++		doStateCount()
+ 		go doShutdown()
+ 		// Shutdown is graceful, so it should not interrupt
+-		// this in-flight response. Add a tiny sleep here to
++		// this in-flight response. Add a sleep here to
+ 		// increase the odds of a failure if shutdown has
+ 		// bugs.
+ 		time.Sleep(20 * time.Millisecond)
+@@ -5568,6 +5575,9 @@ func testServerShutdown(t *testing.T, h2 bool) {
+ 	doShutdown = func() {
+ 		shutdownRes <- cst.ts.Config.Shutdown(context.Background())
+ 	}
++	doStateCount = func() {
++		statesRes <- cst.ts.Config.ExportAllConnsByState()
++	}
+ 	get(t, cst.c, cst.ts.URL) // calls t.Fail on failure
+ 
+ 	if err := <-shutdownRes; err != nil {
+@@ -5579,6 +5589,10 @@ func testServerShutdown(t *testing.T, h2 bool) {
+ 		t.Errorf("onShutdown callback not called, RegisterOnShutdown broken?")
+ 	}
+ 
++	if states := <-statesRes; states[StateActive] != 1 {
++		t.Errorf("connection in wrong state, %v", states)
++	}
++
+ 	res, err := cst.c.Get(cst.ts.URL)
+ 	if err == nil {
+ 		res.Body.Close()
+diff --git a/src/net/http/server.go b/src/net/http/server.go
+index 8252e45aca..ee367526f8 100644
+--- a/src/net/http/server.go
++++ b/src/net/http/server.go
+@@ -323,7 +323,7 @@ func (c *conn) hijackLocked() (rwc net.Conn, buf *bufio.ReadWriter, err error) {
+ 			return nil, nil, fmt.Errorf("unexpected Peek failure reading buffered byte: %v", err)
+ 		}
+ 	}
+-	c.setState(rwc, StateHijacked)
++	c.setState(rwc, StateHijacked, true)
+ 	return
+ }
+ 
+@@ -1703,7 +1703,7 @@ func validNPN(proto string) bool {
+ 	return true
+ }
+ 
+-func (c *conn) setState(nc net.Conn, state ConnState) {
++func (c *conn) setState(nc net.Conn, state ConnState, runHook bool) {
+ 	srv := c.server
+ 	switch state {
+ 	case StateNew:
+@@ -1716,6 +1716,9 @@ func (c *conn) setState(nc net.Conn, state ConnState) {
+ 	}
+ 	packedState := uint64(time.Now().Unix()<<8) | uint64(state)
+ 	atomic.StoreUint64(&c.curState.atomic, packedState)
++	if !runHook {
++		return
++	}
+ 	if hook := srv.ConnState; hook != nil {
+ 		hook(nc, state)
+ 	}
+@@ -1769,7 +1772,7 @@ func (c *conn) serve(ctx context.Context) {
+ 		}
+ 		if !c.hijacked() {
+ 			c.close()
+-			c.setState(c.rwc, StateClosed)
++			c.setState(c.rwc, StateClosed, true)
+ 		}
+ 	}()
+ 
+@@ -1797,6 +1800,8 @@ func (c *conn) serve(ctx context.Context) {
+ 		if proto := c.tlsState.NegotiatedProtocol; validNPN(proto) {
+ 			if fn := c.server.TLSNextProto[proto]; fn != nil {
+ 				h := initNPNRequest{ctx, tlsConn, serverHandler{c.server}}
++				// issue 39776: prevent closeIdleConns from closing these connections
++				c.setState(c.rwc, StateActive, false)
+ 				fn(c.server, tlsConn, h)
+ 			}
+ 			return
+@@ -1817,7 +1822,7 @@ func (c *conn) serve(ctx context.Context) {
+ 		w, err := c.readRequest(ctx)
+ 		if c.r.remain != c.server.initialReadLimitSize() {
+ 			// If we read any bytes off the wire, we're active.
+-			c.setState(c.rwc, StateActive)
++			c.setState(c.rwc, StateActive, true)
+ 		}
+ 		if err != nil {
+ 			const errorHeaders = "\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\n"
+@@ -1899,7 +1904,7 @@ func (c *conn) serve(ctx context.Context) {
+ 			}
+ 			return
+ 		}
+-		c.setState(c.rwc, StateIdle)
++		c.setState(c.rwc, StateIdle, true)
+ 		c.curReq.Store((*response)(nil))
+ 
+ 		if !w.conn.server.doKeepAlives() {
+@@ -2924,7 +2929,7 @@ func (srv *Server) Serve(l net.Listener) error {
+ 		}
+ 		tempDelay = 0
+ 		c := srv.newConn(rw)
+-		c.setState(c.rwc, StateNew) // before Serve can return
++		c.setState(c.rwc, StateNew, true) // before Serve can return
+ 		go c.serve(connCtx)
+ 	}
+ }

--- a/images/hyperkube/Dockerfile.rhel
+++ b/images/hyperkube/Dockerfile.rhel
@@ -1,6 +1,10 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 WORKDIR /go/src/github.com/openshift/origin
 COPY . .
+# apply a patch to net/http2 library that fixes the graceful termination of active connections, more details at: https://github.com/golang/go/issues/39776
+# this patch was prepared based on https://go-review.googlesource.com/c/go/+/240278/. The original patch is targeting the master branch and didn't apply to 1.13 version
+RUN patch -d /usr/local/go -p1 < images/hyperkube/4d8de76-1.13.patch
+RUN go test -v --race images/hyperkube/gc_test.go
 RUN for p in vendor/k8s.io/kubernetes/cmd/kube-apiserver vendor/k8s.io/kubernetes/cmd/kube-controller-manager \
     vendor/k8s.io/kubernetes/cmd/kube-scheduler vendor/k8s.io/kubernetes/cmd/kubelet cmd/watch-termination; do make build WHAT=$p; done && \
     mkdir -p /tmp/build && \

--- a/images/hyperkube/gc_test.go
+++ b/images/hyperkube/gc_test.go
@@ -1,0 +1,165 @@
+package gc_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"golang.org/x/net/http2"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+var startGC = make(chan struct{})
+var lock = sync.Mutex{}
+var counter = 0
+
+type targetHTTPHandler struct {
+}
+
+func (d *targetHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	lock.Lock()
+	counter++
+	if counter == 25 {
+		startGC <- struct{}{}
+	}
+	if r.Proto != "HTTP/2.0" {
+		w.Write([]byte(fmt.Sprintf("unexpected proto %v", r.Proto)))
+		w.WriteHeader(http.StatusInternalServerError)
+		lock.Unlock()
+		return
+	}
+	lock.Unlock()
+	time.Sleep(60 * time.Second)
+	w.Write([]byte("hello from the backend"))
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestGracefulShutdownForActiveStreams(t *testing.T) {
+	// set up the backend server
+	backendHandler := &targetHTTPHandler{}
+	backendServer := httptest.NewUnstartedServer(backendHandler)
+	backendCert, err := tls.X509KeyPair(backendCrt, backendKey)
+	if err != nil {
+		t.Fatalf("backend: invalid x509/key pair: %v", err)
+	}
+	backendServer.TLS = &tls.Config{
+		Certificates: []tls.Certificate{backendCert},
+		NextProtos:   []string{http2.NextProtoTLS},
+	}
+	backendServer.StartTLS()
+	defer backendServer.Close()
+
+	// set up the client
+	clientCACertPool := x509.NewCertPool()
+	clientCACertPool.AppendCertsFromPEM(backendCrt)
+	clientTLSConfig := &tls.Config{
+		RootCAs:    clientCACertPool,
+		NextProtos: []string{http2.NextProtoTLS},
+	}
+
+	client := &http.Client{}
+	client.Transport = &http2.Transport{
+		TLSClientConfig: clientTLSConfig,
+	}
+
+	sendRequest := func(wg *sync.WaitGroup) {
+		defer func() {
+			wg.Done()
+		}()
+		// act
+		resp, err := client.Get(fmt.Sprintf("https://localhost:%d", backendServer.Listener.Addr().(*net.TCPAddr).Port))
+		if err != nil {
+			t.Errorf("%v", err)
+			return
+		}
+
+		// validate
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		t.Logf("body %s", body)
+
+		if resp.StatusCode != 200 {
+			t.Errorf("unexpected HTTP staus: %v, expected: 200", resp.StatusCode)
+		}
+		expectedProto := "HTTP/2.0"
+		if resp.Proto != expectedProto {
+			t.Errorf("unexpected response proto: %v, expected: %v", resp.Proto, expectedProto)
+		}
+	}
+
+	go func() {
+		<-startGC
+		time.Sleep(5 * time.Second) // gives the last connection a chance to go into the sleep state
+
+		// Requires https://github.com/golang/go/issues/39776 to work properly
+		backendServer.Config.Shutdown(context.Background())
+	}()
+
+	wg := sync.WaitGroup{}
+	wg.Add(25)
+	for i := 0; i < 25; i++ {
+		go sendRequest(&wg)
+	}
+
+	wg.Wait()
+}
+
+// valid for localhost
+var backendCrt = []byte(`-----BEGIN CERTIFICATE-----
+MIIC5TCCAc2gAwIBAgIJAOS8kx4rqQxcMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDAeFw0yMDA2MTUxMTE2MDFaFw0yMDA3MTUxMTE2MDFaMBQx
+EjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAPL7bdiu1h8BadQPn5tgN4cBbMLmP8jpNduoC7KExbtKz7mdbCi7t5/vRgEq
+tEgJqcsBbCCZzAYQHExkRqchaiVOQf1JvYywHSJ0IQ9IpIB4WwZiRitKsBoUwufn
+ekpvHNOUwKbjQWdxCz26sCSgDsLNK2COmJwFoTFUQWuC0X1SYsT5KqnJwTMP19Xq
+GFI0sWsZoQxe7QhJBYu8ierA+OkS0yZiBvFX8Cb1ChjUA3D1Bred2eNSZSafij2z
+ZsvpAQea7lUmRVAJe/+HHGgptXiHR+voWh5LnI+SGTfRIjgXSogc6rSlkDxBL3qs
+BSOKoiF8sy9WkowY8FKGGQkMmJcCAwEAAaM6MDgwFAYDVR0RBA0wC4IJbG9jYWxo
+b3N0MAsGA1UdDwQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATANBgkqhkiG9w0B
+AQsFAAOCAQEAvqdSHV2OAY36Xwe+5egq2oH98zfxTyp9hgsIO/8VJf/ukw+sSKFY
+ZEl3ABzjHk9BDyLLoj6DjvjHva6Ghk/ruYg9Q312+dkn/RRCuKx2cOUSq+SFZxra
+Lv4BMO8miiPeVmvP1klhqZZMCV7qpC/MdVVn3SgGYB9ymhGQa0iE0scUk1+zDNIg
+p7iHbi227WZ/pROEFt8sSf1MltaQ/0QI9G2yCxDgjPSNte8vCqVDbXZkXBE5i6qF
+TbvIk4/K13UC3YAgfhedNzf5Smbe6moK008BCp7itKL6IDb20gI9htBsgzolT8O+
+G5lxVI5gSU/VdcGjW0EyWcKEct4LZMUTCg==
+-----END CERTIFICATE-----
+`)
+
+var backendKey = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDy+23YrtYfAWnU
+D5+bYDeHAWzC5j/I6TXbqAuyhMW7Ss+5nWwou7ef70YBKrRICanLAWwgmcwGEBxM
+ZEanIWolTkH9Sb2MsB0idCEPSKSAeFsGYkYrSrAaFMLn53pKbxzTlMCm40FncQs9
+urAkoA7CzStgjpicBaExVEFrgtF9UmLE+SqpycEzD9fV6hhSNLFrGaEMXu0ISQWL
+vInqwPjpEtMmYgbxV/Am9QoY1ANw9Qa3ndnjUmUmn4o9s2bL6QEHmu5VJkVQCXv/
+hxxoKbV4h0fr6FoeS5yPkhk30SI4F0qIHOq0pZA8QS96rAUjiqIhfLMvVpKMGPBS
+hhkJDJiXAgMBAAECggEAIreyFkfE6GE3Ucl5sKWqyWt2stJbQsWvoFb+dN9rsTsb
+OxY3IgrQTdXOVtRXNgPLcuodHPtcn3El2fRp8+9eTz5DR4GFx9hSEV4uaxSiDIkl
+2F+qTv049EELKD92xbPiloimjjHiYnlQdd161YDZGxRdoko9m+1h/r5fKpFihVk8
+5H6RaGb2hga6iuIvAoZ0sGPOIchSOOXC0Dpz7AimSW8JnE2aWNlRu/jiBQ9RxhAr
+WP5Ey2FpNqgQfD22pbx3Ql7ULdFV2GP4owo3eWDbvHtIq+Q9WibE7zfWTtBuTKYu
+oeo2e8mkKR83KmtqWzLRGEgxDvzwT/fk8ldoiSZewQKBgQD8kdEYrqyJA6kGCrQY
+YjX8BXu+c4fkm3yxwGLJiA7RExckQ5smxy1Fzl4I4PApxWStOWxm5Uh2s0xSbDW3
+TnRyuzVq5XehQiB5vFzPgU3ywKLy4hXrKxSotH/k6yHQMF4QJZaPpkxPQNIbdN03
+6yntrdNB4sUxpYbrtAeSYaqziQKBgQD2SEbbOOO6Zl96KAiQ0D3v7vP86H4gjyLV
+w1VDiyRCPimHbT3kCNKQZMQdKPssvf3ie6JBMNQc0K3lkzU2qvihI6jOb6QK6QIF
+5eqySPDV7ZysU4CaFHSLXg6pyJ5XB+3Y8mmxnEm6EmpeOuI+4MCZ5zcFR1+kIRHU
+ORzLGERDHwKBgQDKHXJjuxyNBKXVFOmr/aPPyx+Md+2OjrMJl7g2KDAbNZi2R3e4
+X3mmPA/aMQ9fjfwT9zj9WoxTmQYBi2CtERZ03cVQhtLl9AIDCS6IS6RyF6AOl8gM
+ikwc+VzDdzp23M3ZRAspZ133qhq5KBsDbaf+8LR3LB67rQe8RTQt+wRcaQKBgQDE
+BS7wWU1YFRc1IRwANt61U5k62MlanNJ7FWeNxPdtChD/y0EReLwvVSSKmQ2hxO6I
+DyNLg9Ovw6BFM2+NPXN6vekjtdP5IxALJb4xfMDDZMXomuWmvVUtgAVnuVfdqV/z
+5q2dQemkgffLXE6rATQKyu8N8or7FZ8dLP/v3jamvQKBgER5Rr91lvS2HFXow8Rg
+tAmpti96MRH0SK2gdAoT7Xr9hsqqC8dAtgAdF+jzeecQk5IaNlGS0SRQpCdMIvE1
+Qy8OUgg/TEsBhDpg4FbFXwqlOE1PVsV+HNw578YHkOkamSH1rxTW9EJI8h+aiwqr
+Yw8ovJTCPLC33LushxKas9hY
+-----END PRIVATE KEY-----
+`)


### PR DESCRIPTION
this patch fixes `net/http2` library to properly manage the connection state,
this allow to proper shutdown sequence to occur.
as a result `Server.Shutdown` will wait for the active connections to finish before shutting down the HTTP server

`4d8de76-1.13.patch` was prepared based on https://go-review.googlesource.com/c/go/+/240278
the original patch targets the master branch and didn't apply to golang 1.13.