### PR TITLE
Bug 1872726: [3.11] Upstream: 89160: Remove potentially unhealthy symlink only for dead containers

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -338,9 +338,35 @@ func (cgc *containerGC) evictPodLogsDirectories(allSourcesReady bool) error {
 	logSymlinks, _ := osInterface.Glob(filepath.Join(legacyContainerLogsDir, fmt.Sprintf("*.%s", legacyLogSuffix)))
 	for _, logSymlink := range logSymlinks {
 		if _, err := osInterface.Stat(logSymlink); os.IsNotExist(err) {
+			if containerID, err := getContainerIDFromLegacyLogSymlink(logSymlink); err == nil {
+				status, err := cgc.manager.runtimeService.ContainerStatus(containerID)
+				if err != nil {
+					// TODO: we should handle container not found (i.e. container was deleted) case differently
+					// once https://github.com/kubernetes/kubernetes/issues/63336 is resolved
+					glog.Infof("Error getting ContainerStatus for containerID %q: %v", containerID, err)
+				} else if status.State != runtimeapi.ContainerState_CONTAINER_EXITED {
+					// Here is how container log rotation works (see containerLogManager#rotateLatestLog):
+					//
+					// 1. rename current log to rotated log file whose filename contains current timestamp (fmt.Sprintf("%s.%s", log, timestamp))
+					// 2. reopen the container log
+					// 3. if #2 fails, rename rotated log file back to container log
+					//
+					// There is small but indeterministic amount of time during which log file doesn't exist (between steps #1 and #2, between #1 and #3).
+					// Hence the symlink may be deemed unhealthy during that period.
+					// See https://github.com/kubernetes/kubernetes/issues/52172
+					//
+					// We only remove unhealthy symlink for dead containers
+					glog.V(5).Infof("Container %q is still running, not removing symlink %q.", containerID, logSymlink)
+					continue
+				}
+			} else {
+				glog.V(4).Infof("unable to obtain container Id: %v", err)
+			}
 			err := osInterface.Remove(logSymlink)
 			if err != nil {
 				glog.Errorf("Failed to remove container log dead symlink %q: %v", logSymlink, err)
+			} else {
+				glog.V(4).Infof("removed symlink %s", logSymlink)
 			}
 		}
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/legacy.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/legacy.go
@@ -19,6 +19,7 @@ package kuberuntime
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
@@ -42,6 +43,25 @@ const (
 func legacyLogSymlink(containerID string, containerName, podName, podNamespace string) string {
 	return logSymlink(legacyContainerLogsDir, kubecontainer.BuildPodFullName(podName, podNamespace),
 		containerName, containerID)
+}
+
+// getContainerIDFromLegacyLogSymlink returns error if container Id cannot be parsed
+func getContainerIDFromLegacyLogSymlink(logSymlink string) (string, error) {
+	parts := strings.Split(logSymlink, "-")
+	if len(parts) == 0 {
+		return "", fmt.Errorf("unable to find separator in %q", logSymlink)
+	}
+	containerIDWithSuffix := parts[len(parts)-1]
+	suffix := fmt.Sprintf(".%s", legacyLogSuffix)
+	if !strings.HasSuffix(containerIDWithSuffix, suffix) {
+		return "", fmt.Errorf("%q doesn't end with %q", logSymlink, suffix)
+	}
+	containerIDWithoutSuffix := strings.TrimSuffix(containerIDWithSuffix, suffix)
+	// container can be retrieved with container Id as short as 6 characters
+	if len(containerIDWithoutSuffix) < 6 {
+		return "", fmt.Errorf("container Id %q is too short", containerIDWithoutSuffix)
+	}
+	return containerIDWithoutSuffix, nil
 }
 
 func logSymlink(containerLogsDir, podFullName, containerName, dockerId string) string {


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/origin/pull/24926
addressing: https://bugzilla.redhat.com/show_bug.cgi?id=1823406#c15

As the discussion over #52172 showed, there is race condition between the container log rotation and the kubelet GC which may result in the loss of symlink.

Here is how container log rotation works (see containerLogManager#rotateLatestLog):

    rename current log to rotated log file whose filename contains current timestamp (fmt.Sprintf("%s.%s", log, timestamp))
    reopen the container log
    if #2 fails, rename rotated log file back to container log

There is small but indeterministic amount of time during which log file doesn't exist (between steps #1 and #2, between #1 and #3). Hence the symlink may be deemed unhealthy during that period.

This PR resorts to runtimeService.ContainerStatus() to check whether the container corresponding to the potentially unhealthy symlink is alive or not. The symlink would only be removed for dead containers.