### PR TITLE
Bug 1886620: deflake e2e test "Application behind service load balancer with PDB is not disrupted "

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"strconv"
@@ -16,10 +17,8 @@ import (
 	"github.com/openshift/origin/test/extended/util/disruption"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
@@ -172,10 +171,9 @@ func (t *UpgradeTest) Teardown(f *framework.Framework) {
 func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Service, r events.EventRecorder) error {
 	tcpIngressIP := service.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 	svcPort := int(svc.Spec.Ports[0].Port)
-
+	url := fmt.Sprintf("http://%s/echo?msg=Hello", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort)))
 	// this client reuses connections and detects abrupt breaks
-	continuousClient, err := rest.UnversionedRESTClientFor(&rest.Config{
-		Host:    fmt.Sprintf("http://%s", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort))),
+	continuousClient := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
 			Dial: (&net.Dialer{
@@ -183,18 +181,17 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 			}).Dial,
 			TLSHandshakeTimeout: 15 * time.Second,
 		},
-		ContentConfig: rest.ContentConfig{
-			NegotiatedSerializer: runtime.NewSimpleNegotiatedSerializer(scheme.Codecs.SupportedMediaTypes()[0]),
-		},
-	})
-	if err != nil {
-		return err
 	}
+
 	m.AddSampler(
 		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
-			data, err := continuousClient.Get().AbsPath("echo").Param("msg", "Hello").DoRaw(ctx)
-			if err == nil && !bytes.Contains(data, []byte("Hello")) {
-				err = fmt.Errorf("service returned success but did not contain the correct body contents: %q", string(data))
+			resp, err := continuousClient.Get(url)
+			if err == nil {
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				if err == nil && !bytes.Contains(body, []byte("Hello")) {
+					err = fmt.Errorf("service returned success but did not contain the correct body contents: %q", string(body))
+				}
 			}
 			switch {
 			case err == nil && !previous:
@@ -223,8 +220,7 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 	)
 
 	// this client creates fresh connections and detects failure to establish connections
-	client, err := rest.UnversionedRESTClientFor(&rest.Config{
-		Host:    fmt.Sprintf("http://%s", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort))),
+	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
 			Dial: (&net.Dialer{
@@ -235,18 +231,16 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 			IdleConnTimeout:     15 * time.Second,
 			DisableKeepAlives:   true,
 		},
-		ContentConfig: rest.ContentConfig{
-			NegotiatedSerializer: runtime.NewSimpleNegotiatedSerializer(scheme.Codecs.SupportedMediaTypes()[0]),
-		},
-	})
-	if err != nil {
-		return err
 	}
 	m.AddSampler(
 		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
-			data, err := client.Get().AbsPath("echo").Param("msg", "Hello").DoRaw(ctx)
-			if err == nil && !bytes.Contains(data, []byte("Hello")) {
-				err = fmt.Errorf("service returned success but did not contain the correct body contents: %q", string(data))
+			resp, err := client.Get(url)
+			if err == nil {
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				if err == nil && !bytes.Contains(body, []byte("Hello")) {
+					err = fmt.Errorf("service returned success but did not contain the correct body contents: %q", string(body))
+				}
 			}
 			switch {
 			case err == nil && !previous:


### PR DESCRIPTION
The test "Application behind service load balancer with PDB is not disrupted" basically does the following:

- Creates an app using PDB with 2 pods exposing an app that echoes the request
- Exposes the app using a Service Type LoadBalancer (using externalTrafficPolicy=Local)
- Monitors the application during the upgrade performing GET request to the exposed endpoint and checking that the answer is correct.

To monitor the application there are 2 "threads":
- one that reuses the TCP connection to perform the checks
- other that creates a new TCP connection every time

Previously the test was using the Service with `externalTrafficPolicy=Cluster`, that means that the Cloud Provider LB can forward the traffic to any node, and it is possible that it has to do double hops and NAT inside the cluster. After switching to externalTrafficPolicy=Local it was noticed a big improvement.

The test "service load balancer with PDB is not disrupted during upgrade" is using client-go `UnversionedRESTClientFor()`  for testing the Service under test. Since the application is very simple we don't need all the overhead (it adds headers and more bytes to the requests) and this dependency, that may affect the test without us noticing (i.e it has a rate limiter, I think that is disabled by default but if this changes :shrug: )

The results is that the test went through 5/5 times https://github.com/openshift/origin/pull/25606#issuecomment-709400855

However, there is still a problem, and is that I observed there is always some disruption for NEW connections
```
ct 15 14:27:26.639 I ns/e2e-k8s-service-lb-available-9540 svc/service-test Service started responding to GET requests over new connections
Oct 15 14:30:10.431 E ns/e2e-k8s-service-lb-available-9540 svc/service-test Service stopped responding to GET requests over new connections
```
I've tried to increase the sample to monitor every 3 seconds but still shows errors, however this does not show up in the monitor that reuses the connection.

Since this improves the test, let's merge and iterate.

Signed-off-by: Antonio Ojea <aojea@redhat.com>