### PR TITLE
UPSTREAM: <carry>: remove apiservice from sync in CRD registration when exists

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -195,10 +195,6 @@ func (c *crdRegistrationController) handleVersionUpdate(groupVersion schema.Grou
 	apiServiceName := groupVersion.Version + "." + groupVersion.Group
 
 	if apiserver.APIServiceAlreadyExists(groupVersion) {
-		// Removing APIService from sync means the CRD registration controller won't sync this APIService
-		// anymore. If the APIService is managed externally, this will mean the external component can
-		// update this APIService without CRD controller stomping the changes on it.
-		c.apiServiceRegistration.RemoveAPIServiceToSync(apiServiceName)
 		return nil
 	}
 


### PR DESCRIPTION
Credit to @sttts for finding this out.

This reverts commit d3ceac4e065c3d2689192fda102303030cfdb928.