### PR TITLE
Bug 1870050: Mount ImageFS in node container

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -415,8 +415,8 @@
         },
         {
 	    "type": "bind",
-	    "source": "/var/lib/docker/containers",
-	    "destination": "/var/lib/docker/containers",
+	    "source": "/var/lib/docker",
+	    "destination": "/var/lib/docker",
 	    "options": [
 		"bind",
                 "slave",


### PR DESCRIPTION
Because the atomic-openshift-node container running on RHEL Atomic Host bind mounts `/var/lib/docker/containers` instead of `/var/lib/docker`, the Kubelet gets the wrong disk usage stats when it looks at how much of the `/var/lib/docker` is in use. This results in dangling and unused images never being cleaned up when the ImageFS (i.e. the host's `/var/lib/docker`) fills up, since the Kubelet never triggers its garbage collection.