### PR TITLE
debug multitenant tests

### DIFF
--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -141,7 +141,9 @@ func networkPluginName() string {
 			"--template={{.pluginName}}",
 		).CombinedOutput()
 		pluginName := string(out)
-		if err != nil {
+		if err == nil {
+			e2e.Logf("Detected network plugin name %q", pluginName)
+		} else {
 			e2e.Logf("Could not check network plugin name: %v. Assuming a non-OpenShift plugin", err)
 			pluginName = ""
 		}


### PR DESCRIPTION
with latest multitenant fixes, tests are still failing because they're misdetecting the plugin mode...
eg https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-network-operator/850/pull-ci-openshift-cluster-network-operator-release-4.6-e2e-aws-sdn-multi/1324680410520621056
/cc @squeed