### PR TITLE
Bug 1807714: oc set volume use 'filepath' not 'path' to manipulate filepaths

### DIFF
--- a/pkg/oc/cli/set/volume.go
+++ b/pkg/oc/cli/set/volume.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -667,7 +667,7 @@ func (o *VolumeOptions) setVolumeMount(spec *kapi.PodSpec, info *resource.Info) 
 
 	for _, c := range containers {
 		for _, m := range c.VolumeMounts {
-			if path.Clean(m.MountPath) == path.Clean(opts.MountPath) && m.Name != o.Name {
+			if filepath.Clean(m.MountPath) == filepath.Clean(opts.MountPath) && m.Name != o.Name {
 				return fmt.Errorf("volume mount '%s' already exists for container '%s'", opts.MountPath, c.Name)
 			}
 		}
@@ -679,11 +679,11 @@ func (o *VolumeOptions) setVolumeMount(spec *kapi.PodSpec, info *resource.Info) 
 		}
 		volumeMount := &kapi.VolumeMount{
 			Name:      o.Name,
-			MountPath: path.Clean(opts.MountPath),
+			MountPath: filepath.Clean(opts.MountPath),
 			ReadOnly:  opts.ReadOnly,
 		}
 		if len(opts.SubPath) > 0 {
-			volumeMount.SubPath = path.Clean(opts.SubPath)
+			volumeMount.SubPath = filepath.Clean(opts.SubPath)
 		}
 		c.VolumeMounts = append(c.VolumeMounts, *volumeMount)
 	}
@@ -704,7 +704,7 @@ func (o *VolumeOptions) getVolumeName(spec *kapi.PodSpec, singleResource bool) (
 			matchCount := 0
 			for _, c := range containers {
 				for _, m := range c.VolumeMounts {
-					if path.Clean(m.MountPath) == path.Clean(opts.MountPath) {
+					if filepath.Clean(m.MountPath) == filepath.Clean(opts.MountPath) {
 						name = m.Name
 						matchCount++
 						break


### PR DESCRIPTION
from go docs:
```
from "path" overview:
Package path implements utility routines for manipulating slash-separated paths.
The path package should only be used for paths separated by forward slashes, such as the paths in URLs. This package does not deal with Windows paths with drive letters or backslashes; to manipulate operating system paths, use the path/filepath package.
```
```
"path/filepath" overview:
Package filepath implements utility routines for manipulating filename paths in a way compatible with the target operating system-defined file paths.
The filepath package uses either forward slashes or backslashes, depending on the operating system. To process paths such as URLs that always use forward slashes regardless of the operating system, see the path package.
```