### PR TITLE
Bug 1880741: Remove broken machine-api taint test

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -223,15 +223,8 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return false
 			}
 
-			g.By(fmt.Sprintf("ensure worker taints and conditions are consistent"))
+			g.By(fmt.Sprintf("ensure worker is healthy"))
 			for _, node := range nodeList.Items {
-				if _, ok := node.Labels["node-role.kubernetes.io/worker"]; !ok {
-					continue
-				}
-				if len(node.Spec.Taints) > 0 {
-					e2e.Logf("node/%s had unexpected taints: %#v", node.Name, node.Spec.Taints)
-					return false
-				}
 				for _, condition := range node.Status.Conditions {
 					switch condition.Type {
 					case corev1.NodeReady:
@@ -253,7 +246,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 
 					}
 				}
-				e2e.Logf("node/%s taints and conditions seem ok")
+				e2e.Logf("node/%s conditions seem ok")
 			}
 
 			return true


### PR DESCRIPTION
This test suite is currently checking for labels
and taints on nodes created by the machine-api.
Other components are adding taints to existing workers
which are sometimes selected to scale down during
testing.  This test does not allow for any modification
of labels and taints.

The machine-api is not the sole or final manager of
labels and taints.  We have coverage in our own
test suite that the machine-api adds labels
and taints appropriately, this test is unnecessary
here and does not add cross-component signaling.