### PR TITLE
add a test to ensure that the kubelet is always able to mount secrets…

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -27,6 +27,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/test/e2e/upgrade/alert"
+	"github.com/openshift/origin/test/extended/kubelet"
 	// "github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
@@ -48,6 +49,7 @@ func AllTests() []upgrades.Test {
 		&apps.JobUpgradeTest{},
 		&upgrades.ConfigMapUpgradeTest{},
 		&apps.DaemonSetUpgradeTest{},
+		&kubelet.ResourceVolumeSyncUpgradeTest{},
 	}
 }
 

--- a/test/extended/kubelet/ensure_volumes_fast.go
+++ b/test/extended/kubelet/ensure_volumes_fast.go
@@ -1,0 +1,104 @@
+package kubelet
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+)
+
+var _ = g.Describe("[sig-node][Late] kubelet container creation", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc = exutil.NewCLIWithoutNamespace("kubelet-container-creation")
+	)
+
+	// these appear to fail on a regular basis.  We see it even for service account token secrets, which are guaranteed
+	// to exist before they are added to the pod in admission, but we don't want to perma-break CI
+	//g.It("shouldn't have trouble mounting secrets", func() {
+	//	confirmNoSecretSyncFailure(oc.AdminKubeClient())
+	//})
+	//g.It("shouldn't have trouble mounting configmaps", func() {
+	//	confirmNoConfigMapSyncFailure(oc.AdminKubeClient())
+	//})
+
+	g.It("shouldn't have trouble mounting any volume", func() {
+		confirmNoStuckVolume(oc.AdminKubeClient())
+	})
+})
+
+// these mean that the kubelet wasn't able to get the secret or configmap content
+// this only gets the ones from namespaces that still exist, but our biggest known offender is in openshift-infra which sticks around.
+// if we suspect we're getting more, we can create a list/watch for it.
+func confirmNoEvent(eventMessage string, kubeClient kubernetes.Interface) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+			g.Fail(fmt.Sprintf("panic: %v", r))
+		}
+	}()
+
+	ctx := context.TODO()
+	events, err := kubeClient.CoreV1().Events("").List(ctx, metav1.ListOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	failures := []string{}
+	for _, event := range events.Items {
+		if !strings.Contains(event.Message, eventMessage) {
+			continue
+		}
+
+		failures = append(failures, fmt.Sprintf("%q in %q with %q", event.InvolvedObject.Name, event.InvolvedObject.Namespace, event.Message))
+	}
+
+	if len(failures) > 0 {
+		g.Fail(strings.Join(failures, "\n"))
+	}
+}
+
+func confirmNoSecretSyncFailure(kubeClient kubernetes.Interface) {
+	confirmNoEvent("failed to sync secret cache", kubeClient)
+}
+
+func confirmNoConfigMapSyncFailure(kubeClient kubernetes.Interface) {
+	confirmNoEvent("failed to sync configmap cache", kubeClient)
+}
+
+func confirmNoStuckVolume(kubeClient kubernetes.Interface) {
+	confirmNoEvent("Unable to attach or mount volumes", kubeClient)
+}
+
+// ResourceVolumeSyncUpgradeTest tests that kubelets are able to mount secrets and configmaps in a timely fashion
+type ResourceVolumeSyncUpgradeTest struct {
+}
+
+// Name returns the tracking name of the test.
+func (ResourceVolumeSyncUpgradeTest) Name() string {
+	return "[sig-node][Late] kubelet container creation volume mounting"
+}
+
+// Setup creates a DaemonSet and verifies that it's running
+func (t *ResourceVolumeSyncUpgradeTest) Setup(f *framework.Framework) {
+}
+
+func (t *ResourceVolumeSyncUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	// wait to ensure API is still up after the test ends
+	<-done
+
+	// these appear to fail on a regular basis.  We see it even for service account token secrets, which are guaranteed
+	// to exist before they are added to the pod in admission, but we don't want to perma-break CI
+	//confirmNoSecretSyncFailure(f.ClientSet)
+	//confirmNoConfigMapSyncFailure(f.ClientSet)
+
+	confirmNoStuckVolume(f.ClientSet)
+}
+
+func (t *ResourceVolumeSyncUpgradeTest) Teardown(f *framework.Framework) {
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2291,6 +2291,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [Local]": "should propagate requested groups to the container [Local] [Suite:openshift]",
 
+	"[Top Level] [sig-node][Late] kubelet container creation shouldn't have trouble mounting any volume": "shouldn't have trouble mounting any volume [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL": "Implement packages API server and list packagemanifest info with namespace not NULL [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-operator] OLM should [Serial] olm version should contain the source commit id": "[Serial] olm version should contain the source commit id [Suite:openshift/conformance/serial]",


### PR DESCRIPTION
… and configmaps

At least one cause of crashlooping pods in core namespaces is a failure to start.  The container gets stuck in container creating.

This appears to be the result of the kubelet being unable to get the secret: https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.6/1291710556327120896

This creates a `[late]` test, which checks events in the remaining namespaces to see if we have hit this problem.