### PR TITLE
check apiserver uptime with both new and re-used connections

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -41,7 +41,7 @@ var upgradeSuites = []*ginkgo.TestSuite{
 		},
 		Init: func(opt map[string]string) error {
 			return upgradeInitArguments(opt, func(name string) bool {
-				return name == controlplane.NewKubeAvailableTest().Name() || name == controlplane.NewKubeAvailableTest().Name()
+				return name == controlplane.NewKubeAvailableWithNewConnectionsTest().Name() || name == controlplane.NewKubeAvailableWithNewConnectionsTest().Name()
 			})
 		},
 		TestTimeout: 240 * time.Minute,

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -35,9 +35,12 @@ import (
 
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
-		controlplane.NewKubeAvailableTest(),
-		controlplane.NewOpenShiftAvailableTest(),
-		controlplane.NewOAuthAvailableTest(),
+		controlplane.NewKubeAvailableWithNewConnectionsTest(),
+		controlplane.NewOpenShiftAvailableNewConnectionsTest(),
+		controlplane.NewOAuthAvailableNewConnectionsTest(),
+		controlplane.NewKubeAvailableWithConnectionReuseTest(),
+		controlplane.NewOpenShiftAvailableWithConnectionReuseTest(),
+		controlplane.NewOAuthAvailableWithConnectionReuseTest(),
 		&alert.UpgradeTest{},
 		&frontends.AvailableTest{},
 		&service.UpgradeTest{},

--- a/test/extended/dr/machine_recover.go
+++ b/test/extended/dr/machine_recover.go
@@ -61,9 +61,9 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive
 			disruption.TestData{},
 			[]upgrades.Test{
 				&upgrades.ServiceUpgradeTest{},
-				controlplane.NewKubeAvailableTest(),
-				controlplane.NewOpenShiftAvailableTest(),
-				controlplane.NewOAuthAvailableTest(),
+				controlplane.NewKubeAvailableWithNewConnectionsTest(),
+				controlplane.NewOpenShiftAvailableNewConnectionsTest(),
+				controlplane.NewOAuthAvailableNewConnectionsTest(),
 				&frontends.AvailableTest{},
 			},
 			func() {


### PR DESCRIPTION
Uptime for apiservers can look different between new connections and existing connections.  This adds checks for new connections and runs both sets of tests so we can start to see which fail when.