### PR TITLE
Bug 1826094: Add retry options to Prometheus helper curl command

### DIFF
--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -51,7 +51,7 @@ func TestUnsupportedAllowVersionSkew() bool {
 
 // GetBearerTokenURLViaPod makes http request through given pod
 func GetBearerTokenURLViaPod(ns, execPodName, url, bearer string) (string, error) {
-	cmd := fmt.Sprintf("curl -s -k -H 'Authorization: Bearer %s' %q", bearer, url)
+	cmd := fmt.Sprintf("curl --retry 15 --max-time 2 --retry-delay 1 -s -k -H 'Authorization: Bearer %s' %q", bearer, url)
 	output, err := framework.RunHostCmd(ns, execPodName, cmd)
 	if err != nil {
 		return "", fmt.Errorf("host command failed: %v\n%s", err, output)


### PR DESCRIPTION
Adds `--retry 15 --max-time 2 --retry-delay 1` to the Prometheus query curl call in `test/extended/util/prometheus/helpers.go`. This is to prevent the test from failing during the `e2e-aws-scaleup-rhel7` job, where DNS pods scheduled on newly spun-up rhel7 worker nodes may not immediately be responsive. As seen in the linked BZ, the first test in `test/extended/prometheus/prometheus.go` is hitting DNS errors during the `e2e-aws-scaleup-rhel7` job while the remainder of the prometheus tests are not, despite using the same curl code. Hence why adding the retry options will be beneficial in reducing test failures. 

/assign @Miciah 
/cc @danehans @frobware 