### PR TITLE
Bug 1894011: images/router: Add ART specific Dockerfile

### DIFF
--- a/images/router/haproxy/Dockerfile.art
+++ b/images/router/haproxy/Dockerfile.art
@@ -1,0 +1,29 @@
+#
+# This is the HAProxy router for OpenShift Origin.
+#
+# The standard name for this image is openshift/origin-haproxy-router
+#
+FROM openshift/origin-cli
+
+RUN INSTALL_PKGS="haproxy18 rsyslog" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts,whitelists} && \
+    mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+    setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+    chown -R :0 /var/lib/haproxy && \
+    chmod -R g+w /var/lib/haproxy
+
+COPY . /var/lib/haproxy/
+
+LABEL io.k8s.display-name="OpenShift Origin HAProxy Router" \
+      io.k8s.description="This is a component of OpenShift Origin and contains an HAProxy instance that automatically exposes services within the cluster through routes, and offers TLS termination, reencryption, or SNI-passthrough on ports 80 and 443." \
+      io.openshift.tags="openshift,router,haproxy"
+USER 1001
+EXPOSE 80 443
+WORKDIR /var/lib/haproxy/conf
+ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
+ENTRYPOINT ["/usr/bin/openshift-router"]


### PR DESCRIPTION
PR #25542 introduced a change that allows us to pickup a specific
version of HAProxy during a CI build. Unfortunately this broke ART
builds as there is no external network access that would allow access
to the RPM files.

This commit reflects the state of the Dockerfile as it was before
25542 merged.

There is a complementary commit for ocp-build-data:
  https://github.com/openshift/ocp-build-data/pull/736

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1894011