### PR TITLE
[release 4.6] Bug 1906011: UPSTREAM: 96310: PV e2e: fix race in NFS recycling test

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/storage/persistent_volumes.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/persistent_volumes.go
@@ -307,6 +307,11 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 
 				framework.ExpectNoError(e2epod.DeletePodWithWait(c, pod))
 				framework.Logf("Pod exited without failure; the volume has been recycled.")
+
+				// Delete the PVC and wait for the recycler to finish before the NFS server gets shutdown during cleanup.
+				framework.Logf("Removing second PVC, waiting for the recycler to finish before cleanup.")
+				framework.ExpectNoError(e2epv.DeletePVCandValidatePV(c, ns, pvc, pv, v1.VolumeAvailable))
+				pvc = nil
 			})
 		})
 	})


### PR DESCRIPTION
Fixes flake in the NFS recycling e2e test. Backport of https://github.com/openshift/kubernetes/pull/441