### PR TITLE
Temporary disable tests broken upstream

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -691,7 +691,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods [Conformance]": "should adopt matching pods on creation and release no longer matching pods [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-apps] ReplicaSet should serve a basic image on each replica with a private image": "should serve a basic image on each replica with a private image [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-apps] ReplicaSet should serve a basic image on each replica with a private image": "should serve a basic image on each replica with a private image [Disabled:BrokenUpstream] [Suite:k8s]",
 
 	"[Top Level] [sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]": "should serve a basic image on each replica with a public image  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
@@ -703,7 +703,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-apps] ReplicationController should release no longer matching pods [Conformance]": "should release no longer matching pods [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-apps] ReplicationController should serve a basic image on each replica with a private image": "should serve a basic image on each replica with a private image [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-apps] ReplicationController should serve a basic image on each replica with a private image": "should serve a basic image on each replica with a private image [Disabled:BrokenUpstream] [Suite:k8s]",
 
 	"[Top Level] [sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]": "should serve a basic image on each replica with a public image  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -35,6 +35,11 @@ var (
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {},
+		// tests broken upstream
+		"[Disabled:BrokenUpstream]": {
+			`\[sig-apps\] ReplicationController should serve a basic image on each replica with a private image`,
+			`\[sig-apps\] ReplicaSet should serve a basic image on each replica with a private image`,
+		},
 		// tests too slow to be part of conformance
 		"[Slow]": {},
 		// tests that are known flaky


### PR DESCRIPTION
Namely:
- `[sig-apps] ReplicationController should serve a basic image on each replica with a private image`
- `[sig-apps] ReplicaSet should serve a basic image on each replica with a private image`

See https://github.com/kubernetes/kubernetes/issues/97002

BZ reminding us to re-enable the tests again: https://bugzilla.redhat.com/show_bug.cgi?id=1903674