### PR TITLE
BUg 1870274: [wip] test/extended/dr: add etcd leader disruptive test "Coup d'etat"

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -50,9 +50,10 @@ var staticSuites = []*ginkgo.TestSuite{
 		The disruptive test suite.
 		`),
 		Matches: func(name string) bool {
-			return strings.Contains(name, "[Feature:EtcdRecovery]") || strings.Contains(name, "[Feature:NodeRecovery]")
+			// return strings.Contains(name, "[Feature:EtcdRecovery]") || strings.Contains(name, "[Feature:NodeRecovery]") || strings.Contains(name, "[Feature:EtcdLeaderChange]")
+			return strings.Contains(name, "[Feature:EtcdLeaderChange]")
 		},
-		TestTimeout: 60 * time.Minute,
+		TestTimeout: 90 * time.Minute,
 	},
 	{
 		Name: "kubernetes/conformance",

--- a/test/extended/dr/leader_change.go
+++ b/test/extended/dr/leader_change.go
@@ -1,0 +1,113 @@
+package dr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	promclient "github.com/openshift/origin/test/extended/prometheus/client"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+	apps "k8s.io/kubernetes/test/e2e/upgrades/apps"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/disruption"
+)
+
+var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
+	f := framework.NewDefaultFramework("leader-change")
+	f.SkipNamespaceCreation = true
+	f.SkipPrivilegedPSPBinding = true
+
+	oc := exutil.NewCLIWithoutNamespace("leader-change")
+
+	g.It("[Feature:EtcdLeaderChange] Cluster should remain functional through etcd leader change", func() {
+		framework.Logf("Verify SSH is available before restart")
+		masters, _ := clusterNodes(oc)
+		o.Expect(len(masters)).To(o.BeNumerically(">=", 3))
+
+		disruption.Run(f, "etcd Leader Coup d'etat", "leader-change",
+			disruption.TestData{},
+			[]upgrades.Test{
+				&upgrades.ServiceUpgradeTest{},
+				&upgrades.SecretUpgradeTest{},
+				&apps.ReplicaSetUpgradeTest{},
+				&apps.StatefulSetUpgradeTest{},
+				&apps.DeploymentUpgradeTest{},
+				&apps.DaemonSetUpgradeTest{},
+			},
+			func() {
+				prometheus, err := promclient.NewE2EPrometheusRouterClient(oc)
+				o.Expect(err).ToNot(o.HaveOccurred())
+				err = wait.Poll(30*time.Second, 30*time.Minute, func() (done bool, err error) {
+					framework.Logf("Checking for etcdLeader at %v)", time.Now())
+					etcdLeaderPodName, etcdLeaderContainerID, err := getEtcdLeader(oc, prometheus)
+					if err != nil {
+						framework.Logf("getEtcdLeader: error %v)", err)
+						return false, nil
+					}
+					etcdLeaderNodeName := strings.TrimPrefix(etcdLeaderPodName, "etcd-")
+					framework.Logf("Removing etcd leader from pod %q on node %q with containerID %q)", etcdLeaderPodName, etcdLeaderNodeName, etcdLeaderContainerID)
+					for _, node := range masters {
+						framework.Logf("Checking master: error %v)", err)
+						if node.Name == etcdLeaderNodeName {
+							framework.Logf("Removing etcd leader from pod %q on node %q with containerID %q)", etcdLeaderPodName, node.Name, etcdLeaderContainerID)
+							cmd := fmt.Sprintf("sudo -i /bin/bash -cx 'crictl stop %v'", etcdLeaderContainerID)
+							expectSSH(cmd, node)
+							return false, nil
+						}
+					}
+					framework.Logf("leader %s not removed", etcdLeaderPodName)
+					return false, nil
+				})
+				o.Expect(err).NotTo(o.HaveOccurred())
+			},
+		)
+
+	},
+	)
+})
+
+func getEtcdLeader(oc *exutil.CLI, client prometheusv1.API) (string, string, error) {
+	var etcdLeaderPodName string
+	err := wait.Poll(5*time.Second, 2*time.Minute, func() (done bool, err error) {
+		resp, _, err := client.Query(context.Background(), "etcd_server_is_leader", time.Now())
+		if err != nil {
+			framework.Logf("Failed to query Prometheus: %v", err)
+			return false, nil
+		}
+
+		for _, member := range resp.(model.Vector) {
+			if member.Value == 1 {
+				if member.Metric["pod"] != "" {
+					etcdLeaderPodName = string(member.Metric["pod"])
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	pod, err := oc.AdminKubeClient().CoreV1().Pods("openshift-etcd").Get(context.Background(), etcdLeaderPodName, metav1.GetOptions{})
+	if err != nil {
+		return "", "", err
+	}
+
+	if pod.Status.ContainerStatuses != nil {
+		return etcdLeaderPodName, pod.Status.ContainerStatuses[0].ContainerID[8:], nil
+	}
+
+	return "", "", fmt.Errorf("getEtcdLeader: no containerID found for pod %v", pod)
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2,6 +2,7 @@ package generated
 
 import (
 	"fmt"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/types"
 )
@@ -1656,6 +1657,8 @@ var annotations = map[string]string{
 	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker security test  should pass security tests": "should pass security tests [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-etcd] etcd leader changes are not excessive": "leader changes are not excessive [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdLeaderChange] Cluster should remain functional through etcd leader change": "[Feature:EtcdLeaderChange] Cluster should remain functional through etcd leader change [Serial]",
 
 	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [Serial] [Suite:openshift]",
 


### PR DESCRIPTION
still pretty raw but I think it validates the idea. basically, without needing the etcd API we can conclude with reasonable granularity who the etcd leader is. Since etcd is scraped every 30s we should allow enough time to ensure a new scrape is done. But in general, the idea is to kill the leader as much as possible and see who breaks.