### PR TITLE
Bug 1852289: Add libvirt to the list of unsupported platforms for LB service

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -49,7 +49,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	// ovirt does not support service type loadbalancer because it doesn't program a cloud.
-	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.KubevirtPlatformType {
+	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.KubevirtPlatformType || infra.Status.PlatformStatus.Type == configv1.LibvirtPlatformType {
 		t.unsupportedPlatform = true
 	}
 	if t.unsupportedPlatform {


### PR DESCRIPTION
The upgrade test suite includes an external load balancer service test
which is not supported in libvirt (used for s390x/ppc64le CI). Maybe
there is a possibility/use-case for metal/libvirt deploys to have
external load balancers, but it'd require a publically routable IP and
managing the access to the IP/port. Not sure if that will be supported
in non-cloud platforms.

So for now let's just add a new suite that skips the LB service,
allowing us to run upgrade tests in CI.

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>