### PR TITLE
Bug 1883226: 3.11: fix docker builder unit test failures

### DIFF
--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -129,6 +129,11 @@ func makeVolumeSpec(src localObjectBuildSource, mountPath string) s2iapi.VolumeS
 // Build executes S2I build based on configured builder, S2I builder factory
 // and S2I config validator
 func (s *S2IBuilder) Build() error {
+	return s.buildInternal(getContainerNetworkConfig)
+}
+
+// buildInternal provides a way for tests to mock getContainerNetworkConfigFunc.
+func (s *S2IBuilder) buildInternal(getContainerNetworkConfigFunc getContainerNetworkConfigFn) error {
 
 	var err error
 	ctx := timing.NewContext(context.Background())
@@ -189,7 +194,7 @@ func (s *S2IBuilder) Build() error {
 		}
 	}
 
-	networkMode, resolvConfHostPath, err := getContainerNetworkConfig()
+	networkMode, resolvConfHostPath, err := getContainerNetworkConfigFunc()
 	if err != nil {
 		return err
 	}

--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -116,7 +116,7 @@ func TestDockerBuildError(t *testing.T) {
 	s2iBuilder := newTestS2IBuilder(testS2IBuilderConfig{
 		buildError: expErr,
 	})
-	if err := s2iBuilder.Build(); err != expErr {
+	if err := s2iBuilder.buildInternal(fakeGetContainerNetworkConfig); err != expErr {
 		t.Errorf("s2iBuilder.Build() = %v; want %v", err, expErr)
 	}
 }
@@ -127,7 +127,7 @@ func TestPushError(t *testing.T) {
 	s2iBuilder := newTestS2IBuilder(testS2IBuilderConfig{
 		errPushImage: expErr,
 	})
-	if err := s2iBuilder.Build(); !strings.HasSuffix(err.Error(), expErr.Error()) {
+	if err := s2iBuilder.buildInternal(fakeGetContainerNetworkConfig); !strings.HasSuffix(err.Error(), expErr.Error()) {
 		t.Errorf("s2iBuilder.Build() = %v; want %v", err, expErr)
 	}
 }
@@ -138,7 +138,7 @@ func TestGetStrategyError(t *testing.T) {
 	s2iBuilder := newTestS2IBuilder(testS2IBuilderConfig{
 		getStrategyErr: expErr,
 	})
-	if err := s2iBuilder.Build(); err != expErr {
+	if err := s2iBuilder.buildInternal(fakeGetContainerNetworkConfig); err != expErr {
 		t.Errorf("s2iBuilder.Build() = %v; want %v", err, expErr)
 	}
 }

--- a/pkg/build/builder/util.go
+++ b/pkg/build/builder/util.go
@@ -23,6 +23,8 @@ var (
 	procCGroupPattern = regexp.MustCompile(`\d+:([a-z_,]+):/.*/(\w+-|)([a-z0-9]+).*`)
 )
 
+type getContainerNetworkConfigFn func() (string, string, error)
+
 // MergeEnv will take an existing environment and merge it with a new set of
 // variables. For variables with the same name in both, only the one in the
 // new environment will be kept.

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -263,8 +263,6 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 				g.By("clean up openshift resources for next potential run")
 				err = oc.Run("delete").Args("bc", "sample-pipeline-openshift-client-plugin").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				err = oc.Run("delete").Args("dc", "jenkins-second-deployment").Execute()
-				o.Expect(err).NotTo(o.HaveOccurred())
 				err = oc.Run("delete").Args("bc", "ruby").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				err = oc.Run("delete").Args("is", "ruby").Execute()

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -228,7 +228,6 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 	g.Context("jenkins-client-plugin tests", func() {
 
 		g.It("using the ephemeral template", func() {
-			g.Skip("Bug 1890523: test fails removing the second deployment")
 			defer cleanup(jenkinsEphemeralTemplatePath)
 			setupJenkins(jenkinsEphemeralTemplatePath)
 

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -58,7 +58,6 @@ var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 			})
 
 			g.It("should contain secrets during the source strategy build", func() {
-				g.Skip("Bug 1890328: CI version of docker does not handle symlinks correctly")
 				g.By("creating test build config")
 				err := oc.Run("create").Args("-f", sourceBuildFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -2249,7 +2249,7 @@ EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
-RUN scl enable rh-ruby25 "bundle install"
+RUN scl enable rh-ruby25 "GEM_HOME=~/.gem bundle install"
 CMD ["scl", "enable", "rh-ruby25", "./run.sh"]
 
 USER default

--- a/test/extended/testdata/builds/test-build-app/Dockerfile
+++ b/test/extended/testdata/builds/test-build-app/Dockerfile
@@ -4,7 +4,7 @@ EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
-RUN scl enable rh-ruby25 "bundle install"
+RUN scl enable rh-ruby25 "GEM_HOME=~/.gem bundle install"
 CMD ["scl", "enable", "rh-ruby25", "./run.sh"]
 
 USER default


### PR DESCRIPTION
This is an attempt to fix the origin unit test failures for 3.11. The test is supposedly failing when trying to resolve the container network config.

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/25551/pull-ci-openshift-origin-release-3.11-unit/1309180139887661056

If the test is running inside a crio container, test code tries to establish a connection to crio socket. As the crio socket path is not mounted inside the container, the test fails. This PR tries to fix the test by mocking the function that determines the container network config.