### PR TITLE
Revert "extended/oauth: skip sha256 test until https://github.com/openshift/kubernetes/pull/305 merged"

### DIFF
--- a/test/extended/oauth/token.go
+++ b/test/extended/oauth/token.go
@@ -28,8 +28,6 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 	ctx := context.Background()
 
 	g.It(fmt.Sprintf("accepts classic non-prefixed access tokens"), func() {
-		g.Skip("skipping until https://github.com/openshift/kubernetes/pull/305 merged")
-
 		user, err := oc.AdminUserClient().UserV1().Users().Create(ctx, &userv1.User{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
@@ -66,8 +64,6 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 	})
 
 	g.It(fmt.Sprintf("accepts sha256 access tokens"), func() {
-		g.Skip("skipping until https://github.com/openshift/kubernetes/pull/305 merged")
-
 		user, err := oc.AdminUserClient().UserV1().Users().Create(ctx, &userv1.User{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This reverts commit c26d2f515d264bef0dd8575e608a6571dc3802e6.

Depends on https://github.com/openshift/kubernetes/pull/305.