### PR TITLE
Bug 1890141: move off docker.io in templates/builds/jenkins tests 

### DIFF
--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] Multi-stage image builds", func
 		testDockerfile = `
 FROM scratch as test
 USER 1001
-FROM centos:7
+FROM registry.redhat.io/rhel7
 COPY --from=test /usr/bin/curl /test/
 COPY --from=busybox:latest /bin/echo /test/
 COPY --from=busybox:latest /bin/ping /test/

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -19136,7 +19136,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
     resources: {}
     postCommit: {}
     nodeSelector: null
@@ -19822,7 +19822,7 @@ var _testExtendedTestdataBuildsBuildSecretsTestDockerBuildJson = []byte(`{
       "dockerStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/busybox:latest"
+          "name": "quay.io/quay/busybox:latest"
         },
         "env": [
           {
@@ -19927,7 +19927,7 @@ var _testExtendedTestdataBuildsBuildSecretsTestS2iBuildJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/ruby-25-centos7"
+          "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
         },
         "env": [
           {
@@ -20140,7 +20140,7 @@ var _testExtendedTestdataBuildsBuildTimingTestDockerBuildJson = []byte(`{
         "forcePull": true,
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/busybox:latest"
+          "name": "quay.io/quay/busybox:latest"
         },
         "env": [
           {
@@ -20219,7 +20219,7 @@ var _testExtendedTestdataBuildsBuildTimingTestS2iBuildJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/test-build-simples2i:latest"
+          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
         },
         "env": [
           {
@@ -20538,7 +20538,7 @@ var _testExtendedTestdataBuildsIncrementalAuthBuildJson = []byte(`{
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "incremental": true
           }
@@ -20727,7 +20727,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
 `)
 
 func testExtendedTestdataBuildsStatusfailBadcontextdirs2iYamlBytes() ([]byte, error) {
@@ -20757,7 +20757,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
 `)
 
 func testExtendedTestdataBuildsStatusfailFailedassembleYamlBytes() ([]byte, error) {
@@ -20827,7 +20827,7 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchimagecontentdockerYamlBytes() ([]byte, error) {
@@ -20858,7 +20858,7 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsourcedockerYamlBytes() ([]byte, error) {
@@ -20889,7 +20889,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsources2iYamlBytes() ([]byte, error) {
@@ -20920,7 +20920,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy
@@ -20958,7 +20958,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
       forcePull: true
 `)
 
@@ -20992,7 +20992,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
     type: Source
 `)
 
@@ -21028,7 +21028,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
     type: Source
 `)
 
@@ -21081,7 +21081,7 @@ objects:
           value: "5"
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
       type: Source
     # this test specifically does a push, to help exercise the code that sets
     # environment variables on build pods (i.e., by having a source secret and
@@ -21150,13 +21150,13 @@ items:
       git:
         uri: https://github.com/sclorg/django-ex.git
         ref: refs/pull/121/head
-      dockerfile: FROM centos/python-36-centos7
+      dockerfile: FROM registry.redhat.io/ubi8/python-36:latest
     strategy:
       type: Docker
       dockerStrategy:
         from:
           kind: DockerImage
-          name: centos/python-36-centos7
+          name: registry.redhat.io/ubi8/python-36:latest
     output:
       to:
         kind: ImageStreamTag
@@ -21260,7 +21260,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
       type: Source
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -21278,7 +21278,7 @@ items:
           value: "5"
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
       type: Source
 `)
 
@@ -21407,7 +21407,7 @@ items:
           value: 127.0.0.1:3128
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -21429,7 +21429,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -21456,7 +21456,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -21503,7 +21503,7 @@ var _testExtendedTestdataBuildsTestBuildRevisionJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/openshift/test-build-simples2i:latest"
+              "name": "quay.io/redhat-developer/test-build-simples2i:latest"
             }
           }
         },
@@ -21582,7 +21582,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
   status:
     lastVersion: 0
@@ -21611,7 +21611,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
   status:
     lastVersion: 0
@@ -21639,7 +21639,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
   status:
     lastVersion: 0
@@ -21668,7 +21668,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
   status:
     lastVersion: 0
@@ -21696,7 +21696,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -21722,7 +21722,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/busybox:latest
+          name: quay.io/quay/busybox:latest
     resources: {}
     postCommit: {}
     nodeSelector: 
@@ -21748,7 +21748,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/busybox:latest
+          name: quay.io/quay/busybox:latest
         buildArgs:
         - name: foo
           value: default
@@ -21949,14 +21949,14 @@ var _testExtendedTestdataBuildsTestCdsSourcebuildJson = []byte(`{
         "triggers": [],
         "source":{
           "type":"Dockerfile",
-          "dockerfile":"FROM centos:7\nRUN sleep 10m"
+          "dockerfile":"FROM quay.io/fedora/fedora:34-x86_64 \nRUN sleep 10m"
         },
         "strategy": {
           "type": "Source",
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/busybox:latest"
+              "name": "quay.io/quay/busybox:latest"
             }
           }
         }
@@ -22025,7 +22025,7 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
           "git": {
             "uri":"https://github.com/sclorg/s2i-ruby-container"
           },
-          "contextDir": "2.3/test/puma-test-app"
+          "contextDir": "2.5/test/puma-test-app"
         },
         "strategy": {
           "type": "Source",
@@ -22038,7 +22038,7 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-23-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             }
           }
         },
@@ -22240,14 +22240,14 @@ var _testExtendedTestdataBuildsTestDockerBuildPullsecretJson = []byte(`{
     },
     "spec": {
       "source": {
-        "dockerfile": "FROM docker.io/busybox:latest"
+        "dockerfile": "FROM quay.io/quay/busybox:latest"
       },
       "strategy": {
         "type": "Docker",
         "dockerStrategy": {
           "from": {
             "kind": "DockerImage",
-            "name": "docker.io/busybox:latest"
+            "name": "quay.io/quay/busybox:latest"
           }
         }
       },
@@ -22270,7 +22270,7 @@ var _testExtendedTestdataBuildsTestDockerBuildPullsecretJson = []byte(`{
     },
     "spec": {
       "source": {
-        "dockerfile": "FROM docker.io/busybox:latest"
+        "dockerfile": "FROM quay.io/quay/busybox:latest"
       },
       "strategy": {
         "type": "Docker",
@@ -22324,7 +22324,7 @@ var _testExtendedTestdataBuildsTestDockerBuildJson = []byte(`{
       "dockerStrategy":{
         "from":{
           "kind":"DockerImage",
-          "name":"docker.io/busybox:latest"
+          "name":"quay.io/quay/busybox:latest"
         }
       }
     },
@@ -22380,7 +22380,7 @@ var _testExtendedTestdataBuildsTestDockerNoOutputnameJson = []byte(`{
     "triggers": [],
     "source": {
       "type": "Git",
-      "dockerfile": "FROM docker.io/busybox:latest"
+      "dockerfile": "FROM quay.io/quay/busybox:latest"
     },
     "strategy": {
       "type": "Docker",
@@ -22393,7 +22393,7 @@ var _testExtendedTestdataBuildsTestDockerNoOutputnameJson = []byte(`{
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/busybox:latest"
+          "name": "quay.io/quay/busybox:latest"
         }
       }
     }
@@ -22434,7 +22434,7 @@ var _testExtendedTestdataBuildsTestEnvBuildJson = []byte(`{
       "sourceStrategy":{
         "from":{
           "kind":"DockerImage",
-          "name":"centos/ruby-25-centos7"
+          "name":"registry.redhat.io/rhscl/ruby-25-rhel7:latest"
         }
       }
     },
@@ -22475,7 +22475,7 @@ items:
     - name: latest
       from:
         kind: DockerImage
-        name: centos/nodejs-6-centos7:latest
+        name: registry.redhat.io/ubi8/nodejs-12:latest
 
 - kind: BuildConfig
   apiVersion: v1
@@ -22949,7 +22949,7 @@ var _testExtendedTestdataBuildsTestNosrcBuildJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/openshift/test-build-simples2i:latest"
+              "name": "quay.io/redhat-developer/test-build-simples2i:latest"
             }
           }
         }
@@ -23001,7 +23001,7 @@ var _testExtendedTestdataBuildsTestS2iBuildQuotaJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind":"DockerImage",
-          "name":"docker.io/openshift/test-build-simples2i:latest"
+          "name":"quay.io/redhat-developer/test-build-simples2i:latest"
         },
         "env": [
           {
@@ -23058,7 +23058,7 @@ var _testExtendedTestdataBuildsTestS2iBuildJson = []byte(`{
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/test-build-simples2i:latest"
+          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
         }
       }
     },
@@ -23129,7 +23129,7 @@ var _testExtendedTestdataBuildsTestS2iNoOutputnameJson = []byte(`{
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/test-build-simples2i:latest"
+          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
         }
       }
     }
@@ -23275,7 +23275,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
       env:
         - name: BUILD_LOGLEVEL
           value: "5"
@@ -23411,7 +23411,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
       env:
         - name: BUILD_LOGLEVEL
           value: "5"
@@ -49499,7 +49499,7 @@ spec:
     dockerStrategy:
       from:
         kind: "DockerImage"
-        name: "fedora:23"
+        name: "quay.io/fedora/fedora:34-x86_64"
   output:
     to:
       kind: "ImageStreamTag"
@@ -50555,7 +50555,7 @@ var _testExtendedTestdataImageTestImageJson = []byte(`{
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "openshift/ruby-19-centos:latest",
+  "dockerImageReference": "registry.redhat.io/rhscl/ruby-25-rhel7:latest",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",
@@ -51039,7 +51039,7 @@ spec:
   tags:
   - from:
       kind: DockerImage
-      name: docker.io/openshift/jenkins-slave-maven-centos7:latest
+      name: quay.io/openshift/origin-jenkins-agent-maven:latest
     name: base
   - annotations:
       role: jenkins-slave
@@ -51911,7 +51911,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             }
           }
         ]
@@ -51929,7 +51929,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             }
           }
         ]
@@ -51947,7 +51947,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             }
           }
         ]
@@ -53271,7 +53271,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "centos/ruby-25-centos7"
+                            "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
                         }
                     }
                 }
@@ -53300,7 +53300,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "centos/ruby-25-centos7"
+                            "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
                         }
                     }
                 }
@@ -56489,7 +56489,7 @@ var _testExtendedTestdataRun_policyParallelBcYaml = []byte(`---
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-25-centos7"
+              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
         resources: {}
       status: 
         lastVersion: 0
@@ -56536,7 +56536,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-25-centos7"
+              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
     - 
       kind: "BuildConfig"
       apiVersion: "v1"
@@ -56557,7 +56557,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-25-centos7"
+              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
 `)
 
 func testExtendedTestdataRun_policySerialBcYamlBytes() ([]byte, error) {
@@ -56600,7 +56600,7 @@ var _testExtendedTestdataRun_policySerialLatestOnlyBcYaml = []byte(`---
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-25-centos7"
+              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
         resources: {}
       status: 
         lastVersion: 0
@@ -56911,7 +56911,7 @@ items:
       - type: ConfigChange
     source:
       dockerfile: |
-        FROM openshift/origin-control-plane:latest
+        FROM quay.io/openshift/origin-control-plane:latest
         RUN yum-config-manager --disable origin-local-release ||:
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
@@ -56932,7 +56932,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: openshift/origin-control-plane:latest
+          name: quay.io/openshift/origin-control-plane:latest
     output:
       to:
         kind: ImageStreamTag
@@ -57870,7 +57870,7 @@ objects:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
     output:
       to:
         kind: ImageStreamTag
@@ -58845,7 +58845,7 @@ var _testIntegrationTestdataTestBuildcliJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "incremental": true
           }
@@ -58887,7 +58887,7 @@ var _testIntegrationTestdataTestBuildcliJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "incremental": true
           }

--- a/test/extended/testdata/builds/build-postcommit/sti.yaml
+++ b/test/extended/testdata/builds/build-postcommit/sti.yaml
@@ -20,7 +20,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
     resources: {}
     postCommit: {}
     nodeSelector: null

--- a/test/extended/testdata/builds/build-secrets/test-docker-build.json
+++ b/test/extended/testdata/builds/build-secrets/test-docker-build.json
@@ -44,7 +44,7 @@
       "dockerStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/busybox:latest"
+          "name": "quay.io/quay/busybox:latest"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/build-secrets/test-s2i-build.json
+++ b/test/extended/testdata/builds/build-secrets/test-s2i-build.json
@@ -45,7 +45,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/ruby-25-centos7"
+          "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/build-timing/test-docker-build.json
+++ b/test/extended/testdata/builds/build-timing/test-docker-build.json
@@ -19,7 +19,7 @@
         "forcePull": true,
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/busybox:latest"
+          "name": "quay.io/quay/busybox:latest"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/build-timing/test-s2i-build.json
+++ b/test/extended/testdata/builds/build-timing/test-s2i-build.json
@@ -18,7 +18,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/test-build-simples2i:latest"
+          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/incremental-auth-build.json
+++ b/test/extended/testdata/builds/incremental-auth-build.json
@@ -48,7 +48,7 @@
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "incremental": true
           }

--- a/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
+++ b/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
@@ -12,4 +12,4 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest

--- a/test/extended/testdata/builds/statusfail-failedassemble.yaml
+++ b/test/extended/testdata/builds/statusfail-failedassemble.yaml
@@ -10,4 +10,4 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest

--- a/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
@@ -19,4 +19,4 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest

--- a/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
@@ -11,4 +11,4 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest

--- a/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
@@ -11,4 +11,4 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest

--- a/test/extended/testdata/builds/statusfail-genericreason.yaml
+++ b/test/extended/testdata/builds/statusfail-genericreason.yaml
@@ -11,7 +11,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy

--- a/test/extended/testdata/builds/statusfail-oomkilled.yaml
+++ b/test/extended/testdata/builds/statusfail-oomkilled.yaml
@@ -14,5 +14,5 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
       forcePull: true

--- a/test/extended/testdata/builds/statusfail-postcommithook.yaml
+++ b/test/extended/testdata/builds/statusfail-postcommithook.yaml
@@ -13,5 +13,5 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
     type: Source

--- a/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
+++ b/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
@@ -15,5 +15,5 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
     type: Source

--- a/test/extended/testdata/builds/test-auth-build.yaml
+++ b/test/extended/testdata/builds/test-auth-build.yaml
@@ -32,7 +32,7 @@ objects:
           value: "5"
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
       type: Source
     # this test specifically does a push, to help exercise the code that sets
     # environment variables on build pods (i.e., by having a source secret and

--- a/test/extended/testdata/builds/test-bc-with-pr-ref.yaml
+++ b/test/extended/testdata/builds/test-bc-with-pr-ref.yaml
@@ -40,13 +40,13 @@ items:
       git:
         uri: https://github.com/sclorg/django-ex.git
         ref: refs/pull/121/head
-      dockerfile: FROM centos/python-36-centos7
+      dockerfile: FROM registry.redhat.io/ubi8/python-36:latest
     strategy:
       type: Docker
       dockerStrategy:
         from:
           kind: DockerImage
-          name: centos/python-36-centos7
+          name: registry.redhat.io/ubi8/python-36:latest
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/builds/test-build-cluster-config.yaml
+++ b/test/extended/testdata/builds/test-build-cluster-config.yaml
@@ -15,7 +15,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
       type: Source
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -33,5 +33,5 @@ items:
           value: "5"
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
       type: Source

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -35,7 +35,7 @@ items:
           value: 127.0.0.1:3128
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -57,7 +57,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -84,7 +84,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com

--- a/test/extended/testdata/builds/test-build-revision.json
+++ b/test/extended/testdata/builds/test-build-revision.json
@@ -22,7 +22,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/openshift/test-build-simples2i:latest"
+              "name": "quay.io/redhat-developer/test-build-simples2i:latest"
             }
           }
         },

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -48,7 +48,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
   status:
     lastVersion: 0
@@ -77,7 +77,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
   status:
     lastVersion: 0
@@ -105,7 +105,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
   status:
     lastVersion: 0
@@ -134,7 +134,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
   status:
     lastVersion: 0
@@ -162,7 +162,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-25-centos7
+          name: registry.redhat.io/rhscl/ruby-25-rhel7:latest
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -188,7 +188,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/busybox:latest
+          name: quay.io/quay/busybox:latest
     resources: {}
     postCommit: {}
     nodeSelector: 
@@ -214,7 +214,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/busybox:latest
+          name: quay.io/quay/busybox:latest
         buildArgs:
         - name: foo
           value: default

--- a/test/extended/testdata/builds/test-cds-sourcebuild.json
+++ b/test/extended/testdata/builds/test-cds-sourcebuild.json
@@ -25,14 +25,14 @@
         "triggers": [],
         "source":{
           "type":"Dockerfile",
-          "dockerfile":"FROM centos:7\nRUN sleep 10m"
+          "dockerfile":"FROM quay.io/fedora/fedora:34-x86_64 \nRUN sleep 10m"
         },
         "strategy": {
           "type": "Source",
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/busybox:latest"
+              "name": "quay.io/quay/busybox:latest"
             }
           }
         }

--- a/test/extended/testdata/builds/test-context-build.json
+++ b/test/extended/testdata/builds/test-context-build.json
@@ -42,7 +42,7 @@
           "git": {
             "uri":"https://github.com/sclorg/s2i-ruby-container"
           },
-          "contextDir": "2.3/test/puma-test-app"
+          "contextDir": "2.5/test/puma-test-app"
         },
         "strategy": {
           "type": "Source",
@@ -55,7 +55,7 @@
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-23-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             }
           }
         },

--- a/test/extended/testdata/builds/test-docker-build-pullsecret.json
+++ b/test/extended/testdata/builds/test-docker-build-pullsecret.json
@@ -25,14 +25,14 @@
     },
     "spec": {
       "source": {
-        "dockerfile": "FROM docker.io/busybox:latest"
+        "dockerfile": "FROM quay.io/quay/busybox:latest"
       },
       "strategy": {
         "type": "Docker",
         "dockerStrategy": {
           "from": {
             "kind": "DockerImage",
-            "name": "docker.io/busybox:latest"
+            "name": "quay.io/quay/busybox:latest"
           }
         }
       },
@@ -55,7 +55,7 @@
     },
     "spec": {
       "source": {
-        "dockerfile": "FROM docker.io/busybox:latest"
+        "dockerfile": "FROM quay.io/quay/busybox:latest"
       },
       "strategy": {
         "type": "Docker",

--- a/test/extended/testdata/builds/test-docker-build.json
+++ b/test/extended/testdata/builds/test-docker-build.json
@@ -20,7 +20,7 @@
       "dockerStrategy":{
         "from":{
           "kind":"DockerImage",
-          "name":"docker.io/busybox:latest"
+          "name":"quay.io/quay/busybox:latest"
         }
       }
     },

--- a/test/extended/testdata/builds/test-docker-no-outputname.json
+++ b/test/extended/testdata/builds/test-docker-no-outputname.json
@@ -11,7 +11,7 @@
     "triggers": [],
     "source": {
       "type": "Git",
-      "dockerfile": "FROM docker.io/busybox:latest"
+      "dockerfile": "FROM quay.io/quay/busybox:latest"
     },
     "strategy": {
       "type": "Docker",
@@ -24,7 +24,7 @@
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/busybox:latest"
+          "name": "quay.io/quay/busybox:latest"
         }
       }
     }

--- a/test/extended/testdata/builds/test-env-build.json
+++ b/test/extended/testdata/builds/test-env-build.json
@@ -17,7 +17,7 @@
       "sourceStrategy":{
         "from":{
           "kind":"DockerImage",
-          "name":"centos/ruby-25-centos7"
+          "name":"registry.redhat.io/rhscl/ruby-25-rhel7:latest"
         }
       }
     },

--- a/test/extended/testdata/builds/test-imagechangetriggers.yaml
+++ b/test/extended/testdata/builds/test-imagechangetriggers.yaml
@@ -10,7 +10,7 @@ items:
     - name: latest
       from:
         kind: DockerImage
-        name: centos/nodejs-6-centos7:latest
+        name: registry.redhat.io/ubi8/nodejs-12:latest
 
 - kind: BuildConfig
   apiVersion: v1

--- a/test/extended/testdata/builds/test-nosrc-build.json
+++ b/test/extended/testdata/builds/test-nosrc-build.json
@@ -32,7 +32,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/openshift/test-build-simples2i:latest"
+              "name": "quay.io/redhat-developer/test-build-simples2i:latest"
             }
           }
         }

--- a/test/extended/testdata/builds/test-s2i-build-quota.json
+++ b/test/extended/testdata/builds/test-s2i-build-quota.json
@@ -25,7 +25,7 @@
       "sourceStrategy": {
         "from": {
           "kind":"DockerImage",
-          "name":"docker.io/openshift/test-build-simples2i:latest"
+          "name":"quay.io/redhat-developer/test-build-simples2i:latest"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/test-s2i-build.json
+++ b/test/extended/testdata/builds/test-s2i-build.json
@@ -26,7 +26,7 @@
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/test-build-simples2i:latest"
+          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
         }
       }
     },

--- a/test/extended/testdata/builds/test-s2i-no-outputname.json
+++ b/test/extended/testdata/builds/test-s2i-no-outputname.json
@@ -26,7 +26,7 @@
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/test-build-simples2i:latest"
+          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
         }
       }
     }

--- a/test/extended/testdata/builds/valuefrom/failed-sti-build-value-from-config.yaml
+++ b/test/extended/testdata/builds/valuefrom/failed-sti-build-value-from-config.yaml
@@ -16,7 +16,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
       env:
         - name: BUILD_LOGLEVEL
           value: "5"

--- a/test/extended/testdata/builds/valuefrom/successful-sti-build-value-from-config.yaml
+++ b/test/extended/testdata/builds/valuefrom/successful-sti-build-value-from-config.yaml
@@ -16,7 +16,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: docker.io/openshift/test-build-simples2i:latest
+        name: quay.io/redhat-developer/test-build-simples2i:latest
       env:
         - name: BUILD_LOGLEVEL
           value: "5"

--- a/test/extended/testdata/gssapi/proxy/gssapiproxy-buildconfig.yaml
+++ b/test/extended/testdata/gssapi/proxy/gssapiproxy-buildconfig.yaml
@@ -18,7 +18,7 @@ spec:
     dockerStrategy:
       from:
         kind: "DockerImage"
-        name: "fedora:23"
+        name: "quay.io/fedora/fedora:34-x86_64"
   output:
     to:
       kind: "ImageStreamTag"

--- a/test/extended/testdata/image/test-image.json
+++ b/test/extended/testdata/image/test-image.json
@@ -5,7 +5,7 @@
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "openshift/ruby-19-centos:latest",
+  "dockerImageReference": "registry.redhat.io/rhscl/ruby-25-rhel7:latest",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",

--- a/test/extended/testdata/imagestreamtag-jenkins-slave-pods.yaml
+++ b/test/extended/testdata/imagestreamtag-jenkins-slave-pods.yaml
@@ -6,7 +6,7 @@ spec:
   tags:
   - from:
       kind: DockerImage
-      name: docker.io/openshift/jenkins-slave-maven-centos7:latest
+      name: quay.io/openshift/origin-jenkins-agent-maven:latest
     name: base
   - annotations:
       role: jenkins-slave

--- a/test/extended/testdata/jenkins-plugin/multitag-template.json
+++ b/test/extended/testdata/jenkins-plugin/multitag-template.json
@@ -18,7 +18,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             }
           }
         ]
@@ -36,7 +36,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             }
           }
         ]
@@ -54,7 +54,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             }
           }
         ]

--- a/test/extended/testdata/long_names/fixture.json
+++ b/test/extended/testdata/long_names/fixture.json
@@ -26,7 +26,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "centos/ruby-25-centos7"
+                            "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
                         }
                     }
                 }
@@ -55,7 +55,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "centos/ruby-25-centos7"
+                            "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
                         }
                     }
                 }

--- a/test/extended/testdata/run_policy/parallel-bc.yaml
+++ b/test/extended/testdata/run_policy/parallel-bc.yaml
@@ -32,7 +32,7 @@
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-25-centos7"
+              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
         resources: {}
       status: 
         lastVersion: 0

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-25-centos7"
+              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
     - 
       kind: "BuildConfig"
       apiVersion: "v1"
@@ -44,4 +44,4 @@
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-25-centos7"
+              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"

--- a/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-25-centos7"
+              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
         resources: {}
       status: 
         lastVersion: 0

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -16,7 +16,7 @@ items:
       - type: ConfigChange
     source:
       dockerfile: |
-        FROM openshift/origin-control-plane:latest
+        FROM quay.io/openshift/origin-control-plane:latest
         RUN yum-config-manager --disable origin-local-release ||:
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
@@ -37,7 +37,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: openshift/origin-control-plane:latest
+          name: quay.io/openshift/origin-control-plane:latest
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/templates/templateinstance_readiness.yaml
+++ b/test/extended/testdata/templates/templateinstance_readiness.yaml
@@ -49,7 +49,7 @@ objects:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: docker.io/openshift/test-build-simples2i:latest
+          name: quay.io/redhat-developer/test-build-simples2i:latest
     output:
       to:
         kind: ImageStreamTag

--- a/test/integration/testdata/test-buildcli.json
+++ b/test/integration/testdata/test-buildcli.json
@@ -47,7 +47,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "incremental": true
           }
@@ -89,7 +89,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "incremental": true
           }


### PR DESCRIPTION
@openshift/openshift-team-build-api FYI

@sbose78 this PR currently assumes we can push `docker.io/openshift/test-build-simples2i:latest` to `quay.io/redhat-developer/test-build-simples2i:latest`

/assign @adambkaplan 