### PR TITLE
[release-3.11] Bug 1760807: Update pod affinity check in priority for valid labels

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/vendor/k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -193,25 +193,21 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 		nodeInfo := nodeNameToInfo[allNodeNames[i]]
 		if nodeInfo.Node() != nil {
 			if hasAffinityConstraints || hasAntiAffinityConstraints {
-				// if there aren't any existing pods to check affinity against, still check that the pod has valid
-				// affinity labels set to prevent future errors (see https://bugzilla.redhat.com/show_bug.cgi?id=1760807)
-				if len(nodeInfo.Pods()) == 0 {
-					if hasAffinityConstraints {
-						for _, term := range affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-							_, err := metav1.LabelSelectorAsSelector(term.PodAffinityTerm.LabelSelector)
-							if err != nil {
-								pm.setError(err)
-								return
-							}
+				if hasAffinityConstraints {
+					for _, term := range affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+						_, err := metav1.LabelSelectorAsSelector(term.PodAffinityTerm.LabelSelector)
+						if err != nil {
+							pm.setError(err)
+							return
 						}
 					}
-					if hasAntiAffinityConstraints {
-						for _, term := range affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-							_, err := metav1.LabelSelectorAsSelector(term.PodAffinityTerm.LabelSelector)
-							if err != nil {
-								pm.setError(err)
-								return
-							}
+				}
+				if hasAntiAffinityConstraints {
+					for _, term := range affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+						_, err := metav1.LabelSelectorAsSelector(term.PodAffinityTerm.LabelSelector)
+						if err != nil {
+							pm.setError(err)
+							return
 						}
 					}
 				}

--- a/vendor/k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
@@ -558,6 +558,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 			nodes: []*v1.Node{
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 			},
+			expectErr: "invalid label",
 		},
 		{
 			name: "invalid antiaffinity fails with an error",
@@ -565,6 +566,18 @@ func TestInterPodAffinityPriority(t *testing.T) {
 			nodes: []*v1.Node{
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
 			},
+			expectErr: "invalid label",
+		},
+		{
+			name: "invalid antiaffinity fails with an error and existing pods",
+			pod:  &v1.Pod{Spec: v1.PodSpec{NodeName: "", Affinity: invalidAntiAffinity}},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: labelAzAz1}},
+			},
+			pods: []*v1.Pod{
+				{Spec: v1.PodSpec{NodeName: "machine1"}},
+			},
+			expectErr: "invalid label",
 		},
 	}
 	for _, test := range tests {
@@ -578,12 +591,15 @@ func TestInterPodAffinityPriority(t *testing.T) {
 			}
 			list, err := interPodAffinity.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
 			if err != nil {
-				if !strings.Contains(err.Error(), test.expectErr) {
+				if !strings.Contains(err.Error(), test.expectErr) || len(test.expectErr) == 0{
 					t.Errorf("unexpected error: %v", err)
 				}
 			} else {
 				if !reflect.DeepEqual(test.expectedList, list) {
 					t.Errorf("expected \n\t%#v, \ngot \n\t%#v\n", test.expectedList, list)
+				}
+				if len(test.expectErr) > 0 {
+					t.Errorf("expected error %s, got none", test.expectErr)
 				}
 			}
 		})


### PR DESCRIPTION
This follows up to https://github.com/openshift/origin/pull/25350, which added these checks but only if there were no other pods on the node (making the assumption that these would be checked already if there are other pods on the node). This removes that check