### PR TITLE
Bug 1886160: Increase resiliency of quorum restore test to potentially recoverable errors

### DIFF
--- a/test/extended/dr/common.go
+++ b/test/extended/dr/common.go
@@ -305,3 +305,18 @@ func expectSSH(cmd string, node *corev1.Node) {
 func ssh(cmd string, node *corev1.Node) (*e2essh.Result, error) {
 	return e2essh.IssueSSHCommandWithResult(cmd, e2e.TestContext.Provider, node)
 }
+
+func sshRetryOnFailure(cmd string, node *corev1.Node) (*e2essh.Result, error) {
+	var out *e2essh.Result
+	var err error
+	e2elog.Logf("cmd[%s]: %s", node.Name, cmd)
+	waitErr := wait.PollImmediate(10*time.Second, 1*time.Minute, func() (bool, error) {
+		out, err = e2essh.IssueSSHCommandWithResult(cmd, e2e.TestContext.Provider, node)
+		if err == nil {
+			return true, nil
+		}
+		e2elog.Logf("command %q failed: %v", err)
+		return false, nil
+	})
+	return out, waitErr
+}

--- a/test/extended/dr/machine_recover.go
+++ b/test/extended/dr/machine_recover.go
@@ -55,7 +55,11 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive
 		// expectSSH("true", replacedMaster)
 
 		replacedWorker := workers[rand.Intn(len(workers))]
-		expectSSH("true", replacedWorker)
+		sshOut, err := sshRetryOnFailure("true", replacedWorker)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		if len(sshOut.Stderr) > 0 {
+			framework.Logf("ssh command stderr output: %q", sshOut.Stderr)
+		}
 
 		disruption.Run(f, "Machine Shutdown and Restore", "machine_failure",
 			disruption.TestData{},

--- a/test/extended/dr/machine_recover.go
+++ b/test/extended/dr/machine_recover.go
@@ -51,8 +51,8 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive
 		o.Expect(len(masters)).To(o.BeNumerically(">=", 3))
 		o.Expect(len(workers)).To(o.BeNumerically(">=", 2))
 
-		replacedMaster := masters[rand.Intn(len(masters))]
-		expectSSH("true", replacedMaster)
+		// replacedMaster := masters[rand.Intn(len(masters))]
+		// expectSSH("true", replacedMaster)
 
 		replacedWorker := workers[rand.Intn(len(workers))]
 		expectSSH("true", replacedWorker)

--- a/test/extended/dr/machine_recover.go
+++ b/test/extended/dr/machine_recover.go
@@ -226,7 +226,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive
 					for _, machine := range machines.Items {
 						vanishedMachines.Delete(machine.GetName())
 					}
-					if vanishedMachines.Len() != len(targetMachineNames) {
+					if vanishedMachines.Len() == len(targetMachineNames) {
 						framework.Logf("Machines waiting to go be deleted: %v", vanishedMachines.List())
 						return false, nil
 					}

--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -200,7 +200,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 					}
 
 					framework.Logf("Waiting for machines to be created")
-					err = wait.Poll(30*time.Second, 10*time.Minute, func() (done bool, err error) {
+					err = wait.Poll(30*time.Second, 20*time.Minute, func() (done bool, err error) {
 						mastersList, err := ms.List(context.Background(), metav1.ListOptions{
 							LabelSelector: "machine.openshift.io/cluster-api-machine-role=master",
 						})

--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -148,9 +148,18 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 				}
 
 				framework.Logf("Perform etcd backup on remaining machine %s (machine %s)", survivingNodeName, survivingMachineName)
-				expectSSH("sudo -i /bin/bash -cx 'rm -rf /home/core/backup; /usr/local/bin/cluster-backup.sh ~core/backup'", survivingNode)
+				sshOut, err := sshRetryOnFailure("sudo -i /bin/bash -cx 'rm -rf /home/core/backup; /usr/local/bin/cluster-backup.sh ~core/backup'", survivingNode)
+				o.Expect(err).ToNot(o.HaveOccurred())
+				if len(sshOut.Stderr) > 0 {
+					framework.Logf("cluster-backup ssh command stderr output: %q", sshOut.Stderr)
+				}
+
 				framework.Logf("Restore etcd and control-plane on remaining node %s (machine %s)", survivingNodeName, survivingMachineName)
-				expectSSH("sudo -i /bin/bash -cx '/usr/local/bin/cluster-restore.sh /home/core/backup'", survivingNode)
+				sshOut, err = sshRetryOnFailure("sudo -i /bin/bash -cx '/usr/local/bin/cluster-restore.sh /home/core/backup'", survivingNode)
+				o.Expect(err).ToNot(o.HaveOccurred())
+				if len(sshOut.Stderr) > 0 {
+					framework.Logf("cluster-restore ssh command stderr output: %q", sshOut.Stderr)
+				}
 
 				framework.Logf("Wait for API server to come up")
 				time.Sleep(30 * time.Second)

--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -137,7 +137,10 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 						// there is a small chance the cluster restores the default replica size during
 						// this loop process, so keep forcing quorum guard to be zero, without failing on
 						// errors
-						scaleEtcdQuorum(pollClient, 0)
+						err = scaleEtcdQuorum(pollClient, 0)
+						if err != nil {
+							framework.Logf("Scaling etcd quorum failed: %v", err)
+						}
 
 						// wait to see the control plane go down for good to avoid a transient failure
 						return failures > 4, nil
@@ -188,7 +191,8 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 								return false, nil
 							}
 							if err != nil {
-								return false, err
+								framework.Logf("Error seen when re-creating machines: %v", err)
+								return false, nil
 							}
 							return true, nil
 						})
@@ -201,7 +205,8 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 							LabelSelector: "machine.openshift.io/cluster-api-machine-role=master",
 						})
 						if err != nil {
-							return false, err
+							framework.Logf("Failed to check that machines are created: %v", err)
+							return false, nil
 						}
 						if mastersList.Items == nil {
 							return false, nil


### PR DESCRIPTION
After the restore operation in disruptive test, kube-apiserver restarts due to new revision roll outs. As this is expected to happen when new machines are created, it is acceptable to ignore the error response when api requests are made.