### PR TITLE
Update hello-openshift OWNERS files

### DIFF
--- a/examples/hello-openshift/OWNERS
+++ b/examples/hello-openshift/OWNERS
@@ -7,9 +7,11 @@ reviewers:
   - bparees
   - knobunc
   - adambkaplan
+  - sgreene570
 approvers:
   - mfojtik
   - smarterclayton
   - pweil-
   - jwforres
   - derekwaynecarr
+  - sgreene570

--- a/images/hello-openshift/OWNERS
+++ b/images/hello-openshift/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - mfojtik
+  - smarterclayton
+  - pweil-
+  - jwforres
+  - derekwaynecarr
+  - bparees
+  - knobunc
+  - adambkaplan
+  - sgreene570
+approvers:
+  - mfojtik
+  - smarterclayton
+  - pweil-
+  - jwforres
+  - derekwaynecarr
+  - sgreene570


### PR DESCRIPTION
`images/hello-openshift/OWNERS`: Add initial owners for the `hello-openshift` art dockerfile. This owners file is a copy-paste of the current `examples/hello-openshift/OWNERS` file (with the addition of myself). 

`examples/hello-openshift/OWNERS`: Add myself to the `hello-openshift` code maintainers OWNERS file.

/cc @wking @yselkowitz 