### PR TITLE
Add CSI-certified driver capabilities reporting tool

### DIFF
--- a/cmd/csi_cert_storage_caps/csi_cert_storage_caps.go
+++ b/cmd/csi_cert_storage_caps/csi_cert_storage_caps.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+)
+
+// Manifest yaml structs
+
+type StorageClass struct {
+	FromFile string `yaml:"FromFile"`
+}
+
+type SnapshotClass struct {
+	FromName bool `yaml:"FromName"`
+}
+
+type Capabilities struct {
+	Block    bool `yaml:"block"`
+	RWX      bool `yaml:"RWX"`
+	Snapshot bool `yaml:"snapshotDataSource"`
+}
+
+type DriverInfo struct {
+	Name         string `yaml:"Name"`
+	Capabilities `yaml:"Capabilities"`
+}
+
+type YamlManifest struct {
+	ShortName     string `yaml:"ShortName"`
+	StorageClass  `yaml:"StorageClass"`
+	SnapshotClass `yaml:"SnapshotClass"`
+	DriverInfo    `yaml:"DriverInfo"`
+}
+
+// Test results xml structs
+
+type TestSuite struct {
+	XMLName   xml.Name   `xml:"testsuite"`
+	Name      string     `xml:"name,attr"`
+	Tests     uint       `xml:"tests,attr"`
+	Failures  uint       `xml:"failures,attr"`
+	Errors    uint       `xml:"errors,attr"`
+	Time      float32    `xml:"time,attr"`
+	TestCases []TestCase `xml:"testcase"`
+}
+
+type TestCase struct {
+	XMLName   xml.Name `xml:"testcase"`
+	Name      string   `xml:"name,attr"`
+	ClassName string   `xml:"classname,attr"`
+	Time      float32  `xml:"time,attr"`
+	Passed    string   `xml:"passed"`
+	Failure   string   `xml:"failure"`
+	Skipped   Skip     `xml:"skipped"`
+}
+
+type Skip struct {
+	Message string `xml:"message,attr"`
+}
+
+func parseManifest(manifestFilename string) {
+	yamlFile, err := ioutil.ReadFile(manifestFilename)
+	if err != nil {
+		fmt.Println("Failed to", err)
+		return
+	}
+
+	var yamlManifest YamlManifest
+	err = yaml.Unmarshal(yamlFile, &yamlManifest)
+	if err != nil {
+		fmt.Println("Error parsing", err)
+		return
+	}
+	fmt.Println("Driver short name:                 ", yamlManifest.ShortName)
+	fmt.Println("Driver name:                       ", yamlManifest.DriverInfo.Name)
+	fmt.Println("Storage class:                     ", yamlManifest.StorageClass.FromFile)
+	fmt.Println("Raw block VM disks supported:      ", yamlManifest.DriverInfo.Capabilities.Block)
+	fmt.Println("Live migration supported:          ", yamlManifest.DriverInfo.Capabilities.RWX)
+	fmt.Println("Snapshotting tested:               ", yamlManifest.SnapshotClass.FromName)
+	fmt.Println("VM snapshots supported:            ", yamlManifest.DriverInfo.Capabilities.Snapshot)
+	fmt.Println("Storage-assisted cloning supported:", yamlManifest.DriverInfo.Capabilities.Snapshot)
+}
+
+func parseResults(resultsFilename string, listPassedTests bool, listFailedTests bool) bool {
+	xmlFile, err := os.Open(resultsFilename)
+	if err != nil {
+		fmt.Println("Failed to", err)
+		return false
+	}
+
+	byteValue, _ := ioutil.ReadAll(xmlFile)
+	var testSuite TestSuite
+	err = xml.Unmarshal(byteValue, &testSuite)
+	if err != nil {
+		fmt.Println("Failed to", err)
+		return false
+	}
+
+	if testSuite.Failures == 0 {
+		fmt.Println("CSI test results are all successful")
+	} else {
+		fmt.Println("NOTE: CSI test results indicate some failures, so reported driver capabilities might be inaccurate")
+	}
+
+	fmt.Println("Test Suite Name:", testSuite.Name, "| Tests:", testSuite.Tests, "| Failures:", testSuite.Failures,
+		"| Errors:", testSuite.Errors, "| Time:", testSuite.Time)
+	fmt.Println("---")
+
+	if listPassedTests {
+		countPassed := 0
+		for i := 0; i < len(testSuite.TestCases); i++ {
+			if len(testSuite.TestCases[i].Failure) == 0 && len(testSuite.TestCases[i].Skipped.Message) == 0 {
+				fmt.Println("[Passed]", testSuite.TestCases[i].Name)
+				countPassed++
+			}
+		}
+		fmt.Println("Tests Passed:", countPassed)
+		fmt.Println("---")
+	}
+
+	if testSuite.Failures > 0 && listFailedTests {
+		countFailed := 0
+		for i := 0; i < len(testSuite.TestCases); i++ {
+			if len(testSuite.TestCases[i].Failure) > 0 {
+				fmt.Println("[Failed]", testSuite.TestCases[i].Name)
+				countFailed++
+			}
+		}
+		fmt.Println("Tests Failed:", countFailed)
+		fmt.Println("---")
+	}
+
+	xmlFile.Close()
+	return true
+}
+
+func main() {
+	manifestFilename := flag.String("m", "manifest.yaml", "Driver manifest.yaml")
+	resultsFilename := flag.String("r", "", "CSI test results junit_e2e.xml")
+	listPassedTests := flag.Bool("p", false, "Lists the passed CSI tests")
+	listFailedTests := flag.Bool("f", false, "Lists the failed CSI tests")
+
+	flag.Parse()
+
+	if len(*resultsFilename) == 0 || len(*manifestFilename) == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if parseResults(*resultsFilename, *listPassedTests, *listFailedTests) {
+		parseManifest(*manifestFilename)
+	}
+}

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -14,7 +14,7 @@ platform="$(os::build::host_platform)"
 
 build_targets=("$@")
 if [[ -z "$@" ]]; then
-    build_targets=(cmd/openshift-tests)
+    build_targets=(cmd/openshift-tests, cmd/csi_cert_storage_caps)
 fi
 
 OS_BUILD_PLATFORMS=("${OS_BUILD_PLATFORMS[@]:-${platform}}")

--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -3,10 +3,13 @@ WORKDIR /go/src/github.com/openshift/origin
 COPY . .
 RUN make; \
     mkdir -p /tmp/build; \
-    cp /go/src/github.com/openshift/origin/openshift-tests /tmp/build/openshift-tests
+    cp /go/src/github.com/openshift/origin/openshift-tests /tmp/build/openshift-tests; \
+    cp /go/src/github.com/openshift/origin/csi_cert_storage_caps /tmp/build/csi_cert_storage_caps
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:cli
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
+COPY --from=builder /tmp/build/csi_cert_storage_caps /usr/bin/
+
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com && \


### PR DESCRIPTION
We add a tool (csi_cert_storage_caps) for listing storage capabilities of a CSI certified driver, mostly but not only for CDI purposes. The tool first looks at the CSI test results junit_e2e.xml and warns if there are failed test cases (listing them if -f flag is passed). Next, it parses the Driver manifest.yaml and lists driver capabilities.

Since the tool (as a stand-alone binary) is using the input (manifest.yaml) and output (results  junit_e2e.xml) of the CDI certification tests we think the natural way for deploying it is as part of CSI certification testing container.

We currently run the CSI tests as following:
```
$ podman run -v `pwd`:/data:z --rm -it $CONTAINER sh -c "KUBECONFIG=/data/kubeconfig.yaml TEST_CSI_DRIVER_FILES=/data/manifest.yaml /usr/bin/openshift-tests run openshift/csi --junit-dir /data/results"
```
And locally run the reporting tool:
```
$ csi_cert_storage_caps 
Usage of csi_cert_storage_caps:
  -f	Lists the failed CSI tests
  -m string
    	Driver manifest.yaml (default "manifest.yaml")
  -r string
    	CSI test results junit_e2e.xml

$ csi_cert_storage_caps -m manifest.yaml -r results/junit_e2e_20200728-160628.xml
CSI test results are all successful
Test Suite Name: openshift-tests | Tests: 151 | Failures: 0 | Errors: 0 | Time: 917
---
Driver short name:                  rook-ceph
Driver name:                        rook-ceph.rbd.csi.ceph.com
Storage class:                      storageclass.yaml
Raw block VM disks supported:       true
Live migration supported:           true
Snapshotting tested:                true
VM snapshots supported:             true
Storage-assisted cloning supported: true
```
So with this patch, users will be able to run the reporting tool from the container, similarly to the tests:
```
$ podman run -v `pwd`:/data:z --rm -it $CONTAINER sh -c "/usr/bin/csi_cert_storage_caps -m /data/manifest.yaml -r /data/results/junit_e2e_20200728-160628.xml"
```