### PR TITLE
test: Allow test suites to define additional checks for suite failure

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -34,7 +34,7 @@ type UpgradeTest struct {
 
 func (UpgradeTest) Name() string { return "check-for-critical-alerts" }
 func (UpgradeTest) DisplayName() string {
-	return "Check if critical alerts are firing after upgrade success"
+	return "[sig-arch] Check if critical alerts are firing after upgrade success"
 }
 
 // Setup creates parameters to query Prometheus
@@ -94,7 +94,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 
 	helper.RunQueries(tests, t.oc, ns, execPod.Name, t.url, t.bearerToken)
 
-	framework.Logf("No crtical alerts firing post-upgrade")
+	framework.Logf("No critical alerts firing post-upgrade")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -34,7 +34,7 @@ type UpgradeTest struct {
 
 func (UpgradeTest) Name() string { return "k8s-service-lb-available" }
 func (UpgradeTest) DisplayName() string {
-	return "Application behind service load balancer with PDB is not disrupted"
+	return "[sig-network-edge] Application behind service load balancer with PDB is not disrupted"
 }
 
 func shouldTestPDBs() bool { return true }

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -18,8 +18,10 @@ type KubeAvailableTest struct {
 	availableTest
 }
 
-func (KubeAvailableTest) Name() string        { return "kubernetes-api-available" }
-func (KubeAvailableTest) DisplayName() string { return "Kubernetes APIs remain available" }
+func (KubeAvailableTest) Name() string { return "kubernetes-api-available" }
+func (KubeAvailableTest) DisplayName() string {
+	return "[sig-api-machinery] Kubernetes APIs remain available"
+}
 func (t *KubeAvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	t.availableTest.test(f, done, upgrade, monitor.StartKubeAPIMonitoring)
 }
@@ -29,8 +31,10 @@ type OpenShiftAvailableTest struct {
 	availableTest
 }
 
-func (OpenShiftAvailableTest) Name() string        { return "openshift-api-available" }
-func (OpenShiftAvailableTest) DisplayName() string { return "OpenShift APIs remain available" }
+func (OpenShiftAvailableTest) Name() string { return "openshift-api-available" }
+func (OpenShiftAvailableTest) DisplayName() string {
+	return "[sig-api-machinery] OpenShift APIs remain available"
+}
 func (t *OpenShiftAvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	t.availableTest.test(f, done, upgrade, monitor.StartOpenShiftAPIMonitoring)
 }

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -44,7 +44,7 @@ type Frontend struct {
 
 func (AvailableTest) Name() string { return "frontend-ingress-available" }
 func (AvailableTest) DisplayName() string {
-	return "Cluster frontend ingress remain available"
+	return "[sig-network-edge] Cluster frontend ingress remain available"
 }
 
 // Setup finds the routes the platform exposes by default


### PR DESCRIPTION
Future changes will test invariants reported by events, such as whether
images were pulled from outside of the current code base. Also updates
the junit reporting for the "error level events" to be reported as a
flake, and corrects the duration to include "late" tests.