### PR TITLE
[release-4.5] Fix commit checker

### DIFF
--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euxo pipefail
+
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/tools/rebasehelpers/commitchecker/commitchecker.go
+++ b/tools/rebasehelpers/commitchecker/commitchecker.go
@@ -17,8 +17,8 @@ func main() {
 	commits, err := util.CommitsBetween(start, end)
 	if err != nil {
 		if err == util.ErrNotCommit {
-			_, _ = fmt.Fprintf(os.Stderr, "WARNING: one of the provided commits does not exist, not a true branch\n")
-			os.Exit(0)
+			_, _ = fmt.Fprintf(os.Stderr, "ERROR: one of the provided commits does not exist, not a true branch\n")
+			os.Exit(1)
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: couldn't find commits from %s..%s: %v\n", start, end, err)
 		os.Exit(1)


### PR DESCRIPTION
If we are not able to verify a commit we must fail, not silently show an error message and claim it's ok.

https://storage.googleapis.com/origin-ci-test/pr-logs/pull/25326/pull-ci-openshift-origin-release-4.4-verify/1287675728137031680/artifacts/verify/logs/raw_test_output.log
```
=== BEGIN TEST SUITE github.com/openshift/origin/test/verify/upstream-commits ===
=== BEGIN TEST CASE ===
hack/verify-upstream-commits.sh:19: executing 'commitchecker' expecting success
SUCCESS after 0.016s: hack/verify-upstream-commits.sh:19: executing 'commitchecker' expecting success
There was no output from the command.
Standard error from the command:
WARNING: one of the provided commits does not exist, not a true branch
=== END TEST CASE ===
=== END TEST SUITE ===
```

The root cause is fixed on release-4.5, the <=4.4 PR also pick https://github.com/openshift/origin/pull/24722

/cc @sttts 