### PR TITLE
test/e2e/upgrade: Give clusters 3 minutes to acknowledge updates

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -294,7 +294,7 @@ func clusterUpgrade(c configv1client.Interface, dc dynamic.Interface, config *re
 	}
 
 	// wait until the cluster acknowledges the update
-	if err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
 		cv, _, err := monitor.Check(updated.Generation, desired)
 		if err != nil || cv == nil {
 			return false, err


### PR DESCRIPTION
We're flaking [with near-misses today][1], so bump the threshold to reduce flake failures to keep development flowing until we fix that.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1843505#c7