### PR TITLE
bug 1861189: UPSTREAM: <drop>: make pdb tests pass reliably

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/apps/disruption.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/disruption.go
@@ -131,10 +131,12 @@ var _ = SIGDescribe("DisruptionController", func() {
 		framework.ExpectHaveKey(updated.Status.DisruptedPods, pod.Name, "Expecting the DisruptedPods have %s", pod.Name)
 
 		ginkgo.By("Patching PodDisruptionBudget status")
-		patched, _ := patchPDBOrDie(cs, dc, ns, defaultName, func(old *policyv1beta1.PodDisruptionBudget) (bytes []byte, err error) {
-			oldBytes, _ := json.Marshal(old)
+		patched := patchPDBOrDie(cs, dc, ns, defaultName, func(old *policyv1beta1.PodDisruptionBudget) (bytes []byte, err error) {
+			oldBytes, err := json.Marshal(old)
+			framework.ExpectNoError(err, "failed to marshal JSON for old data")
 			old.Status.DisruptedPods = make(map[string]metav1.Time)
-			newBytes, _ := json.Marshal(old)
+			newBytes, err := json.Marshal(old)
+			framework.ExpectNoError(err, "failed to marshal JSON for new data")
 			return jsonpatch.CreateMergePatch(oldBytes, newBytes)
 		}, "status")
 		framework.ExpectEmpty(patched.Status.DisruptedPods, "Expecting the PodDisruptionBudget's be empty")
@@ -274,10 +276,10 @@ var _ = SIGDescribe("DisruptionController", func() {
 		createReplicaSetOrDie(cs, ns, 3, false)
 
 		ginkgo.By("First trying to evict a pod which shouldn't be evictable")
+		waitForPodsOrDie(cs, ns, 3) // make sure that they are running and so would be evictable with a different pdb
+
 		pod, err := locateRunningPod(cs, ns)
 		framework.ExpectNoError(err)
-
-		waitForPodsOrDie(cs, ns, 3) // make sure that they are running and so would be evictable with a different pdb
 		e := &policyv1beta1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pod.Name,
@@ -303,16 +305,18 @@ var _ = SIGDescribe("DisruptionController", func() {
 		ginkgo.By("Patching the pdb to disallow a pod to be evicted")
 		patchPDBOrDie(cs, dc, ns, defaultName, func(old *policyv1beta1.PodDisruptionBudget) (bytes []byte, err error) {
 			oldData, err := json.Marshal(old)
+			framework.ExpectNoError(err, "failed to marshal JSON for old data")
 			old.Spec.MinAvailable = nil
 			maxUnavailable := intstr.FromInt(0)
 			old.Spec.MaxUnavailable = &maxUnavailable
-			newData, _ := json.Marshal(old)
+			newData, err := json.Marshal(old)
+			framework.ExpectNoError(err, "failed to marshal JSON for new data")
 			return jsonpatch.CreateMergePatch(oldData, newData)
 		})
 
+		waitForPodsOrDie(cs, ns, 3)
 		pod, err = locateRunningPod(cs, ns) // locate a new running pod
 		framework.ExpectNoError(err)
-		waitForPodsOrDie(cs, ns, 3)
 		e = &policyv1beta1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pod.Name,
@@ -370,8 +374,8 @@ type updateFunc func(pdb *policyv1beta1.PodDisruptionBudget) *policyv1beta1.PodD
 type updateRestAPI func(ctx context.Context, podDisruptionBudget *policyv1beta1.PodDisruptionBudget, opts metav1.UpdateOptions) (*policyv1beta1.PodDisruptionBudget, error)
 type patchFunc func(pdb *policyv1beta1.PodDisruptionBudget) ([]byte, error)
 
-func updatePDBOrDie(cs kubernetes.Interface, ns string, name string, f updateFunc, api updateRestAPI) (updated *policyv1beta1.PodDisruptionBudget, err error) {
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+func updatePDBOrDie(cs kubernetes.Interface, ns string, name string, f updateFunc, api updateRestAPI) (updated *policyv1beta1.PodDisruptionBudget) {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		old, err := cs.PolicyV1beta1().PodDisruptionBudgets(ns).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -385,22 +389,24 @@ func updatePDBOrDie(cs kubernetes.Interface, ns string, name string, f updateFun
 
 	framework.ExpectNoError(err, "Waiting for the PDB update to be processed in namespace %s", ns)
 	waitForPdbToBeProcessed(cs, ns, name)
-	return updated, err
+	return updated
 }
 
-func patchPDBOrDie(cs kubernetes.Interface, dc dynamic.Interface, ns string, name string, f patchFunc, subresources ...string) (updated *policyv1beta1.PodDisruptionBudget, err error) {
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+func patchPDBOrDie(cs kubernetes.Interface, dc dynamic.Interface, ns string, name string, f patchFunc, subresources ...string) (updated *policyv1beta1.PodDisruptionBudget) {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		old := getPDBStatusOrDie(dc, ns, name)
 		patchBytes, err := f(old)
+		framework.ExpectNoError(err)
 		if updated, err = cs.PolicyV1beta1().PodDisruptionBudgets(ns).Patch(context.TODO(), old.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, subresources...); err != nil {
 			return err
 		}
+		framework.ExpectNoError(err)
 		return nil
 	})
 
 	framework.ExpectNoError(err, "Waiting for the pdb update to be processed in namespace %s", ns)
 	waitForPdbToBeProcessed(cs, ns, name)
-	return updated, err
+	return updated
 }
 
 func deletePDBOrDie(cs kubernetes.Interface, ns string, name string) {
@@ -431,15 +437,17 @@ func deletePDBCollection(cs kubernetes.Interface, ns string) {
 
 func waitForPDBCollectionToBeDeleted(cs kubernetes.Interface, ns string) {
 	ginkgo.By("Waiting for the PDB collection to be deleted")
-	wait.PollImmediate(framework.Poll, schedulingTimeout, func() (bool, error) {
+	err := wait.PollImmediate(framework.Poll, schedulingTimeout, func() (bool, error) {
 		pdbList, err := cs.PolicyV1beta1().PodDisruptionBudgets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
-		framework.ExpectNoError(err, "Listing PDB set in namespace %s", ns)
-		framework.ExpectEqual(len(pdbList.Items), 0, "Expecting No PDBs returned in namespace %s", ns)
+		if len(pdbList.Items) != 0 {
+			return false, nil
+		}
 		return true, nil
 	})
+	framework.ExpectNoError(err, "Waiting for the PDB collection to be deleted in namespace %s", ns)
 }
 
 func createPodsOrDie(cs kubernetes.Interface, ns string, n int) {
@@ -453,8 +461,8 @@ func createPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
 					{
-						Name:  "busybox",
-						Image: imageutils.GetE2EImage(imageutils.EchoServer),
+						Name:  "donothing",
+						Image: imageutils.GetPauseImageName(),
 					},
 				},
 				RestartPolicy: v1.RestartPolicyAlways,
@@ -483,7 +491,7 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 		ready := 0
 		for i := range pods.Items {
 			pod := pods.Items[i]
-			if podutil.IsPodReady(&pod) {
+			if podutil.IsPodReady(&pod) && pod.ObjectMeta.DeletionTimestamp.IsZero() {
 				ready++
 			}
 		}
@@ -498,8 +506,8 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 
 func createReplicaSetOrDie(cs kubernetes.Interface, ns string, size int32, exclusive bool) {
 	container := v1.Container{
-		Name:  "busybox",
-		Image: imageutils.GetE2EImage(imageutils.EchoServer),
+		Name:  "donothing",
+		Image: imageutils.GetPauseImageName(),
 	}
 	if exclusive {
 		container.Ports = []v1.ContainerPort{
@@ -542,7 +550,7 @@ func locateRunningPod(cs kubernetes.Interface, ns string) (pod *v1.Pod, err erro
 
 		for i := range podList.Items {
 			p := podList.Items[i]
-			if podutil.IsPodReady(&p) {
+			if podutil.IsPodReady(&p) && p.ObjectMeta.DeletionTimestamp.IsZero() {
 				pod = &p
 				return true, nil
 			}
@@ -601,6 +609,7 @@ func waitForPdbToObserveHealthyPods(cs kubernetes.Interface, ns string, healthyC
 func getPDBStatusOrDie(dc dynamic.Interface, ns string, name string) *policyv1beta1.PodDisruptionBudget {
 	pdbStatusResource := policyv1beta1.SchemeGroupVersion.WithResource("poddisruptionbudgets")
 	unstruct, err := dc.Resource(pdbStatusResource).Namespace(ns).Get(context.TODO(), name, metav1.GetOptions{}, "status")
+	framework.ExpectNoError(err)
 	pdb, err := unstructuredToPDB(unstruct)
 	framework.ExpectNoError(err, "Getting the status of the pdb %s in namespace %s", name, ns)
 	return pdb


### PR DESCRIPTION
pdbs were fixed to be more tolerant of certain classes of delete. This means old tests and new cluster break because the delete isn't constrained.  We need https://github.com/kubernetes/kubernetes/pull/92991 . I pulled the entire file in to be sure.

This will go away once we revendor, but the level in o/k is right.  If pdb tests pass, we should green button this.