### PR TITLE
Bug 1861214: test: network: unskip endpoint slices

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1897,7 +1897,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] EndpointSlice should have Endpoints and EndpointSlices pointing to API Server": "should have Endpoints and EndpointSlices pointing to API Server [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete": "should mirror a custom Endpoints resource through create update and delete [Disabled:Broken] [Suite:k8s]",
+	"[Top Level] [sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete": "should mirror a custom Endpoints resource through create update and delete [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service": "[Slow] [Serial] should create valid firewall rules for LoadBalancer type service [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -99,9 +99,6 @@ var (
 
 			`Cluster should restore itself after quorum loss`, // https://bugzilla.redhat.com/show_bug.cgi?id=1837157
 
-			// Disabled as per networking team. Follow-up tracked via https://bugzilla.redhat.com/show_bug.cgi?id=1861214
-			`EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete`,
-
 			// Perma-fail
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1862322
 			`an end user can use OLM can subscribe to the operator`,


### PR DESCRIPTION
unskip the test
[sig-network] EndpointSliceMirroring should mirror a custom Endpoints resource through create update and delete

