### PR TITLE
Bug 1881529: openshift-sdn: bump EgressNetworkPolicyMaxRules to 1000

### DIFF
--- a/pkg/network/apis/network/types.go
+++ b/pkg/network/apis/network/types.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	ClusterNetworkDefault       = "default"
-	EgressNetworkPolicyMaxRules = 50
+	EgressNetworkPolicyMaxRules = 1000
 )
 
 // +genclient


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-network-operator/pull/796, for https://issues.redhat.com/browse/SDN-1199
