### PR TITLE
Bug 1881319: IPtable rules are racy when pod is created before svc

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -445,7 +445,9 @@ func (proxier *Proxier) probability(n int) string {
 
 // Sync is called to synchronize the proxier state to iptables as soon as possible.
 func (proxier *Proxier) Sync() {
+	proxier.mu.Lock()
 	proxier.changesPending = true
+	proxier.mu.Unlock()
 	proxier.syncRunner.Run()
 }
 
@@ -476,8 +478,7 @@ func (proxier *Proxier) OnServiceAdd(service *api.Service) {
 
 func (proxier *Proxier) OnServiceUpdate(oldService, service *api.Service) {
 	if proxier.serviceChanges.Update(oldService, service) && proxier.isInitialized() {
-		proxier.changesPending = true
-		proxier.syncRunner.Run()
+		proxier.Sync()
 	}
 }
 
@@ -502,8 +503,7 @@ func (proxier *Proxier) OnEndpointsAdd(endpoints *api.Endpoints) {
 
 func (proxier *Proxier) OnEndpointsUpdate(oldEndpoints, endpoints *api.Endpoints) {
 	if proxier.endpointsChanges.Update(oldEndpoints, endpoints) && proxier.isInitialized() {
-		proxier.changesPending = true
-		proxier.syncRunner.Run()
+		proxier.Sync()
 	}
 }
 


### PR DESCRIPTION
We have a race condition because the `proxier.changesPending` which
was introduced in 0c9e44a08d12c115c72900af6c7513a7d178ea2b is not
locked properly. So most of the times in half of the SDN pods, the
REJECT rule gets created for not finding an endpoint and it does
not get replaced by the correct rules because the `SyncProxyRules`
does not get run because the value of `proxier.changesPending` is racy.

As a consequence of this, until there is a next update that sets
the value of `proxier.changesPending` correctly, the service rejects
requests from users. This patch uses the `proxier.mu.Lock()` on
`proxier.changesPending` when its changed from `Sync()`.
`OnEndpointsUpdate` and `OnServiceUpdate` then in turn call `Sync()`.



