### PR TITLE
Bug 1883350: [release-4.3] Re-enable skipped conformance tests for IBM Cloud

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -522,18 +522,9 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1825027
 			`\[Feature:Platform\] Managed cluster should ensure control plane operators do not make themselves unevictable`,
 
-			// Prometheus is not reporting router metrics
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1825029
-			`\[Feature:Prometheus\]\[Conformance\] Prometheus when installed on the cluster should provide ingress metrics`,
-			`\[Conformance\]\[Area:Networking\]\[Feature:Router\] The HAProxy router should enable openshift-monitoring to pull metrics`,
-
 			// ROKS cluster role bindings don't match expected results
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1825030
 			`TestAuthorizationResourceAccessReview should succeed`,
-
-			// Test does not allow enough time for the pods to be created before deleting them
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1825372
-			`Pod Container Status should never report success for a pending container`,
 		},
 		"[Skipped:gce]": {
 			// Requires creation of a different compute instance in a different zone and is not compatible with volumeBindingMode of WaitForFirstConsumer which we use in 4.x


### PR DESCRIPTION
Cherry-pick of #25220

Re-enabling selected tests now that associated bugs have been fixed and are in the Red Hat OpenShift on IBM Cloud v4.3 builds.
```
[Feature:Prometheus][Conformance] Prometheus when installed on the cluster should provide ingress metrics
[Conformance][Area:Networking][Feature:Router] The HAProxy router should enable openshift-monitoring to pull metrics
[k8s.io] [sig-node] Pods Extended [k8s.io] Pod Container Status should never report success for a pending container
```