### PR TITLE
Bug 1861746: bring back must-gather audit e2e

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -115,8 +115,6 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 	})
 
 	g.It("runs successfully for audit logs", func() {
-		g.Skip("this test is flaking like crazy on Azure (not sure of other platforms")
-
 		// On IBM ROKS, events will not be part of the output, since audit logs do not include control plane logs.
 		if e2e.TestContext.Provider == ibmcloud.ProviderName {
 			g.Skip("ROKs doesn't have audit logs")


### PR DESCRIPTION
/hold
for debugging azure, where it flaked most heavily 