### PR TITLE
Make oc mirror tests aware of HTTP/2

### DIFF
--- a/test/extended/images/mirror.go
+++ b/test/extended/images/mirror.go
@@ -223,7 +223,7 @@ func requestHasStatusCode(pod *testPod, URL, token, statusCode string) {
 	out, err := runHTTPRequest(pod, URL, headers)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	m := regexp.MustCompile(fmt.Sprintf(`(?m)^< HTTP/1\.1 %s `, statusCode)).FindString(out)
+	m := regexp.MustCompile(fmt.Sprintf(`(?m)^< HTTP/(?:1\.1|2) %s `, statusCode)).FindString(out)
 	if len(m) == 0 {
 		err = fmt.Errorf("unexpected status code (expected %s): %s", statusCode, out)
 	}


### PR DESCRIPTION
Fixes the problem that was found at https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/24887/pull-ci-openshift-origin-master-e2e-aws-image-registry/1324783058502553600