### PR TITLE
extended/oauth: skip sha256 test until https://github.com/openshift/kubernetes/pull/305 merged

### DIFF
--- a/test/extended/oauth/token.go
+++ b/test/extended/oauth/token.go
@@ -26,6 +26,8 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 	ctx := context.Background()
 
 	g.It(fmt.Sprintf("accepts classic non-prefixed access tokens"), func() {
+		g.Skip("skipping until https://github.com/openshift/kubernetes/pull/305 merged")
+
 		user, err := oc.AdminUserClient().UserV1().Users().Create(ctx, &userv1.User{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
@@ -62,6 +64,8 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 	})
 
 	g.It(fmt.Sprintf("accepts sha256 access tokens"), func() {
+		g.Skip("skipping until https://github.com/openshift/kubernetes/pull/305 merged")
+
 		user, err := oc.AdminUserClient().UserV1().Users().Create(ctx, &userv1.User{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
We have no way to atomatically switch over to sha256~. Hence, we disable e2e first for sha256: and then
re-enable them for sha256~.