### PR TITLE
BUG 1863009: vSphere provision failure on ocp46

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -439,7 +439,7 @@ replace (
 	k8s.io/kubectl => k8s.io/kubectl v0.19.0-rc.2
 	k8s.io/kubelet => k8s.io/kubelet v0.19.0-rc.2
 	k8s.io/kubernetes => github.com/openshift/kubernetes v1.20.0-alpha.0.0.20200803060402-d32435439579
-	k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200803060402-d32435439579
+	k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200826132615-f71a7ab366cf
 	k8s.io/metrics => k8s.io/metrics v0.19.0-rc.2
 	k8s.io/repo-infra => k8s.io/repo-infra v0.0.1-alpha.1
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.19.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/openshift/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-2020080
 github.com/openshift/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20200803060402-d32435439579/go.mod h1:+7rIJYlH+r3D4eWt4HVRk52OcWNLyFDIi0uT5DdivUQ=
 github.com/openshift/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20200803060402-d32435439579 h1:dAQitjT7Z0epj09lRnuPgJmcnveN4xZX44S8lD4J7nQ=
 github.com/openshift/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20200803060402-d32435439579/go.mod h1:Fgq/XF/OXIjTpvL79ZjF1h/cXPVUFAxocIQDGRfoQYw=
-github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200803060402-d32435439579 h1:8Nq+512XQ4TMOFZP2PVfj0OsWVPNq1F9lRPebSNWGeU=
-github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200803060402-d32435439579/go.mod h1:V29rgRnfGKqV/Igb/rcTI+h7Xt22XoO914odfbs03ik=
+github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200826132615-f71a7ab366cf h1:6WYK5JAFYXehPZbVkkkSqeibs7clN3mRHZmiXG+K79w=
+github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200826132615-f71a7ab366cf/go.mod h1:kUaainILK6Zy9oE3FRx+pp7y5+eTb73H3Z4oEmzaxQ8=
 github.com/openshift/library-go v0.0.0-20200722204747-e3f2c82ff290 h1:x2MMkmR0gr+3UazejQcIafWCXh8d0W+6EWTtWLyGBnQ=
 github.com/openshift/library-go v0.0.0-20200722204747-e3f2c82ff290/go.mod h1:/gVyoY2dl35bcCCgs+36UmGt6n/kn3f64hfDduujQ1c=
 github.com/openshift/onsi-ginkgo v4.5.0-origin.1+incompatible h1:GtzyDU5vBFU40hz4GWd1qU5FJByNljWdgkM2LtdelGk=

--- a/vendor/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
+++ b/vendor/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
@@ -259,6 +259,16 @@ func (nm *NodeManager) GetNode(nodeName k8stypes.NodeName) (v1.Node, error) {
 	return *node, nil
 }
 
+func (nm *NodeManager) getNodes() map[string]*v1.Node {
+	nm.registeredNodesLock.RLock()
+	defer nm.registeredNodesLock.RUnlock()
+	registeredNodes := make(map[string]*v1.Node, len(nm.registeredNodes))
+	for nodeName, node := range nm.registeredNodes {
+		registeredNodes[nodeName] = node
+	}
+	return registeredNodes
+}
+
 func (nm *NodeManager) addNode(node *v1.Node) {
 	nm.registeredNodesLock.Lock()
 	nm.registeredNodes[node.ObjectMeta.Name] = node
@@ -288,11 +298,9 @@ func (nm *NodeManager) GetNodeInfo(nodeName k8stypes.NodeName) (NodeInfo, error)
 //
 // This method is a getter but it can cause side-effect of updating NodeInfo objects.
 func (nm *NodeManager) GetNodeDetails() ([]NodeDetails, error) {
-	nm.registeredNodesLock.Lock()
-	defer nm.registeredNodesLock.Unlock()
 	var nodeDetails []NodeDetails
 
-	for nodeName, nodeObj := range nm.registeredNodes {
+	for nodeName, nodeObj := range nm.getNodes() {
 		nodeInfo, err := nm.GetNodeInfoWithNodeObject(nodeObj)
 		if err != nil {
 			return nil, err
@@ -304,10 +312,7 @@ func (nm *NodeManager) GetNodeDetails() ([]NodeDetails, error) {
 }
 
 func (nm *NodeManager) refreshNodes() (errList []error) {
-	nm.registeredNodesLock.Lock()
-	defer nm.registeredNodesLock.Unlock()
-
-	for nodeName := range nm.registeredNodes {
+	for nodeName := range nm.getNodes() {
 		nodeInfo, err := nm.getRefreshedNodeInfo(convertToK8sType(nodeName))
 		if err != nil {
 			errList = append(errList, err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2669,7 +2669,7 @@ k8s.io/kubernetes/third_party/forked/gonum/graph
 k8s.io/kubernetes/third_party/forked/gonum/graph/internal/linear
 k8s.io/kubernetes/third_party/forked/gonum/graph/simple
 k8s.io/kubernetes/third_party/forked/gonum/graph/traverse
-# k8s.io/legacy-cloud-providers v0.0.0 => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200803060402-d32435439579
+# k8s.io/legacy-cloud-providers v0.0.0 => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200826132615-f71a7ab366cf
 k8s.io/legacy-cloud-providers/aws
 k8s.io/legacy-cloud-providers/azure
 k8s.io/legacy-cloud-providers/azure/auth


### PR DESCRIPTION
Refactor locks on registeredNodesLocks

All internal calls in these methods were already using atomic operations such as `addNode` or `GetNode`.
This lock instead was volume creation and destroying the ability to provision volume with `thin` SC.

Now the node map will be copied, and all group operations will be executed on a copy, leaving lock for others to use.

Cherry-pick https://github.com/kubernetes/kubernetes/pull/93971