### PR TITLE
Bug 1868490: upgrade test use LoadBalancers with ExternalTrafficPolicy set to Local

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -50,6 +50,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("creating a TCP service " + serviceName + " with type=LoadBalancer in namespace " + ns.Name)
 	tcpService, err := jig.CreateTCPService(func(s *v1.Service) {
 		s.Spec.Type = v1.ServiceTypeLoadBalancer
+		s.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 		if s.Annotations == nil {
 			s.Annotations = make(map[string]string)
 		}


### PR DESCRIPTION
cherry-pick from https://github.com/openshift/origin/pull/25406

Use ExternalTrafficPolicy set to Local for the service used in the test
[sig-network-edge] Application behind service load balancer with PDB is not disrupted
This avoid that we do a double hop inside the cluster to reach the pod, since the traffic goes directly from the load balancer to the node that has the pod running.

Signed-off-by: Antonio Ojea <aojea@redhat.com>