### PR TITLE
test: Increase allowed telemetry series by 100

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -103,7 +103,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		tests := map[string]bool{
 			// We want to limit the number of total series sent, the cluster:telemetry_selected_series:count
 			// rule contains the count of the all the series that are sent via telemetry.
-			`max_over_time(cluster:telemetry_selected_series:count[2h]) >= 500`: false,
+			`max_over_time(cluster:telemetry_selected_series:count[2h]) >= 600`: false,
 		}
 		helper.RunQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 


### PR DESCRIPTION
We recently increased the series published to telemetry by about
100 (to include resource counts for all CRDs). Bump the allowed
test limits similarly to 600.

Consequence of openshift/cluster-monitoring-operator#951