### PR TITLE
[sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap: do not oc cp nonexisting folders

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -889,7 +889,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:LDAP] LDAP should start an OpenLDAP test server": "should start an OpenLDAP test server [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap": "can sync groups from ldap [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap": "can sync groups from ldap [Disabled:Broken]",
 
 	"[Top Level] [sig-auth][Feature:OAuthServer] ClientSecretWithPlus should create oauthclient": "should create oauthclient [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -32,6 +32,8 @@ var (
 		"[Disabled:Broken]": {
 			`should idle the service and DeploymentConfig properly`,       // idling with a single service and DeploymentConfig
 			`should answer endpoint and wildcard queries for the cluster`, // currently not supported by dns operator https://github.com/openshift/cluster-dns-operator/issues/43
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1902702 - [sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap: oc cp over non-existing directory/file fails
+			`\[sig-auth\]\[Feature:LDAP\]\[Serial\] ldap group sync can sync groups from ldap`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {},


### PR DESCRIPTION
> When trying to upload an unexisting file to a pod, kubectl currently doesn't print any error message and terminates with a zero exit code.

https://github.com/kubernetes/kubernetes/pull/90333

With https://github.com/openshift/oc/pull/648 where the new check is coming in, the test starts to fail since `test/extended/authentication/ldap` does not exist.

Skipping the test for now. Opening https://bugzilla.redhat.com/show_bug.cgi?id=1902702 to address the broken parts.