### PR TITLE
[wip] test/extended/dr: bump timeout for new machines

### DIFF
--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -188,7 +188,8 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 								return false, nil
 							}
 							if err != nil {
-								return false, err
+								framework.Logf("Debug: error creating machine %q: %q", master, err.Error())
+								return false, nil
 							}
 							return true, nil
 						})

--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 						continue
 					}
 
-					framework.Logf("Destroying %s", masterMachine)
+					framework.Logf("Destroying master: %s IPs: %v", masterMachine, node.Status.Addresses)
 					err = ms.Delete(context.Background(), masterMachine, metav1.DeleteOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())
 				}
@@ -162,7 +162,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				if expectedNumberOfMasters == 1 {
-					framework.Logf("Cannot create new masters, you must manually create masters and update their DNS entries according to the docs")
+					framework.Logf("Cannot create new masters, you must manually create masters")
 				} else {
 					framework.Logf("Create new masters")
 					for _, master := range masterMachines {
@@ -231,6 +231,14 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 						return true, nil
 					})
 					o.Expect(err).NotTo(o.HaveOccurred())
+				}
+
+				node, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/master="})
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				// verify new node IPs
+				for _, node := range node.Items {
+					framework.Logf("New master: %q IPs: %v", node.Name, node.Status.Addresses)
 				}
 
 				framework.Logf("Force new revision of etcd-pod")

--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -181,7 +181,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 						newMaster.SetUID("")
 						newMaster.SetCreationTimestamp(metav1.NewTime(time.Time{}))
 						// retry until the machine gets created
-						err := wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
+						err := wait.PollImmediate(5*time.Second, 20*time.Minute, func() (bool, error) {
 							_, err := ms.Create(context.Background(), newMaster, metav1.CreateOptions{})
 							if errors.IsAlreadyExists(err) {
 								framework.Logf("Waiting for old machine object %s to be deleted so we can create a new one", master)

--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -181,7 +181,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 						newMaster.SetUID("")
 						newMaster.SetCreationTimestamp(metav1.NewTime(time.Time{}))
 						// retry until the machine gets created
-						err := wait.PollImmediate(5*time.Second, 10*time.Minute, func() (bool, error) {
+						err := wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
 							_, err := ms.Create(context.Background(), newMaster, metav1.CreateOptions{})
 							if errors.IsAlreadyExists(err) {
 								framework.Logf("Waiting for old machine object %s to be deleted so we can create a new one", master)


### PR DESCRIPTION
Machines take longer to delete/come back in 4.6+ bumping timeout.


```
fail [github.com/openshift/origin/test/extended/dr/quorum_restore.go:195]: Unexpected error:
    <*errors.StatusError | 0xc001cb10e0>: {
        ErrStatus: {
            TypeMeta: {Kind: "Status", APIVersion: "v1"},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "Internal error occurred: resource quota evaluation timed out",
            Reason: "InternalError",
            Details: {
                Name: "",
                Group: "",
                Kind: "",
                UID: "",
                Causes: [
                    {
                        Type: "",
                        Message: "resource quota evaluation timed out",
                        Field: "",
                    },
                ],
                RetryAfterSeconds: 0,
            },
            Code: 500,
        },
    }
    Internal error occurred: resource quota evaluation timed out
occurred
```
ref: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-etcd-operator/459/pull-ci-openshift-cluster-etcd-operator-master-e2e-disruptive/1311384501846282240

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>