### PR TITLE
Bug 1847363: test: use ubi instead of centos

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -74,7 +74,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	}
 	t.oc.SetupProject()
 	ns := t.oc.Namespace()
-	execPod := exutil.CreateCentosExecPodOrFail(t.oc.AdminKubeClient(), ns, "execpod", nil)
+	execPod := exutil.CreateUbiExecPodOrFail(t.oc.AdminKubeClient(), ns, "execpod", nil)
 	defer func() {
 		t.oc.AdminKubeClient().CoreV1().Pods(ns).Delete(ctx, execPod.Name, *metav1.NewDeleteOptions(1))
 	}()

--- a/test/e2e/upgrade/monitor.go
+++ b/test/e2e/upgrade/monitor.go
@@ -328,7 +328,7 @@ func triggerReboot(kubeClient kubernetes.Interface, target string, attempt int, 
 						RunAsUser:  &zero,
 						Privileged: &isTrue,
 					},
-					Image: "centos:7",
+					Image: "ubi8/ubi",
 					Command: []string{
 						"/bin/bash",
 						"-c",

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -57,7 +57,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		}
 		oc.SetupProject()
 		ns := oc.Namespace()
-		execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+		execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 		defer func() {
 			oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 		}()
@@ -74,7 +74,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 	g.It("should have a Watchdog alert in firing state the entire cluster run", func() {
 		oc.SetupProject()
 		ns := oc.Namespace()
-		execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+		execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 		defer func() {
 			oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 		}()
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		oc.SetupProject()
 		ns := oc.Namespace()
 
-		execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+		execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 		defer func() {
 			oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 		}()
@@ -136,7 +136,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			oc.SetupProject()
 			ns := oc.Namespace()
 
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
@@ -160,7 +160,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 		g.It("should start and expose a secured proxy and unsecured metrics", func() {
 			oc.SetupProject()
 			ns := oc.Namespace()
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
@@ -287,7 +287,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 		g.It("should have a AlertmanagerReceiversNotConfigured alert in firing state", func() {
 			oc.SetupProject()
 			ns := oc.Namespace()
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
@@ -302,7 +302,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 		g.It("should have important platform topology metrics", func() {
 			oc.SetupProject()
 			ns := oc.Namespace()
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
@@ -327,7 +327,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 		g.It("should have non-Pod host cAdvisor metrics", func() {
 			oc.SetupProject()
 			ns := oc.Namespace()
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
@@ -340,7 +340,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 		g.It("shouldn't have failing rules evaluation", func() {
 			oc.SetupProject()
 			ns := oc.Namespace()
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
@@ -354,7 +354,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			g.It("should be able to get the sdn ovs flows", func() {
 				oc.SetupProject()
 				ns := oc.Namespace()
-				execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+				execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 				defer func() {
 					oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 				}()
@@ -372,7 +372,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			}
 			oc.SetupProject()
 			ns := oc.Namespace()
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
@@ -387,7 +387,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			oc.SetupProject()
 			ns := oc.Namespace()
 
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
@@ -434,7 +434,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}()
 
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) {
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{
 					"k8s.v1.cni.cncf.io/networks": "secondary",
 				}

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus
 			ns := oc.Namespace()
 			appTemplate := exutil.FixturePath("testdata", "builds", "build-pruning", "successful-build-config.yaml")
 
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -309,7 +309,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 				g.Skip("prometheus not found on this cluster")
 			}
 
-			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			execPod := exutil.CreateUbiExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()

--- a/test/extended/util/pods.go
+++ b/test/extended/util/pods.go
@@ -52,11 +52,11 @@ func RemovePodsWithPrefixes(oc *CLI, prefixes ...string) error {
 	return nil
 }
 
-// CreateCentosExecPodOrFail creates a centos:7 pause pod used as a vessel for kubectl exec commands.
+// CreateUbiExecPodOrFail creates a ubi8 pause pod used as a vessel for kubectl exec commands.
 // Pod name is uniquely generated.
-func CreateCentosExecPodOrFail(client kubernetes.Interface, ns, generateName string, tweak func(*v1.Pod)) *v1.Pod {
+func CreateUbiExecPodOrFail(client kubernetes.Interface, ns, generateName string, tweak func(*v1.Pod)) *v1.Pod {
 	return pod.CreateExecPodOrFail(client, ns, generateName, func(pod *v1.Pod) {
-		pod.Spec.Containers[0].Image = "centos:7"
+		pod.Spec.Containers[0].Image = "ubi8/ubi"
 		pod.Spec.Containers[0].Command = []string{"sh", "-c", "trap exit TERM; while true; do sleep 5; done"}
 		pod.Spec.Containers[0].Args = nil
 


### PR DESCRIPTION
There is no centos for s390x architecture, so instead use an image that's guaranteed to be multiarch.

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>