### PR TITLE
bug 1875592: move ISI test to disruptive since it leaves an unstable cluster

### DIFF
--- a/test/extended/images/imagestreamimport.go
+++ b/test/extended/images/imagestreamimport.go
@@ -30,7 +30,14 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-imageregistry][Feature:ImageStreamImport][Serial] ImageStream API", func() {
+// This test is currently disruptive because it doesn't wait for the cluster state to return to a set of stable
+// operators (everything available, not progressing, not degraded) and the machine config operator to have finished
+// rolling the change to every node.
+// This causes instability in the tests that follow it that expect a stable clusters.  Examples include scheduling tests
+// that require all workers schedulable with functional networking and storage tests which require long running connections
+// on both apiservers and kubelets to exec into them.
+// After meeting the standard for stability, this test is likely to be [Slow]
+var _ = g.Describe("[sig-imageregistry][Feature:ImageStreamImport][Serial][Disruptive] ImageStream API", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("imagestream-api")
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1707,13 +1707,13 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range should deny an import of a repository exceeding limit on openshift.io/image-tags resource": "should deny an import of a repository exceeding limit on openshift.io/image-tags resource [Disabled:SpecialConfig] [Suite:openshift]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial] ImageStream API TestImportImageFromBlockedRegistry": "TestImportImageFromBlockedRegistry [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Disruptive] ImageStream API TestImportImageFromBlockedRegistry": "TestImportImageFromBlockedRegistry [Suite:openshift]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial] ImageStream API TestImportImageFromInsecureRegistry": "TestImportImageFromInsecureRegistry [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Disruptive] ImageStream API TestImportImageFromInsecureRegistry": "TestImportImageFromInsecureRegistry [Suite:openshift]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial] ImageStream API TestImportRepositoryFromBlockedRegistry": "TestImportRepositoryFromBlockedRegistry [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Disruptive] ImageStream API TestImportRepositoryFromBlockedRegistry": "TestImportRepositoryFromBlockedRegistry [Suite:openshift]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial] ImageStream API TestImportRepositoryFromInsecureRegistry": "TestImportRepositoryFromInsecureRegistry [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Disruptive] ImageStream API TestImportRepositoryFromInsecureRegistry": "TestImportRepositoryFromInsecureRegistry [Suite:openshift]",
 
 	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Annotation trigger reconciles after the image is overwritten": "reconciles after the image is overwritten [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
This test is currently disruptive because it doesn't wait for the cluster state to return to a set of stable operators (everything available, not progressing, not degraded) and the machine config operator to have finished rolling the change to every node. This causes instability in the tests that follow it that expect a stable clusters.  Examples include scheduling tests that require all workers schedulable with functional networking and storage tests which require long running connections on both apiservers and kubelets to exec into them. After meeting the standard for stability, this test is likely to be [Slow]

Found in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.6/1300627052105306112 specifically, but consistent with other unstable tests in storage and scheduling.