### PR TITLE
test/extended: Fix "avaiable" -> "available" typos

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 	oc := exutil.NewCLI("oc-adm-must-gather").AsAdmin()
 
 	g.JustBeforeEach(func() {
-		// wait for the default service account to be avaiable
+		// wait for the default service account to be available
 		err := exutil.WaitForServiceAccount(oc.KubeClient().CoreV1().ServiceAccounts(oc.Namespace()), "default")
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})

--- a/test/extended/util/ldap.go
+++ b/test/extended/util/ldap.go
@@ -151,7 +151,7 @@ func CreateLDAPTestServer(oc *CLI) (string, []byte, error) {
 		return true, nil
 	})
 	if err != nil {
-		return "", nil, fmt.Errorf("replica for %s not avaiable: %v", serverDeployment.Name, err)
+		return "", nil, fmt.Errorf("replica for %s not available: %v", serverDeployment.Name, err)
 	}
 
 	// Confirm ldap server availability. Since the ldap client does not support SNI, a TLS passthrough route will not


### PR DESCRIPTION
Fixing typos from 273a9d851f (#23132) and 18999867ab (#25039).

Generated with:

```console
$ sed -i 's/avaiable/available/g' $(git grep -l avaiable)
```