### PR TITLE
apiserver: remove terminates kube-apiserver gracefully test

### DIFF
--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -17,28 +17,6 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 
 	oc := exutil.NewCLI("terminating-kube-apiserver")
 
-	g.It("kubelet terminates kube-apiserver gracefully", func() {
-		t := g.GinkgoT()
-
-		client, err := kubernetes.NewForConfig(oc.AdminConfig())
-		if err != nil {
-			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
-		}
-
-		evs, err := client.CoreV1().Events("openshift-kube-apiserver").List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
-		}
-
-		for _, ev := range evs.Items {
-			if ev.Reason != "NonGracefulTermination" {
-				continue
-			}
-
-			t.Errorf("kube-apiserver reports a non-graceful termination: %#v. Probably kubelet or CRI-O is not giving the time to cleanly shut down. This can lead to connection refused and network I/O timeout errors in other components.", ev)
-		}
-	})
-
 	g.It("kube-apiserver terminates within graceful termination period", func() {
 		t := g.GinkgoT()
 


### PR DESCRIPTION
This proposes removing the `kubelet terminates kube-apiserver gracefully` test. watch-termination does not use a flock to protect concurrent access to the log and lockfile. We changed the static pod UIDs to include an updated UID when they change, so the kubelet starts deleting UID1, while UID2 is starting.

Additionally, there is a case where apiserver is exiting with a 1 exit code. The test case looks at the entire event history looking for a NonGracefulTermination. This is problematic when there is a case where the exit code of 1 is triggered.

watch-termination logs: https://bugzilla.redhat.com/show_bug.cgi?id=1882750#c31

Either the test, exit code strategy, or watch-termination application need to be updated to account for these scenarios.

cc @sttts @deads2k 