### PR TITLE
WIP: Detect and report unexpected leader elections

### DIFF
--- a/pkg/monitor/etcd.go
+++ b/pkg/monitor/etcd.go
@@ -1,0 +1,73 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+/*
+Under ideal conditions, the following etcd term/election timeline is expected:
+
+term  elections  reason
+1     -          no bootstrap member
+2     1          bootstrap member elected
+3     2          bootstrap member removed, master elected
+4     3          new etcd pod rev to drop bootstrap member from config
+
+Elections 1 and 2 occur during etcd pivot and before Prometheus is scraping any
+metrics, and so will be invisible. Election 3 is the first election that should
+be collected in the metrics data. Any other elections are suspicious and could
+indicate a problem (e.g. IO contention, packet loss) that we want to investigate.
+
+So, only 1 leader change is expected to be observed unless the test is either
+disruptive or an upgrade.
+*/
+const ExpectedLeaderChanges = 1
+
+func startEtcdMonitoring(ctx context.Context, m Recorder, prometheus prometheusv1.API) {
+	expectedCount := ExpectedLeaderChanges
+	ticker := time.NewTicker(30 * time.Second)
+	go func() {
+		lastCount := 0
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				result, _, err := prometheus.Query(context.Background(), "max by (job) (etcd_server_leader_changes_seen_total)", time.Now())
+				if err != nil {
+					// TODO: How do we log from here?
+					fmt.Printf("etcd monitor couldn't query prometheus: %v\n", err)
+					break
+				}
+				count := 0
+				if vec, isVector := result.(model.Vector); isVector {
+					if len(vec) > 0 {
+						count = int(vec[0].Value)
+					}
+				}
+				if count != lastCount {
+					switch {
+					case count <= expectedCount:
+						m.Record(Condition{
+							Level:   Info,
+							Locator: "etcd",
+							Message: fmt.Sprintf("observed expected leader election, expected total %d, last observed %d", expectedCount, count),
+						})
+					case count > expectedCount:
+						m.Record(Condition{
+							Level:   Error,
+							Locator: "etcd",
+							Message: fmt.Sprintf("observed unexpected leader election, expected total %d, last observed %d", expectedCount, count),
+						})
+					}
+				}
+				lastCount = count
+			}
+		}
+	}()
+}

--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("etcd-leader-change").AsAdmin()
 	g.It("leader changes are not excessive", func() {
-		prometheus, err := client.NewE2EPrometheusRouterClient(oc)
+		prometheus, err := client.NewE2EPrometheusRouterClient(oc.AdminKubeClient(), oc.AdminRouteClient())
 		o.Expect(err).ToNot(o.HaveOccurred())
 		g.By("Examining the rate of increase in the number of etcd leadership changes for last five minutes")
 		result, _, err := prometheus.Query(context.Background(), "increase((max by (job) (etcd_server_leader_changes_seen_total) or 0*absent(etcd_server_leader_changes_seen_total))[15m:1m])", time.Now())

--- a/test/extended/prometheus/client/via_route.go
+++ b/test/extended/prometheus/client/via_route.go
@@ -11,23 +11,21 @@ import (
 
 	"github.com/prometheus/client_golang/api"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"k8s.io/client-go/transport"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/transport"
 
 	routev1 "github.com/openshift/api/route/v1"
-
-	"github.com/openshift/origin/test/extended/util"
+	routev1client "github.com/openshift/client-go/route/clientset/versioned"
 )
 
 // NewE2EPrometheusRouterClient returns a Prometheus HTTP API client configured to
 // use the Prometheus route host, a bearer token, and no certificate verification.
-func NewE2EPrometheusRouterClient(oc *util.CLI) (prometheusv1.API, error) {
-	kubeClient := oc.AdminKubeClient()
-	routeClient := oc.AdminRouteClient()
-
+func NewE2EPrometheusRouterClient(kubeClient kubernetes.Interface, routeClient routev1client.Interface) (prometheusv1.API, error) {
 	// wait for prometheus service to exist
 	err := wait.PollImmediate(time.Minute, time.Second, func() (bool, error) {
 		_, err := kubeClient.CoreV1().Services("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})


### PR DESCRIPTION
Under ideal conditions, the following etcd term/election timeline is expected:

```
term  elections  reason
1     -          no bootstrap member
2     1          bootstrap member elected
3     2          bootstrap member removed, master elected
4     3          new etcd pod rev to drop bootstrap member from config
```

Elections 1 and 2 occur during etcd pivot and before Prometheus is scraping any
metrics, and so will be invisible. Election 3 is the first election that should
be collected in the metrics data. Any other elections are suspicious and could
indicate a problem (e.g. IO contention, packet loss) that we want to
investigate.

So, only 1 leader change is expected to be observed unless the test is either
disruptive or an upgrade.

This change adds a new monitor which adds a synthetic flake when unexpected
leader elections are detected so that we can identify and analyze CI runs in an
effort to reduce or eliminate such elections.

If in the future global CI Prometheus metrics are aggregated and made available
for analysis, this monitor can probably be removed.