### PR TITLE
Bug 1860837: Re-enable prometheus named network metrics test.

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -429,7 +429,6 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			helper.RunQueries(queries, oc, ns, execPod.Name, url, bearerToken)
 		})
 		g.It("should provide named network metrics", func() {
-			g.Skip("Disabling on master, https://bugzilla.redhat.com/show_bug.cgi?id=1860837")
 			oc.SetupProject()
 			ns := oc.Namespace()
 


### PR DESCRIPTION
Now that https://github.com/openshift/origin/pull/25328 is merged, the test should be fixed.
We can remove the skip and re-enable the test.
