### PR TITLE
Add a new baseline performance test

### DIFF
--- a/test/extended/baseline/baseline.go
+++ b/test/extended/baseline/baseline.go
@@ -1,0 +1,18 @@
+package baseline
+
+import (
+	"time"
+
+	g "github.com/onsi/ginkgo"
+)
+
+// This test is intended to be run by itself against a new cluster to collect
+// baseline performance data.
+var _ = g.Describe("[sig-scalability][Suite:openshift/scalability] Managed cluster should", func() {
+	defer g.GinkgoRecover()
+
+	g.It("approach fixed resource consumption in the steady state", func() {
+		g.By("observing the cluster at rest for 15 minutes at any point after installation")
+		time.Sleep(15 * time.Minute)
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/authentication"
 	_ "github.com/openshift/origin/test/extended/authorization"
 	_ "github.com/openshift/origin/test/extended/authorization/rbac"
+	_ "github.com/openshift/origin/test/extended/baseline"
 	_ "github.com/openshift/origin/test/extended/bootstrap_user"
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/cli"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2323,6 +2323,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-scalability][Feature:Performance][Serial][Slow] Mirror cluster it should read the node info": "it should read the node info",
 
+	"[Top Level] [sig-scalability][Suite:openshift/scalability] Managed cluster should approach fixed resource consumption in the steady state": "approach fixed resource consumption in the steady state [Slow]",
+
 	"[Top Level] [sig-scheduling] GPUDevicePluginAcrossRecreate [Feature:Recreate] run Nvidia GPU Device Plugin tests with a recreation": "run Nvidia GPU Device Plugin tests with a recreation [Disabled:SpecialConfig] [Suite:k8s]",
 
 	"[Top Level] [sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied. [Conformance]": "should create a LimitRange with defaults and ensure pod has those defaults applied. [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",


### PR DESCRIPTION
Introduce a new baseline performance test which does nothing but sleep for 15
minutes. This test is intended to be executed by itself (or in addition to other
such "passive" tests) against a new cluster.

Periodic data collected in this manner will hopefully be more reliable as
control data for regression analysis and to detect things like slow leaks
without confounding factors introduced by workloads and other invasive testing.