### PR TITLE
hello-openshift: Echo listening port in HTTP responses via headers

### DIFF
--- a/examples/hello-openshift/hello_openshift.go
+++ b/examples/hello-openshift/hello_openshift.go
@@ -2,14 +2,23 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 )
 
 func helloHandler(w http.ResponseWriter, r *http.Request) {
 	response := os.Getenv("RESPONSE")
 	if len(response) == 0 {
 		response = "Hello OpenShift!"
+	}
+
+	// Echo back the port the request was received on
+	// via a "request-port" header.
+	addr := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
+	if tcpAddr, ok := addr.(*net.TCPAddr); ok {
+		w.Header().Set("request-port", strconv.Itoa(tcpAddr.Port))
 	}
 
 	fmt.Fprintln(w, response)


### PR DESCRIPTION
Set the "request-port" header on hello-openshift HTTP responses so that clients reaching the hello-openshift application know which port the HTTP listener was accessed on. This will be useful for the Ingress Operator fault detection work. See https://github.com/openshift/enhancements/pull/438 and https://issues.redhat.com/browse/NE-199 for additional context.