### PR TITLE
Bug 1884195: test/extended/operators: add etcd-quorum-guard to unevictable whitelist

### DIFF
--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -31,7 +31,7 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
 		excludedNamespaces := sets.NewString("openshift-kube-apiserver", "openshift-kube-controller-manager", "openshift-kube-scheduler", "openshift-etcd", "openshift-openstack-infra", "openshift-ovirt-infra")
 		// exclude these pods from checks
-		whitelistPods := sets.NewString("network-operator", "dns-operator", "olm-operators", "gcp-routes-controller", "ovnkube-master", "must-gather")
+		whitelistPods := sets.NewString("network-operator", "dns-operator", "olm-operators", "gcp-routes-controller", "ovnkube-master", "must-gather", "etcd-quorum-guard")
 		for _, pod := range pods.Items {
 			// exclude non-control plane namespaces
 			if !hasPrefixSet(pod.Namespace, namespacePrefixes) {


### PR DESCRIPTION
To resolve a bug that makes it possible to delete 2 masters simultaneously if kubelet unreachable we removed timeouts for NoExecute and NoSchedule tolerations[1]. But because `etcd-quorum-guard` is not whitelisted the net result is a test failure[2].

```
fail [github.com/openshift/origin/test/extended/operators/tolerations.go:72]: Nov 19 13:12:12.123: 
6 pods found with invalid tolerations:
openshift-machine-config-operator/etcd-quorum-guard-9779b9595-4tz7t tolerates node.kubernetes.io/not-ready with no tolerationSeconds
openshift-machine-config-operator/etcd-quorum-guard-9779b9595-4tz7t tolerates node.kubernetes.io/unreachable with no tolerationSeconds
openshift-machine-config-operator/etcd-quorum-guard-9779b9595-jpj49 tolerates node.kubernetes.io/not-ready with no tolerationSeconds
openshift-machine-config-operator/etcd-quorum-guard-9779b9595-jpj49 tolerates node.kubernetes.io/unreachable with no tolerationSeconds
openshift-machine-config-operator/etcd-quorum-guard-9779b9595-mdft8 tolerates node.kubernetes.io/not-ready with no tolerationSeconds
openshift-machine-config-operator/etcd-quorum-guard-9779b9595-mdft8 tolerates node.kubernetes.io/unreachable with no tolerationSeconds
```

[1] https://github.com/openshift/cluster-etcd-operator/pull/426
[2] https://github.com/openshift/machine-config-operator/pull/2133

cc @michaelgugino 

NOTE: change is not needed in 4.6+ because we migrated `etcd-quorum-guard` to `openshift-etcd` namespace which is already whitelisted.