### PR TITLE
skip service type load balancer upgrade test on ovirt

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -30,6 +32,8 @@ import (
 type UpgradeTest struct {
 	jig        *service.TestJig
 	tcpService *v1.Service
+
+	unsupportedPlatform bool
 }
 
 func (UpgradeTest) Name() string { return "k8s-service-lb-available" }
@@ -41,6 +45,18 @@ func shouldTestPDBs() bool { return true }
 
 // Setup creates a service with a load balancer and makes sure it's reachable.
 func (t *UpgradeTest) Setup(f *framework.Framework) {
+	configClient, err := configclient.NewForConfig(f.ClientConfig())
+	framework.ExpectNoError(err)
+	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	// ovirt does not support service type loadbalancer because it doesn't program a cloud.
+	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType {
+		t.unsupportedPlatform = true
+	}
+	if t.unsupportedPlatform {
+		return
+	}
+
 	serviceName := "service-test"
 	jig := service.NewTestJig(f.ClientSet, f.Namespace.Name, serviceName)
 
@@ -107,6 +123,10 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 
 // Test runs a connectivity check to the service.
 func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	if t.unsupportedPlatform {
+		return
+	}
+
 	client, err := framework.LoadClientset()
 	framework.ExpectNoError(err)
 


### PR DESCRIPTION
Upgrade tests are programmatically added.  This introduces a very simple programmatic skip at the time when the test runs.

If we find that we have many of these, we can write a filter, but such a filter will require a client.