### PR TITLE
Bug 1883235: Adjust wait duration for marketplace test

### DIFF
--- a/test/extended/marketplace/marketplace_labels.go
+++ b/test/extended/marketplace/marketplace_labels.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-operator][Feature:Marketplace] Marketplace resources wi
 	var (
 		oc            = exutil.NewCLI("marketplace")
 		marketplaceNs = "openshift-marketplace"
-		resourceWait  = 60 * time.Second
+		resourceWait  = 2 * time.Minute
 
 		opsrcYamltem = exutil.FixturePath("testdata", "marketplace", "opsrc", "02-opsrc.yaml")
 	)


### PR DESCRIPTION
Increase from 60s to 2 mins due to recent increase in initial delay
in the catalog pod.

Signed-off-by: Vu Dinh <vdinh@redhat.com>