### PR TITLE
Bug 1872038: openshift-tests: fix upgrade test suites reference to controlplane availability tests

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/test/ginkgo"
 	"github.com/openshift/origin/test/e2e/upgrade"
+	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 )
 
 // upgradeSuites are all known upgade test suites this binary should run
@@ -39,7 +40,9 @@ var upgradeSuites = []*ginkgo.TestSuite{
 			return strings.Contains(name, "[Feature:ClusterUpgrade]") && strings.Contains(name, "[Suite:openshift]")
 		},
 		Init: func(opt map[string]string) error {
-			return upgradeInitArguments(opt, func(name string) bool { return name == "control-plane-available" })
+			return upgradeInitArguments(opt, func(name string) bool {
+				return name == controlplane.NewKubeAvailableTest().Name() || name == controlplane.NewKubeAvailableTest().Name()
+			})
 		},
 		TestTimeout: 240 * time.Minute,
 	},


### PR DESCRIPTION
This link broke in https://github.com/openshift/origin/commit/8ec84ded0375928c4d1ceecec21e6fddb718c501.

Kudos to @cgwalters for noticing.