### PR TITLE
UPSTREAM: <carry>: Bug 1893156: include / prefix in instance ID output

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_instances.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_instances.go
@@ -221,7 +221,7 @@ func (i *Instances) InstanceID(ctx context.Context, name types.NodeName) (string
 	}
 	localName := types.NodeName(md.Name)
 	if localName == name {
-		return md.UUID, nil
+		return "/" + md.UUID, nil
 	}
 
 	srv, err := getServerByName(i.compute, name)


### PR DESCRIPTION
When we want to read an instance ID from the metadata service, cloud provider doesn't include "/" prefix, which is required for successful parsing of provider the ID later.
This commit adds the missing "/" prefix to the output.

Cherry-picked from https://github.com/openshift/kubernetes/pull/343