### PR TITLE
oauth: switch from sha256: to sha256~ as token prefix

### DIFF
--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -179,10 +179,10 @@ func testCodeFlow(oc *exutil.CLI, newRequestTokenOptions oauthserver.NewRequestT
 }
 
 func toTokenName(token string) string {
-	if strings.HasPrefix(token, "sha256:") {
-		withoutPrefix := strings.TrimPrefix(token, "sha256:")
+	if strings.HasPrefix(token, "sha256~") {
+		withoutPrefix := strings.TrimPrefix(token, "sha256~")
 		h := sha256.Sum256([]byte(withoutPrefix))
-		return "sha256:" + base64.RawURLEncoding.EncodeToString(h[0:])
+		return "sha256~" + base64.RawURLEncoding.EncodeToString(h[0:])
 	}
 	return token
 }

--- a/test/extended/oauth/token.go
+++ b/test/extended/oauth/token.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/pborman/uuid"
+
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	"github.com/openshift/client-go/user/clientset/versioned"
@@ -37,7 +39,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 		oc.AddResourceToDelete(userv1.GroupVersion.WithResource("users"), user)
 
 		g.By("creating a classic oauth access token")
-		token := "0123456789012345678900123456789001234567890123"
+		token := base64.RawURLEncoding.EncodeToString([]byte(uuid.New()))
 		classicTokenObject, err := oc.AdminOauthClient().OauthV1().OAuthAccessTokens().Create(ctx, &oauthv1.OAuthAccessToken{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: token,
@@ -73,7 +75,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 		oc.AddResourceToDelete(userv1.GroupVersion.WithResource("users"), user)
 
 		g.By("creating a classic oauth access token")
-		token := "0123456789012345678900123456789001234567890123"
+		token := base64.RawURLEncoding.EncodeToString([]byte(uuid.New()))
 		bs := sha256.Sum256([]byte(token))
 		hash := base64.RawURLEncoding.EncodeToString(bs[:])
 		classicTokenObject, err := oc.AdminOauthClient().OauthV1().OAuthAccessTokens().Create(ctx, &oauthv1.OAuthAccessToken{

--- a/test/extended/oauth/token.go
+++ b/test/extended/oauth/token.go
@@ -59,7 +59,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 		o.Expect(gotUser.Name).To(o.Equal(user.Name))
 
 		g.By("not-authenticating using a sha256 prefixed access token as bearer token")
-		_, err = whoamiWithToken("sha256:"+token, oc)
+		_, err = whoamiWithToken("sha256~"+token, oc)
 		o.Expect(errors.IsUnauthorized(err)).To(o.BeTrue())
 	})
 
@@ -80,7 +80,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 		hash := base64.RawURLEncoding.EncodeToString(bs[:])
 		classicTokenObject, err := oc.AdminOauthClient().OauthV1().OAuthAccessTokens().Create(ctx, &oauthv1.OAuthAccessToken{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "sha256:" + hash[0:],
+				Name: "sha256~" + hash[0:],
 			},
 			UserName:    user.Name,
 			UserUID:     string(user.UID),
@@ -92,12 +92,12 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 		oc.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthaccesstokens"), classicTokenObject)
 
 		g.By("authenticating using the sha256 prefixed access token as bearer token")
-		gotUser, err := whoamiWithToken("sha256:"+token, oc)
+		gotUser, err := whoamiWithToken("sha256~"+token, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(gotUser.Name).To(o.Equal(user.Name))
 
 		g.By("not-authenticating using a sha256 prefixed hash as bearer token")
-		_, err = whoamiWithToken("sha256:"+hash[0:], oc)
+		_, err = whoamiWithToken("sha256~"+hash[0:], oc)
 		o.Expect(errors.IsUnauthorized(err)).To(o.BeTrue())
 
 		g.By("not-authenticating using a non-prefixed token as bearer token")


### PR DESCRIPTION
Colon is not a valid character in oauth bearer token (although it is valid in bearer tokens in general, and in http headers too. Tilde is a little less elegantly looking, but is valid and unused right now.