### PR TITLE
report install time for a junit test

### DIFF
--- a/test/extended/operators/install_duration.go
+++ b/test/extended/operators/install_duration.go
@@ -1,0 +1,60 @@
+package operators
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/origin/pkg/test/ginkgo/result"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+)
+
+var _ = g.Describe("[sig-arch] Managed cluster should", func() {
+	defer g.GinkgoRecover()
+
+	g.It("install quickly", func() {
+		// read when bootstrapping completed
+		kubeConfig, err := e2e.LoadConfig()
+		o.Expect(err).ToNot(o.HaveOccurred())
+		configClient, err := configclient.NewForConfig(kubeConfig)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		clusterVersion, err := configClient.ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// clusterVersion is one of the first created resources, use that as "when the install started"
+		startTime := clusterVersion.CreationTimestamp
+		// we determine completion time by looking at the last transition time for Available, which ends up with "Done applying 4.6.0-0.nightly-2020-09-12-230035"
+		var installCompleteTime *metav1.Time
+		for _, condition := range clusterVersion.Status.Conditions {
+			if condition.Type != configv1.OperatorAvailable {
+				continue
+			}
+			if condition.Status != configv1.ConditionTrue {
+				continue
+			}
+			installCompleteTime = &condition.LastTransitionTime
+			break
+		}
+		if installCompleteTime == nil {
+			o.Expect(fmt.Errorf("install did not complete: CVO not ready %#v", clusterVersion.Status.Conditions)).ToNot(o.HaveOccurred())
+		}
+		installDuration := installCompleteTime.Sub(startTime.Time)
+
+		kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		bootstrapCompleteConfigMap, err := kubeClient.CoreV1().ConfigMaps("kube-system").Get(context.Background(), "bootstrap", metav1.GetOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+		bootstrapDuration := bootstrapCompleteConfigMap.CreationTimestamp.Sub(startTime.Time)
+
+		// TODO figure out how to make a fake junit test with this duration for test-grid/sippy to inspect
+		result.Flakef("bootstrapping took %0.2f minutes; install took %0.2f minutes", bootstrapDuration.Minutes(), installDuration.Minutes())
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -763,6 +763,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] ClusterOperators should define at least one related object that is not a namespace": "at least one related object that is not a namespace [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-arch] Managed cluster should bootstrap quickly": "bootstrap quickly [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-arch] Managed cluster should ensure control plane operators do not make themselves unevictable": "ensure control plane operators do not make themselves unevictable [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch] Managed cluster should ensure control plane pods do not run in best-effort QoS": "ensure control plane pods do not run in best-effort QoS [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -773,6 +773,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] Managed cluster should have operators on the cluster version": "have operators on the cluster version [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-arch] Managed cluster should install quickly": "install quickly [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-arch] Managed cluster should recover when operator-owned objects are deleted [Disruptive]": "when operator-owned objects are deleted [Disruptive] [Serial] [Suite:openshift]",
 
 	"[Top Level] [sig-arch] Managed cluster should should expose cluster services outside the cluster": "should expose cluster services outside the cluster [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This will allow us to track it in every platform that runs e2e.  This informs test grid charts about how long tests take.

If test-grid has it, then I think sippy can have it too.