### PR TITLE
Bug 1876913: Fix test to verify git proxies

### DIFF
--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -1,9 +1,6 @@
 package builds
 
 import (
-	"fmt"
-	"strings"
-
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
@@ -49,10 +46,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 				buildLog, err := br.Logs()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(buildLog).NotTo(o.ContainSubstring("clone"))
-				if !strings.Contains(buildLog, `unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to`) {
-					fmt.Fprintf(g.GinkgoWriter, "\nbuild log:\n%s\n", buildLog)
-				}
-				o.Expect(buildLog).To(o.ContainSubstring(`unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to`))
+				o.Expect(buildLog).To(o.MatchRegexp(`unable to access '%s': Failed( to)? connect to`, "https://github.com/openshift/ruby-hello-world.git/"))
 
 				g.By("verifying the build sample-build-1 status")
 				o.Expect(br.Build.Status.Phase).Should(o.BeEquivalentTo(buildv1.BuildPhaseFailed))


### PR DESCRIPTION
Update to RHEL 8 bumped git to v2.x. As a result, the "Failed to
connect" error message was altered.