### PR TITLE
test: Assess average series rather than max over the test window

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -104,8 +104,11 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 
 		tests := map[string]bool{
 			// We want to limit the number of total series sent, the cluster:telemetry_selected_series:count
-			// rule contains the count of the all the series that are sent via telemetry.
-			`max_over_time(cluster:telemetry_selected_series:count[2h]) >= 600`: false,
+			// rule contains the count of the all the series that are sent via telemetry. It is permissible
+			// for some scenarios to generate more series than 600, we just want the basic state to be below
+			// a threshold.
+			`avg_over_time(cluster:telemetry_selected_series:count[1h]) >= 600`:  false,
+			`max_over_time(cluster:telemetry_selected_series:count[1h]) >= 1200`: false,
 		}
 		err := helper.RunQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
With the recent increase in cluster metrics, some disruptive tests
can trigger errors that result in a burst of
cluster_operator_conditions or alerts series that then clear after
the disruption. We want to run the full suite after we run a
disruption, and in general we are concerned with average over max,
so shorten the interval we check to 1h and calculate the average.

When looking at telemetry from 4.7 CI clusters, the disruptive tests
BRIEFLY peak at 600 series and then fall to 300 almost immediately
after.  Using the average, the total count is closer to 400 over the
hour the tests run and that better represents the desired goal of
the test (to limit average load, not spikes). Check the maximum as
double the average.

Resolves failures encountered when attempting to run the disruptive
suite (destroy the cluster and recover) and then the conformance
suite. Subsequent PR will remove the skip on disruptive

@marun, @lilic 