### PR TITLE
e2e/oauth: unescape token taken from redirect url fragment

### DIFF
--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -479,7 +479,11 @@ func getTokenFromResponse(resp *http.Response) string {
 	locationTokenRegexp := regexp.MustCompile("access_token=([^&]*)")
 
 	if matches := locationTokenRegexp.FindStringSubmatch(locationHeader); len(matches) > 1 {
-		return matches[1]
+		token, err := url.QueryUnescape(matches[1])
+		if err != nil {
+			return "<query-unescape-failed-in-getTokenFromResponse>"
+		}
+		return token
 	}
 
 	return ""


### PR DESCRIPTION
The colon of `sha256:<token>` is escaped to `%3A`. Because we don't parse the URl, but pick it via regex, the result is unescaped.