### PR TITLE
Bug 1904683: add build s2i as root uid image for associated tests

### DIFF
--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -2,6 +2,8 @@ package builds
 
 import (
 	"context"
+	"fmt"
+	"github.com/openshift/origin/test/extended/util/image"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -35,7 +37,8 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 		Before(oc)
 		defer After(oc)
 
-		err := oc.Run("new-app").Args("docker.io/openshift/test-build-roots2i~https://github.com/sclorg/nodejs-ex", "--name", "nodejsfail").Execute()
+		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i"))
+		err := oc.Run("new-app").Args(firstArgString, "--name", "nodejsfail").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		err = exutil.WaitForABuild(oc.BuildClient().BuildV1().Builds(oc.Namespace()), "nodejsfail-1", nil, nil, nil)
@@ -111,7 +114,8 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 		roleBinding, err = oc.AdminKubeClient().RbacV1().RoleBindings(oc.Namespace()).Create(context.Background(), roleBinding, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = oc.Run("new-build").Args("docker.io/openshift/test-build-roots2i~https://github.com/sclorg/nodejs-ex", "--name", "nodejspass").Execute()
+		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i"))
+		err = oc.Run("new-build").Args(firstArgString, "--name", "nodejspass").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		err = exutil.WaitForABuild(oc.BuildClient().BuildV1().Builds(oc.Namespace()), "nodejspass-1", nil, nil, nil)

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -20,6 +20,10 @@ func init() {
 		// used by oc mirror test, should be moved to publish to quay
 		"docker.io/library/registry:2.7.1": -1,
 
+		// used by build s2i e2e's to verify that builder with USER root are not allowed
+		// the github.com/openshift/build-test-images repo is built out of github.com/openshift/release
+		"registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i": -1,
+
 		// moved to GCR
 		"k8s.gcr.io/sig-storage/csi-attacher:v2.2.0":              -1,
 		"k8s.gcr.io/sig-storage/csi-attacher:v3.0.0":              -1,

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -50,3 +50,4 @@ k8s.gcr.io/sig-storage/livenessprobe:v1.1.0 quay.io/openshift/community-e2e-imag
 k8s.gcr.io/sig-storage/mock-driver:v3.1.0 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-mock-driver-v3-1-0-PWpfweH52dPLzByS
 k8s.gcr.io/sig-storage/nfs-provisioner:v2.2.2 quay.io/openshift/community-e2e-images:e2e-22-k8s-gcr-io-sig-storage-nfs-provisioner-v2-2-2-dbgtOCwYmEGggl01
 k8s.gcr.io/sig-storage/snapshot-controller:v2.1.1 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-snapshot-controller-v2-1-1-n5BM_jX2npV3RxHM
+registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-svc-ci-openshift-org-ocp-4-7-test-build-roots2i-ZzDWhWn0wPB9cLFM


### PR DESCRIPTION
/assign @smarterclayton 

hey - one of the docker.io refs used in build e2e's was not handled with your change from last week

please see https://github.com/openshift/origin/blob/master/test/extended/builds/s2i_root.go#L114

as a rule, official s2i builders do not run with root uid, so we don't have any officially s2i builder images to use instead in order to validate that such builders are not allowed

Also, in talking to @bparees this guy is so old, we are not sure which repo/Dockerfile manages this one  ... it might have been manually created and pushed to docker.io ... so perhaps we need to do work along those lines to recreate all that ... either that, or pull docker.io/... and push to quay.io/....

Lastly, and related, I had trouble finding example in openshift/release in order to `Define a standard CI build and publish the image to quay.io in the openshift namespace` and `Have the automation promote the image to the quay mirror location.` per https://github.com/openshift/origin/blob/master/test/extended/util/image/README.md#to-add-a-new-image

Any guidance would be appreciated