### PR TITLE
Bug 1828858: use LoadBalancers with ExternalTrafficPolicy set to Local

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -50,6 +50,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("creating a TCP service " + serviceName + " with type=LoadBalancer in namespace " + ns.Name)
 	tcpService, err := jig.CreateTCPService(func(s *v1.Service) {
 		s.Spec.Type = v1.ServiceTypeLoadBalancer
+		s.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 		if s.Annotations == nil {
 			s.Annotations = make(map[string]string)
 		}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -27,8 +27,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/test/e2e/upgrade/alert"
-
-	// "github.com/openshift/origin/test/e2e/upgrade/service"
+	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 	"github.com/openshift/origin/test/extended/util/disruption/frontends"
@@ -41,8 +40,7 @@ func AllTests() []upgrades.Test {
 		controlplane.NewOAuthAvailableTest(),
 		&alert.UpgradeTest{},
 		&frontends.AvailableTest{},
-		// Broken by 1.19 rebase, fix tracked by https://bugzilla.redhat.com/show_bug.cgi?id=1861944
-		// &service.UpgradeTest{},
+		&service.UpgradeTest{},
 		&upgrades.SecretUpgradeTest{},
 		&apps.ReplicaSetUpgradeTest{},
 		&apps.StatefulSetUpgradeTest{},


### PR DESCRIPTION
Use  ExternalTrafficPolicy set to Local for the service used in the test
`[sig-network-edge] Application behind service load balancer with PDB is not disrupted ` 
This avoid that we do a double hop inside the cluster to reach the pod, since the traffic goes directly from the load balancer to the node that has the pod running.