### PR TITLE
[wip] test/extended/etcd: temporarily whitelist new v1 resources

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -193,6 +193,16 @@ var kindWhiteList = sets.NewString(
 	"ClusterResourceQuota",
 	"SecurityContextConstraints",
 	"RoleBindingRestriction",
+	// TODO @hexfusion
+	// temporary whitelist to unblock rebase
+	"Event",
+	"Events",
+	"CertificateSigningRequest",
+	"CertificateSigningRequests",
+	"IngressClass",
+	"IngressClasses",
+	"Ingress",
+	"Ingresses",
 )
 
 // namespace used for all tests, do not change this


### PR DESCRIPTION
unblocking rebase.

```
fail [github.com/openshift/origin@/test/extended/etcd/etcd_test_runner.go:80]: test failed:
no test data for events.k8s.io/v1, Kind=Event.  Please add a test for your new type to etcdStorageData.
no test data for certificates.k8s.io/v1, Kind=CertificateSigningRequest.  Please add a test for your new type to etcdStorageData.
no test data for networking.k8s.io/v1, Kind=IngressClass.  Please add a test for your new type to etcdStorageData.
no test data for networking.k8s.io/v1, Kind=Ingress.  Please add a test for your new type to etcdStorageData.
```

ref: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_kubernetes/166/pull-ci-openshift-kubernetes-master-e2e-aws-serial/1285974488860594176

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>