### PR TITLE
adds a new monitoring test for checking OAuth API server

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -37,6 +37,7 @@ func AllTests() []upgrades.Test {
 	return []upgrades.Test{
 		controlplane.NewKubeAvailableTest(),
 		controlplane.NewOpenShiftAvailableTest(),
+		controlplane.NewOAuthAvailableTest(),
 		&alert.UpgradeTest{},
 		&frontends.AvailableTest{},
 		// Broken by 1.19 rebase, fix tracked by https://bugzilla.redhat.com/show_bug.cgi?id=1861944

--- a/test/extended/dr/machine_recover.go
+++ b/test/extended/dr/machine_recover.go
@@ -63,6 +63,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive
 				&upgrades.ServiceUpgradeTest{},
 				controlplane.NewKubeAvailableTest(),
 				controlplane.NewOpenShiftAvailableTest(),
+				controlplane.NewOAuthAvailableTest(),
 				&frontends.AvailableTest{},
 			},
 			func() {

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -48,6 +48,24 @@ func (t *openShiftAvailableTest) Test(f *framework.Framework, done <-chan struct
 	t.availableTest.test(f, done, upgrade, monitor.StartOpenShiftAPIMonitoring)
 }
 
+// NewOauthAvailableTest tests that the OAuth APIs remains available during and after a cluster upgrade.
+func NewOAuthAvailableTest() upgrades.Test {
+	return &oauthAvailableTest{availableTest{name: "oauth-api-available"}}
+}
+
+// oauthAvailableTest tests that the OAuth APIs remains available during and after a cluster upgrade.
+type oauthAvailableTest struct {
+	availableTest
+}
+
+func (t oauthAvailableTest) Name() string { return t.availableTest.name }
+func (oauthAvailableTest) DisplayName() string {
+	return "[sig-api-machinery] OAuth APIs remain available"
+}
+func (t *oauthAvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	t.availableTest.test(f, done, upgrade, monitor.StartOAuthAPIMonitoring)
+}
+
 type availableTest struct {
 	// name helps distinguish which API server in particular is unavailable.
 	name string


### PR DESCRIPTION
We created a new server (OAuth API server) that is responsible for managing `oauth.openshift.io` and `user.openshift.io`. Before these groups were managed by the OpenShift API server.

This PR adds a new monitoring test for checking the availability of the new server.