### PR TITLE
test: Allow tests that check invariants over time to be constrained

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -70,7 +70,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	time.Sleep(alertCheckSleep)
 	cancel()
 
-	if helper.TestUnsupportedAllowVersionSkew() {
+	if exutil.TolerateVersionSkewInTests() {
 		e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
 	}
 	t.oc.SetupProject()

--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -30,7 +30,11 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
 		}
 
+		eventsAfterTime := exutil.LimitTestsToStartTime()
 		for _, ev := range evs.Items {
+			if ev.LastTimestamp.Time.Before(eventsAfterTime) {
+				continue
+			}
 			if ev.Reason != "NonGracefulTermination" {
 				continue
 			}
@@ -52,7 +56,11 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
 		}
 
+		eventsAfterTime := exutil.LimitTestsToStartTime()
 		for _, ev := range evs.Items {
+			if ev.LastTimestamp.Time.Before(eventsAfterTime) {
+				continue
+			}
 			if ev.Reason != "GracefulTerminationTimeout" {
 				continue
 			}
@@ -74,7 +82,11 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
 		}
 
+		eventsAfterTime := exutil.LimitTestsToStartTime()
 		for _, ev := range evs.Items {
+			if ev.LastTimestamp.Time.Before(eventsAfterTime) {
+				continue
+			}
 			if ev.Reason != "LateConnections" {
 				continue
 			}
@@ -96,7 +108,11 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
 		}
 
+		eventsAfterTime := exutil.LimitTestsToStartTime()
 		for _, ev := range evs.Items {
+			if ev.LastTimestamp.Time.Before(eventsAfterTime) {
+				continue
+			}
 			if ev.Reason != "NonReadyRequests" {
 				continue
 			}

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -104,8 +104,11 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 
 		tests := map[string]bool{
 			// We want to limit the number of total series sent, the cluster:telemetry_selected_series:count
-			// rule contains the count of the all the series that are sent via telemetry.
-			`max_over_time(cluster:telemetry_selected_series:count[2h]) >= 600`: false,
+			// rule contains the count of the all the series that are sent via telemetry. It is permissible
+			// for some scenarios to generate more series than 600, we just want the basic state to be below
+			// a threshold.
+			`avg_over_time(cluster:telemetry_selected_series:count[1h]) >= 600`:  false,
+			`max_over_time(cluster:telemetry_selected_series:count[1h]) >= 1200`: false,
 		}
 		err := helper.RunQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/util/conditions.go
+++ b/test/extended/util/conditions.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// LimitTestsToStartTime returns a time.Time which should be the earliest
+// that a test in the e2e suite will consider. By default this is the empty
+// Time object, and if TEST_LIMIT_START_TIME is set to a unix timestamp in
+// seconds from the epoch, will return that time.
+//
+// Tests should use this when looking at the historical record for failures -
+// events that happen before this time are considered to be ignorable.
+//
+// Disruptive tests use this value to signal when the disruption has healed
+// so that normal conformance results are not impacted.
+func LimitTestsToStartTime() time.Time {
+	s := os.Getenv("TEST_LIMIT_START_TIME")
+	if len(s) == 0 {
+		return time.Time{}
+	}
+	seconds, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(seconds, 0)
+}
+
+// DurationSinceStartInSeconds returns the current time minus the start
+// limit time, and if no start limit time is set it returns one hour. It
+// also rounds the duration to seconds. Used by tests that want to look
+// at a range such as prometheus metrics instead of hardcoding an interval.
+// This function clamps the returned value to [time.Minute, 24*time.Hour].
+func DurationSinceStartInSeconds() time.Duration {
+	start := LimitTestsToStartTime()
+	if start.IsZero() {
+		return time.Hour
+	}
+	interval := time.Now().Sub(start).Round(time.Second)
+	switch {
+	case interval < 0:
+		return time.Hour
+	case interval < time.Minute:
+		return time.Minute
+	case interval > 24*time.Hour:
+		return 24 * time.Hour
+	default:
+		return interval
+	}
+}
+
+// TolerateVersionSkewInTests returns true if the test invoker has indicated
+// that version skew is known present via the TEST_UNSUPPORTED_ALLOW_VERSION_SKEW
+// environment variable. Tests that may fail if the component is skewed may then
+// be skipped or alter their behavior. The version skew is assumed to be one minor
+// release - for instance, if a test would fail because the previous version of
+// the kubelet does not yet support a value, when this function returns true it
+// would be acceptable for the test to invoke Skipf().
+//
+// Used by the node version skew environment (Kube @ version N, nodes @ version N-1)
+// to ensure OpenShift works when control plane and worker nodes are not updated,
+// as can occur during test suites.
+func TolerateVersionSkewInTests() bool {
+	if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+		return true
+	}
+	return false
+}

--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -40,14 +39,6 @@ type PrometheusResponse struct {
 type prometheusResponseData struct {
 	ResultType string       `json:"resultType"`
 	Result     model.Vector `json:"result"`
-}
-
-// TestUnsupportedAllowVersionSkew returns whether TEST_UNSUPPORTED_ALLOW_VERSION_SKEW is set
-func TestUnsupportedAllowVersionSkew() bool {
-	if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
-		return true
-	}
-	return false
 }
 
 // GetBearerTokenURLViaPod makes http request through given pod


### PR DESCRIPTION
A number of cluster invariants check without time boundaries - for 
instance, kube-apiserver hasn't failed to gracefully restart from all
events stored in the api, or prometheus not reporting any alerts since the
start of the test. However, when these tests run after induced disruption
(like recovering a master or a restored cluster) the test would then fail
because it sees the disruption. The current behavior is useful for
assessing install, but can't scale to disruption events.

Instead of tests hardcoding arbitrary intervals, standardize the lookback
window into a pair of utility functions, one for the complete valid range,
and one for a more limited "look back a reasonable period of time". Allow
the test invoker to pass an environment variable
TEST_LIMIT_START_TIME=<unix_timestamp_in_seconds_since_epoch> that will
automatically constrain how far back tests look. This allows the tests to
continue to observe installation failures by default, and for disruption
suites to pass the time after the disruption to the test suite to limit how
far the lookback extends.

Update all arbitrary prometheus range queries to use the "reasonable" 
window (1h by default) that can be clamped or extended by the start time.

@marun, @sttts

Includes #25783 because I also changed that code and then wanted to parameterize it here.