### PR TITLE
Skip table tests broken by 1.20 rebase

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -497,9 +497,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata [Conformance]": "should return a 406 for a backend which does not implement metadata [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls": "should return chunks of table results for list calls [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls": "should return chunks of table results for list calls [Disabled:Broken] [Suite:k8s]",
 
-	"[Top Level] [sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes": "should return generic metadata details across all namespaces for nodes [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes": "should return generic metadata details across all namespaces for nodes [Disabled:Broken] [Suite:k8s]",
 
 	"[Top Level] [sig-api-machinery] Servers with support for Table transformation should return pod details": "should return pod details [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -34,6 +34,10 @@ var (
 			`should answer endpoint and wildcard queries for the cluster`, // currently not supported by dns operator https://github.com/openshift/cluster-dns-operator/issues/43
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1902702 - [sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap: oc cp over non-existing directory/file fails
 			`\[sig-auth\]\[Feature:LDAP\]\[Serial\] ldap group sync can sync groups from ldap`,
+
+			// Will be fixed by the bump to 1.20: https://github.com/openshift/origin/pull/25765
+			`\[sig-api-machinery\] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes`,
+			`\[sig-api-machinery\] Servers with support for Table transformation should return chunks of table results for list calls`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {},


### PR DESCRIPTION
The following tests fail consistently after the merge of the 1.20 rebase, and this is blocking testing and merge of most repos. Rather than wait for the [1.20 origin bump](https://github.com/openshift/origin/pull/25765) to fix these tests, skip and unblock everyone.

/cc @mfojtik @sttts @tnozicka @soltysh 