### PR TITLE
handle cases where pod sandboxes fail after pod deletion

### DIFF
--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -168,6 +168,11 @@ func testSystemDTimeout(events []*monitor.EventInterval) []*JUnitTestCase {
 	return []*JUnitTestCase{failure, success}
 }
 
+type testCategorizer struct {
+	by        string
+	substring string
+}
+
 func testPodSandboxCreation(events []*monitor.EventInterval) []*JUnitTestCase {
 	const testName = "[sig-network] pods should successfully create sandboxes"
 	// we can further refine this signal by subdividing different failure modes if it is pertinent.  Right now I'm seeing
@@ -175,10 +180,7 @@ func testPodSandboxCreation(events []*monitor.EventInterval) []*JUnitTestCase {
 	// 2. dial tcp 10.0.76.225:6443: i/o timeout
 	// 3. error getting pod: pods "terminate-cmd-rpofb45fa14c-96bb-40f7-bd9e-346721740cac" not found
 	// 4. write child: broken pipe
-	bySubStrings := []struct {
-		by        string
-		substring string
-	}{
+	bySubStrings := []testCategorizer{
 		{by: " by reading container", substring: "error reading container (probably exited) json message: EOF"},
 		{by: " by not timing out", substring: "i/o timeout"},
 		{by: " by writing network status", substring: "error setting the networks status"},
@@ -187,31 +189,44 @@ func testPodSandboxCreation(events []*monitor.EventInterval) []*JUnitTestCase {
 		{by: " by other", substring: " "}, // always matches
 	}
 
-	successes := []*JUnitTestCase{}
-	for _, by := range bySubStrings {
-		successes = append(successes, &JUnitTestCase{Name: testName + by.by})
-	}
-
 	failures := []string{}
+	flakes := []string{}
+	eventsForPods := getEventsByPod(events)
 	for _, event := range events {
-		if strings.Contains(event.Message, "reason/FailedCreatePodSandBox Failed to create pod sandbox") {
-			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
+		if !strings.Contains(event.Message, "reason/FailedCreatePodSandBox Failed to create pod sandbox") {
+			continue
+		}
+		deletionTime := getPodDeletionTime(eventsForPods[event.Locator], event.Locator)
+		if deletionTime == nil {
+			// this indicates a failure to create the sandbox that should not happen
+			failures = append(failures, fmt.Sprintf("%v - never deleted - %v", event.Locator, event.Message))
+		} else {
+			timeBetweenDeleteAndFailure := event.From.Sub(*deletionTime)
+			switch {
+			case timeBetweenDeleteAndFailure < 1*time.Second:
+				// nothing here, one second is close enough to be ok, the kubelet and CNI just didn't know
+			case timeBetweenDeleteAndFailure < 5*time.Second:
+				// withing five seconds, it ought to be long enough to know, but it's close enough to flake and not fail
+				flakes = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator, timeBetweenDeleteAndFailure.Seconds(), event.Message))
+			case deletionTime.Before(event.From):
+				// something went wrong.  More than five seconds after the pod ws deleted, the CNI is trying to set up pod sandboxes and can't
+				failures = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator, timeBetweenDeleteAndFailure.Seconds(), event.Message))
+			default:
+				// something went wrong.  deletion happend after we had a failure to create the pod sandbox
+				failures = append(failures, fmt.Sprintf("%v - deletion came AFTER sandbox failure - %v", event.Locator, event.Message))
+			}
 		}
 	}
-	if len(failures) == 0 {
+	if len(failures) == 0 && len(flakes) == 0 {
+		successes := []*JUnitTestCase{}
+		for _, by := range bySubStrings {
+			successes = append(successes, &JUnitTestCase{Name: testName + by.by})
+		}
 		return successes
 	}
 
 	ret := []*JUnitTestCase{}
-	failuresBySubtest := map[string][]string{}
-	for _, failure := range failures {
-		for _, by := range bySubStrings {
-			if strings.Contains(failure, by.substring) {
-				failuresBySubtest[by.by] = append(failuresBySubtest[by.by], failure)
-				break // break after first match so we only add each failure one bucket
-			}
-		}
-	}
+	failuresBySubtest, flakesBySubtest := categorizeBySubset(bySubStrings, failures, flakes)
 
 	// now iterate the individual failures to create failure entries
 	for by, subFailures := range failuresBySubtest {
@@ -224,7 +239,79 @@ func testPodSandboxCreation(events []*monitor.EventInterval) []*JUnitTestCase {
 		}
 		ret = append(ret, failure)
 	}
+	for by, subFlakes := range flakesBySubtest {
+		flake := &JUnitTestCase{
+			Name:      testName + by,
+			SystemOut: strings.Join(subFlakes, "\n"),
+			FailureOutput: &FailureOutput{
+				Output: fmt.Sprintf("%d failures to create the sandbox\n\n%v", len(subFlakes), strings.Join(subFlakes, "\n")),
+			},
+		}
+		ret = append(ret, flake)
+		// write a passing test to trigger detection of this issue as a flake. Doing this first to try to see how frequent the issue actually is
+		success := &JUnitTestCase{
+			Name: testName + by,
+		}
+		ret = append(ret, success)
+	}
 
-	// write a passing test to trigger detection of this issue as a flake. Doing this first to try to see how frequent the issue actually is
-	return append(ret, successes...)
+	return append(ret)
+}
+
+// categorizeBySubset returns a map keyed by category for failures and flakes.  If a category is present in both failures and flakes, all are listed under failures.
+func categorizeBySubset(categorizers []testCategorizer, failures, flakes []string) (map[string][]string, map[string][]string) {
+	failuresBySubtest := map[string][]string{}
+	flakesBySubtest := map[string][]string{}
+	for _, failure := range failures {
+		for _, by := range categorizers {
+			if strings.Contains(failure, by.substring) {
+				failuresBySubtest[by.by] = append(failuresBySubtest[by.by], failure)
+				break // break after first match so we only add each failure one bucket
+			}
+		}
+	}
+
+	for _, flake := range flakes {
+		for _, by := range categorizers {
+			if strings.Contains(flake, by.substring) {
+				if _, isFailure := failuresBySubtest[by.by]; isFailure {
+					failuresBySubtest[by.by] = append(failuresBySubtest[by.by], flake)
+				} else {
+					flakesBySubtest[by.by] = append(flakesBySubtest[by.by], flake)
+				}
+				break // break after first match so we only add each failure one bucket
+			}
+		}
+	}
+	return failuresBySubtest, flakesBySubtest
+}
+
+func getPodCreationTime(events []*monitor.EventInterval, podLocator string) *time.Time {
+	for _, event := range events {
+		if event.Locator == podLocator && event.Message == "reason/Created" {
+			return &event.From
+		}
+	}
+	return nil
+}
+
+func getPodDeletionTime(events []*monitor.EventInterval, podLocator string) *time.Time {
+	for _, event := range events {
+		if event.Locator == podLocator && event.Message == "reason/Deleted" {
+			return &event.From
+		}
+	}
+	return nil
+}
+
+// getEventsByPod returns map keyed by pod locator with all events associated with it.
+func getEventsByPod(events []*monitor.EventInterval) map[string][]*monitor.EventInterval {
+	eventsByPods := map[string][]*monitor.EventInterval{}
+	for _, event := range events {
+		if !strings.Contains(event.Locator, "pod/") {
+			continue
+		}
+		eventsByPods[event.Locator] = append(eventsByPods[event.Locator], event)
+	}
+	return eventsByPods
 }


### PR DESCRIPTION
1. if pod sandbox creation fails before deletion, fail.
2. if pod sandbox creation fails within one second of deletion, allow grace.
3. if pod sandbox creation fails within five seconds of deletion, flake
4. if pod sandbox creation fails more than five seconds after deletion, fail.



