### PR TITLE
WIP: e2e: topomgr: more tests robustness fixes

### DIFF
--- a/test/extended/topology_manager/resourcealign.go
+++ b/test/extended/topology_manager/resourcealign.go
@@ -55,7 +55,7 @@ var _ = g.Describe("[Serial][sig-node][Feature:TopologyManager] Configured clust
 		// we don't handle yet an uneven device amount on worker nodes. IOW, we expect the same amount of devices on each node
 	})
 
-	g.Context("[Disabled:Broken] with non-gu workload", func() {
+	g.Context("with non-gu workload", func() {
 		t.DescribeTable("should run with no regressions",
 			func(pps PodParamsList) {
 				if requestCpu, ok := enoughCoresInTheCluster(workerNodes, pps); !ok {

--- a/test/extended/topology_manager/utils.go
+++ b/test/extended/topology_manager/utils.go
@@ -306,6 +306,8 @@ func createPodsAndWait(client clientset.Interface, namespace string, phaseChecke
 			defer wg.Done()
 			defer g.GinkgoRecover()
 
+			e2e.Logf("creating pod: %#v", testPods[idx])
+
 			created, err := client.CoreV1().Pods(namespace).Create(context.Background(), testPods[idx], metav1.CreateOptions{})
 			e2e.ExpectNoError(err)
 
@@ -314,6 +316,8 @@ func createPodsAndWait(client clientset.Interface, namespace string, phaseChecke
 
 			updatedPods[idx], err = client.CoreV1().Pods(created.Namespace).Get(context.Background(), created.Name, metav1.GetOptions{})
 			e2e.ExpectNoError(err)
+
+			e2e.Logf("created pod: %#v", updatedPods[idx])
 		}(i)
 	}
 	wg.Wait()

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -11,10 +11,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP": "test RequestHeaders IdP [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster [Disabled:Broken] with non-gu workload should run with no regressions with single pod, single container requesting 1 core": "with single pod, single container requesting 1 core",
-
-	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster [Disabled:Broken] with non-gu workload should run with no regressions with single pod, single container requesting multiple cores": "with single pod, single container requesting multiple cores",
-
 	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster with gu workload attached to SRIOV networks should let resource-aligned PODs have working SRIOV network interface": "should let resource-aligned PODs have working SRIOV network interface [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster with gu workload saturating NUMA nodes should allow a pod requesting as many cores as a full NUMA node have": "should allow a pod requesting as many cores as a full NUMA node have [Suite:openshift/conformance/serial]",
@@ -36,6 +32,10 @@ var annotations = map[string]string{
 	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster with gu workload should guarantee NUMA-aligned cpu cores in gu pods with single pod, single container requesting 1 core, 1 device": "with single pod, single container requesting 1 core, 1 device [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster with gu workload should guarantee NUMA-aligned cpu cores in gu pods with single pod, single container requesting 4 cores, 1 device": "with single pod, single container requesting 4 cores, 1 device [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster with non-gu workload should run with no regressions with single pod, single container requesting 1 core": "with single pod, single container requesting 1 core [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster with non-gu workload should run with no regressions with single pod, single container requesting multiple cores": "with single pod, single container requesting multiple cores [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]": "CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6] [sig-cluster-lifecycle] [Suite:k8s]",
 


### PR DESCRIPTION
Add debug logs to make troubleshooting easier when test fail.
This was caused by a resurgence of https://bugzilla.redhat.com/show_bug.cgi?id=1851623

Related: https://github.com/openshift/origin/pull/25373

Signed-off-by: Francesco Romani <fromani@redhat.com>