### PR TITLE
Bug 1857928: Re-enable olm tests

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -179,7 +179,7 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 				return ""
 			}
 			return output
-		}, 5*time.Minute, time.Second).Should(o.Equal("[]"))
+		}, 5*time.Minute, time.Second).Should(o.Equal("[\"\"]"))
 
 		for _, v := range files {
 			configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", v, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace()), "SOURCENAME=redhat-operators", "SOURCENAMESPACE=openshift-marketplace", "PACKAGE=amq-streams", "CHANNEL=stable").OutputToFile("config.json")

--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -29,7 +29,7 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 		// a pod in a namespace that begins with kube-* or openshift-* must come from our release payload
 		// TODO components in openshift-operators may not come from our payload, may want to weaken restriction
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
-		excludeNamespaces := sets.NewString("openshift-operator-lifecycle-manager")
+		excludeNamespaces := sets.NewString("openshift-operator-lifecycle-manager", "openshift-marketplace")
 		excludePodPrefix := sets.NewString(
 			"revision-pruner-",  // operators have retry logic built in. these are like jobs but cannot rely on jobs
 			"installer-",        // operators have retry logic built in. these are like jobs but cannot rely on jobs

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2329,7 +2329,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-operator] an end user can use OLM Report Upgradeable in OLM ClusterOperators status": "Report Upgradeable in OLM ClusterOperators status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-operator] an end user can use OLM can subscribe to the operator": "can subscribe to the operator [Disabled:Broken] [Suite:openshift]",
+	"[Top Level] [sig-operator] an end user can use OLM can subscribe to the operator": "can subscribe to the operator [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-scalability][Feature:Performance] Load cluster should populate the cluster [Slow][Serial]": "should populate the cluster [Slow][Serial] [Suite:openshift]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -31,10 +31,6 @@ var (
 		"[Disabled:Broken]": {
 			`should idle the service and DeploymentConfig properly`,       // idling with a single service and DeploymentConfig
 			`should answer endpoint and wildcard queries for the cluster`, // currently not supported by dns operator https://github.com/openshift/cluster-dns-operator/issues/43
-
-			// Perma-fail
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1862322
-			`an end user can use OLM can subscribe to the operator`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {},


### PR DESCRIPTION
This reverts https://github.com/openshift/origin/pull/25352

Apparently the operator used for testing (amq) removed their stable channel, which has since been restored.