### PR TITLE
Fix "should provide named network metrics" test.

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -454,8 +454,8 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 
 			g.By("verifying named metrics keys")
 			queries := map[string]bool{
-				fmt.Sprintf(`pod_network_name_info{pod="%s",namespace="%s",interface="eth0"} == 0`, execPod.Name, execPod.Namespace):         true,
-				fmt.Sprintf(`pod_network_name_info{pod="%s",namespace="%s",network_name="secondary"} == 0`, execPod.Name, execPod.Namespace): true,
+				fmt.Sprintf(`pod_network_name_info{pod="%s",namespace="%s",interface="eth0"} == 0`, execPod.Name, execPod.Namespace):                true,
+				fmt.Sprintf(`pod_network_name_info{pod="%s",namespace="%s",network_name="%s/secondary"} == 0`, execPod.Name, execPod.Namespace, ns): true,
 			}
 			helper.RunQueries(queries, oc, ns, execPod.Name, url, bearerToken)
 		})


### PR DESCRIPTION
The network name is now produced as the composition of namespace and the network name.
This is introduced by a change in multus https://github.com/openshift/multus-cni/commit/e7c8977423a6c221074f173a497a5de0aaa98649
so the change in the test reflects the change in the way the interface name is added to
the pod.

