### PR TITLE
bug 1886174: skip test during skew testing that won't run on 4.6

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/registry/rbac/validation"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	"github.com/openshift/api/authorization"
 	"github.com/openshift/api/build"
@@ -161,6 +163,9 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] The default clust
 	oc := exutil.NewCLI("default-rbac-policy")
 
 	g.It("should have correct RBAC rules", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions have different rules")
+		}
 		kubeInformers := informers.NewSharedInformerFactory(oc.AdminKubeClient(), 20*time.Minute)
 		ruleResolver := exutil.NewRuleResolver(kubeInformers.Rbac().V1()) // signal what informers we want to use early
 

--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
@@ -32,6 +34,9 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("oc-adm-must-gather").AsAdmin()
 	g.It("runs successfully", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions no longer collect audit logs")
+		}
 		// makes some tokens that should not show in the audit logs
 		const tokenName = "must-gather-audit-logs-token-plus-some-padding-here-to-make-the-limit"
 		oauthClient := oauthv1client.NewForConfigOrDie(oc.AdminConfig())

--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -11,6 +12,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
@@ -35,6 +37,10 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 	})
 
 	g.Context("Using a OAuth client with a non-default token max age", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions have different oauth token rules")
+		}
+
 		var oAuthClientResource *oauthv1.OAuthClient
 		var accessTokenMaxAgeSeconds int32
 

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -158,6 +158,9 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 		})
 
 		g.It("should start and expose a secured proxy and unsecured metrics", func() {
+			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+				e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and CVO switched metrics to secured")
+			}
 			oc.SetupProject()
 			ns := oc.Namespace()
 			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)

--- a/vendor/k8s.io/kubernetes/test/e2e/apps/disruption.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/disruption.go
@@ -19,6 +19,7 @@ package apps
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -269,6 +270,9 @@ var _ = SIGDescribe("DisruptionController", func() {
 	}
 
 	ginkgo.It("should block an eviction until the PDB is updated to allow it", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and 1.19 changed eviction rules")
+		}
 		ginkgo.By("Creating a pdb that targets all three pods in a test replica set")
 		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(3), defaultLabels)
 		createReplicaSetOrDie(cs, ns, 3, false)


### PR DESCRIPTION
details in each skip message.