### PR TITLE
Bug 1896956: Bump scale timeouts to 20 mins to reduce load on vSphere CI

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -25,7 +25,7 @@ import (
 const (
 	machineAPIGroup       = "machine.openshift.io"
 	machineSetOwningLabel = "machine.openshift.io/cluster-api-machineset"
-	scalingTime           = 12 * time.Minute
+	scalingTime           = 20 * time.Minute
 )
 
 // machineSetClient returns a client for machines scoped to the proper namespace


### PR DESCRIPTION
Vsphere CI is overloaded ATM, in order to mitigate the issues with growing CI usage setting 20 minute timeouts (opposed to 30 min in [cluster-api-actuator-pkg](https://github.com/openshift/cluster-api-actuator-pkg/blob/a79c589c0f28ea83cf71238cfa44a42dd4971736/pkg/framework/machinesets.go#L335)) on the scale tests.