### PR TITLE
Bug 1874251: UPSTREAM: 94204: Add impersonated user to system:authenticated group

### DIFF
--- a/vendor/k8s.io/kubernetes/test/cmd/authorization.sh
+++ b/vendor/k8s.io/kubernetes/test/cmd/authorization.sh
@@ -71,8 +71,8 @@ run_impersonation_tests() {
 
     # --as-group
     kubectl create -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}" --as=user1 --as-group=group2 --as-group=group1 --as-group=,,,chameleon
-    kube::test::get_object_assert 'csr/foo' '{{len .spec.groups}}' '3'
-    kube::test::get_object_assert 'csr/foo' '{{range .spec.groups}}{{.}} {{end}}' 'group2 group1 ,,,chameleon '
+    kube::test::get_object_assert 'csr/foo' '{{len .spec.groups}}' '4'
+    kube::test::get_object_assert 'csr/foo' '{{range .spec.groups}}{{.}} {{end}}' 'group2 group1 ,,,chameleon system:authenticated '
     kubectl delete -f hack/testdata/csr.yml "${kube_flags_with_token[@]:?}"
   fi
 


### PR DESCRIPTION
Currently we add the `system:authenticated` group for any authenticated user (except when the user is `system:anonymous` or the user is in `system:unauthenticated` group). 
On the other hand, if a group is specified (via `--as-group`) for an impersonated user, we don't add `system:authenticated`. The impersonated user's information is stored in the request context and is used to serve the request.

This causes priority and fairness matching to fail if there are no `FlowSchema` rules explicitly permitting the specified group. The `catch-all` flow schema needs the user to be in either the 'system:authenticated' or the 'system:unauthenticated' group. An impersonated user with a specified group is in neither.
If there is no match, the request fails with a panic. Here is an example:

Potential solutions:
Solution A: change the impersonation filter to add `system:authenticated` group, with some constraints:
- the user is not `system:anonymous`
- the user is not in `system:unauthenticated` group

I would like to know if this approach have any other ripple effects. But today I can simulate this by doing the following:
`kubectl -n kube-system get services --as=test --as-group=mygroup --as-group=system:authenticated`

Solution B: change the `catch-all` flow schema rules to allow `all` group
```
kind: FlowSchema
spec:
    subjects:
    - group:
        name: '*'
      kind: Group
```
