### PR TITLE
Bug 1861944: test/e2e: re-enable service upgrade

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -27,7 +27,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/test/e2e/upgrade/alert"
-	// "github.com/openshift/origin/test/e2e/upgrade/service"
+	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 	"github.com/openshift/origin/test/extended/util/disruption/frontends"
@@ -39,8 +39,7 @@ func AllTests() []upgrades.Test {
 		controlplane.NewOpenShiftAvailableTest(),
 		&alert.UpgradeTest{},
 		&frontends.AvailableTest{},
-		// Broken by 1.19 rebase, fix tracked by https://bugzilla.redhat.com/show_bug.cgi?id=1861944
-		// &service.UpgradeTest{},
+		&service.UpgradeTest{},
 		&upgrades.SecretUpgradeTest{},
 		&apps.ReplicaSetUpgradeTest{},
 		&apps.StatefulSetUpgradeTest{},


### PR DESCRIPTION
This was disabled in:

  https://github.com/openshift/origin/pull/25314