### PR TITLE
Bug 1879554: Use multi-arch registry for buildah images

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -20354,7 +20354,7 @@ func testExtendedTestdataBuildsClusterConfigYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsCustomBuildDockerfile = []byte(`FROM quay.io/buildah/stable:latest
+var _testExtendedTestdataBuildsCustomBuildDockerfile = []byte(`FROM registry.redhat.io/rhel8/buildah:latest
 # For simplicity, /tmp/build contains the inputs we’ll be building when we
 # run this custom builder image. Normally the custom builder image would
 # fetch this content from some location at build time. (e.g. via git clone).

--- a/test/extended/testdata/builds/custom-build/Dockerfile
+++ b/test/extended/testdata/builds/custom-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/buildah/stable:latest
+FROM registry.redhat.io/rhel8/buildah:latest
 # For simplicity, /tmp/build contains the inputs we’ll be building when we
 # run this custom builder image. Normally the custom builder image would
 # fetch this content from some location at build time. (e.g. via git clone).


### PR DESCRIPTION
At least until https://github.com/containers/buildah/issues/2002 is resolved.

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>