### PR TITLE
tests/extended/OWNERS: add ashcrow to approvers

### DIFF
--- a/test/extended/OWNERS
+++ b/test/extended/OWNERS
@@ -9,6 +9,7 @@ reviewers:
   - adambkaplan
 approvers:
   - smarterclayton
+  - ashcrow
   - bparees
   - mfojtik
   - knobunc


### PR DESCRIPTION
As pillar lead for MCO/CoreOS - we will likely do more
tests here and so should have an approver.