### PR TITLE
Bug 1710766: Add e2e form kubeconfigs on masters

### DIFF
--- a/test/extended/apiserver/kubeconfigs.go
+++ b/test/extended/apiserver/kubeconfigs.go
@@ -1,0 +1,41 @@
+package apiserver
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLI("apiserver")
+
+	for _, kubeconfig := range []string{
+		"localhost.kubeconfig",
+		"lb-ext.kubeconfig",
+		"lb-int.kubeconfig",
+		"localhost-recovery.kubeconfig",
+	} {
+		g.It(fmt.Sprintf("%q should be present on all masters and work", kubeconfig), func() {
+			masterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+				LabelSelector: `node-role.kubernetes.io/master`,
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			framework.Logf("Discovered %d master nodes.", len(masterNodes.Items))
+			o.Expect(masterNodes.Items).NotTo(o.HaveLen(0))
+			for _, master := range masterNodes.Items {
+				g.By("Testing master node " + master.Name)
+				kubeconfigPath := "/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/" + kubeconfig
+				framework.Logf("Verifying kubeconfig %q on master %s", master.Name)
+				out, err := oc.AsAdmin().Run("debug").Args("node/"+master.Name, "--image=docker.io/library/centos:latest", "--", "chroot", "/host", "/bin/bash", "-euxo", "pipefail", "-c", fmt.Sprintf(`oc --kubeconfig "%s" get namespace kube-system`, kubeconfigPath)).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				framework.Logf(out)
+			}
+		})
+	}
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -9,6 +9,14 @@ import (
 var annotations = map[string]string{
 	"[Top Level] Recreate [Feature:Recreate] recreate nodes and ensure they function upon restart": "recreate nodes and ensure they function upon restart [Disabled:Broken] [sig-cluster-lifecycle] [Suite:k8s]",
 
+	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-ext.kubeconfig\" should be present on all masters and work": "\"lb-ext.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
+
+	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-int.kubeconfig\" should be present on all masters and work": "\"lb-int.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
+
+	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"localhost-recovery.kubeconfig\" should be present on all masters and work": "\"localhost-recovery.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
+
+	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"localhost.kubeconfig\" should be present on all masters and work": "\"localhost.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
+
 	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP": "test RequestHeaders IdP [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster [Disabled:Broken] with non-gu workload should run with no regressions with single pod, single container requesting 1 core": "with single pod, single container requesting 1 core",


### PR DESCRIPTION
Adding conformance test verifying kubeconfigs on masters are present and working.

Requires:
- [x] https://github.com/openshift/cluster-kube-apiserver-operator/pull/858

/cc @deads2k @sttts