### PR TITLE
Bug 1882556: test: Access Git over HTTPS instead of git://

### DIFF
--- a/test/extended/builds/controllers.go
+++ b/test/extended/builds/controllers.go
@@ -589,7 +589,7 @@ func configChangeBuildConfig(ns string) *buildv1.BuildConfig {
 	bc.Name = "testcfgbc"
 	bc.Namespace = ns
 	bc.Spec.Source.Git = &buildv1.GitBuildSource{}
-	bc.Spec.Source.Git.URI = "git://github.com/openshift/ruby-hello-world.git"
+	bc.Spec.Source.Git.URI = "https://github.com/openshift/ruby-hello-world.git"
 	bc.Spec.Strategy.DockerStrategy = &buildv1.DockerBuildStrategy{}
 	configChangeTrigger := buildv1.BuildTriggerPolicy{Type: buildv1.ConfigChangeBuildTriggerType}
 	bc.Spec.Triggers = append(bc.Spec.Triggers, configChangeTrigger)
@@ -642,7 +642,7 @@ func imageChangeBuildConfig(ns, name string, strategy buildv1.BuildStrategy) *bu
 			CommonSpec: buildv1.CommonSpec{
 				Source: buildv1.BuildSource{
 					Git: &buildv1.GitBuildSource{
-						URI: "git://github.com/openshift/ruby-hello-world.git",
+						URI: "https://github.com/openshift/ruby-hello-world.git",
 					},
 					ContextDir: "contextimage",
 				},

--- a/test/extended/images/imagechange_buildtrigger.go
+++ b/test/extended/images/imagechange_buildtrigger.go
@@ -190,7 +190,7 @@ func imageChangeBuildConfig(namespace, name string, strategy buildv1.BuildStrate
 			CommonSpec: buildv1.CommonSpec{
 				Source: buildv1.BuildSource{
 					Git: &buildv1.GitBuildSource{
-						URI: "git://github.com/openshift/ruby-hello-world.git",
+						URI: "https://github.com/openshift/ruby-hello-world.git",
 					},
 					ContextDir: "contextimage",
 				},

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -21495,7 +21495,7 @@ var _testExtendedTestdataBuildsTestBuildRevisionJson = []byte(`{
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -21569,7 +21569,7 @@ items:
     source:
       type: Git
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
     strategy:
       type: Source
       sourceStrategy:
@@ -21598,7 +21598,7 @@ items:
     source:
       type: Git
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
     strategy:
       type: Source
       sourceStrategy:
@@ -32108,7 +32108,7 @@ metadata:
 spec:
   source:
     git:
-      uri: git://github.com/openshift/ruby-hello-world.git
+      uri: https://github.com/openshift/ruby-hello-world.git
   strategy:
     jenkinsPipelineStrategy: {}
 ' | oc create -f -"
@@ -36959,7 +36959,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:
@@ -36998,7 +36998,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:
@@ -37522,7 +37522,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-2
+        uri: https://github.com/mfojtik/sinatra-example-2
       type: Git
     strategy:
       sourceStrategy:
@@ -37646,7 +37646,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-1
+        uri: https://github.com/mfojtik/sinatra-example-1
       type: Git
     strategy:
       sourceStrategy:
@@ -37688,7 +37688,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-1
+        uri: https://github.com/mfojtik/sinatra-example-1
       type: Git
     strategy:
       sourceStrategy:
@@ -37798,7 +37798,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-app-example
+        uri: https://github.com/mfojtik/sinatra-app-example
       type: Git
     strategy:
       sourceStrategy:
@@ -37847,7 +37847,7 @@ items:
       type: git
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-app-example
+        uri: https://github.com/mfojtik/sinatra-app-example
       type: Git
     strategy:
       sourceStrategy:
@@ -46062,7 +46062,7 @@ spec:
   runPolicy: Serial
   source:
     git:
-      uri: git://github.com/openshift/ruby-hello-world.git
+      uri: https://github.com/openshift/ruby-hello-world.git
     secrets: null
     type: Git
   strategy:
@@ -46132,7 +46132,7 @@ var _testExtendedTestdataCmdTestCmdTestdataTestBuildcliJson = []byte(`{
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -46174,7 +46174,7 @@ var _testExtendedTestdataCmdTestCmdTestdataTestBuildcliJson = []byte(`{
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -53262,7 +53262,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                 "source": {
                     "type": "Git",
                     "git": {
-                        "uri": "git://github.com/openshift/ruby-hello-world.git"
+                        "uri": "https://github.com/openshift/ruby-hello-world.git"
                     }
                 },
                 "strategy": {
@@ -53291,7 +53291,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                 "source": {
                     "type": "Git",
                     "git": {
-                        "uri": "git://github.com/openshift/ruby-hello-world.git"
+                        "uri": "https://github.com/openshift/ruby-hello-world.git"
                     }
                 },
                 "strategy": {
@@ -56483,7 +56483,7 @@ var _testExtendedTestdataRun_policyParallelBcYaml = []byte(`---
         source: 
           type: "Git"
           git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
+            uri: "https://github.com/openshift/ruby-hello-world.git"
         strategy: 
           type: "Source"
           sourceStrategy: 
@@ -56530,7 +56530,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
         source: 
           type: "Git"
           git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
+            uri: "https://github.com/openshift/ruby-hello-world.git"
         strategy: 
           type: "Source"
           sourceStrategy: 
@@ -56551,7 +56551,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
         source: 
           type: "Git"
           git: 
-            uri: "git://github.com/openshift/invalidrepo.git"
+            uri: "https://github.com/openshift/invalidrepo.git"
         strategy: 
           type: "Source"
           sourceStrategy: 
@@ -56594,7 +56594,7 @@ var _testExtendedTestdataRun_policySerialLatestOnlyBcYaml = []byte(`---
         source: 
           type: "Git"
           git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
+            uri: "https://github.com/openshift/ruby-hello-world.git"
         strategy: 
           type: "Source"
           sourceStrategy: 
@@ -58710,7 +58710,7 @@ var _testIntegrationTestdataTestBuildcliBeta2Json = []byte(`{
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -58752,7 +58752,7 @@ var _testIntegrationTestdataTestBuildcliBeta2Json = []byte(`{
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -58837,7 +58837,7 @@ var _testIntegrationTestdataTestBuildcliJson = []byte(`{
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -58879,7 +58879,7 @@ var _testIntegrationTestdataTestBuildcliJson = []byte(`{
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {

--- a/test/extended/testdata/builds/test-build-revision.json
+++ b/test/extended/testdata/builds/test-build-revision.json
@@ -14,7 +14,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -35,7 +35,7 @@ items:
     source:
       type: Git
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
     strategy:
       type: Source
       sourceStrategy:
@@ -64,7 +64,7 @@ items:
     source:
       type: Git
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
     strategy:
       type: Source
       sourceStrategy:

--- a/test/extended/testdata/cmd/test/cmd/env.sh
+++ b/test/extended/testdata/cmd/test/cmd/env.sh
@@ -40,7 +40,7 @@ metadata:
 spec:
   source:
     git:
-      uri: git://github.com/openshift/ruby-hello-world.git
+      uri: https://github.com/openshift/ruby-hello-world.git
   strategy:
     jenkinsPipelineStrategy: {}
 ' | oc create -f -"

--- a/test/extended/testdata/cmd/test/cmd/testdata/app-scenarios/new-project-deployed-app.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/app-scenarios/new-project-deployed-app.yaml
@@ -17,7 +17,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:
@@ -56,7 +56,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/openshift/ruby-hello-world.git
+        uri: https://github.com/openshift/ruby-hello-world.git
       type: Git
     strategy:
       sourceStrategy:

--- a/test/extended/testdata/cmd/test/cmd/testdata/app-scenarios/new-project-no-build.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/app-scenarios/new-project-no-build.yaml
@@ -13,7 +13,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-2
+        uri: https://github.com/mfojtik/sinatra-example-2
       type: Git
     strategy:
       sourceStrategy:

--- a/test/extended/testdata/cmd/test/cmd/testdata/app-scenarios/new-project-one-build.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/app-scenarios/new-project-one-build.yaml
@@ -14,7 +14,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-1
+        uri: https://github.com/mfojtik/sinatra-example-1
       type: Git
     strategy:
       sourceStrategy:
@@ -56,7 +56,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-example-1
+        uri: https://github.com/mfojtik/sinatra-example-1
       type: Git
     strategy:
       sourceStrategy:

--- a/test/extended/testdata/cmd/test/cmd/testdata/app-scenarios/new-project-two-deployment-configs.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/app-scenarios/new-project-two-deployment-configs.yaml
@@ -13,7 +13,7 @@ items:
     resources: {}
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-app-example
+        uri: https://github.com/mfojtik/sinatra-app-example
       type: Git
     strategy:
       sourceStrategy:
@@ -62,7 +62,7 @@ items:
       type: git
     source:
       git:
-        uri: git://github.com/mfojtik/sinatra-app-example
+        uri: https://github.com/mfojtik/sinatra-app-example
       type: Git
     strategy:
       sourceStrategy:

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-bc.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-bc.yaml
@@ -7,7 +7,7 @@ spec:
   runPolicy: Serial
   source:
     git:
-      uri: git://github.com/openshift/ruby-hello-world.git
+      uri: https://github.com/openshift/ruby-hello-world.git
     secrets: null
     type: Git
   strategy:

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-buildcli.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-buildcli.json
@@ -39,7 +39,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -81,7 +81,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {

--- a/test/extended/testdata/long_names/fixture.json
+++ b/test/extended/testdata/long_names/fixture.json
@@ -17,7 +17,7 @@
                 "source": {
                     "type": "Git",
                     "git": {
-                        "uri": "git://github.com/openshift/ruby-hello-world.git"
+                        "uri": "https://github.com/openshift/ruby-hello-world.git"
                     }
                 },
                 "strategy": {
@@ -46,7 +46,7 @@
                 "source": {
                     "type": "Git",
                     "git": {
-                        "uri": "git://github.com/openshift/ruby-hello-world.git"
+                        "uri": "https://github.com/openshift/ruby-hello-world.git"
                     }
                 },
                 "strategy": {

--- a/test/extended/testdata/run_policy/parallel-bc.yaml
+++ b/test/extended/testdata/run_policy/parallel-bc.yaml
@@ -26,7 +26,7 @@
         source: 
           type: "Git"
           git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
+            uri: "https://github.com/openshift/ruby-hello-world.git"
         strategy: 
           type: "Source"
           sourceStrategy: 

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -17,7 +17,7 @@
         source: 
           type: "Git"
           git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
+            uri: "https://github.com/openshift/ruby-hello-world.git"
         strategy: 
           type: "Source"
           sourceStrategy: 
@@ -38,7 +38,7 @@
         source: 
           type: "Git"
           git: 
-            uri: "git://github.com/openshift/invalidrepo.git"
+            uri: "https://github.com/openshift/invalidrepo.git"
         strategy: 
           type: "Source"
           sourceStrategy: 

--- a/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
@@ -17,7 +17,7 @@
         source: 
           type: "Git"
           git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
+            uri: "https://github.com/openshift/ruby-hello-world.git"
         strategy: 
           type: "Source"
           sourceStrategy: 

--- a/test/integration/testdata/test-buildcli-beta2.json
+++ b/test/integration/testdata/test-buildcli-beta2.json
@@ -39,7 +39,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -81,7 +81,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {

--- a/test/integration/testdata/test-buildcli.json
+++ b/test/integration/testdata/test-buildcli.json
@@ -39,7 +39,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -81,7 +81,7 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {


### PR DESCRIPTION
Avoid failures [like][1]:

```
Sep 24 03:16:53.079: INFO: 2020-09-24T03:13:20.835804050Z Cloning "git://github.com/openshift/ruby-hello-world.git" ...
2020-09-24T03:13:36.841370114Z WARNING: timed out waiting for git server, will wait 1m4s
2020-09-24T03:14:40.928268255Z WARNING: timed out waiting for git server, will wait 4m16s
2020-09-24T03:16:50.848349366Z error: fatal: unable to connect to github.com:
2020-09-24T03:16:50.848349366Z github.com[0: 140.82.113.3]: errno=Connection timed out
```

Because our Proxy configuration allows for HTTP and HTTPS requests to be pointed at the egress proxy, but does not allow for Git's native protocol on port 9418 to be proxied out.

Generated with:

```console
$ sed -i 's|git://github.com|https://github.com|g' $(git grep -l git://github.com)
$ git add -p  # exclude the git_url hunks, since those are GitHub webhook payloads, and the semantics require git:// URIs.
```

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ocp-4.6-e2e-aws-proxy/1308949438701506560