### PR TITLE
Bug 1861218: Tune storage tests for 4.6

### DIFF
--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -24,7 +24,6 @@ var (
 
 			// BETA features in 1.19, enabled by default
 			// Their enablement is tracked via bz's targeted at 4.6.
-			`\[Feature:ExpandCSIVolumes\]`, // https://bugzilla.redhat.com/show_bug.cgi?id=1861218
 			`\[Feature:SCTPConnectivity\]`, // https://bugzilla.redhat.com/show_bug.cgi?id=1861606
 		},
 		// tests for features that are not implemented in openshift


### PR DESCRIPTION
Remove `ExpandCSIVolumes` rule, it does not match anything.

cc @openshift/storage 