### PR TITLE
Disable named network metrics test.

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -429,6 +429,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			helper.RunQueries(queries, oc, ns, execPod.Name, url, bearerToken)
 		})
 		g.It("should provide named network metrics", func() {
+			g.Skip("Disabling on master, https://bugzilla.redhat.com/show_bug.cgi?id=1860837")
 			oc.SetupProject()
 			ns := oc.Namespace()
 


### PR DESCRIPTION
Disabling as it's blocking e2e tests. This is traced in https://bugzilla.redhat.com/show_bug.cgi?id=1860837
