### PR TITLE
Bug 1874671: Add NET_RAW capability to internal_ports test

### DIFF
--- a/test/extended/networking/internal_ports.go
+++ b/test/extended/networking/internal_ports.go
@@ -84,6 +84,11 @@ var _ = ginkgo.Describe("[sig-network] Internal connectivity", func() {
 										},
 									},
 								},
+								SecurityContext: &v1.SecurityContext{
+									Capabilities: &v1.Capabilities{
+										Add: []v1.Capability{"NET_RAW"},
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
Fixes #1874671 - helps fix the tests for the PR dropping the capabilities https://github.com/openshift/machine-config-operator/pull/2051

The "TCP and UDP on ports" test does a tcpdump which
requires the NET_RAW capability to be enabled.
We are dropping NET_RAW from the default list of
capabilities in cri-o, so need to explicitly add it
to the test here.

This is blocking https://github.com/openshift/machine-config-operator/pull/2051

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>