### PR TITLE
[release-3.11] Bug 1889868: Clean up 3.11.z build tests

### DIFF
--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -111,6 +111,7 @@ func makeBuild() *buildapiv1.Build {
 }
 
 func TestDockerBuildError(t *testing.T) {
+	t.Skipf("Bug 1889868: skipping test requiring access to a docker socket")
 	expErr := errors.New("Artificial exception: Error building")
 	s2iBuilder := newTestS2IBuilder(testS2IBuilderConfig{
 		buildError: expErr,
@@ -121,6 +122,7 @@ func TestDockerBuildError(t *testing.T) {
 }
 
 func TestPushError(t *testing.T) {
+	t.Skipf("Bug 1889868: skipping test requiring access to a docker socket")
 	expErr := errors.New("Artificial exception: Error pushing image")
 	s2iBuilder := newTestS2IBuilder(testS2IBuilderConfig{
 		errPushImage: expErr,
@@ -131,6 +133,7 @@ func TestPushError(t *testing.T) {
 }
 
 func TestGetStrategyError(t *testing.T) {
+	t.Skipf("Bug 1889868: skipping test requiring access to a docker socket")
 	expErr := errors.New("Artificial exception: config error")
 	s2iBuilder := newTestS2IBuilder(testS2IBuilderConfig{
 		getStrategyErr: expErr,

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -228,6 +228,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 	g.Context("jenkins-client-plugin tests", func() {
 
 		g.It("using the ephemeral template", func() {
+			g.Skip("Bug 1890523: test fails removing the second deployment")
 			defer cleanup(jenkinsEphemeralTemplatePath)
 			setupJenkins(jenkinsEphemeralTemplatePath)
 

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -58,6 +58,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 			})
 
 			g.It("should contain secrets during the source strategy build", func() {
+				g.Skip("Bug 1890328: CI version of docker does not handle symlinks correctly")
 				g.By("creating test build config")
 				err := oc.Run("create").Args("-f", sourceBuildFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -171,7 +171,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("Uploading file"))
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("as binary input for the build ..."))
-					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
+					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
 				g.It("should accept --from-dir as input", func() {
@@ -183,7 +183,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					g.By(fmt.Sprintf("verifying the build %q status", br.BuildPath))
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("Uploading directory"))
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("as binary input for the build ..."))
-					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
+					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
 				g.It("should accept --from-repo as input", func() {
@@ -197,7 +197,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("Uploading"))
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring(`at commit "HEAD"`))
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("as binary input for the build ..."))
-					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
+					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
 				g.It("should accept --from-repo with --commit as input", func() {
@@ -217,11 +217,12 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring(fmt.Sprintf("at commit \"%s\"", commit)))
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("as binary input for the build ..."))
 					o.Expect(buildLog).To(o.ContainSubstring(fmt.Sprintf("\"commit\":\"%s\"", commit)))
-					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
+					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
 				// run one valid binary build so we can do --from-build later
 				g.It("should reject binary build requests without a --from-xxxx value", func() {
+					g.Skip("Bug 1890507: ruby build fails with corrupted gem")
 					g.By("starting a valid build with a directory")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build-binary", "--follow", fmt.Sprintf("--from-dir=%s", exampleBuild))
 					br.AssertSuccess()
@@ -229,7 +230,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					o.Expect(err).NotTo(o.HaveOccurred())
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("Uploading directory"))
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("as binary input for the build ..."))
-					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
+					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 
 					g.By("starting a build without a --from-xxxx value")
 					br, err = exutil.StartBuildAndWait(oc, "sample-build-binary")
@@ -249,7 +250,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring(fmt.Sprintf("Uploading file from %q as binary input for the build", exampleGemfileURL)))
-					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
+					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
 				g.It("shoud accept --from-archive with https URL as an input", func() {
@@ -260,7 +261,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring(fmt.Sprintf("Uploading archive from %q as binary input for the build", exampleArchiveURL)))
-					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
+					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 			})
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -2057,7 +2057,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: centos/ruby-25-centos7:latest
     type: Source
 `)
 
@@ -2092,7 +2092,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: centos/ruby-25-centos7:latest
     type: Source
 `)
 
@@ -2249,8 +2249,8 @@ EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
-RUN scl enable rh-ruby22 "bundle install"
-CMD ["scl", "enable", "rh-ruby22", "./run.sh"]
+RUN scl enable rh-ruby25 "bundle install"
+CMD ["scl", "enable", "rh-ruby25", "./run.sh"]
 
 USER default
 `)

--- a/test/extended/testdata/builds/statusfail-postcommithook.yaml
+++ b/test/extended/testdata/builds/statusfail-postcommithook.yaml
@@ -13,5 +13,5 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: centos/ruby-25-centos7:latest
     type: Source

--- a/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
+++ b/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
@@ -14,5 +14,5 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-23-centos7:latest
+        name: centos/ruby-25-centos7:latest
     type: Source

--- a/test/extended/testdata/builds/test-build-app/Dockerfile
+++ b/test/extended/testdata/builds/test-build-app/Dockerfile
@@ -4,7 +4,7 @@ EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
-RUN scl enable rh-ruby22 "bundle install"
-CMD ["scl", "enable", "rh-ruby22", "./run.sh"]
+RUN scl enable rh-ruby25 "bundle install"
+CMD ["scl", "enable", "rh-ruby25", "./run.sh"]
 
 USER default


### PR DESCRIPTION
    - unit: Skip or alter pkg/build/builder unit tests which require
      access to a Docker socket. This is not available in OCP 4 pods.
    - extended: Update tests to use ruby 2.5 instead of 2.3
    - extended: Manually pick 847153a73442ee91f6879d7d7f7644bf340700f4
      to fix the message we verify the successful build against.
    - extended: skipping s2i secrets test. CI is running an outdated
      version of docker, which contains a bug impacting symlinks that
      exist within a container [1].
    - extended: skip Binary build test that fails with corrupted gem
      [2].
    - extended: skip Jenkins pipeline test that fails to clean itself
      up [3].
    
    [1] https://bugzilla.redhat.com/show_bug.cgi?id=1890328
    [2] https://bugzilla.redhat.com/show_bug.cgi?id=1890507
    [3] https://bugzilla.redhat.com/show_bug.cgi?id=1890523