### PR TITLE
Fix skipping of SDN tests

### DIFF
--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -136,7 +136,7 @@ func networkPluginName() string {
 	if cachedNetworkPluginName == nil {
 		// We don't use exutil.NewCLI() here because it can't be called from BeforeEach()
 		out, err := exec.Command(
-			"oc", "--config="+exutil.KubeConfigPath(),
+			"oc", "--kubeconfig="+exutil.KubeConfigPath(),
 			"get", "clusternetwork", "default",
 			"--template={{.pluginName}}",
 		).CombinedOutput()


### PR DESCRIPTION
Our attempt to determine the plugin mode was generating

pluginName="Flag --config has been deprecated, use --kubeconfig instead\nredhat/openshift-ovs-networkpolicy"

resulting in us never running the openshift-sdn-specific tests