### PR TITLE
Bug 1857824: Fix incorrect retrieval of sandbox pods and incorrect host port initialization

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -347,14 +347,13 @@ func (node *OsdnNode) Start() error {
 		return err
 	}
 
-	if err = node.podManager.InitRunningPods(existingSandboxPods, existingOFPodNetworks, runningPods); err != nil {
+	if err = node.podManager.InitRunningPods(existingSandboxPods, existingOFPodNetworks, runningPods, networkChanged); err != nil {
 		return err
 	}
 
 	glog.V(2).Infof("Starting openshift-sdn pod manager")
 	if err := node.podManager.Start(cniserver.CNIServerRunDir, node.localSubnetCIDR,
-		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String(),
-		networkChanged); err != nil {
+		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String()); err != nil {
 		return err
 	}
 

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -473,7 +473,8 @@ func (node *OsdnNode) UpdatePod(pod kapi.Pod) error {
 	return err
 }
 
-func (node *OsdnNode) GetRunningPods(namespace string) ([]kapi.Pod, error) {
+// GetRunningPods returns a mapping of all running pods, as: namespace/name -> kapi.Pod
+func (node *OsdnNode) GetRunningPods(namespace string) (map[string]kapi.Pod, error) {
 	fieldSelector := fields.Set{"spec.nodeName": node.hostName}.AsSelector()
 	opts := metav1.ListOptions{
 		LabelSelector: labels.Everything().String(),
@@ -485,10 +486,10 @@ func (node *OsdnNode) GetRunningPods(namespace string) ([]kapi.Pod, error) {
 	}
 
 	// Filter running pods
-	pods := make([]kapi.Pod, 0, len(podList.Items))
+	pods := make(map[string]kapi.Pod)
 	for _, pod := range podList.Items {
 		if pod.Status.Phase == kapi.PodRunning {
-			pods = append(pods, pod)
+			pods[getPodKey(pod.Namespace, pod.Name)] = pod
 		}
 	}
 	return pods, nil

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -191,42 +191,34 @@ func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetwork
 	return m.cniServer.Start(m.handleCNIRequest)
 }
 
-func (m *podManager) InitRunningPods(existingSandboxPods map[string]*kruntimeapi.PodSandbox, existingOFPodNetworks map[string]podNetworkInfo, cRunningPods []kapi.Pod) error {
+func (m *podManager) InitRunningPods(existingSandboxPods map[string]*kruntimeapi.PodSandbox, existingOFPodNetworks map[string]podNetworkInfo, cRunningPods map[string]kapi.Pod) error {
 	m.runningPodsLock.Lock()
 	defer m.runningPodsLock.Unlock()
-
-	for _, cPod := range cRunningPods {
-		cKey := getPodKey(cPod.Namespace, cPod.Name)
-
+	for _, sandbox := range existingSandboxPods {
+		cKey := getPodKey(sandbox.Metadata.Namespace, sandbox.Metadata.Name)
+		cPod, exists := cRunningPods[cKey]
+		if !exists {
+			glog.Warningf("No running pod for ready sandbox: %s with sandbox id: %s", cKey, sandbox.Id)
+			continue
+		}
 		var v1Pod v1.Pod
 		if err := kapiv1.Convert_core_Pod_To_v1_Pod(&cPod, &v1Pod, nil); err != nil {
 			glog.Warningf("Could not convert core pod: %s to v1Pod", cKey)
 			continue
 		}
-
 		podPortMapping := constructPodPortMapping(&v1Pod, net.ParseIP(v1Pod.Status.PodIP))
-
 		vnid, err := m.policy.GetVNID(cPod.Namespace)
 		if err != nil {
 			glog.Warningf("No VNID for pod %s", cKey)
 			continue
 		}
-
-		sandbox, ok := existingSandboxPods[cKey]
-		if !ok {
-			glog.Warningf("No sandbox for pod %s", cKey)
-			continue
-		}
-
 		podNetworkInfo, ok := existingOFPodNetworks[sandbox.Id]
 		if !ok {
 			glog.Warningf("No network information for pod %s", cKey)
 			continue
 		}
-
 		m.runningPods[cKey] = &runningPod{podPortMapping: podPortMapping, vnid: vnid, ofport: podNetworkInfo.ofport}
 	}
-
 	glog.V(5).Infof("Finished initializing podManager with running pods at start-up")
 	return nil
 }

--- a/pkg/network/node/pod_test.go
+++ b/pkg/network/node/pod_test.go
@@ -318,7 +318,7 @@ func TestPodManager(t *testing.T) {
 		podManager := newDefaultPodManager()
 		podManager.podHandler = podTester
 		_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16", false)
+		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
 		if err != nil {
 			t.Fatalf("could not start PodManager: %v", err)
 		}
@@ -417,7 +417,7 @@ func TestDirectPodUpdate(t *testing.T) {
 	podManager := newDefaultPodManager()
 	podManager.podHandler = podTester
 	_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16", false)
+	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
 	if err != nil {
 		t.Fatalf("could not start PodManager: %v", err)
 	}


### PR DESCRIPTION
PR: https://github.com/openshift/origin/pull/23522 fixed syncing initial SDN state for hostport pods. There was however a mistake in that patch, namely: it overlooked that `existingSandboxPods` was a map of sandboxID -> PodSandbox and was retrieving the sandbox using the `podKey` (namespace/name). This lead to other initialization errors when the SDN restarts. This patch reverses the logic, and thus loops over the sandboxes and then retrieves the running pods.

I have not been able to build the images yet, as to test this on a live cluster where I've reproduced the problem. But logically this makes sense. 

/cc @aojea 
/assign @danwinship @squeed 