### PR TITLE
WIP: debugging missing configmaps.yaml and secrets.yaml

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -104,8 +104,8 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 			{pluginOutputDir, "cluster-scoped-resources", "config.openshift.io", "projects.yaml"},
 			{pluginOutputDir, "cluster-scoped-resources", "config.openshift.io", "schedulers.yaml"},
 			// TODO: This got broken and we need to fix this. Disabled temporarily.
-			// {pluginOutputDir, "namespaces", "openshift-kube-apiserver", "core", "configmaps.yaml"},
-			// {pluginOutputDir, "namespaces", "openshift-kube-apiserver", "core", "secrets.yaml"},
+			{pluginOutputDir, "namespaces", "openshift-kube-apiserver", "core", "configmaps.yaml"},
+			{pluginOutputDir, "namespaces", "openshift-kube-apiserver", "core", "secrets.yaml"},
 			{pluginOutputDir, "host_service_logs", "masters", "crio_service.log"},
 			{pluginOutputDir, "host_service_logs", "masters", "kubelet_service.log"},
 		}


### PR DESCRIPTION
Existing report: https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/25245/pull-ci-openshift-origin-master-e2e-gcp/1280552415996678144

Findings:
TBD