### PR TITLE
test: Report an error message when a pod fails in a cmd test

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -1658,9 +1659,9 @@ func RunOneShotCommandPod(
 			return false, nil
 		}
 
-		if podHasErrored(cmdPod) {
+		if err := podHasErrored(cmdPod); err != nil {
 			e2e.Logf("pod %q errored trying to run the command: %v", pod.Name, err)
-			return false, nil
+			return false, err
 		}
 		return podHasCompleted(cmdPod), nil
 	})
@@ -1693,10 +1694,13 @@ func podHasCompleted(pod *corev1.Pod) bool {
 		pod.Status.ContainerStatuses[0].State.Terminated.Reason == "Completed"
 }
 
-func podHasErrored(pod *corev1.Pod) bool {
-	return len(pod.Status.ContainerStatuses) > 0 &&
+func podHasErrored(pod *corev1.Pod) error {
+	if len(pod.Status.ContainerStatuses) > 0 &&
 		pod.Status.ContainerStatuses[0].State.Terminated != nil &&
-		pod.Status.ContainerStatuses[0].State.Terminated.Reason == "Error"
+		pod.Status.ContainerStatuses[0].State.Terminated.Reason == "Error" {
+		return errors.New(pod.Status.ContainerStatuses[0].State.Terminated.Message)
+	}
+	return nil
 }
 
 func getPodLogs(oc *CLI, pod *corev1.Pod) (string, error) {
@@ -1722,13 +1726,14 @@ func newCommandPod(name, image, command string, args []string, volumeMounts []co
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Containers: []corev1.Container{
 				{
-					Name:            name,
-					Image:           image,
-					Command:         []string{command},
-					Args:            args,
-					VolumeMounts:    volumeMounts,
-					ImagePullPolicy: "Always",
-					Env:             env,
+					Name:                     name,
+					Image:                    image,
+					Command:                  []string{command},
+					Args:                     args,
+					VolumeMounts:             volumeMounts,
+					ImagePullPolicy:          "Always",
+					Env:                      env,
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 		},


### PR DESCRIPTION
The logic for testing for pod failure lost the reason why, so no
debug output was possible. Instead, update the one shot pod to
capture fallback logs and then have the executor report that as
the error message.

E.g.

    Jul 22 20:13:43.152: INFO: pod "test-cmd" errored trying to run the command: <nil>

because err was nil in the context it was invoked.

Noticed in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/25304/pull-ci-openshift-origin-master-e2e-cmd/1286015364055961600