### PR TITLE
Update OLM e2e to include quotes on substring check

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -74,8 +74,8 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 				// Ensure expected version exists in spec.versions and is both served and stored
 				raw, err := oc.AsAdmin().Run("get").Args("crds", fmt.Sprintf("%s.%s", api.plural, api.group), fmt.Sprintf("-o=jsonpath={.spec.versions[?(@.name==\"%s\")]}", api.version)).Output()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(raw).To(o.ContainSubstring("served:true"))
-				o.Expect(raw).To(o.ContainSubstring("storage:true"))
+				o.Expect(raw).To(o.MatchRegexp(`served.?:true`))
+				o.Expect(raw).To(o.MatchRegexp(`storage.?:true`))
 			}
 		})
 	}


### PR DESCRIPTION
This test fails (ex https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oc/491/pull-ci-openshift-oc-master-e2e-aws/1286712821660258304) with:

```
fail [github.com/openshift/origin@/test/extended/operators/olm.go:77]: Expected
<truncated long json output.... "served":true,"storage":true,"subresources":{"status":{}}}
to contain substring
    <string>: served:true
```