### PR TITLE
Report API server unavailability in e2e tests

### DIFF
--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -24,6 +24,15 @@ import (
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 )
 
+const (
+	LocatorKubeAPIServerNewConnection         = "kube-apiserver-new-connection"
+	LocatorOpenshiftAPIServerNewConnection    = "openshift-apiserver-new-connection"
+	LocatorOAuthAPIServerNewConnection        = "oauth-apiserver-new-connection"
+	LocatorKubeAPIServerReusedConnection      = "kube-apiserver-reused-connection"
+	LocatorOpenshiftAPIServerReusedConnection = "openshift-apiserver-reused-connection"
+	LocatorOAuthAPIServerReusedConnection     = "oauth-apiserver-reused-connection"
+)
+
 // Start begins monitoring the cluster referenced by the default kube configuration until
 // context is finished.
 func Start(ctx context.Context) (*Monitor, error) {
@@ -166,32 +175,32 @@ func startServerMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.
 
 func StartKubeAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
 	// default gets auto-created, so this should always exist
-	return StartServerMonitoringWithNewConnections(ctx, m, clusterConfig, timeout, "kube-apiserver-new-connection", "/api/v1/namespaces/default")
+	return StartServerMonitoringWithNewConnections(ctx, m, clusterConfig, timeout, LocatorKubeAPIServerNewConnection, "/api/v1/namespaces/default")
 }
 
 func StartOpenShiftAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
 	// this request should never 404, but should be empty/small
-	return StartServerMonitoringWithNewConnections(ctx, m, clusterConfig, timeout, "openshift-apiserver-new-connection", "/apis/image.openshift.io/v1/namespaces/default/imagestreams")
+	return StartServerMonitoringWithNewConnections(ctx, m, clusterConfig, timeout, LocatorOpenshiftAPIServerNewConnection, "/apis/image.openshift.io/v1/namespaces/default/imagestreams")
 }
 
 func StartOAuthAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
 	// this should be relatively small and should not ever 404
-	return StartServerMonitoringWithNewConnections(ctx, m, clusterConfig, timeout, "oauth-apiserver-new-connection", "/apis/oauth.openshift.io/v1/oauthclients")
+	return StartServerMonitoringWithNewConnections(ctx, m, clusterConfig, timeout, LocatorOAuthAPIServerNewConnection, "/apis/oauth.openshift.io/v1/oauthclients")
 }
 
 func StartKubeAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
 	// default gets auto-created, so this should always exist
-	return StartServerMonitoringWithConnectionReuse(ctx, m, clusterConfig, timeout, "kube-apiserver-reuse-connection", "/api/v1/namespaces/default")
+	return StartServerMonitoringWithConnectionReuse(ctx, m, clusterConfig, timeout, LocatorKubeAPIServerReusedConnection, "/api/v1/namespaces/default")
 }
 
 func StartOpenShiftAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
 	// this request should never 404, but should be empty/small
-	return StartServerMonitoringWithConnectionReuse(ctx, m, clusterConfig, timeout, "openshift-apiserver-reuse-connection", "/apis/image.openshift.io/v1/namespaces/default/imagestreams")
+	return StartServerMonitoringWithConnectionReuse(ctx, m, clusterConfig, timeout, LocatorOpenshiftAPIServerReusedConnection, "/apis/image.openshift.io/v1/namespaces/default/imagestreams")
 }
 
 func StartOAuthAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config, timeout time.Duration) error {
 	// this should be relatively small and should not ever 404
-	return StartServerMonitoringWithConnectionReuse(ctx, m, clusterConfig, timeout, "oauth-apiserver-reuse-connection", "/apis/oauth.openshift.io/v1/oauthclients")
+	return StartServerMonitoringWithConnectionReuse(ctx, m, clusterConfig, timeout, LocatorOAuthAPIServerReusedConnection, "/apis/oauth.openshift.io/v1/oauthclients")
 }
 
 func findContainerStatus(status []corev1.ContainerStatus, name string, position int) *corev1.ContainerStatus {

--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -27,7 +27,7 @@ import (
 // Start begins monitoring the cluster referenced by the default kube configuration until
 // context is finished.
 func Start(ctx context.Context) (*Monitor, error) {
-	m := NewMonitor()
+	m := NewMonitorWithInterval(time.Second)
 	cfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
 	clusterConfig, err := cfg.ClientConfig()
 	if err != nil {

--- a/pkg/monitor/sampler.go
+++ b/pkg/monitor/sampler.go
@@ -24,17 +24,18 @@ func StartSampling(ctx context.Context, recorder Recorder, interval time.Duratio
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				return
-			}
 			success := s.isAvailable()
 			condition, ok := sampleFn(success)
 			if condition != nil {
 				recorder.Record(*condition)
 			}
 			s.setAvailable(ok)
+
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -114,10 +114,14 @@ func testServerAvailability(locator string, events []*monitor.EventInterval, dur
 	errDuration, errMessages := disruption.GetDisruption(events, locator)
 
 	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)
-	successTest := &JUnitTestCase{Name: testName}
+	successTest := &JUnitTestCase{
+		Name:     testName,
+		Duration: duration.Seconds(),
+	}
 	if percent := float64(errDuration) / float64(duration); percent > tolerateDisruptionPercent {
 		test := &JUnitTestCase{
-			Name: testName,
+			Name:     testName,
+			Duration: duration.Seconds(),
 			FailureOutput: &FailureOutput{
 				Output: fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Truncate(time.Second), 100*percent),
 			},

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -8,6 +8,12 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/test/extended/util/disruption"
+)
+
+const (
+	// Max. duration of API server unreachability, in fraction of total test duration.
+	tolerateDisruptionPercent = 0.01
 )
 
 func createEventsForTests(tests []*testCase) []*monitor.EventInterval {
@@ -84,8 +90,35 @@ func createSyntheticTestsFromMonitor(m *monitor.Monitor, eventsForTests []*monit
 	syntheticTestResults = append(syntheticTestResults, testPodTransitions(events)...)
 	syntheticTestResults = append(syntheticTestResults, testSystemDTimeout(events)...)
 	syntheticTestResults = append(syntheticTestResults, testPodSandboxCreation(events)...)
+	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorKubeAPIServerNewConnection, events, monitorDuration)...)
+	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOpenshiftAPIServerNewConnection, events, monitorDuration)...)
+	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOAuthAPIServerNewConnection, events, monitorDuration)...)
+	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorKubeAPIServerReusedConnection, events, monitorDuration)...)
+	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOpenshiftAPIServerReusedConnection, events, monitorDuration)...)
+	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOAuthAPIServerReusedConnection, events, monitorDuration)...)
 
 	return syntheticTestResults, buf, errBuf
+}
+
+func testServerAvailability(locator string, events []*monitor.EventInterval, duration time.Duration) []*JUnitTestCase {
+	errDuration, errMessages := disruption.GetDisruption(events, locator)
+
+	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)
+	successTest := &JUnitTestCase{Name: testName}
+	if percent := float64(errDuration) / float64(duration); percent > tolerateDisruptionPercent {
+		test := &JUnitTestCase{
+			Name: testName,
+			FailureOutput: &FailureOutput{
+				Output: fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Truncate(time.Second), 100*percent),
+			},
+			SystemOut: strings.Join(errMessages, "\n"),
+		}
+		// Return *two* tests results to pretend this is a flake not to fail whole testsuite.
+		return []*JUnitTestCase{test, successTest}
+	} else {
+		successTest.SystemOut = fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Truncate(time.Second), 100*percent)
+		return []*JUnitTestCase{successTest}
+	}
 }
 
 func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) []*JUnitTestCase {

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -97,6 +97,16 @@ func createSyntheticTestsFromMonitor(m *monitor.Monitor, eventsForTests []*monit
 	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOpenshiftAPIServerReusedConnection, events, monitorDuration)...)
 	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOAuthAPIServerReusedConnection, events, monitorDuration)...)
 
+	fmt.Fprintln(buf, "Synthetic test results:")
+	for _, test := range syntheticTestResults {
+		status := "passed"
+		if test.FailureOutput != nil {
+			status = "failed"
+		}
+		fmt.Fprintf(buf, "%s: %s\n", status, test.Name)
+	}
+	fmt.Fprintln(buf, "(duplicates are used to mark some failures as flake and not to fail the whole suite")
+	fmt.Fprintln(buf)
 	return syntheticTestResults, buf, errBuf
 }
 


### PR DESCRIPTION
Currently, API server availabilities are tracked under `[sig-arch] Monitor cluster while tests execute`. Create a separate test for them when the API servers are unreachable more than 1% of the test time.

In addition:
* Print status of synthetic tests to stdout for better debug-ability of these test.
* Change monitor interval to 1s to be able to detect outages shorter than 15s.

~WIP: the third commit actually injects some fake errors to see how it works in prow.~