### PR TITLE
Bug 1857025: Sanitize TLS config that has key bundled with cert

### DIFF
--- a/pkg/route/controller/routeapihelpers/validation_test.go
+++ b/pkg/route/controller/routeapihelpers/validation_test.go
@@ -1624,6 +1624,49 @@ func TestExtendedValidateRoute(t *testing.T) {
 			},
 			expectedErrors: 0,
 		},
+		{
+			name: "bz1843856",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+						Certificate: testCertificate + "\n" + testPrivateKey,
+					},
+				},
+			},
+			expectRoute: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+						Certificate: testCertificate + "\n",
+						Key:         testPrivateKey + "\n",
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Edge termination with private key in both cert and key fields",
+			route: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+						Certificate: testCertificate + "\n" + testPrivateKey,
+						Key:         testExpiredCertificateKey,
+					},
+				},
+			},
+			expectRoute: &routev1.Route{
+				Spec: routev1.RouteSpec{
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationEdge,
+						Certificate: testCertificate + "\n",
+						Key:         testPrivateKey + "\n" + testExpiredCertificateKey + "\n",
+					},
+				},
+			},
+			expectedErrors: 0,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Modify the extended validation logic to copy any private key found in the certificate field of a route's TLS configuration to its key field.

Extended validation validates a route's TLS configuration using any key that is specified in either the TLS configuration's certificate field or its key field.  As a result, a route that specifies the certificate and key together in the certificate field may pass extended validation and be admitted.  However, the certificate manager only wrote the certificate out if the TLS configuration had a nonempty key field.  As a result, a route with a valid certificate and key could be admitted but the certificate and key not written out, which would cause HAProxy to fail to load.

* `pkg/route/controller/routeapihelpers/validation.go` (`splitCertKey`): New function.  Take sanitized PEM data and split it into public and private parts.
(`ExtendedValidateRoute`): Use `splitCertKey` to parse out any private parts that are in the certificate field of the TLS configuration.  Prepend any private parts found in the certificate data to the TLS configuration's key.
* `pkg/route/controller/routeapihelpers/validation_test.go`: Add test cases.