### PR TITLE
Bug 1862426: gather the audit logs for oauth apiserver

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -76,15 +76,6 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 			{pluginOutputDir, "host_service_logs", "masters", "kubelet_service.log"},
 		}
 
-		// Skip the kube and openshift apiserver audit logs on IBM ROKS clusters
-		// since those components live outside of the cluster.
-		if e2e.TestContext.Provider != ibmcloud.ProviderName {
-			expectedFiles = append(expectedFiles,
-				[]string{pluginOutputDir, "audit_logs", "kube-apiserver.audit_logs_listing"},
-				[]string{pluginOutputDir, "audit_logs", "openshift-apiserver.audit_logs_listing"},
-			)
-		}
-
 		for _, expectedDirectory := range expectedDirectories {
 			o.Expect(path.Join(expectedDirectory...)).To(o.BeADirectory())
 		}


### PR DESCRIPTION
Adjust tests as must-gather will no longer collect audit logs by default (https://github.com/openshift/must-gather/pull/144).