### PR TITLE
[WIP] router/metrics: experiment with metrics refresh

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -223,7 +223,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			// greater than zero over two successive
 			// scrapes once the first scrape shows an
 			// increase in total connections.
-			err = wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
+			err = wait.PollImmediate(1*time.Millisecond, 5*time.Minute, func() (bool, error) {
 				refreshMetrics := func() (map[string]*dto.MetricFamily, error) {
 					startTime := time.Now()
 					results, err := getBearerTokenURLViaPod(ns, execPodName, fmt.Sprintf("http://%s:%d/metrics", host, metricsPort), bearerToken)


### PR DESCRIPTION
Experiment with the wait delay between successive metrics refresh
calls to see if this reduces the number of times this test flakes in
CI.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1835371

Current refresh timings from a CI run:

$ grep refresh ~/test.log
Sep  7 14:29:48.028: INFO: metrics refresh completed in 2s
Sep  7 14:30:02.231: INFO: metrics refresh completed in 1s
Sep  7 14:30:22.463: INFO: metrics refresh completed in 7s
Sep  7 14:30:36.381: INFO: metrics refresh completed in 1s
Sep  7 14:30:38.340: INFO: metrics refresh completed in 2s
Sep  7 14:30:40.226: INFO: metrics refresh completed in 1s
Sep  7 14:30:52.249: INFO: metrics refresh completed in 1s
Sep  7 14:31:06.299: INFO: metrics refresh completed in 1s
Sep  7 14:31:21.403: INFO: metrics refresh completed in 2s
Sep  7 14:31:34.355: INFO: metrics refresh completed in 1s
Sep  7 14:31:48.349: INFO: metrics refresh completed in 1s
Sep  7 14:31:49.832: INFO: metrics refresh completed in 1s
Sep  7 14:31:52.324: INFO: metrics refresh completed in 1s
Sep  7 14:32:06.834: INFO: metrics refresh completed in 2s
Sep  7 14:32:08.171: INFO: metrics refresh completed in 1s
Sep  7 14:32:09.369: INFO: metrics refresh completed in 1s
Sep  7 14:32:12.232: INFO: metrics refresh completed in 1s
Sep  7 14:32:26.912: INFO: metrics refresh completed in 2s
Sep  7 14:32:40.470: INFO: metrics refresh completed in 1s
Sep  7 14:32:52.285: INFO: metrics refresh completed in 1s
Sep  7 14:33:06.267: INFO: metrics refresh completed in 1s
Sep  7 14:33:07.743: INFO: metrics refresh completed in 1s
Sep  7 14:33:10.731: INFO: metrics refresh completed in 2s
Sep  7 14:33:25.198: INFO: metrics refresh completed in 2s
Sep  7 14:33:26.649: INFO: metrics refresh completed in 1s
Sep  7 14:33:28.265: INFO: metrics refresh completed in 1s
Sep  7 14:33:43.129: INFO: metrics refresh completed in 2s
Sep  7 14:34:02.588: INFO: metrics refresh completed in 8s
Sep  7 14:34:14.335: INFO: metrics refresh completed in 1s
Sep  7 14:34:15.545: INFO: metrics refresh completed in 1s
Sep  7 14:34:16.883: INFO: metrics refresh completed in 1s
Sep  7 14:34:19.051: INFO: metrics refresh completed in 2s
Sep  7 14:34:32.274: INFO: metrics refresh completed in 1s
Sep  7 14:34:46.331: INFO: metrics refresh completed in 1s
Sep  7 14:34:47.798: INFO: metrics refresh completed in 1s
Sep  7 14:34:50.252: INFO: metrics refresh completed in 1s
Sep  7 14:35:02.318: INFO: metrics refresh completed in 1s