### PR TITLE
allow operators to settle after MCPs are done upgrading

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -439,6 +439,37 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 		return err
 	}
 
+	if err := disruption.RecordJUnit(
+		f,
+		"[sig-cluster-lifecycle] ClusterOperators are available and not degraded after upgrade",
+		func() error {
+			framework.Logf("Waiting for operators to settle after upgrade")
+			if err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+				coList, err := c.ConfigV1().ClusterOperators().List(context.Background(), metav1.ListOptions{})
+				if err != nil {
+					framework.Logf("error getting ClusterOperators %v", err)
+					return false, nil
+				}
+				settled := true
+				for _, co := range coList.Items {
+					available := findCondition(co.Status.Conditions, configv1.OperatorAvailable)
+					degraded := findCondition(co.Status.Conditions, configv1.OperatorDegraded)
+					if !conditionHasStatus(available, configv1.ConditionTrue) ||
+						conditionHasStatus(degraded, configv1.ConditionTrue) {
+						settled = false
+						break
+					}
+				}
+				return settled, nil
+			}); err != nil {
+				return fmt.Errorf("ClusterOperators did not settle: %v", err)
+			}
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The upgrade test currently just waits for the MCPs to complete their rollout before immediately checking if all ClusterOperators are available and not degraded.  This is causing quite a few false failures in CI, `authentication` and `openshift-apiserver` in particular.

Example job
https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.7/1336793136516567040

The PR checks the ClusterOperators every 10s for up to 5m to see if they have settled after the MCP rollout.  If they don't settle within 5m, the test fails.

@deads2k @fabianvf 