### PR TITLE
[WIP] Bug 1882853: Add cluster proxy settings to url tester exutil

### DIFF
--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -52,6 +52,9 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 		ns := oc.KubeFramework().Namespace.Name
 
 		tester := exurl.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)
+		// Ammend cluster proxy settings to tester pod when applicable
+		proxy := exutil.GetClusterProxyConfig(oc.AdminConfig())
+		tester.WithProxy(proxy.Spec.HTTPProxy)
 
 		tests := []*exurl.Test{}
 

--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -48,6 +48,10 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			urlTester := url.NewTester(oc.AdminKubeClient(), oc.Namespace()).WithErrorPassthrough(true)
+			// Get cluster proxy config
+			proxy := exutil.GetClusterProxyConfig(oc.AdminConfig())
+			urlTester.WithProxy(proxy.Spec.HTTPProxy)
+
 			defer urlTester.Close()
 			hostname := getHostnameForRoute(oc, "idle-test")
 			urlTester.Within(urlTimeout, url.Expect("GET", "http://"+hostname).Through(hostname).HasStatusCode(200))

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -59,6 +59,9 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	g.Describe("The HAProxy router", func() {
 		g.It("should respond with 503 to unrecognized hosts", func() {
 			t := url.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)
+			// Get cluster proxy config
+			proxy := exutil.GetClusterProxyConfig(oc.AdminConfig())
+			t.WithProxy(proxy.Spec.HTTPProxy)
 			defer t.Close()
 			t.Within(
 				time.Minute,
@@ -85,6 +88,9 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 
 			g.By("verifying the router reports the correct behavior")
 			t := url.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)
+			// Get cluster proxy config
+			proxy := exutil.GetClusterProxyConfig(oc.AdminConfig())
+			t.WithProxy(proxy.Spec.HTTPProxy)
 			defer t.Close()
 			t.Within(
 				3*time.Minute,

--- a/test/extended/util/jenkins/ref.go
+++ b/test/extended/util/jenkins/ref.go
@@ -70,13 +70,18 @@ func NewRef(oc *exutil.CLI) *JenkinsRef {
 	token, err := oc.Run("whoami").Args("-t").Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
+	t := exurl.NewTester(oc.AdminKubeClient(), oc.Namespace())
+	// Get cluster proxy config
+	proxy := exutil.GetClusterProxyConfig(oc.AdminConfig())
+	t.WithProxy(proxy.Spec.HTTPProxy)
+
 	j := &JenkinsRef{
 		oc:         oc,
 		host:       serviceIP,
 		port:       port,
 		namespace:  oc.Namespace(),
 		token:      token,
-		uri_tester: exurl.NewTester(oc.AdminKubeClient(), oc.Namespace()),
+		uri_tester: t,
 	}
 	return j
 }

--- a/test/extended/util/proxy.go
+++ b/test/extended/util/proxy.go
@@ -3,8 +3,13 @@ package util
 import (
 	"context"
 
+	v1 "github.com/openshift/api/config/v1"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rest "k8s.io/client-go/rest"
+
+	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 )
 
 // IsClusterProxyEnabled returns true if the cluster has a global proxy enabled
@@ -17,4 +22,11 @@ func IsClusterProxyEnabled(oc *CLI) (bool, error) {
 		return false, err
 	}
 	return len(proxy.Status.HTTPProxy) > 0 || len(proxy.Status.HTTPSProxy) > 0, nil
+}
+
+func GetClusterProxyConfig(oc *rest.Config) *v1.Proxy {
+	configClient := configclientset.NewForConfigOrDie(oc)
+	proxy, _ := configClient.ConfigV1().Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
+
+	return proxy
 }


### PR DESCRIPTION
This PR is an attempt to resolve https://bugzilla.redhat.com/show_bug.cgi?id=1882853 by having the url tester util in `test/extended/util/url/url.go` apply available cluster proxy settings to the url tester execpod. Tests that utilize cluster ingress from within the cluster and utilize the url tester util can pass a proxy host to the `Tester` struct via the new `WithProxy` function.

This PR adds a helper function to get the cluster proxy config to the new `test/extended/util/proxy.go` file.

https://github.com/openshift/release/pull/12375 will allow this PR to be verified on the `e2e-aws-proxy` job. 
