### PR TITLE
UPSTREAM: <carry>: apiserver: skip local IPs and probes for LateConnections – fix race

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -354,7 +354,7 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 		Listener:   s.SecureServingInfo.Listener,
 		lateStopCh: lateStopCh,
 	}
-	lateConnectionEventf = s.Eventf
+	lateConnectionEventf.Store(eventfFunc(s.Eventf))
 
 	// close socket after delayed stopCh
 	stoppedCh, err := s.NonBlockingRun(delayedStopCh)


### PR DESCRIPTION
In unit tests we create multiple apiservers in parallel, leading to a race writing the global variable.