### PR TITLE
Bug 1895053: Verify builds can mount proxy trustedCA

### DIFF
--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -1,8 +1,11 @@
 package builds
 
 import (
+	"context"
+
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -82,6 +85,30 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 				o.Expect(buildLog).To(o.ContainSubstring("proxy3"), "build log should include proxy host")
 				o.Expect(buildLog).To(o.ContainSubstring("proxy4"), "build log should include proxy host")
 			})
+		})
+
+		g.Describe("start build with cluster-wide custom PKI", func() {
+
+			g.It("should mount the custom PKI into the build if specified", func() {
+				ctx := context.TODO()
+				proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				if len(proxy.Spec.TrustedCA.Name) == 0 {
+					g.Skip("cluster custom PKI is not configured")
+				}
+				caData, err := oc.AsAdmin().KubeClient().CoreV1().ConfigMaps("openshift-config").Get(ctx, proxy.Spec.TrustedCA.Name, metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				caBundle, present := caData.Data["ca-bundle.crt"]
+				if !present {
+					g.Skip("cluster custom PKI is missing key ca-bundle.crt")
+				}
+				br, _ := exutil.StartBuildAndWait(oc, "sample-docker-build-proxy-ca")
+				br.AssertSuccess()
+				buildLog, err := br.Logs()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(buildLog).To(o.ContainSubstring(caBundle))
+			})
+
 		})
 	})
 })

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -21413,6 +21413,22 @@ items:
           value: https://envuser:password@proxy3.com
         - name: SOME_HTTPS_PROXY
           value: https://envuser:password@proxy4.com
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: sample-docker-build-proxy-ca
+  spec:
+    mountTrustedCA: true
+    source:
+      dockerfile: |
+        FROM registry.redhat.io/ubi8/ubi:latest
+        RUN cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: cli
+          namespace: openshift
 `)
 
 func testExtendedTestdataBuildsTestBuildProxyYamlBytes() ([]byte, error) {

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -90,3 +90,19 @@ items:
           value: https://envuser:password@proxy3.com
         - name: SOME_HTTPS_PROXY
           value: https://envuser:password@proxy4.com
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: sample-docker-build-proxy-ca
+  spec:
+    mountTrustedCA: true
+    source:
+      dockerfile: |
+        FROM registry.redhat.io/ubi8/ubi:latest
+        RUN cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: cli
+          namespace: openshift

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1235,6 +1235,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with broken proxy should start a build and wait for the build to fail": "should start a build and wait for the build to fail",
 
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with cluster-wide custom PKI should mount the custom PKI into the build if specified": "should mount the custom PKI into the build if specified",
+
 	"[Top Level] [sig-builds][Feature:Builds][Slow] builds with a context directory  docker context directory build should docker build an application using a context directory": "should docker build an application using a context directory",
 
 	"[Top Level] [sig-builds][Feature:Builds][Slow] builds with a context directory  s2i context directory build should s2i build an application using a context directory": "should s2i build an application using a context directory",


### PR DESCRIPTION
Verify builds can mount the cluster's custom PKI trust bundle if one is
set on the cluster proxy configuration. When `mountProxyTrustedCA` is
set to `true`, builds should add the container's trust bundle as a
read-only mount. The custom PKI should be readable during the build
execution, but should not be present in the resulting image.