### PR TITLE
Bug 1908764: Skew 4.5 to 4.6 tests are failing due to a misplaced skip (prevents all tests from running)

### DIFF
--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -37,14 +37,13 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 	})
 
 	g.Context("Using a OAuth client with a non-default token max age", func() {
-		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
-			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions have different oauth token rules")
-		}
-
 		var oAuthClientResource *oauthv1.OAuthClient
 		var accessTokenMaxAgeSeconds int32
 
 		g.JustBeforeEach(func() {
+			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+				e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions have different oauth token rules")
+			}
 			var err error
 			oAuthClientResource, err = oc.AdminOAuthClient().OauthV1().OAuthClients().Create(context.Background(), &oauthv1.OAuthClient{
 				ObjectMeta:               metav1.ObjectMeta{Name: fmt.Sprintf("%s-%05d", oc.Namespace(), accessTokenMaxAgeSeconds)},


### PR DESCRIPTION
The skip function must run inside of the correct ginkgo blocks,
otherwise it panics during code init and the test process exits
without running any tests.

I.e. skew tests are not running at all due to this panic:

```

Dec 13 19:44:59.825: INFO: Test is disabled to allow cluster components to have different versions, and skewed versions have different oauth token rules
panic: Your test failed.

...

goroutine 1 [running]:
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/skipper.skip.func1(0xc0003bdd00, 0x7d, 0x997c048, 0x76, 0x29, 0xc000c8e240, 0x239)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/skipper/skipper.go:81 +0xa1
panic(0x4b6e9a0, 0x6501de0)
	/opt/rh/go-toolset-1.13/root/usr/lib/go-toolset-1.13-golang/src/runtime/panic.go:679 +0x1b2
ithub.com/openshift/origin/vendor/github.com/onsi/ginkgo.Describe(0x5a7c009, 0x32, 0x5d34aa8, 0x965bad)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:289 +0xd6
github.com/openshift/origin/test/extended/oauth.init()
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/oauth/expiration.go:24 +0x54
```

https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.6/1338185336429219840

Has been broken since this change went in in 4.5 to 4.6 skew tests