### PR TITLE
Fix panic dereferencing nil

### DIFF
--- a/test/e2e/upgrade/monitor.go
+++ b/test/e2e/upgrade/monitor.go
@@ -155,13 +155,17 @@ func (m *versionMonitor) Describe(f *framework.Framework) {
 				disruption.RecordJUnitResult(f, fmt.Sprintf("Operator upgrade %s", item.Name), 0, "")
 			}
 
+			newVersion := ""
+			if m.lastCV != nil {
+				newVersion = m.lastCV.Status.Desired.Version
+			}
 			fmt.Fprintf(tw,
 				"%s\t%s %s %s\t%s\t%s\n",
 				item.Name,
 				findConditionShortStatus(available, configv1.ConditionTrue),
 				findConditionShortStatus(degraded, configv1.ConditionFalse),
 				findConditionShortStatus(progressing, configv1.ConditionFalse),
-				findVersion(item.Status.Versions, "operator", m.oldVersion, m.lastCV.Status.Desired.Version),
+				findVersion(item.Status.Versions, "operator", m.oldVersion, newVersion),
 				findConditionMessage(item.Status.Conditions, configv1.OperatorProgressing),
 			)
 		}


### PR DESCRIPTION
```
	github.com/onsi/ginkgo@v4.5.0-origin.1+incompatible/internal/codelocation/code_location.go:19 +0x78
github.com/onsi/ginkgo.GinkgoRecover()
	github.com/onsi/ginkgo@v4.5.0-origin.1+incompatible/ginkgo_dsl.go:278 +0x66
panic(0x4fa8540, 0x8c5a1a0)
	runtime/panic.go:969 +0x175
github.com/openshift/origin/test/e2e/upgrade.(*versionMonitor).Describe(0xc001914480, 0xc00145af20)
	github.com/openshift/origin/test/e2e/upgrade/monitor.go:164 +0x702
github.com/openshift/origin/test/e2e/upgrade.clusterUpgrade(0xc00145af20, 0x647cb20, 0xc001fdcf60, 0x644f820, 0xc0020e4000, 0xc00099c480, 0x0, 0x0, 0x0, 0x0, ...)
	github.com/openshift/origin/test/e2e/upgrade/upgrade.go:330 +0x76c
github.com/openshift/origin/test/e2e/upgrade.glob..func1.1.1()
```

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/25731/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1334452788603654144#1:build-log.txt%3A573

/cc @soltysh 