### PR TITLE
hello-openshift: Set BZ component in OWNERS

### DIFF
--- a/images/hello-openshift/OWNERS
+++ b/images/hello-openshift/OWNERS
@@ -15,3 +15,4 @@ approvers:
   - jwforres
   - derekwaynecarr
   - sgreene570
+component: Routing


### PR DESCRIPTION
The Network Edge team maintains the hello-openshift image. Add the routing component to `images/hello-openshift/OWNERS` to satisfy the ART BZ component requirement. 