### PR TITLE
Update expected text for test-cmd timeout

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -46696,10 +46696,10 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/request-timeout"
 # This test validates the global request-timeout option
 os::cmd::expect_success 'oc create deploymentconfig testdc --image=busybox'
-os::cmd::expect_success_and_text 'oc get dc/testdc -w -v=5 --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get dc/testdc -w -v=5 --request-timeout=1s 2>&1' 'request canceled'
 os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1s' 'testdc'
 os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1' 'testdc'
-os::cmd::expect_success_and_text 'oc get pods --watch -v=5 --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get pods --watch -v=5 --request-timeout=1s 2>&1' 'request canceled'
 
 echo "request-timeout: ok"
 os::test::junit::declare_suite_end

--- a/test/extended/testdata/cmd/test/cmd/timeout.sh
+++ b/test/extended/testdata/cmd/test/cmd/timeout.sh
@@ -13,10 +13,10 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/request-timeout"
 # This test validates the global request-timeout option
 os::cmd::expect_success 'oc create deploymentconfig testdc --image=busybox'
-os::cmd::expect_success_and_text 'oc get dc/testdc -w -v=5 --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get dc/testdc -w -v=5 --request-timeout=1s 2>&1' 'request canceled'
 os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1s' 'testdc'
 os::cmd::expect_success_and_text 'oc get dc/testdc --request-timeout=1' 'testdc'
-os::cmd::expect_success_and_text 'oc get pods --watch -v=5 --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
+os::cmd::expect_success_and_text 'oc get pods --watch -v=5 --request-timeout=1s 2>&1' 'request canceled'
 
 echo "request-timeout: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Required for the oc 1.19 bump, see https://github.com/openshift/oc/pull/491#issuecomment-667254495

Note: this is only broken in the 1.19 oc bump, because the output of this command changed between 1.18 and 1.19

1.19:
```
$ ./oc get deployment.apps/openshift-kube-scheduler-operator -w -v=5 --request-timeout=1s
NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
openshift-kube-scheduler-operator   1/1     1            1           4h45m
I0731 14:09:15.563497   81453 streamwatcher.go:117] Unable to decode an event from the watch stream: net/http: request canceled (Client.Timeout or context cancellation while reading body)
```
vs pre-1.19:
```
$ oc get deployment.apps/openshift-kube-scheduler-operator -w -v=5 --request-timeout=1s
NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
openshift-kube-scheduler-operator   1/1     1            1           4h47m
I0731 14:11:22.804399   81548 table_printer.go:44] Unable to decode server response into a Table. Falling back to hardcoded types: attempt to decode non-Table object into a v1beta1.Table
STATUS                              REASON          MESSAGE
Failure                             InternalError   an error on the server ("unable to decode an event from the watch stream: net/http: request canceled (Client.Timeout exceeded while reading body)") has prevented the request from succeeding
```

~~So while this will un-block `oc` it might break CI until the oc bump goes through. This is currently the only failing test on the oc bump so it should be short-lived. If we button-merge the oc bump, I think we'll end up with CI broken on this anyway.~~

edit: to fix this I just updated it to match on `request canceled` instead of `Timeout or context cancellation while reading body`. It's loose but should still catch what we want without breaking