### PR TITLE
BUILD-187: Check Event if lastTriggeredImageID is cleared

### DIFF
--- a/test/extended/builds/imagechangetriggers.go
+++ b/test/extended/builds/imagechangetriggers.go
@@ -2,15 +2,19 @@ package builds
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	eventsv1 "k8s.io/api/events/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
+	buildv1 "github.com/openshift/api/build/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -35,7 +39,8 @@ var _ = g.Describe("[sig-builds][Feature:Builds] imagechangetriggers", func() {
 			}
 		})
 
-		g.It("imagechangetriggers should trigger builds of all types", func() {
+		g.It("should trigger builds of all types", func() {
+			// AsAdmin is required because Custom strategy builds need admin privileges in a default cluster configuration
 			err := oc.AsAdmin().Run("create").Args("-f", buildFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -53,6 +58,58 @@ var _ = g.Describe("[sig-builds][Feature:Builds] imagechangetriggers", func() {
 				return true, nil
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
+		g.It("should fire a warning event if the BuildConfig image change trigger was cleared", func() {
+			ctx := context.Background()
+			// AsAdmin is required because Custom strategy builds need admin privileges in a default cluster configuration
+			err := oc.AsAdmin().Run("apply").Args("-f", buildFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = exutil.WaitForABuild(oc.BuildClient().BuildV1().Builds(oc.Namespace()), "bc-docker-1", nil, nil, nil)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			buildConfig, err := oc.BuildClient().BuildV1().BuildConfigs(oc.Namespace()).Get(ctx, "bc-docker", metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			newTriggers := []buildv1.BuildTriggerPolicy{}
+			for _, trigger := range buildConfig.Spec.Triggers {
+				if trigger.ImageChange == nil {
+					newTriggers = append(newTriggers, trigger)
+					continue
+				}
+				o.Expect(trigger.ImageChange.LastTriggeredImageID).NotTo(o.BeEmpty())
+				trigger.ImageChange.LastTriggeredImageID = ""
+				newTriggers = append(newTriggers, trigger)
+			}
+			buildConfig.Spec.Triggers = newTriggers
+			_, err = oc.BuildClient().BuildV1().BuildConfigs(oc.Namespace()).Update(ctx, buildConfig, metav1.UpdateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			var foundEvent *eventsv1.Event
+
+			waitForEvent := func() (bool, error) {
+				// Events require admin permission
+				events, err := oc.AdminKubeClient().EventsV1().Events(oc.Namespace()).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return false, fmt.Errorf("failed to list events in namespace %s: %v", oc.Namespace(), err)
+				}
+				for _, event := range events.Items {
+					if event.Type == "Warning" &&
+						event.Regarding.APIVersion == "build.openshift.io/v1" &&
+						event.Regarding.Kind == "BuildConfig" &&
+						event.Regarding.Name == "bc-docker" {
+						foundEvent = &event
+						return true, nil
+					}
+				}
+				framework.Logf("Waiting for warning event for BuildConfig %s...", "bc-docker")
+				return false, nil
+
+			}
+
+			err = wait.Poll(5*time.Second, 5*time.Minute, waitForEvent)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(foundEvent.Reason).To(o.Equal("ImageChangeTriggerCleared"))
 		})
 	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1121,7 +1121,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-builds][Feature:Builds] custom build with buildah  being created from new-build should complete build with custom builder image": "should complete build with custom builder image [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] imagechangetriggers  imagechangetriggers should trigger builds of all types": "imagechangetriggers should trigger builds of all types [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] imagechangetriggers  should fire a warning event if the BuildConfig image change trigger was cleared": "should fire a warning event if the BuildConfig image change trigger was cleared [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-builds][Feature:Builds] imagechangetriggers  should trigger builds of all types": "should trigger builds of all types [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-builds][Feature:Builds] oc new-app  should fail with a --name longer than 58 characters": "should fail with a --name longer than 58 characters [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
Verify that if the lastTriggeredImageID is cleared on a BuildConfig, it
fires a Warning event with reason "ImageChangeTriggerCleared".