### PR TITLE
Bug 1887850: update SCC test to either pass or fail, but never flake

### DIFF
--- a/test/extended/authorization/scc.go
+++ b/test/extended/authorization/scc.go
@@ -7,7 +7,6 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	"github.com/openshift/origin/pkg/test/ginkgo/result"
 	exutil "github.com/openshift/origin/test/extended/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,11 +24,11 @@ var _ = g.Describe("[sig-auth][Feature:SCC][Early]", func() {
 		// deads2k chose five as a number that passes nearly all the time on 4.6.  If this gets worse, we should double check against 4.6.
 		// if I was wrong about 4.6, then adjust this up.  If I am right about 4.6, then fix whatever regressed this.
 		// Because the CVO starts a static pod that races with the cluster-policy-controller, it is impractical to get this value to 0.
-		numFailuresOkForFlake := 5
+		numFailuresForFail := 5
 		if isFIPS {
 			// for whatever reason, fips fails more frequently.  this isn't good and it's bad practice to have platform
 			// dependent tests, but we need to start the ratchet somewhere to prevent regressions.
-			numFailuresOkForFlake = 10
+			numFailuresForFail = 10
 		}
 
 		events, err := kubeClient.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{})
@@ -54,11 +53,12 @@ var _ = g.Describe("[sig-auth][Feature:SCC][Early]", func() {
 
 		numFailingPods := len(denialStrings)
 		failMessage := fmt.Sprintf("%d pods failed on SCC errors\n%s\n", numFailingPods, strings.Join(denialStrings, "\n"))
-		if numFailingPods > numFailuresOkForFlake {
+		if numFailingPods > numFailuresForFail {
 			g.Fail(failMessage)
 			return
 		}
 
-		result.Flakef(failMessage)
+		// given a low threshold, there isn't much space left to mark a flake over a fail.
+		//result.Flakef(failMessage)
 	})
 })


### PR DESCRIPTION
This will provide a clear signal on regression and prevent unnecessary noise.

Because the CVO starts as a static pod, concurrent with the cluster-policy-controller, there is a time period when namespaces can be created and content placed in them by the CVO before the controller assigning SCC UIDs has had a chance to actually create the range allocations.  Below a certain threshold (I chose five), this is acceptable.  We were dealing with dozens in the past.