### PR TITLE
Bug 1907938: Nodes goes into NotReady state (VMware)

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0f7cfa4789bdfcec6a27aace5cf6e1e2ea4fa19fe2fae1c87d698cccdc01c84f
-updated: 2020-07-09T10:00:16.576926+02:00
+hash: ce4c4ac1ff87e40bdadde78c514ea0d23b66b64bc8512c7d66fd5a3590e1a557
+updated: 2020-12-17T16:32:21.888625+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: a7dc8b61c822528f973a5e4e7b272055c6fdb43e
@@ -913,7 +913,7 @@ imports:
   - user/informers/externalversions/user/v1
   - user/listers/user/v1
 - name: github.com/openshift/library-go
-  version: eeebfaa62843201e865e96a61eb961ee2c446775
+  version: 07b0830b874034180d0e35d352241fec31ab1060
   subpackages:
   - pkg/apiserver/admission/admissionrestconfig
   - pkg/apiserver/admission/admissiontimeout
@@ -942,6 +942,7 @@ imports:
   - pkg/image/internal/digest
   - pkg/image/internal/reference
   - pkg/image/reference
+  - pkg/network
   - pkg/network/networkutils
   - pkg/oauth/oauthdiscovery
   - pkg/operator/events
@@ -1633,7 +1634,7 @@ imports:
   - test/integration
   - test/integration/fixtures
 - name: k8s.io/apimachinery
-  version: 486331e63b6ae160381030bac9dfb4c3c93452d2
+  version: f810590f3b946cec313a5daa38f61332b49b01fe
   repo: https://github.com/openshift/kubernetes-apimachinery.git
   subpackages:
   - pkg/api/apitesting
@@ -1699,7 +1700,7 @@ imports:
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
-  version: e7585ae3a3784f2c0ca4b69d57e0b048aaf47502
+  version: ccec12e504b9e5a58b5d878f690f988880cad263
   repo: https://github.com/openshift/kubernetes-apiserver.git
   subpackages:
   - pkg/admission
@@ -1850,7 +1851,7 @@ imports:
   - pkg/printers
   - pkg/resource
 - name: k8s.io/client-go
-  version: 13306934dd770b6e6bbeb9488f028c81c32c6411
+  version: cea66ed5144fe6f24eb0faefaecf77cbac335f05
   repo: https://github.com/openshift/kubernetes-client-go.git
   subpackages:
   - discovery
@@ -2209,12 +2210,12 @@ imports:
   subpackages:
   - config/v1alpha1
 - name: k8s.io/kube-scheduler
-  version: 03ae14b8002f6f0f0e9d68b173cb9aa8c06a39ed
+  version: b9788b571b6fcea8886692285083b260a9c7688c
   repo: https://github.com/openshift/kubernetes-kube-scheduler.git
   subpackages:
   - config/v1
   - config/v1alpha1
-  - config/v1alpha2
+  - config/v1beta1
   - extender/v1
 - name: k8s.io/kubectl
   version: 9fb4d7b8ee32055adec23f29c6cfedb7ce9cd8aa
@@ -2302,7 +2303,7 @@ imports:
   - pkg/apis/deviceplugin/v1beta1
   - pkg/apis/pluginregistration/v1
 - name: k8s.io/kubernetes
-  version: cb0cba374fbdfc57e00b127d6f266aaa58bfcc46
+  version: 65a1d9482ceb5223bf76b2ab49f0244740ffbf34
   repo: https://github.com/openshift/kubernetes.git
   subpackages:
   - cmd/cloud-controller-manager/app
@@ -2374,7 +2375,6 @@ imports:
   - openshift-kube-apiserver/configdefault
   - openshift-kube-apiserver/enablement
   - openshift-kube-apiserver/openshiftkubeapiserver
-  - pkg/api/endpoints
   - pkg/api/legacyscheme
   - pkg/api/persistentvolume
   - pkg/api/persistentvolumeclaim
@@ -2937,7 +2937,7 @@ imports:
   - pkg/scheduler/apis/config/scheme
   - pkg/scheduler/apis/config/v1
   - pkg/scheduler/apis/config/v1alpha1
-  - pkg/scheduler/apis/config/v1alpha2
+  - pkg/scheduler/apis/config/v1beta1
   - pkg/scheduler/apis/config/validation
   - pkg/scheduler/core
   - pkg/scheduler/framework/plugins
@@ -3203,7 +3203,7 @@ imports:
   - third_party/forked/gonum/graph/traverse
   - third_party/forked/ipvs
 - name: k8s.io/legacy-cloud-providers
-  version: b6226989142af5acc03b7f747df109059f31b32c
+  version: d6949cc45921ccc0b669ada4e6cf711eb53cdd61
   repo: https://github.com/openshift/kubernetes-legacy-cloud-providers.git
   subpackages:
   - aws

--- a/glide.yaml
+++ b/glide.yaml
@@ -115,9 +115,9 @@ import:
 - package: github.com/openshift/client-go
   version: 05eb9880269c5ff1696fe20f511f9efa8bbdba0e
 - package: github.com/openshift/library-go
-  version: eeebfaa62843201e865e96a61eb961ee2c446775
+  version: 07b0830b874034180d0e35d352241fec31ab1060
 - package: github.com/openshift/apiserver-library-go
-  version: master
+  version: a7bc13e3e6504ddc7056ab9a5d2d6c61f7eb45b9
 
 # forks third
 - package: github.com/onsi/ginkgo

--- a/vendor/github.com/openshift/library-go/go.mod
+++ b/vendor/github.com/openshift/library-go/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/ldap.v2 v2.5.1

--- a/vendor/github.com/openshift/library-go/pkg/config/client/client_config.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/client/client_config.go
@@ -2,14 +2,12 @@ package client
 
 import (
 	"io/ioutil"
-	"net"
-	"net/http"
-	"time"
-
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"net/http"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/network"
 )
 
 // GetKubeConfigOrInClusterConfig loads in-cluster config if kubeConfigFile is empty or the file if not,
@@ -101,10 +99,7 @@ func (c ClientTransportOverrides) DefaultClientTransport(rt http.RoundTripper) h
 		return rt
 	}
 
-	transport.DialContext = (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext
+	transport.DialContext = network.DefaultClientDialContext()
 
 	// Hold open more internal idle connections
 	transport.MaxIdleConnsPerHost = 100

--- a/vendor/github.com/openshift/library-go/pkg/network/dialer.go
+++ b/vendor/github.com/openshift/library-go/pkg/network/dialer.go
@@ -1,0 +1,13 @@
+package network
+
+import (
+	"context"
+	"net"
+)
+
+type DialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
+// DefaultDialContext returns a DialContext function from a network dialer with default options sets.
+func DefaultClientDialContext() DialContext {
+	return dialerWithDefaultOptions()
+}

--- a/vendor/github.com/openshift/library-go/pkg/network/dialer_linux.go
+++ b/vendor/github.com/openshift/library-go/pkg/network/dialer_linux.go
@@ -1,0 +1,93 @@
+// +build linux
+
+package network
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func dialerWithDefaultOptions() DialContext {
+	nd := &net.Dialer{
+		// TCP_USER_TIMEOUT does affect the behaviour of connect() which is controlled by this field so we set it to the same value
+		Timeout: 25 * time.Second,
+		// KeepAlive must to be set to a negative value to stop std library from applying the default values
+		// by doing so we ensure that the options we are interested in won't be overwritten
+		KeepAlive: time.Duration(-1),
+		Control: func(network, address string, con syscall.RawConn) error {
+			var errs []error
+			err := con.Control(func(fd uintptr) {
+				optionsErr := setDefaultSocketOptions(int(fd))
+				if optionsErr != nil {
+					errs = append(errs, optionsErr)
+				}
+			})
+			if err != nil {
+				errs = append(errs, err)
+			}
+			return utilerrors.NewAggregate(errs)
+		},
+	}
+	return nd.DialContext
+}
+
+// setDefaultSocketOptions sets custom socket options so that we can detect connections to an unhealthy (dead) peer quickly.
+// In particular we set TCP_USER_TIMEOUT that specifies the maximum amount of time that transmitted data may remain
+// unacknowledged before TCP will forcibly close the connection.
+//
+// Note
+// TCP_USER_TIMEOUT can't be too low because a single dropped packet might drop the entire connection.
+// Ideally it should be set to: TCP_KEEPIDLE + TCP_KEEPINTVL * TCP_KEEPCNT
+func setDefaultSocketOptions(fd int) error {
+	// specifies the maximum amount of time in milliseconds that transmitted data may remain
+	// unacknowledged before TCP will forcibly close the corresponding connection and return ETIMEDOUT to the application
+	tcpUserTimeoutInMilliSeconds := int(25 * time.Second / time.Millisecond)
+
+	// specifies the interval at which probes are sent in seconds
+	tcpKeepIntvl := int(roundDuration(5*time.Second, time.Second))
+
+	// specifies the threshold for sending the first KEEP ALIVE probe in seconds
+	tcpKeepIdle := int(roundDuration(2*time.Second, time.Second))
+
+	// enable keep-alive probes
+	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
+		return wrapSyscallError("setsockopt", err)
+	}
+
+	if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, tcpUserTimeoutInMilliSeconds); err != nil {
+		return wrapSyscallError("setsockopt", err)
+	}
+
+	if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, tcpKeepIntvl); err != nil {
+		return wrapSyscallError("setsockopt", err)
+	}
+
+	if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, tcpKeepIdle); err != nil {
+		return wrapSyscallError("setsockopt", err)
+	}
+	return nil
+}
+
+// roundDurationUp rounds d to the next multiple of to.
+//
+// note that it was copied from the std library
+func roundDuration(d time.Duration, to time.Duration) time.Duration {
+	return (d + to - 1) / to
+}
+
+// wrapSyscallError takes an error and a syscall name. If the error is
+// a syscall.Errno, it wraps it in a os.SyscallError using the syscall name.
+//
+// note that it was copied from the std library
+func wrapSyscallError(name string, err error) error {
+	if _, ok := err.(syscall.Errno); ok {
+		err = os.NewSyscallError(name, err)
+	}
+	return err
+}

--- a/vendor/github.com/openshift/library-go/pkg/network/dialer_others.go
+++ b/vendor/github.com/openshift/library-go/pkg/network/dialer_others.go
@@ -1,0 +1,19 @@
+// +build !linux
+
+package network
+
+import (
+	"net"
+	"time"
+
+	"k8s.io/klog"
+)
+
+func dialerWithDefaultOptions() DialContext {
+	klog.V(2).Info("Creating the default network Dialer (unsupported platform). It may take up to 15 minutes to detect broken connections and establish a new one")
+	nd := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	return nd.DialContext
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller.go
@@ -7,6 +7,8 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"k8s.io/klog"
 )
 
 type LogLevelController struct {
@@ -41,6 +43,11 @@ func (c LogLevelController) sync(ctx context.Context, syncCtx factory.SyncContex
 	// if operator operatorSpec OperatorLogLevel is empty, default to "Normal"
 	// TODO: This should be probably done by defaulting the CR field?
 	if len(desiredLogLevel) == 0 {
+		desiredLogLevel = operatorv1.Normal
+	}
+
+	if !ValidLogLevel(desiredLogLevel) {
+		klog.Warningf("OperatorLogLevelInvalid: Invalid logLevel %q, falling back to %q", desiredLogLevel, operatorv1.Normal)
 		desiredLogLevel = operatorv1.Normal
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller_test.go
@@ -85,6 +85,15 @@ func TestClusterOperatorLoggingController(t *testing.T) {
 			},
 			startingVerbosity: 4,
 			expectedVerbosity: 2,
+			evalEvents: func(events []*corev1.Event, t *testing.T) {
+				if len(events) != 1 {
+					t.Errorf("expected exactly one event, got %d", len(events))
+					return
+				}
+				if !strings.Contains(events[0].Message, `Operator log level changed from "Debug" to "Normal"`) {
+					t.Errorf("expected message to be %q, got %q", `Operator log level changed from "Debug" to "Normal"`, events[0].Message)
+				}
+			},
 		},
 		{
 			name: "when OperatorLogLevel is set to Normal operator must set V(2) once",

--- a/vendor/github.com/openshift/library-go/pkg/operator/loglevel/util.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/loglevel/util.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -23,6 +24,18 @@ func LogLevelToVerbosity(logLevel operatorv1.LogLevel) int {
 	default:
 		return 2
 	}
+}
+
+var validLogLevels = sets.NewString(
+	string(operatorv1.Normal),
+	string(operatorv1.Debug),
+	string(operatorv1.Trace),
+	string(operatorv1.TraceAll),
+	"", // Tolerate empty value, it gets defaulted.
+)
+
+func ValidLogLevel(logLevel operatorv1.LogLevel) bool {
+	return validLogLevels.Has(string(logLevel))
 }
 
 // verbosityFn is exported so it can be unit tested

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/staticpod/controller/prune"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -191,13 +192,14 @@ func (c RevisionController) isLatestRevisionCurrent(revision int32) (bool, strin
 }
 
 func (c RevisionController) createNewRevision(recorder events.Recorder, revision int32) error {
+	// Create a new InProgress status configmap
 	statusConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: c.targetNamespace,
 			Name:      nameFor("revision-status", revision),
 		},
 		Data: map[string]string{
-			"status":   "InProgress",
+			"status":   prune.StatusInProgress,
 			"revision": fmt.Sprintf("%d", revision),
 		},
 	}
@@ -205,6 +207,26 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 	if err != nil {
 		return err
 	}
+
+	// After we create a new revision, check if any of the previous existing
+	// revisions got interrupted while InProgress and mark them Abandoned.
+	configMaps, err := c.configMapGetter.ConfigMaps(c.targetNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, configMap := range configMaps.Items {
+		if !strings.HasPrefix(configMap.Name, "revision-status-") || configMap.Name == statusConfigMap.Name {
+			continue
+		}
+		if configMap.Data["status"] == prune.StatusInProgress {
+			configMap.Data["status"] = prune.StatusAbandoned
+			_, _, err = resourceapply.ApplyConfigMap(c.configMapGetter, recorder, &configMap)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	ownerRefs := []metav1.OwnerReference{{
 		APIVersion: "v1",
 		Kind:       "ConfigMap",

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/bindata/bindata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/bindata/bindata.go
@@ -88,10 +88,10 @@ spec:
           name: kubelet-dir
       resources:
         requests:
-          memory: 100M
+          memory: 200M
           cpu: 150m
         limits:
-          memory: 100M
+          memory: 200M
           cpu: 150m
   restartPolicy: Never
   priorityClassName: system-node-critical

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/manifests/installer-pod.yaml
@@ -32,10 +32,10 @@ spec:
           name: kubelet-dir
       resources:
         requests:
-          memory: 100M
+          memory: 200M
           cpu: 150m
         limits:
-          memory: 100M
+          memory: 200M
           cpu: 150m
   restartPolicy: Never
   priorityClassName: system-node-critical

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/bindata/bindata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/bindata/bindata.go
@@ -72,10 +72,10 @@ spec:
     imagePullPolicy: IfNotPresent
     resources:
       requests:
-        memory: 100M
+        memory: 200M
         cpu: 150m
       limits:
-        memory: 100M
+        memory: 200M
         cpu: 150m
     securityContext:
       privileged: true

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/manifests/pruner-pod.yaml
@@ -16,10 +16,10 @@ spec:
     imagePullPolicy: IfNotPresent
     resources:
       requests:
-        memory: 100M
+        memory: 200M
         cpu: 150m
       limits:
-        memory: 100M
+        memory: 200M
         cpu: 150m
     securityContext:
       privileged: true

--- a/vendor/github.com/openshift/library-go/test/library/encryption/e_log.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/e_log.go
@@ -26,7 +26,7 @@ func NewE(t *testing.T, options ...func(*E)) *E {
 	// that means we don't have any visibility when running the tests from a local machine
 	//
 	// thus std logger will be used when the test are run from a local machine to give instant feedback
-	if len(os.Getenv("PROW_JOB_ID")) == 0 {
+	if len(os.Getenv("OPENSHIFT_BUILD_COMMIT")) == 0 {
 		e.local = true
 	}
 

--- a/vendor/github.com/openshift/library-go/test/library/encryption/perf_helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/perf_helpers.go
@@ -38,7 +38,7 @@ func watchForMigrationControllerProgressingCondition(t testing.TB, getOperatorCo
 		return false, nil
 	})
 	if err != nil {
-		t.Logf("failed waiting for the condition %q with the reason %q to be set to true", "EncryptionMigrationControllerProgressing", "Migrating")
+		t.Logf("failed waiting for the condition %q with the reason %q to be set to true, err was %v", "EncryptionMigrationControllerProgressing", "Migrating", err)
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/transport/cache.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/transport/cache.go
@@ -18,11 +18,12 @@ package transport
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	libgonetwork "github.com/openshift/library-go/pkg/network"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -89,10 +90,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 
 	dial := config.Dial
 	if dial == nil {
-		dial = (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext
+		dial = libgonetwork.DefaultClientDialContext()
 	}
 
 	// If we use are reloading files, we need to handle certificate rotation properly


### PR DESCRIPTION
we will carry a patch that allows the clients (Kubelet, KCM, etc.) to detect broken connections to the api server more quickly than the default TCP timeout of 15 minutes.

Note: this patch will be dropped in future releases once http2/ping is introduced.