### PR TITLE
Bug 1862322: e2e/extended: disable OLM 'can subscribe to the operator' test

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2307,7 +2307,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-operator] an end user can use OLM Report Upgradeable in OLM ClusterOperators status": "Report Upgradeable in OLM ClusterOperators status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-operator] an end user can use OLM can subscribe to the operator": "can subscribe to the operator [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-operator] an end user can use OLM can subscribe to the operator": "can subscribe to the operator [Disabled:Broken] [Suite:openshift]",
 
 	"[Top Level] [sig-operator][Feature:Marketplace] Marketplace diff name test [ocp-25672] create the samename opsrc&csc [Serial]": "[ocp-25672] create the samename opsrc&csc [Serial] [Suite:openshift/conformance/serial]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -113,6 +113,10 @@ var (
 			// Test passes but container it uses exits with non-zero.
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1861526
 			`ServiceAccounts should set ownership and permission when RunAsUser or FsGroup is present`,
+
+			// Perma-fail
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1862322
+			`an end user can use OLM can subscribe to the operator`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
After it even fails in https://github.com/openshift/origin/pull/25351, let's disable this test.