### PR TITLE
WIP: Revert "Bug 1863009: bump(k8s.io/legacy-cloud-providers)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -439,7 +439,7 @@ replace (
 	k8s.io/kubectl => k8s.io/kubectl v0.19.0-rc.2
 	k8s.io/kubelet => k8s.io/kubelet v0.19.0-rc.2
 	k8s.io/kubernetes => github.com/openshift/kubernetes v1.20.0-alpha.0.0.20200826132615-f71a7ab366cf
-	k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200826132615-f71a7ab366cf
+	k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200803060402-d32435439579
 	k8s.io/metrics => k8s.io/metrics v0.19.0-rc.2
 	k8s.io/repo-infra => k8s.io/repo-infra v0.0.1-alpha.1
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.19.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/openshift/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-2020082
 github.com/openshift/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20200826132615-f71a7ab366cf/go.mod h1:vx/reZx/iefWuS3A7hRi4cwoptpCkVhqqITKpUsIkWs=
 github.com/openshift/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20200826132615-f71a7ab366cf h1:A30pBAUeL4ogH6sAamr346lPGvNybGo/2YO/POhHPc4=
 github.com/openshift/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20200826132615-f71a7ab366cf/go.mod h1:MUq2YTU8mwp7qYhM8Gu95ZSBOIp2+OyDSY7dOeHgCTA=
-github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200826132615-f71a7ab366cf h1:6WYK5JAFYXehPZbVkkkSqeibs7clN3mRHZmiXG+K79w=
-github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200826132615-f71a7ab366cf/go.mod h1:kUaainILK6Zy9oE3FRx+pp7y5+eTb73H3Z4oEmzaxQ8=
+github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200803060402-d32435439579 h1:8Nq+512XQ4TMOFZP2PVfj0OsWVPNq1F9lRPebSNWGeU=
+github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200803060402-d32435439579/go.mod h1:V29rgRnfGKqV/Igb/rcTI+h7Xt22XoO914odfbs03ik=
 github.com/openshift/library-go v0.0.0-20200722204747-e3f2c82ff290 h1:x2MMkmR0gr+3UazejQcIafWCXh8d0W+6EWTtWLyGBnQ=
 github.com/openshift/library-go v0.0.0-20200722204747-e3f2c82ff290/go.mod h1:/gVyoY2dl35bcCCgs+36UmGt6n/kn3f64hfDduujQ1c=
 github.com/openshift/onsi-ginkgo v4.5.0-origin.1+incompatible h1:GtzyDU5vBFU40hz4GWd1qU5FJByNljWdgkM2LtdelGk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2671,7 +2671,7 @@ k8s.io/kubernetes/third_party/forked/gonum/graph
 k8s.io/kubernetes/third_party/forked/gonum/graph/internal/linear
 k8s.io/kubernetes/third_party/forked/gonum/graph/simple
 k8s.io/kubernetes/third_party/forked/gonum/graph/traverse
-# k8s.io/legacy-cloud-providers v0.0.0 => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200826132615-f71a7ab366cf
+# k8s.io/legacy-cloud-providers v0.0.0 => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200803060402-d32435439579
 k8s.io/legacy-cloud-providers/aws
 k8s.io/legacy-cloud-providers/azure
 k8s.io/legacy-cloud-providers/azure/auth


### PR DESCRIPTION
This reverts commit 8a9ad2c17359167acd9f585dfd6f097f1ec55b49, #25427.

Might be related to some origin panics.

Manual revert to work around context conflicts with the subsequent 2f12af0fc2025.