### PR TITLE
test/extended/operators: Require CPU and memory requests

### DIFF
--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -29,7 +29,7 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 		// a pod in a namespace that begins with kube-* or openshift-* must come from our release payload
 		// TODO components in openshift-operators may not come from our payload, may want to weaken restriction
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
-		excludeNamespaces := sets.NewString("openshift-operator-lifecycle-manager", "openshift-marketplace")
+		excludeNamespaces := sets.NewString("openshift-operator-lifecycle-manager", "openshift-marketplace", "openshift-service-catalog-removed")
 		excludePodPrefix := sets.NewString(
 			"revision-pruner-",  // operators have retry logic built in. these are like jobs but cannot rely on jobs
 			"installer-",        // operators have retry logic built in. these are like jobs but cannot rely on jobs

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -813,9 +813,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] ClusterOperators should define at least one related object that is not a namespace": "at least one related object that is not a namespace [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should ensure control plane operators do not make themselves unevictable": "ensure control plane operators do not make themselves unevictable [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] Managed cluster should ensure control plane containers have requests set for cpu and memory": "ensure control plane containers have requests set for cpu and memory [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should ensure control plane pods do not run in best-effort QoS": "ensure control plane pods do not run in best-effort QoS [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] Managed cluster should ensure control plane operators do not make themselves unevictable": "ensure control plane operators do not make themselves unevictable [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch] Managed cluster should ensure pods use downstream images from our release image with proper ImagePullPolicy": "should ensure pods use downstream images from our release image with proper ImagePullPolicy [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
The outgoing QoS check landed in aeb8caad73 (#22787).  But while setting a request for a single type (e.g. just CPU) on a single container is enough to move a pod from the BestEffort class to the Burstable class, it's not enough to protect a pod from eviction if a separate, non-requested resource is constrained on the node.  Because all containers will consume both memory and CPU, require, as part of OCP-core policy, all OCP-core containers to set requests for both resource types.  Future work can compare the requested values with measured consumption, but I'm punting on that for now.