### PR TITLE
test/extended/etcd: leader_change: round count and smooth results

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -19,12 +19,12 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 	g.It("leader changes are not excessive", func() {
 		prometheus, err := client.NewE2EPrometheusRouterClient(oc)
 		o.Expect(err).ToNot(o.HaveOccurred())
-		g.By("Examining the rate of increase in the number of etcd leadership changes for last five minutes")
-		result, _, err := prometheus.Query(context.Background(), "increase((max by (job) (etcd_server_leader_changes_seen_total) or 0*absent(etcd_server_leader_changes_seen_total))[15m:1m])", time.Now())
+		g.By("Examining the rate of increase in the number of etcd leadership changes for last fifteen minutes")
+		result, _, err := prometheus.Query(context.Background(), "round(increase((max by (job) (etcd_server_leader_changes_seen_total) or 0*absent(etcd_server_leader_changes_seen_total))[15m:1s]))", time.Now())
 		o.Expect(err).ToNot(o.HaveOccurred())
-		leaderChangeLastFiveMinutes := result.(model.Vector)[0].Value
-		if leaderChangeLastFiveMinutes != 0 {
-			o.Expect(fmt.Errorf("Leader changes observed last 5m %q: Leader changes are a result of stopping the etcd leader process or from latency (disk or network), review etcd performance metrics", leaderChangeLastFiveMinutes)).ToNot(o.HaveOccurred())
+		leaderChangeLast15Minutes := result.(model.Vector)[0].Value
+		if leaderChangeLast15Minutes != 0 {
+			o.Expect(fmt.Errorf("Leader changes observed last 15m %q: Leader changes are a result of stopping the etcd leader process or from latency (disk or network), review etcd performance metrics", leaderChangeLast15Minutes)).ToNot(o.HaveOccurred())
 		}
 	})
 })


### PR DESCRIPTION
Folowup to https://github.com/openshift/origin/pull/25524

Updated test to reflect the proper interval of 15m vs 5m. Also added round() to make the results more reasonable to understand.

For example, the current output for the number of elections in the failure would be a decimal.

```
fail [github.com/openshift/origin/test/extended/etcd/leader_changes.go:24]: Expected
    <model.SampleValue>: 1.0714285714285714
to be ==
    <int>: 0
```

I also reduce the increase() compare interval to 1s. This helps to smooth out the results which actually would reflect a much higer number than expected in cases where multiple elections happened in less than 1 minute. You can see the result of the smoothing below.

![before-round-smooth](https://user-images.githubusercontent.com/1249749/93711272-ee107980-fb1a-11ea-9786-15b58c7c202c.png)
![after-round-smooth](https://user-images.githubusercontent.com/1249749/93711274-ee107980-fb1a-11ea-8c12-149217806103.png)

Followup to 