### PR TITLE
Updating openshift-enterprise-tests builder & base images to be consistent with ART

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -1,11 +1,11 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/origin
 COPY . .
 RUN make; \
     mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/origin/openshift-tests /tmp/build/openshift-tests
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:tools
+FROM registry.svc.ci.openshift.org/ocp/4.7:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \


### PR DESCRIPTION
Updating openshift-enterprise-tests builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/openshift-enterprise-tests.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/oc/pull/607 . Allow it to merge and then run `/test all` on this PR.