### PR TITLE
Bug 1879907: Add storage capabilities report for CSI certification tests

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -128,7 +129,11 @@ func newRunCommand() *cobra.Command {
 					return err
 				}
 				opt.MatchFn = matchFn
-				return opt.Run(args)
+				err = opt.Run(args)
+				if !opt.DryRun && len(args) > 0 && strings.HasPrefix(args[0], "openshift/csi") {
+					printStorageCapabilities(opt.Out)
+				}
+				return err
 			})
 		},
 	}

--- a/cmd/openshift-tests/storagecaps.go
+++ b/cmd/openshift-tests/storagecaps.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// Manifest yaml structs
+
+type StorageClass struct {
+	FromFile string `yaml:"FromFile"`
+}
+
+type SnapshotClass struct {
+	FromName bool `yaml:"FromName"`
+}
+
+type Capabilities struct {
+	Block    bool `yaml:"block"`
+	RWX      bool `yaml:"RWX"`
+	Snapshot bool `yaml:"snapshotDataSource"`
+}
+
+type DriverInfo struct {
+	Name         string `yaml:"Name"`
+	Capabilities `yaml:"Capabilities"`
+}
+
+type YamlManifest struct {
+	ShortName     string `yaml:"ShortName"`
+	StorageClass  `yaml:"StorageClass"`
+	SnapshotClass `yaml:"SnapshotClass"`
+	DriverInfo    `yaml:"DriverInfo"`
+}
+
+func printStorageCapabilities(out io.Writer) {
+	manifestFilename := strings.Split(os.Getenv(manifestEnvVar), ",")[0]
+	if manifestFilename == "" {
+		fmt.Fprintln(out, "No manifest filename passed")
+		return
+	}
+
+	yamlFile, err := ioutil.ReadFile(manifestFilename)
+	if err != nil {
+		fmt.Fprintln(out, "Failed to", err)
+		return
+	}
+
+	var yamlManifest YamlManifest
+	err = yaml.Unmarshal(yamlFile, &yamlManifest)
+	if err != nil {
+		fmt.Fprintln(out, "Error parsing", err)
+		return
+	}
+
+	supportsSnapshot := yamlManifest.DriverInfo.Capabilities.Snapshot && yamlManifest.SnapshotClass.FromName
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Storage Capabilities (guaranteed only on full CSI test suite with 0 fails)")
+	fmt.Fprintln(out, "==========================================================================")
+	fmt.Fprintln(out, "Driver short name:                 ", yamlManifest.ShortName)
+	fmt.Fprintln(out, "Driver name:                       ", yamlManifest.DriverInfo.Name)
+	fmt.Fprintln(out, "Storage class:                     ", yamlManifest.StorageClass.FromFile)
+	fmt.Fprintln(out, "Raw block VM disks supported:      ", yamlManifest.DriverInfo.Capabilities.Block)
+	fmt.Fprintln(out, "Live migration supported:          ", yamlManifest.DriverInfo.Capabilities.RWX)
+	fmt.Fprintln(out, "VM snapshots supported:            ", supportsSnapshot)
+	fmt.Fprintln(out, "Storage-assisted cloning supported:", supportsSnapshot)
+	fmt.Fprintln(out)
+}


### PR DESCRIPTION
Following the discussion in [PR #25439](https://github.com/openshift/origin/pull/25439), we add storage capabilities report following the CSI certification tests:
```
$ podman run -v `pwd`:/data:z --rm -it $CONTAINER sh -c "KUBECONFIG=/data/kubeconfig.yaml TEST_CSI_DRIVER_FILES=/data/manifest.yaml /usr/bin/openshift-tests run openshift/csi --junit-dir /data/results"

openshift-tests version: v4.1.0-3107-g627d022
…
Writing JUnit report to /data/results/junit_e2e_20200907-091404.xml

32 pass, 146 skip (4m35s)

Storage Capabilities (guaranteed only on full CSI test suite with 0 fails)
==========================================================================
Driver short name:                  ceph-test
Driver name:                        test.rbd.csi.ceph.com
Storage class:                      ceph-rbd-sc.yaml
Raw block VM disks supported:       true
Live migration supported:           false
VM snapshots supported:             false
Storage-assisted cloning supported: false
```