### PR TITLE
Bug 1887509: e2e: node: filter out worker nodes without MCD

### DIFF
--- a/test/extended/topology_manager/resourcealign.go
+++ b/test/extended/topology_manager/resourcealign.go
@@ -49,7 +49,12 @@ var _ = g.Describe("[Serial][sig-node][Feature:TopologyManager] Configured clust
 		e2e.ExpectNoError(err)
 		o.Expect(workerNodes).ToNot(o.BeEmpty())
 
-		topoMgrNodes = filterNodeWithTopologyManagerPolicy(workerNodes, client, oc, kubeletconfigv1beta1.SingleNumaNodeTopologyManager)
+		mcdNodes := filterNodesWithMachineConfigDaemon(workerNodes, client)
+		if len(mcdNodes) == 0 {
+			g.Skip("found no worker nodes with the MCD running")
+		}
+
+		topoMgrNodes = filterNodeWithTopologyManagerPolicy(mcdNodes, client, oc, kubeletconfigv1beta1.SingleNumaNodeTopologyManager)
 
 		deviceResourceName = getValueFromEnv(resourceNameEnvVar, defaultResourceName, "resource name")
 		// we don't handle yet an uneven device amount on worker nodes. IOW, we expect the same amount of devices on each node

--- a/test/extended/topology_manager/utils.go
+++ b/test/extended/topology_manager/utils.go
@@ -82,6 +82,18 @@ func findNodeWithMultiNuma(nodes []corev1.Node, c clientset.Interface, oc *exuti
 	return nil, 0
 }
 
+func filterNodesWithMachineConfigDaemon(workerNodes []corev1.Node, client clientset.Interface) []corev1.Node {
+	var mcdEnabledNodes []corev1.Node
+	for _, node := range workerNodes {
+		if _, err := exutil.GetMachineConfigDaemonByNode(client, &node); err != nil {
+			e2e.Logf("MCD not running on worker node %qw", node.Name)
+			continue
+		}
+		mcdEnabledNodes = append(mcdEnabledNodes, node)
+	}
+	return mcdEnabledNodes
+}
+
 func filterNodeWithTopologyManagerPolicy(workerNodes []corev1.Node, client clientset.Interface, oc *exutil.CLI, policy string) []corev1.Node {
 	ocRaw := (*oc).WithoutNamespace()
 

--- a/test/extended/util/pods.go
+++ b/test/extended/util/pods.go
@@ -76,8 +76,8 @@ func CreateUbiExecPodOrFail(client kubernetes.Interface, ns, generateName string
 	})
 }
 
-// getMachineConfigDaemonByNode finds the privileged daemonset from the Machine Config Operator
-func getMachineConfigDaemonByNode(c clientset.Interface, node *corev1.Node) (*corev1.Pod, error) {
+// GetMachineConfigDaemonByNode finds the privileged daemonset from the Machine Config Operator
+func GetMachineConfigDaemonByNode(c clientset.Interface, node *corev1.Node) (*corev1.Pod, error) {
 	listOptions := metav1.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}).String(),
 		LabelSelector: labels.SelectorFromSet(labels.Set{"k8s-app": "machine-config-daemon"}).String(),
@@ -96,7 +96,7 @@ func getMachineConfigDaemonByNode(c clientset.Interface, node *corev1.Node) (*co
 
 // ExecCommandOnMachineConfigDaemon returns the output of the command execution on the machine-config-daemon pod that runs on the specified node
 func ExecCommandOnMachineConfigDaemon(c clientset.Interface, oc *CLI, node *corev1.Node, command []string) (string, error) {
-	mcd, err := getMachineConfigDaemonByNode(c, node)
+	mcd, err := GetMachineConfigDaemonByNode(c, node)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The topology manager e2e tests expect MCD running
in order to be able to extract the node Kubelet and
check the test precoditions.

So we add another pre-filter to rule out worker nodes
without MCD running. If no suitable worker nodes are
found, the tests must just skip.

Bug-Url: https://bugzilla.redhat.com/1887509
Signed-off-by: Francesco Romani <fromani@redhat.com>