### PR TITLE
Bug 1866411: Add --node-name and --node-ip flags to sdn

### DIFF
--- a/pkg/cmd/server/kubernetes/network/sdn_linux.go
+++ b/pkg/cmd/server/kubernetes/network/sdn_linux.go
@@ -54,8 +54,8 @@ func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.
 
 	node, err := sdnnode.New(&sdnnode.OsdnNodeConfig{
 		PluginName:         options.NetworkConfig.NetworkPluginName,
-		Hostname:           options.NodeName,
-		SelfIP:             options.NodeIP,
+		NodeName:           options.NodeName,
+		NodeIP:             options.NodeIP,
 		DNSIP:              options.DNSIP,
 		RuntimeEndpoint:    runtimeEndpoint,
 		CNIBinDir:          cniBinDir,

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -41,6 +41,8 @@ type NodeArgs struct {
 
 	// NodeName is the hostname to identify this node with the master.
 	NodeName string
+	// NodeIP is the ip address used as selfIP in the OsdnNodeConfig
+	NodeIP string
 
 	MasterCertDir string
 	ConfigDir     flag.StringFlag
@@ -68,6 +70,8 @@ func BindNodeNetworkArgs(args *NodeArgs, flags *pflag.FlagSet, prefix string) {
 	flags.StringVar(&args.RecursiveResolvConf, prefix+"recursive-resolv-conf", args.RecursiveResolvConf, "An optional upstream resolv.conf that will override the DNS config.")
 
 	flags.StringVar(&args.NetworkPluginName, prefix+"network-plugin", args.NetworkPluginName, "The network plugin to be called for configuring networking for pods.")
+	flags.StringVar(&args.NodeIP, prefix+"node-ip", args.NodeIP, "The node IP address to be used by the SDN.")
+	flags.StringVar(&args.NodeName, prefix+"node-name", args.NodeName, "The hostname to be used by the SDN.")
 }
 
 // NewDefaultNetworkArgs creates NodeArgs with sub-objects created and default values set.

--- a/pkg/cmd/server/start/start_network.go
+++ b/pkg/cmd/server/start/start_network.go
@@ -164,6 +164,13 @@ func (o NetworkOptions) RunNetwork(stopCh <-chan struct{}) error {
 		validationResults = validation.ValidateNodeConfig(nodeConfig, nil)
 	}
 
+	if o.NodeArgs.NodeIP != "" {
+		nodeConfig.NodeIP = o.NodeArgs.NodeIP
+	}
+	if o.NodeArgs.NodeName != "" {
+		nodeConfig.NodeName = o.NodeArgs.NodeName
+	}
+
 	if len(validationResults.Warnings) != 0 {
 		for _, warning := range validationResults.Warnings {
 			glog.Warningf("Warning: %v, node start will continue.", warning)

--- a/pkg/network/node/subnets.go
+++ b/pkg/network/node/subnets.go
@@ -139,24 +139,24 @@ func (node *OsdnNode) getLocalSubnet() (string, error) {
 	}
 	err := utilwait.ExponentialBackoff(backoff, func() (bool, error) {
 		var err error
-		subnet, err = node.networkClient.Network().HostSubnets().Get(node.hostName, metav1.GetOptions{})
+		subnet, err = node.networkClient.Network().HostSubnets().Get(node.nodeName, metav1.GetOptions{})
 		if err == nil {
 			if subnet.HostIP == node.localIP {
 				return true, nil
 			} else {
 				glog.Warningf("HostIP %q for local subnet does not match with nodeIP %q, "+
-					"Waiting for master to update subnet for node %q ...", subnet.HostIP, node.localIP, node.hostName)
+					"Waiting for master to update subnet for node %q ...", subnet.HostIP, node.localIP, node.nodeName)
 				return false, nil
 			}
 		} else if kapierrors.IsNotFound(err) {
-			glog.Warningf("Could not find an allocated subnet for node: %s, Waiting...", node.hostName)
+			glog.Warningf("Could not find an allocated subnet for node: %s, Waiting...", node.nodeName)
 			return false, nil
 		} else {
 			return false, err
 		}
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to get subnet for this host: %s, error: %v", node.hostName, err)
+		return "", fmt.Errorf("failed to get subnet for this host: %s, error: %v", node.nodeName, err)
 	}
 
 	if err = node.networkInfo.ValidateNodeIP(subnet.HostIP); err != nil {


### PR DESCRIPTION
Currently openshift sdn tries to figure out the node name from the
hostname, and the IP address through a DNS query of that hostname.

With this code we're allowing to pass a flag to override both values.

After this is done we'll modify openshift-ansible to fill these flags
with environment variables that read fieldRefs.