### PR TITLE
split the crashlooping pod test to more precisely tag recycler pods

### DIFF
--- a/test/extended/operators/cluster.go
+++ b/test/extended/operators/cluster.go
@@ -16,105 +16,140 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
+var _ = g.Describe("[sig-storage] Managed cluster should", func() {
+	defer g.GinkgoRecover()
+
+	g.It("have no crashlooping recycler pods over four minutes", func() {
+		crashloopingContainerCheck(inCoreNamespaces, recyclerPod)
+	})
+})
+
+type podFilter func(pod *corev1.Pod) bool
+
+func inCoreNamespaces(pod *corev1.Pod) bool {
+	return strings.HasPrefix(pod.Namespace, "openshift-") || strings.HasPrefix(pod.Namespace, "kube-")
+}
+
+func not(filterFn podFilter) podFilter {
+	return func(pod *corev1.Pod) bool {
+		return !filterFn(pod)
+	}
+}
+
+func recyclerPod(pod *corev1.Pod) bool {
+	return strings.HasPrefix(pod.Name, "recycler-for-nfs-")
+}
+
 var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	g.It("have no crashlooping pods in core namespaces over four minutes", func() {
-		c, err := e2e.LoadClientset()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		restartingContainers := make(map[containerName]int)
-		podsWithProblems := make(map[string]*corev1.Pod)
-		var lastPending map[string]*corev1.Pod
-		wait.PollImmediate(5*time.Second, 4*time.Minute, func() (bool, error) {
-			allPods, err := c.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			var pods []*corev1.Pod
-			for i := range allPods.Items {
-				pod := &allPods.Items[i]
-				if !strings.HasPrefix(pod.Namespace, "openshift-") && !strings.HasPrefix(pod.Namespace, "kube-") {
-					continue
-				}
-				pods = append(pods, pod)
-			}
-
-			pending := make(map[string]*corev1.Pod)
-			for _, pod := range pods {
-				if pod.Status.Phase == corev1.PodPending {
-					hasInitContainerRunning := false
-					for _, initContainerStatus := range pod.Status.InitContainerStatuses {
-						if initContainerStatus.State.Running != nil {
-							hasInitContainerRunning = true
-							break
-						}
-					}
-					if !hasInitContainerRunning {
-						pending[fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)] = pod
-					}
-				}
-			}
-			lastPending = pending
-
-			var names []string
-			for _, pod := range pods {
-				if pod.Status.Phase == corev1.PodSucceeded {
-					continue
-				}
-				switch {
-				case hasCreateContainerError(pod):
-				case hasImagePullError(pod):
-				case isCrashLooping(pod):
-				case hasExcessiveRestarts(pod, 2, restartingContainers):
-				case hasFailingContainer(pod):
-				default:
-					continue
-				}
-				key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-				names = append(names, key)
-				podsWithProblems[key] = pod
-			}
-			if len(names) > 0 {
-				e2e.Logf("Some pods in error: %s", strings.Join(names, ", "))
-			}
-			return false, nil
-		})
-		var msg []string
-		ns := make(map[string]struct{})
-		for _, pod := range podsWithProblems {
-			delete(lastPending, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
-			if strings.HasPrefix(pod.Name, "samename-") {
-				continue
-			}
-			if _, ok := ns[pod.Namespace]; !ok {
-				e2e.DumpAllNamespaceInfo(c, pod.Namespace)
-				ns[pod.Namespace] = struct{}{}
-			}
-			status, _ := json.MarshalIndent(pod.Status, "", "  ")
-			e2e.Logf("Pod status %s/%s:\n%s", pod.Namespace, pod.Name, string(status))
-			msg = append(msg, fmt.Sprintf("Pod %s/%s is not healthy: %v", pod.Namespace, pod.Name, pod.Status.Message))
-		}
-
-		for _, pod := range lastPending {
-			if strings.HasPrefix(pod.Name, "must-gather-") {
-				e2e.Logf("Pod status %s/%s ignored for being pending", pod.Namespace, pod.Name)
-				continue
-			}
-			if _, ok := ns[pod.Namespace]; !ok {
-				e2e.DumpAllNamespaceInfo(c, pod.Namespace)
-				ns[pod.Namespace] = struct{}{}
-			}
-			status, _ := json.MarshalIndent(pod.Status, "", "  ")
-			e2e.Logf("Pod status %s/%s:\n%s", pod.Namespace, pod.Name, string(status))
-			if len(pod.Status.Message) == 0 {
-				pod.Status.Message = "unknown error"
-			}
-			msg = append(msg, fmt.Sprintf("Pod %s/%s was pending entire time: %v", pod.Namespace, pod.Name, pod.Status.Message))
-		}
-
-		o.Expect(msg).To(o.BeEmpty())
+		crashloopingContainerCheck(inCoreNamespaces, not(recyclerPod))
 	})
 })
+
+func crashloopingContainerCheck(podFilters ...podFilter) {
+	c, err := e2e.LoadClientset()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	restartingContainers := make(map[containerName]int)
+	podsWithProblems := make(map[string]*corev1.Pod)
+	var lastPending map[string]*corev1.Pod
+	wait.PollImmediate(5*time.Second, 4*time.Minute, func() (bool, error) {
+		allPods, err := c.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var pods []*corev1.Pod
+		for i := range allPods.Items {
+			pod := &allPods.Items[i]
+			accept := true
+			for _, filterFn := range podFilters {
+				if !filterFn(pod) {
+					accept = false
+					break
+				}
+			}
+			if !accept {
+				continue
+			}
+			pods = append(pods, pod)
+		}
+
+		pending := make(map[string]*corev1.Pod)
+		for _, pod := range pods {
+			if pod.Status.Phase == corev1.PodPending {
+				hasInitContainerRunning := false
+				for _, initContainerStatus := range pod.Status.InitContainerStatuses {
+					if initContainerStatus.State.Running != nil {
+						hasInitContainerRunning = true
+						break
+					}
+				}
+				if !hasInitContainerRunning {
+					pending[fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)] = pod
+				}
+			}
+		}
+		lastPending = pending
+
+		var names []string
+		for _, pod := range pods {
+			if pod.Status.Phase == corev1.PodSucceeded {
+				continue
+			}
+			switch {
+			case hasCreateContainerError(pod):
+			case hasImagePullError(pod):
+			case isCrashLooping(pod):
+			case hasExcessiveRestarts(pod, 2, restartingContainers):
+			case hasFailingContainer(pod):
+			default:
+				continue
+			}
+			key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+			names = append(names, key)
+			podsWithProblems[key] = pod
+		}
+		if len(names) > 0 {
+			e2e.Logf("Some pods in error: %s", strings.Join(names, ", "))
+		}
+		return false, nil
+	})
+	var msg []string
+	ns := make(map[string]struct{})
+	for _, pod := range podsWithProblems {
+		delete(lastPending, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+		if strings.HasPrefix(pod.Name, "samename-") {
+			continue
+		}
+		if _, ok := ns[pod.Namespace]; !ok {
+			e2e.DumpAllNamespaceInfo(c, pod.Namespace)
+			ns[pod.Namespace] = struct{}{}
+		}
+		status, _ := json.MarshalIndent(pod.Status, "", "  ")
+		e2e.Logf("Pod status %s/%s:\n%s", pod.Namespace, pod.Name, string(status))
+		msg = append(msg, fmt.Sprintf("Pod %s/%s is not healthy: %v", pod.Namespace, pod.Name, pod.Status.Message))
+	}
+
+	for _, pod := range lastPending {
+		if strings.HasPrefix(pod.Name, "must-gather-") {
+			e2e.Logf("Pod status %s/%s ignored for being pending", pod.Namespace, pod.Name)
+			continue
+		}
+		if _, ok := ns[pod.Namespace]; !ok {
+			e2e.DumpAllNamespaceInfo(c, pod.Namespace)
+			ns[pod.Namespace] = struct{}{}
+		}
+		status, _ := json.MarshalIndent(pod.Status, "", "  ")
+		e2e.Logf("Pod status %s/%s:\n%s", pod.Namespace, pod.Name, string(status))
+		if len(pod.Status.Message) == 0 {
+			pod.Status.Message = "unknown error"
+		}
+		msg = append(msg, fmt.Sprintf("Pod %s/%s was pending entire time: %v", pod.Namespace, pod.Name, pod.Status.Message))
+	}
+
+	o.Expect(msg).To(o.BeEmpty())
+}
 
 func hasCreateContainerError(pod *corev1.Pod) bool {
 	for _, status := range append(append([]corev1.ContainerStatus{}, pod.Status.InitContainerStatuses...), pod.Status.ContainerStatuses...) {

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -10891,6 +10891,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Pre-provisioned PV (xfs)][Slow] volumes should store data": "should store data [Suite:k8s]",
 
+	"[Top Level] [sig-storage] Managed cluster should have no crashlooping recycler pods over four minutes": "have no crashlooping recycler pods over four minutes [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-storage] Mounted flexvolume volume expand [Slow] [Feature:ExpandInUsePersistentVolumes] should be resizable when mounted": "should be resizable when mounted [Suite:k8s]",
 
 	"[Top Level] [sig-storage] Mounted volume expand Should verify mounted devices can be resized": "Should verify mounted devices can be resized [Suite:openshift/conformance/parallel] [Suite:k8s]",


### PR DESCRIPTION
it looks like we have a significant number of recycler pod problems compared against "other" pods.  Both are problematic, but recycler pods are less bad and specifically storage related. This refactors the test and allows filtering.

Review with whitespace off