### PR TITLE
test: check for type assertion on watch result chan

### DIFF
--- a/test/extended/builds/run_policy.go
+++ b/test/extended/builds/run_policy.go
@@ -79,7 +79,10 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 				// Wait for it to become running
 				for {
 					event := <-buildWatch.ResultChan()
-					build := event.Object.(*buildv1.Build)
+					build, ok := event.Object.(*buildv1.Build)
+					if !ok {
+						continue
+					}
 					o.Expect(IsBuildComplete(build)).Should(o.BeFalse())
 					if build.Name == startedBuilds[0] && build.Status.Phase == buildv1.BuildPhaseRunning {
 						break
@@ -97,7 +100,10 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 
 				for {
 					event := <-buildWatch.ResultChan()
-					build := event.Object.(*buildv1.Build)
+					build, ok := event.Object.(*buildv1.Build)
+					if !ok {
+						continue
+					}
 					if build.Name == startedBuilds[0] {
 						if IsBuildComplete(build) {
 							break
@@ -160,7 +166,10 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 				sawCompletion := false
 				for {
 					event := <-buildWatch.ResultChan()
-					build := event.Object.(*buildv1.Build)
+					build, ok := event.Object.(*buildv1.Build)
+					if !ok {
+						continue
+					}
 					var lastCompletion time.Time
 					if build.Status.Phase == buildv1.BuildPhaseComplete {
 						o.Expect(hasConditionState(build, buildv1.BuildPhaseComplete, true)).Should(o.BeTrue())
@@ -232,7 +241,10 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 				var cancelTime, cancelTime2 time.Time
 				for {
 					event := <-buildWatch.ResultChan()
-					build := event.Object.(*buildv1.Build)
+					build, ok := event.Object.(*buildv1.Build)
+					if !ok {
+						continue
+					}
 					if build.Status.Phase == buildv1.BuildPhasePending || build.Status.Phase == buildv1.BuildPhaseRunning {
 						if build.Status.Phase == buildv1.BuildPhaseRunning {
 							o.Expect(hasConditionState(build, buildv1.BuildPhaseRunning, true)).Should(o.BeTrue())
@@ -284,7 +296,11 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 				for done == false {
 					select {
 					case event := <-buildWatch.ResultChan():
-						build := event.Object.(*buildv1.Build)
+						build, ok := event.Object.(*buildv1.Build)
+						if !ok {
+							continue
+						}
+
 						if build.Status.Phase == buildv1.BuildPhasePending {
 							o.Expect(hasConditionState(build, buildv1.BuildPhasePending, true)).Should(o.BeTrue())
 							if build.Name == "sample-serial-build-fail-2" {
@@ -364,7 +380,10 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 				for !done {
 					select {
 					case event := <-buildWatch.ResultChan():
-						build := event.Object.(*buildv1.Build)
+						build, ok := event.Object.(*buildv1.Build)
+						if !ok {
+							continue
+						}
 						if build.Status.Phase == buildv1.BuildPhasePending || build.Status.Phase == buildv1.BuildPhaseRunning {
 							if build.Status.Phase == buildv1.BuildPhaseRunning {
 								o.Expect(hasConditionState(build, buildv1.BuildPhaseRunning, true)).Should(o.BeTrue())
@@ -424,7 +443,11 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 				// Wait for the first build to become running
 				for {
 					event := <-buildWatch.ResultChan()
-					build := event.Object.(*buildv1.Build)
+					build, ok := event.Object.(*buildv1.Build)
+					if !ok {
+						continue
+					}
+
 					if build.Name == startedBuilds[0] {
 						if build.Status.Phase == buildv1.BuildPhaseRunning {
 							buildVerified[build.Name] = true
@@ -447,7 +470,10 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 				// will be the last build created.
 				for {
 					event := <-buildWatch.ResultChan()
-					build := event.Object.(*buildv1.Build)
+					build, ok := event.Object.(*buildv1.Build)
+					if !ok {
+						continue
+					}
 					e2e.Logf("got event for build %s with phase %s", build.Name, build.Status.Phase)
 					// The second build should be cancelled
 					if build.Status.Phase == buildv1.BuildPhaseCancelled {

--- a/test/extended/builds/webhook.go
+++ b/test/extended/builds/webhook.go
@@ -272,7 +272,10 @@ Loop:
 		case <-time.After(10 * time.Second):
 			t.Fatalf("timed out waiting for build event")
 		case event := <-watch.ResultChan():
-			actual := event.Object.(*buildv1.Build)
+			actual, ok := event.Object.(*buildv1.Build)
+			if !ok {
+				continue
+			}
 			t.Logf("Saw build object %#v", actual)
 			if actual.Status.Phase != buildv1.BuildPhasePending {
 				continue
@@ -317,7 +320,10 @@ func TestWebhookGitHubPing(t g.GinkgoTInterface, oc *exutil.CLI) {
 		case <-timer.C:
 			// nothing should happen
 		case event := <-watch.ResultChan():
-			build := event.Object.(*buildv1.Build)
+			build, ok := event.Object.(*buildv1.Build)
+			if !ok {
+				continue
+			}
 			t.Fatalf("Unexpected build created: %#v", build)
 		}
 	}

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -754,7 +754,10 @@ func (d *deployerPodInvariantChecker) doChecking() {
 			if t != watch.Added && t != watch.Modified && t != watch.Deleted {
 				o.Expect(fmt.Errorf("unexpected event: %#v", event)).NotTo(o.HaveOccurred())
 			}
-			pod := event.Object.(*corev1.Pod)
+			pod, ok := event.Object.(*corev1.Pod)
+			if !ok {
+				continue
+			}
 			if !strings.HasSuffix(pod.Name, "-deploy") {
 				continue
 			}

--- a/test/extended/images/imagechange_buildtrigger.go
+++ b/test/extended/images/imagechange_buildtrigger.go
@@ -280,7 +280,7 @@ func runTest(t g.GinkgoTInterface, oc *exutil.CLI, testname string, projectAdmin
 		event := <-buildWatch.ResultChan()
 		o.Expect(event.Type).To(o.Equal(watchapi.Added))
 
-		newBuild := event.Object.(*buildv1.Build)
+		newBuild, ok := event.Object.(*buildv1.Build)
 		build1Name := newBuild.Name
 		strategy := newBuild.Spec.Strategy
 		expectedFromName := registryHostname + "/openshift/test-image-trigger:" + tag
@@ -334,7 +334,10 @@ func runTest(t g.GinkgoTInterface, oc *exutil.CLI, testname string, projectAdmin
 		// we just triggered
 		g.By("waiting for a new build to be added")
 		for {
-			event = <-buildWatch.ResultChan()
+			event, ok = <-buildWatch.ResultChan()
+			if !ok {
+				continue
+			}
 			newBuild = event.Object.(*buildv1.Build)
 			if newBuild.Name != build1Name {
 				break
@@ -361,7 +364,11 @@ func runTest(t g.GinkgoTInterface, oc *exutil.CLI, testname string, projectAdmin
 		g.By("waiting for a new build to be updated")
 		for {
 			event = <-buildWatch.ResultChan()
-			newBuild = event.Object.(*buildv1.Build)
+			var ok bool
+			newBuild, ok = event.Object.(*buildv1.Build)
+			if !ok {
+				continue
+			}
 			if newBuild.Name != build1Name {
 				break
 			}

--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -228,7 +228,10 @@ func waitForDelete(projectName string, w watch.Interface) {
 		for {
 			select {
 			case event := <-w.ResultChan():
-				project := event.Object.(*projectv1.Project)
+				project, ok := event.Object.(*projectv1.Project)
+				if !ok {
+					continue
+				}
 				framework.Logf("got %#v %#v", event, project)
 				if event.Type == watch.Deleted && project.Name == projectName {
 					return
@@ -246,7 +249,10 @@ func waitForAdd(projectName string, w watch.Interface) {
 		for {
 			select {
 			case event := <-w.ResultChan():
-				project := event.Object.(*projectv1.Project)
+				project, ok := event.Object.(*projectv1.Project)
+				if !ok {
+					continue
+				}
 				framework.Logf("got %#v %#v", event, project)
 				if event.Type == watch.Added && project.Name == projectName {
 					return
@@ -265,7 +271,10 @@ func waitForOnlyAdd(projectName string, w watch.Interface) {
 		for {
 			select {
 			case event := <-w.ResultChan():
-				project := event.Object.(*projectv1.Project)
+				project, ok := event.Object.(*projectv1.Project)
+				if !ok {
+					continue
+				}
 				framework.Logf("got %#v %#v", event, project)
 				if project.Name == projectName {
 					// the first event we see for the expected project must be an ADD


### PR DESCRIPTION
In some cases the metav1.Status can be returned, like when the API server
dropped out or the watch cache is not initialized yet or there is a networking
glitch. In such case, this change in test will cause it to retry until the expected
object is returned.