### PR TITLE
bug 1877932: don't retry the GRPC connection in our tests

### DIFF
--- a/test/extended/etcd/etcd_test_runner.go
+++ b/test/extended/etcd/etcd_test_runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/ibmcloud"
 	"go.etcd.io/etcd/clientv3"
 	etcdv3 "go.etcd.io/etcd/clientv3"
+	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -105,6 +106,10 @@ func (e *etcdPortForwardClient) newEtcdClient() (etcdv3.KV, error) {
 		Endpoints:   []string{"https://127.0.0.1:" + port},
 		DialTimeout: 5 * time.Second,
 		TLS:         tlsConfig,
+		DialOptions: []grpc.DialOption{
+			grpc.WithBlock(), // block until the underlying connection is up
+			grpc.WithDefaultCallOptions(grpc.WaitForReady(false)), // trying to avoid cases where the same connection keeps retrying: https://godoc.org/google.golang.org/grpc#WaitForReady
+		},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Based on logs from https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.6/1303933478840045568 on the failing test, it looks like the grpc client itself is retrying on failures forever.  This stops that I think