### PR TITLE
test: Upgrade test should log more granular failures

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -27,6 +27,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/test/e2e/upgrade/alert"
+
 	// "github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
@@ -127,9 +128,7 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 		upgCtx, err := getUpgradeContext(client, upgradeToImage)
 		framework.ExpectNoError(err, "determining what to upgrade to version=%s image=%s", "", upgradeToImage)
 
-		disruption.Run(
-			"Cluster upgrade",
-			"upgrade",
+		disruption.Run(f, "Cluster upgrade", "upgrade",
 			disruption.TestData{
 				UpgradeType:    upgrades.ClusterUpgrade,
 				UpgradeContext: *upgCtx,
@@ -137,7 +136,7 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 			upgradeTests,
 			func() {
 				for i := 1; i < len(upgCtx.Versions); i++ {
-					framework.ExpectNoError(clusterUpgrade(client, dynamicClient, config, upgCtx.Versions[i]), fmt.Sprintf("during upgrade to %s", upgCtx.Versions[i].NodeImage))
+					framework.ExpectNoError(clusterUpgrade(f, client, dynamicClient, config, upgCtx.Versions[i]), fmt.Sprintf("during upgrade to %s", upgCtx.Versions[i].NodeImage))
 				}
 			},
 		)
@@ -238,7 +237,7 @@ func getUpgradeContext(c configv1client.Interface, upgradeImage string) (*upgrad
 
 var errControlledAbort = fmt.Errorf("beginning abort")
 
-func clusterUpgrade(c configv1client.Interface, dc dynamic.Interface, config *rest.Config, version upgrades.VersionContext) error {
+func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynamic.Interface, config *rest.Config, version upgrades.VersionContext) error {
 	fmt.Fprintf(os.Stderr, "\n\n\n")
 	defer func() { fmt.Fprintf(os.Stderr, "\n\n\n") }()
 
@@ -271,40 +270,58 @@ func clusterUpgrade(c configv1client.Interface, dc dynamic.Interface, config *re
 		framework.Logf("Upgrade will be aborted and the cluster will roll back to the current version after %d%% of operators have upgraded", upgradeAbortAt)
 	}
 
-	// trigger the update
-	cv, err := c.ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	oldImage := cv.Status.Desired.Image
-	oldVersion := cv.Status.Desired.Version
-	desired := configv1.Update{
-		Version: version.Version.String(),
-		Image:   version.NodeImage,
-		Force:   true,
-	}
-	cv.Spec.DesiredUpdate = &desired
-	updated, err := c.ConfigV1().ClusterVersions().Update(context.Background(), cv, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
+	var (
+		desired  configv1.Update
+		original *configv1.ClusterVersion
+		updated  *configv1.ClusterVersion
+	)
 
 	monitor := versionMonitor{
-		client:     c,
-		oldVersion: oldVersion,
+		client: c,
 	}
+	defer monitor.Describe(f)
 
-	// wait until the cluster acknowledges the update
-	if err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
-		cv, _, err := monitor.Check(updated.Generation, desired)
-		if err != nil || cv == nil {
-			return false, err
-		}
-		return cv.Status.ObservedGeneration >= updated.Generation, nil
+	// trigger the update and record verification as an independent step
+	if err := disruption.RecordJUnit(
+		f,
+		"[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade",
+		func() error {
+			cv, err := c.ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
 
-	}); err != nil {
-		monitor.Output()
-		return fmt.Errorf("Cluster did not acknowledge request to upgrade in a reasonable time: %v", err)
+			original = cv
+			cv = cv.DeepCopy()
+			desired = configv1.Update{
+				Version: version.Version.String(),
+				Image:   version.NodeImage,
+				Force:   true,
+			}
+			monitor.oldVersion = original.Status.Desired.Version
+
+			cv.Spec.DesiredUpdate = &desired
+			cv, err = c.ConfigV1().ClusterVersions().Update(context.Background(), cv, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+			updated = cv
+
+			// wait until the cluster acknowledges the update
+			if err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+				cv, _, err := monitor.Check(updated.Generation, desired)
+				if err != nil || cv == nil {
+					return false, err
+				}
+				return cv.Status.ObservedGeneration >= updated.Generation, nil
+
+			}); err != nil {
+				return fmt.Errorf("timed out waiting for cluster to acknowledge upgrade: %v", err)
+			}
+			return nil
+		},
+	); err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -325,9 +342,9 @@ func clusterUpgrade(c configv1client.Interface, dc dynamic.Interface, config *re
 		}
 
 		if !aborted && monitor.ShouldUpgradeAbort(abortAt) {
-			framework.Logf("Instructing the cluster to return to %s / %s", oldVersion, oldImage)
+			framework.Logf("Instructing the cluster to return to %s / %s", original.Status.Desired.Version, original.Status.Desired.Image)
 			desired = configv1.Update{
-				Image: oldImage,
+				Image: original.Status.Desired.Image,
 				Force: true,
 			}
 			if err := retry.RetryOnConflict(wait.Backoff{Steps: 10, Duration: time.Second}, func() error {
@@ -351,7 +368,6 @@ func clusterUpgrade(c configv1client.Interface, dc dynamic.Interface, config *re
 		return monitor.Reached(cv, desired)
 
 	}); err != nil {
-		monitor.Output()
 		if lastMessage != "" {
 			return fmt.Errorf("Cluster did not complete upgrade: %v: %s", err, lastMessage)
 		}

--- a/test/extended/dr/machine_recover.go
+++ b/test/extended/dr/machine_recover.go
@@ -57,7 +57,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive
 		replacedWorker := workers[rand.Intn(len(workers))]
 		expectSSH("true", replacedWorker)
 
-		disruption.Run("Machine Shutdown and Restore", "machine_failure",
+		disruption.Run(f, "Machine Shutdown and Restore", "machine_failure",
 			disruption.TestData{},
 			[]upgrades.Test{
 				&upgrades.ServiceUpgradeTest{},

--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -77,7 +77,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 			e2eskipper.Skipf("machine API is not enabled and automatic recovery test is not possible")
 		}
 
-		disruption.Run("Quorum Loss and Restore", "quorum_restore",
+		disruption.Run(f, "Quorum Loss and Restore", "quorum_restore",
 			disruption.TestData{},
 			[]upgrades.Test{
 				&upgrades.ServiceUpgradeTest{},


### PR DESCRIPTION
If CVO failed to acknowledge upgrade within the time limit, display
a specific error. If we failed to upgrade, give each failing operator
their own failed junit result including the condition and message.