### PR TITLE
bug 1875006: add logging for etcd test when we create new port forwards

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -19,6 +19,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
+	"k8s.io/kubernetes/test/e2e/framework"
 	etcddata "k8s.io/kubernetes/test/integration/etcd"
 
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -373,6 +374,7 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, kubeConfig *restclient.Config, e
 	}
 
 	for _, resourceToPersist := range etcddata.GetResources(tt, serverResources) {
+		g.By(fmt.Sprintf("testing %v", resourceToPersist.Mapping.Resource))
 		mapping := resourceToPersist.Mapping
 		gvResource := mapping.Resource
 		gvk := mapping.GroupVersionKind
@@ -445,6 +447,7 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, kubeConfig *restclient.Config, e
 				}
 				output, err = getFromEtcd(etcdClient3, testData.ExpectedEtcdPath)
 				if err != nil {
+					framework.Logf(err.Error())
 					lastErr = err
 					continue
 				}


### PR DESCRIPTION
Trying to diagnose bits like https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.6/1301127862794850304