### PR TITLE
test: report API server version in etcd storage test

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -276,6 +276,8 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, kubeConfig *restclient.Config, e
 		t.Fatal(err)
 	}
 
+	t.Logf("Kubernetes API server version: %+v", version)
+
 	etcdStorageData := etcddata.GetEtcdStorageData()
 
 	removeStorageData(t, etcdStorageData,


### PR DESCRIPTION
Due to high CI failures in this test, lets make sure the version reported by API server is the correct one.