### PR TITLE
rename 'foo' build arg to avoid conflicts with 'foo' env's in the tools image

### DIFF
--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -368,7 +368,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 				})
 				g.It("Should accept build args that are specified in the Dockerfile", func() {
 					g.By("starting the build with --build-arg flag")
-					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=foo=bar")
+					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=foofoo=bar")
 					br.AssertSuccess()
 					verifyNodeSelector(oc, br.BuildName)
 					buildLog, err := br.Logs()

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -21690,8 +21690,8 @@ items:
       type: Dockerfile
       dockerfile: |-
         FROM centos/ruby-25-centos7
-        ARG foo
-        RUN echo $foo
+        ARG foofoo
+        RUN echo $foofoo
     strategy:
       type: Docker
       dockerStrategy:
@@ -21716,8 +21716,8 @@ items:
       type: Dockerfile
       dockerfile: |-
         FROM centos/ruby-25-centos7
-        ARG foo
-        RUN echo $foo
+        ARG foofoo
+        RUN echo $foofoo
     strategy:
       type: Docker
       dockerStrategy:
@@ -21725,7 +21725,7 @@ items:
           kind: DockerImage
           name: quay.io/quay/busybox:latest
         buildArgs:
-        - name: foo
+        - name: foofoo
           value: default
     resources: {}
     postCommit: {}

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -181,8 +181,8 @@ items:
       type: Dockerfile
       dockerfile: |-
         FROM centos/ruby-25-centos7
-        ARG foo
-        RUN echo $foo
+        ARG foofoo
+        RUN echo $foofoo
     strategy:
       type: Docker
       dockerStrategy:
@@ -207,8 +207,8 @@ items:
       type: Dockerfile
       dockerfile: |-
         FROM centos/ruby-25-centos7
-        ARG foo
-        RUN echo $foo
+        ARG foofoo
+        RUN echo $foofoo
     strategy:
       type: Docker
       dockerStrategy:
@@ -216,7 +216,7 @@ items:
           kind: DockerImage
           name: quay.io/quay/busybox:latest
         buildArgs:
-        - name: foo
+        - name: foofoo
           value: default
     resources: {}
     postCommit: {}


### PR DESCRIPTION
should address build-args error in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/24887/pull-ci-openshift-origin-master-e2e-gcp-builds/1324783058666131456

see the discussion starting with https://coreos.slack.com/archives/C014MHHKUSF/p1604958101444400?thread_ts=1604938369.426700&cid=C014MHHKUSF

/assign @bparees 
/assign @smarterclayton 
@adambkaplan fyi