### PR TITLE
Remove 'oc explain' tests for the CRs in metal3.io

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -74,11 +74,6 @@ var (
 
 		{Group: "packages.operators.coreos.com", Version: "v1", Resource: "packagemanifests"},
 
-		// metal3.io groups:
-
-		{Group: "metal3.io", Version: "v1alpha1", Resource: "baremetalhosts"},
-		{Group: "metal3.io", Version: "v1alpha1", Resource: "provisionings"},
-
 		// openshift.io groups:
 
 		{Group: "autoscaling.openshift.io", Version: "v1beta1", Resource: "machineautoscalers"},


### PR DESCRIPTION
The Provisioning and Baremetal host CRs would be created only when the Platform type is Baremetal. The recent change https://github.com/openshift/origin/pull/25708 to update 'oc explain' tests does not take that into consideration.