### PR TITLE
Bug 1903524: [3.11] UPSTREAM: 97013: Fix FibreChannel volume plugin corrupting filesystem on detach

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/fc/fc_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/fc/fc_test.go
@@ -192,7 +192,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 
 	fakeManager2 := NewFakeDiskManager()
 	defer fakeManager2.Cleanup()
-	unmounter, err := plug.(*fcPlugin).newUnmounterInternal("vol1", types.UID("poduid"), fakeManager2, fakeMounter)
+	unmounter, err := plug.(*fcPlugin).newUnmounterInternal("vol1", types.UID("poduid"), fakeManager2, fakeMounter, fakeExec)
 	if err != nil {
 		t.Errorf("Failed to make a new Unmounter: %v", err)
 	}

--- a/vendor/k8s.io/kubernetes/pkg/volume/fc/fc_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/fc/fc_util.go
@@ -112,6 +112,16 @@ func findDiskWWIDs(wwid string, io ioHandler, deviceUtil volumeutil.DeviceUtil) 
 	return "", ""
 }
 
+// Flushes any outstanding I/O to the device
+func flushDevice(deviceName string, exec mount.Exec) {
+	out, err := exec.Run("blockdev", "--flushbufs", deviceName)
+	if err != nil {
+		// Ignore the error and continue deleting the device. There is will be no retry on error.
+		glog.Warningf("Failed to flush device %s: %s\n%s", deviceName, err, string(out))
+	}
+	glog.V(4).Infof("Flushed device %s", deviceName)
+}
+
 // Removes a scsi device based upon /dev/sdX name
 func removeFromScsiSubsystem(deviceName string, io ioHandler) {
 	fileName := "/sys/block/" + deviceName + "/device/delete"
@@ -272,7 +282,7 @@ func (util *FCUtil) DetachDisk(c fcDiskUnmounter, devicePath string) error {
 	glog.V(4).Infof("fc: DetachDisk devicePath: %v, dstPath: %v, devices: %v", devicePath, dstPath, devices)
 	var lastErr error
 	for _, device := range devices {
-		err := util.detachFCDisk(c.io, device)
+		err := util.detachFCDisk(c.io, c.exec, device)
 		if err != nil {
 			glog.Errorf("fc: detachFCDisk failed. device: %v err: %v", device, err)
 			lastErr = fmt.Errorf("fc: detachFCDisk failed. device: %v err: %v", device, err)
@@ -286,11 +296,12 @@ func (util *FCUtil) DetachDisk(c fcDiskUnmounter, devicePath string) error {
 }
 
 // detachFCDisk removes scsi device file such as /dev/sdX from the node.
-func (util *FCUtil) detachFCDisk(io ioHandler, devicePath string) error {
+func (util *FCUtil) detachFCDisk(io ioHandler, exec mount.Exec, devicePath string) error {
 	// Remove scsi device from the node.
 	if !strings.HasPrefix(devicePath, "/dev/") {
 		return fmt.Errorf("fc detach disk: invalid device name: %s", devicePath)
 	}
+	flushDevice(devicePath, exec)
 	arr := strings.Split(devicePath, "/")
 	dev := arr[len(arr)-1]
 	removeFromScsiSubsystem(dev, io)
@@ -369,7 +380,7 @@ func (util *FCUtil) DetachBlockFCDisk(c fcDiskUnmapper, mapPath, devicePath stri
 		if err.Error() != volumepathhandler.ErrDeviceNotFound {
 			return fmt.Errorf("fc: failed to get loopback for destination path: %v, err: %v", dstPath, err)
 		}
-		glog.Warning("fc: loopback for destination path: %s not found", dstPath)
+		glog.Warningf("fc: loopback for destination path: %s not found", dstPath)
 	}
 
 	// Detach volume from kubelet node
@@ -385,7 +396,7 @@ func (util *FCUtil) DetachBlockFCDisk(c fcDiskUnmapper, mapPath, devicePath stri
 	}
 	var lastErr error
 	for _, device := range devices {
-		err = util.detachFCDisk(c.io, device)
+		err = util.detachFCDisk(c.io, c.exec, device)
 		if err != nil {
 			glog.Errorf("fc: detachFCDisk failed. device: %v err: %v", device, err)
 			lastErr = fmt.Errorf("fc: detachFCDisk failed. device: %v err: %v", device, err)


### PR DESCRIPTION
FibreChannel volume plugin misses one important step when removing a device: "multipath -f". It flushes all multipath buffers to its individual paths. Without it, a filesystem on the device may get corrupted.

~~/hold~~
* The PR is not upstream yet, see https://github.com/kubernetes/kubernetes/pull/97013
  * We may need to merge it even before though, upstream is frozen...
* ~I need to test it.~ Testsed with iSCSI instead of FC.