### PR TITLE
Bug 1879907: Distinguish CSI/CNV features in storage capabilities report

### DIFF
--- a/cmd/openshift-tests/storagecaps.go
+++ b/cmd/openshift-tests/storagecaps.go
@@ -20,9 +20,19 @@ type SnapshotClass struct {
 }
 
 type Capabilities struct {
-	Block    bool `yaml:"block"`
-	RWX      bool `yaml:"RWX"`
-	Snapshot bool `yaml:"snapshotDataSource"`
+	Persistence         bool `yaml:"persistence"`
+	Block               bool `yaml:"block"`
+	FsGroup             bool `yaml:"fsGroup"`
+	Exec                bool `yaml:"exec"`
+	SnapshotDataSource  bool `yaml:"snapshotDataSource"`
+	PVCDataSource       bool `yaml:"pvcDataSource"`
+	MultiPODs           bool `yaml:"multipods"`
+	RWX                 bool `yaml:"RWX"`
+	ControllerExpansion bool `yaml:"controllerExpansion"`
+	NodeExpansion       bool `yaml:"nodeExpansion"`
+	VolumeLimits        bool `yaml:"volumeLimits"`
+	SingleNodeVolume    bool `yaml:"singleNodeVolume"`
+	Topology            bool `yaml:"topology"`
 }
 
 type DriverInfo struct {
@@ -57,17 +67,30 @@ func printStorageCapabilities(out io.Writer) {
 		return
 	}
 
-	supportsSnapshot := yamlManifest.DriverInfo.Capabilities.Snapshot && yamlManifest.SnapshotClass.FromName
-
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Storage Capabilities (guaranteed only on full CSI test suite with 0 fails)")
 	fmt.Fprintln(out, "==========================================================================")
-	fmt.Fprintln(out, "Driver short name:                 ", yamlManifest.ShortName)
-	fmt.Fprintln(out, "Driver name:                       ", yamlManifest.DriverInfo.Name)
-	fmt.Fprintln(out, "Storage class:                     ", yamlManifest.StorageClass.FromFile)
-	fmt.Fprintln(out, "Raw block VM disks supported:      ", yamlManifest.DriverInfo.Capabilities.Block)
-	fmt.Fprintln(out, "Live migration supported:          ", yamlManifest.DriverInfo.Capabilities.RWX)
-	fmt.Fprintln(out, "VM snapshots supported:            ", supportsSnapshot)
-	fmt.Fprintln(out, "Storage-assisted cloning supported:", supportsSnapshot)
+	fmt.Fprintln(out, "Driver short name:                        ", yamlManifest.ShortName)
+	fmt.Fprintln(out, "Driver name:                              ", yamlManifest.DriverInfo.Name)
+	fmt.Fprintln(out, "Storage class:                            ", yamlManifest.StorageClass.FromFile)
+	fmt.Fprintln(out, "Supported OpenShift / CSI features:")
+	fmt.Fprintln(out, "  Persistent volumes:                     ", yamlManifest.DriverInfo.Capabilities.Persistence)
+	fmt.Fprintln(out, "  Raw block mode:                         ", yamlManifest.DriverInfo.Capabilities.Block)
+	fmt.Fprintln(out, "  FSGroup:                                ", yamlManifest.DriverInfo.Capabilities.FsGroup)
+	fmt.Fprintln(out, "  Executable files on a volume:           ", yamlManifest.DriverInfo.Capabilities.Exec)
+	fmt.Fprintln(out, "  Volume snapshots:                       ", yamlManifest.DriverInfo.Capabilities.SnapshotDataSource)
+	fmt.Fprintln(out, "  Volume cloning:                         ", yamlManifest.DriverInfo.Capabilities.PVCDataSource)
+	fmt.Fprintln(out, "  Use volume from multiple pods on a node:", yamlManifest.DriverInfo.Capabilities.MultiPODs)
+	fmt.Fprintln(out, "  ReadWriteMany access mode:              ", yamlManifest.DriverInfo.Capabilities.RWX)
+	fmt.Fprintln(out, "  Volume expansion for controller:        ", yamlManifest.DriverInfo.Capabilities.ControllerExpansion)
+	fmt.Fprintln(out, "  Volume expansion for node:              ", yamlManifest.DriverInfo.Capabilities.NodeExpansion)
+	fmt.Fprintln(out, "  Volume limits:                          ", yamlManifest.DriverInfo.Capabilities.VolumeLimits)
+	fmt.Fprintln(out, "  Volume can run on single node:          ", yamlManifest.DriverInfo.Capabilities.SingleNodeVolume)
+	fmt.Fprintln(out, "  Topology:                               ", yamlManifest.DriverInfo.Capabilities.Topology)
+	fmt.Fprintln(out, "Supported CNV features:")
+	fmt.Fprintln(out, "  Raw block VM disks:                     ", yamlManifest.DriverInfo.Capabilities.Block)
+	fmt.Fprintln(out, "  Live migration:                         ", yamlManifest.DriverInfo.Capabilities.RWX)
+	fmt.Fprintln(out, "  VM snapshots:                           ", yamlManifest.DriverInfo.Capabilities.SnapshotDataSource)
+	fmt.Fprintln(out, "  Storage-assisted cloning:               ", yamlManifest.DriverInfo.Capabilities.SnapshotDataSource)
 	fmt.Fprintln(out)
 }


### PR DESCRIPTION
As commented by @jsafrane in [Bugzilla bug 1879907](https://bugzilla.redhat.com/show_bug.cgi?id=1879907), capabilities report mixes CSI and CNV features. This PR distinguishes between the two, e.g.:
```
Driver short name:                       ceph-test
Driver name:                             test.rbd.csi.ceph.com
Storage class:                           ceph-rbd-sc.yaml
Supported CSI features:
  Data is persisted across pod restarts: true
  Raw block mode:                        true
  Volume ownership via fsGroup:          true
  Exec a file in the volume:             true
  Populate data from snapshot:           true
  Populate data from PVC:                true
  Use volume from multiple pods on node: true
  ReadWriteMany access mode:             true
  Volume expansion for controller:       true
  Volume expansion for node:             true
  Volume limits:                         true
  Volume can run on single node:         true
  Topolgy:                               true
Supported CNV features:
  Raw block VM disks:                    true
  Live migration:                        true
  VM snapshots:                          true
  Storage-assisted cloning:              true

```