### PR TITLE
make the error message specific to which API server connection blipped

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -35,8 +35,8 @@ import (
 
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
-		&controlplane.KubeAvailableTest{},
-		&controlplane.OpenShiftAvailableTest{},
+		controlplane.NewKubeAvailableTest(),
+		controlplane.NewOpenShiftAvailableTest(),
 		&alert.UpgradeTest{},
 		&frontends.AvailableTest{},
 		&service.UpgradeTest{},

--- a/test/extended/dr/machine_recover.go
+++ b/test/extended/dr/machine_recover.go
@@ -61,8 +61,8 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive
 			disruption.TestData{},
 			[]upgrades.Test{
 				&upgrades.ServiceUpgradeTest{},
-				&controlplane.KubeAvailableTest{},
-				&controlplane.OpenShiftAvailableTest{},
+				controlplane.NewKubeAvailableTest(),
+				controlplane.NewOpenShiftAvailableTest(),
 				&frontends.AvailableTest{},
 			},
 			func() {

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"k8s.io/client-go/rest"
@@ -13,33 +14,43 @@ import (
 	"github.com/openshift/origin/test/extended/util/disruption"
 )
 
-// KubeAvailableTest tests that the Kubernetes control plane remains available during and after a cluster upgrade.
-type KubeAvailableTest struct {
+// NewKubeAvailableTest tests that the Kubernetes control plane remains available during and after a cluster upgrade.
+func NewKubeAvailableTest() upgrades.Test {
+	return &kubeAvailableTest{availableTest{name: "kubernetes-api-available"}}
+}
+
+type kubeAvailableTest struct {
 	availableTest
 }
 
-func (KubeAvailableTest) Name() string { return "kubernetes-api-available" }
-func (KubeAvailableTest) DisplayName() string {
+func (t kubeAvailableTest) Name() string { return t.availableTest.name }
+func (kubeAvailableTest) DisplayName() string {
 	return "[sig-api-machinery] Kubernetes APIs remain available"
 }
-func (t *KubeAvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+func (t *kubeAvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	t.availableTest.test(f, done, upgrade, monitor.StartKubeAPIMonitoring)
 }
 
-// OpenShiftAvailableTest tests that the OpenShift APIs remains available during and after a cluster upgrade.
-type OpenShiftAvailableTest struct {
+// NewOpenShiftAvailableTest tests that the OpenShift APIs remains available during and after a cluster upgrade.
+func NewOpenShiftAvailableTest() upgrades.Test {
+	return &kubeAvailableTest{availableTest{name: "openshift-api-available"}}
+}
+
+type openShiftAvailableTest struct {
 	availableTest
 }
 
-func (OpenShiftAvailableTest) Name() string { return "openshift-api-available" }
-func (OpenShiftAvailableTest) DisplayName() string {
+func (t openShiftAvailableTest) Name() string { return t.availableTest.name }
+func (openShiftAvailableTest) DisplayName() string {
 	return "[sig-api-machinery] OpenShift APIs remain available"
 }
-func (t *OpenShiftAvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+func (t *openShiftAvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	t.availableTest.test(f, done, upgrade, monitor.StartOpenShiftAPIMonitoring)
 }
 
 type availableTest struct {
+	// name helps distinguish which API server in particular is unavailable.
+	name string
 }
 
 type starter func(ctx context.Context, m *monitor.Monitor, clusterConfig *rest.Config, timeout time.Duration) error
@@ -67,7 +78,7 @@ func (t *availableTest) test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.08, end.Sub(start), m.Events(time.Time{}, time.Time{}), "API was unreachable during disruption")
+	disruption.ExpectNoDisruption(f, 0.08, end.Sub(start), m.Events(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption", t.name))
 }
 
 // Teardown cleans up any remaining resources.


### PR DESCRIPTION
This will help us narrow down messages like https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.6/1286281612429889536 more easily.

/assign @mfojtik 