### PR TITLE
[release-3.11] Bug 1887306: UPSTREAM: 94712: [credentialprovider] avoid potential secret leaking while reading .dockercfg

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/credentialprovider/config_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/credentialprovider/config_test.go
@@ -264,3 +264,96 @@ func TestDockerConfigEntryJSONCompatibleEncode(t *testing.T) {
 		}
 	}
 }
+
+func TestReadDockerConfigFileFromBytes(t *testing.T) {
+	testCases := []struct {
+		id               string
+		input            []byte
+		expectedCfg      DockerConfig
+		errorExpected    bool
+		expectedErrorMsg string
+	}{
+		{
+			id:    "valid input, no error expected",
+			input: []byte(`{"http://foo.example.com":{"username": "foo", "password": "bar", "email": "foo@example.com"}}`),
+			expectedCfg: DockerConfig(map[string]DockerConfigEntry{
+				"http://foo.example.com": {
+					Username: "foo",
+					Password: "bar",
+					Email:    "foo@example.com",
+				},
+			}),
+		},
+		{
+			id:               "invalid input, error expected",
+			input:            []byte(`{"http://foo.example.com":{"username": "foo", "password": "bar", "email": "foo@example.com"`),
+			errorExpected:    true,
+			expectedErrorMsg: "error occurred while trying to unmarshal json",
+		},
+	}
+
+	for _, tc := range testCases {
+		cfg, err := readDockerConfigFileFromBytes(tc.input)
+		if err != nil && !tc.errorExpected {
+			t.Fatalf("Error was not expected: %v", err)
+		}
+		if err != nil && tc.errorExpected {
+			if !reflect.DeepEqual(err.Error(), tc.expectedErrorMsg) {
+				t.Fatalf("Expected error message: `%s` got `%s`", tc.expectedErrorMsg, err.Error())
+			}
+		} else {
+			if !reflect.DeepEqual(cfg, tc.expectedCfg) {
+				t.Fatalf("expected: %v got %v", tc.expectedCfg, cfg)
+			}
+		}
+	}
+}
+
+func TestReadDockerConfigJSONFileFromBytes(t *testing.T) {
+	testCases := []struct {
+		id               string
+		input            []byte
+		expectedCfg      DockerConfig
+		errorExpected    bool
+		expectedErrorMsg string
+	}{
+		{
+			id:    "valid input, no error expected",
+			input: []byte(`{"auths": {"http://foo.example.com":{"username": "foo", "password": "bar", "email": "foo@example.com"}, "http://bar.example.com":{"username": "bar", "password": "baz", "email": "bar@example.com"}}}`),
+			expectedCfg: DockerConfig(map[string]DockerConfigEntry{
+				"http://foo.example.com": {
+					Username: "foo",
+					Password: "bar",
+					Email:    "foo@example.com",
+				},
+				"http://bar.example.com": {
+					Username: "bar",
+					Password: "baz",
+					Email:    "bar@example.com",
+				},
+			}),
+		},
+		{
+			id:               "invalid input, error expected",
+			input:            []byte(`{"auths": {"http://foo.example.com":{"username": "foo", "password": "bar", "email": "foo@example.com"}, "http://bar.example.com":{"username": "bar", "password": "baz", "email": "bar@example.com"`),
+			errorExpected:    true,
+			expectedErrorMsg: "error occurred while trying to unmarshal json",
+		},
+	}
+
+	for _, tc := range testCases {
+		cfg, err := readDockerConfigJsonFileFromBytes(tc.input)
+		if err != nil && !tc.errorExpected {
+			t.Fatalf("Error was not expected: %v", err)
+		}
+		if err != nil && tc.errorExpected {
+			if !reflect.DeepEqual(err.Error(), tc.expectedErrorMsg) {
+				t.Fatalf("Expected error message: `%s` got `%s`", tc.expectedErrorMsg, err.Error())
+			}
+		} else {
+			if !reflect.DeepEqual(cfg, tc.expectedCfg) {
+				t.Fatalf("expected: %v got %v", tc.expectedCfg, cfg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
/assign @sttts 