### PR TITLE
add kubevirt as a provide to openshift tests

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -18,6 +18,9 @@ import (
 	// Initialize ovirt as a provider
 	_ "github.com/openshift/origin/test/extended/util/ovirt"
 
+	// Initialize kubevirt as a provider
+	_ "github.com/openshift/origin/test/extended/util/kubevirt"
+
 	// these are loading important global flags that we need to get and set
 	_ "k8s.io/kubernetes/test/e2e"
 	_ "k8s.io/kubernetes/test/e2e/lifecycle"

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -49,7 +49,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	// ovirt does not support service type loadbalancer because it doesn't program a cloud.
-	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType {
+	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.KubevirtPlatformType {
 		t.unsupportedPlatform = true
 	}
 	if t.unsupportedPlatform {

--- a/test/extended/util/kubevirt/provider.go
+++ b/test/extended/util/kubevirt/provider.go
@@ -1,0 +1,18 @@
+package kubevirt
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func init() {
+	framework.RegisterProvider("kubevirt", newProvider)
+}
+
+func newProvider() (framework.ProviderInterface, error) {
+	return &Provider{}, nil
+}
+
+// Provider is a structure to handle kubevirt for e2e testing
+type Provider struct {
+	framework.NullProvider
+}


### PR DESCRIPTION
Our main goal is creating a tenant cluster on top of existing OpenShift/Kubernetes cluster by creating virtualMachines (using kubevirt) for every node in the tenant cluster (masters and also workers nodes)
You can find more information here: openshift/enhancements#417