### PR TITLE
bug 1861201: make must-gather test resilient to failures and disk timing

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -15,17 +15,15 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	"github.com/openshift/client-go/image/clientset/versioned"
 	oauthv1client "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	"github.com/openshift/library-go/pkg/image/imageutil"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
-
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/ibmcloud"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
 var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
@@ -126,6 +124,11 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 	})
 
 	g.It("runs successfully for audit logs", func() {
+		// On IBM ROKS, events will not be part of the output, since audit logs do not include control plane logs.
+		if e2e.TestContext.Provider == ibmcloud.ProviderName {
+			g.Skip("ROKs doesn't have audit logs")
+		}
+
 		// makes some tokens that should not show in the audit logs
 		const tokenName = "must-gather-audit-logs-token-plus-some-padding-here-to-make-the-limit"
 		oauthClient := oauthv1client.NewForConfigOrDie(oc.AdminConfig())
@@ -154,9 +157,6 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		}, metav1.CreateOptions{})
 		o.Expect(err2).NotTo(o.HaveOccurred())
 
-		// let audit log writes occurs to disk (best effort, should be enough to make the test fail most of the time)
-		time.Sleep(10 * time.Second)
-
 		tempDir, err := ioutil.TempDir("", "test.oc-adm-must-gather.")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// defer os.RemoveAll(tempDir)
@@ -173,9 +173,9 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 
 		pluginOutputDir := getPluginOutputDir(oc, tempDir)
 
-		expectedDirectories := [][]string{
-			{pluginOutputDir, "audit_logs", "kube-apiserver"},
-			{pluginOutputDir, "audit_logs", "openshift-apiserver"},
+		expectedDirectoriesToExpectedCount := map[string]int{
+			path.Join(pluginOutputDir, "audit_logs", "kube-apiserver"):      1000,
+			path.Join(pluginOutputDir, "audit_logs", "openshift-apiserver"): 10, // openshift apiservers don't necessarily get much traffic.  Especially early in a run
 		}
 
 		expectedFiles := [][]string{
@@ -183,71 +183,86 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 			{pluginOutputDir, "audit_logs", "openshift-apiserver.audit_logs_listing"},
 		}
 
-		// make sure we do not log OAuth tokens
-		for _, auditDirectory := range expectedDirectories {
-			eventsChecked := 0
-			err := filepath.Walk(path.Join(auditDirectory...), func(path string, info os.FileInfo, err error) error {
-				g.By(path)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				if info.IsDir() {
-					return nil
-				}
-
-				if (strings.Contains(path, "-termination-") && strings.HasSuffix(path, ".log.gz")) || strings.HasSuffix(path, "termination.log.gz") {
-					// these are expected, but have unstructured log format
-					return nil
-				}
-
-				isAuditFile := (strings.Contains(path, "-audit-") && strings.HasSuffix(path, ".log.gz")) || strings.HasSuffix(path, "audit.log.gz")
-				o.Expect(isAuditFile).To(o.BeTrue())
-
-				// at this point, we expect only audit files with json events, one per line
-
-				readFile := false
-
-				file, err := os.Open(path)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				defer file.Close()
-
-				fi, err := file.Stat()
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				// it will happen that the audit files are sometimes empty, we can
-				// safely ignore these files since they don't provide valuable information
-				if fi.Size() == 0 {
-					return nil
-				}
-
-				gzipReader, err := gzip.NewReader(file)
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				scanner := bufio.NewScanner(gzipReader)
-				for scanner.Scan() {
-					text := scanner.Text()
-					if !strings.HasSuffix(text, "}") {
-						continue // ignore truncated data
+		// for some crazy reason, it seems that the files from must-gather take time to appear on disk for reading.  I don't understand why
+		// but this was in a previous commit and I don't want to immediately flake: https://github.com/openshift/origin/commit/006745a535848e84dcbcdd1c83ae86deddd3a229#diff-ad1c47fa4213de16d8b3237df5d71724R168
+		// so we're going to try to get a pass every 10 seconds for a minute.  If we pass, great.  If we don't, we report the
+		// last error we had.
+		var lastErr error
+		err = wait.PollImmediate(10*time.Second, 1*time.Minute, func() (bool, error) {
+			// make sure we do not log OAuth tokens
+			for auditDirectory, expectedNumberOfAuditEntries := range expectedDirectoriesToExpectedCount {
+				eventsChecked := 0
+				err := filepath.Walk(auditDirectory, func(path string, info os.FileInfo, err error) error {
+					g.By(path)
+					o.Expect(err).NotTo(o.HaveOccurred())
+					if info.IsDir() {
+						return nil
 					}
-					o.Expect(text).To(o.HavePrefix(`{"kind":"Event",`))
-					for _, token := range []string{"oauthaccesstokens", "oauthauthorizetokens", tokenName} {
-						o.Expect(text).NotTo(o.ContainSubstring(token))
+
+					if (strings.Contains(path, "-termination-") && strings.HasSuffix(path, ".log.gz")) || strings.HasSuffix(path, "termination.log.gz") {
+						// these are expected, but have unstructured log format
+						return nil
 					}
-					readFile = true
-					eventsChecked++
+
+					isAuditFile := (strings.Contains(path, "-audit-") && strings.HasSuffix(path, ".log.gz")) || strings.HasSuffix(path, "audit.log.gz")
+					o.Expect(isAuditFile).To(o.BeTrue())
+
+					// at this point, we expect only audit files with json events, one per line
+
+					readFile := false
+
+					file, err := os.Open(path)
+					o.Expect(err).NotTo(o.HaveOccurred())
+					defer file.Close()
+
+					fi, err := file.Stat()
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					// it will happen that the audit files are sometimes empty, we can
+					// safely ignore these files since they don't provide valuable information
+					// TODO this doesn't seem right.  It should be really unlikely, but we'll deal with later
+					if fi.Size() == 0 {
+						return nil
+					}
+
+					gzipReader, err := gzip.NewReader(file)
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					scanner := bufio.NewScanner(gzipReader)
+					for scanner.Scan() {
+						text := scanner.Text()
+						if !strings.HasSuffix(text, "}") {
+							continue // ignore truncated data
+						}
+						o.Expect(text).To(o.HavePrefix(`{"kind":"Event",`))
+						for _, token := range []string{"oauthaccesstokens", "oauthauthorizetokens", tokenName} {
+							o.Expect(text).NotTo(o.ContainSubstring(token))
+						}
+						readFile = true
+						eventsChecked++
+					}
+					// ignore this error as we usually fail to read the whole GZ file
+					// o.Expect(scanner.Err()).NotTo(o.HaveOccurred())
+					o.Expect(readFile).To(o.BeTrue())
+
+					return nil
+				})
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				if eventsChecked <= expectedNumberOfAuditEntries {
+					lastErr = fmt.Errorf("expected %d audit events for %q, but only got %d", expectedNumberOfAuditEntries, auditDirectory, eventsChecked)
+					return false, nil
 				}
-				// ignore this error as we usually fail to read the whole GZ file
-				// o.Expect(scanner.Err()).NotTo(o.HaveOccurred())
-				o.Expect(readFile).To(o.BeTrue())
 
-				return nil
-			})
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			// On IBM ROKS, events will not be part of the output, since audit logs do not include
-			// control plane logs.
-			if e2e.TestContext.Provider != ibmcloud.ProviderName {
-				o.Expect(eventsChecked).To(o.BeNumerically(">", 1000))
+				// reset lastErr if we succeeded.
+				lastErr = nil
 			}
-		}
+
+			// if we get here, it means both directories checked out ok
+			return true, nil
+		})
+		o.Expect(lastErr).NotTo(o.HaveOccurred()) // print the last error first if we have one
+		o.Expect(err).NotTo(o.HaveOccurred())     // otherwise be sure we fail on the timeout if it happened
 
 		emptyFiles := []string{}
 		for _, expectedFile := range expectedFiles {


### PR DESCRIPTION
Apparently it takes a while for logs to appear, so we retry on a loop to avoid that.
The openshift-apiserver will have many fewer requests than the kube-apiserver, so have two different counts.
Update the error message to more clearly indicate which audit log is broken for better debugging in the future.

