### PR TITLE
Bug 1913751: Add openshift/network/third-party suite, for CNI plugin conformance

### DIFF
--- a/cmd/openshift-tests/cni.go
+++ b/cmd/openshift-tests/cni.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+)
+
+// Determines whether a test should be run for third-party network plugin conformance testing
+func inCNISuite(name string) bool {
+	if strings.Contains(name, "[Suite:k8s]") && strings.Contains(name, "[sig-network]") {
+		// Run all upstream sig-network conformance tests
+		if strings.Contains(name, "[Conformance]") {
+			return true
+		}
+		// Run all upstream NetworkPolicy tests except named port tests. (Neither
+		// openshift-sdn nor ovn-kubernetes supports named ports in NetworkPolicy,
+		// so we don't require third party tests to support them either.)
+		if strings.Contains(name, "NetworkPolicy") && !strings.Contains(name, "named port") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -187,6 +187,15 @@ var staticSuites = []*ginkgo.TestSuite{
 		TestTimeout: 20 * time.Minute,
 	},
 	{
+		Name: "openshift/network/third-party",
+		Description: templates.LongDesc(`
+		The conformance testing suite for certified third-party CNI plugins.
+		`),
+		Matches: func(name string) bool {
+			return !isDisabled(name) && inCNISuite(name)
+		},
+	},
+	{
 		Name: "all",
 		Description: templates.LongDesc(`
 		Run all tests.


### PR DESCRIPTION
This adds a new suite `openshift/network/third-party`, which will be used for testing OCP compliance of third-party network plugins. Currently, [the conformance testing instructions](https://redhat-connect.gitbook.io/openshift-badges/badges/container-network-interface-cni/workflow/running-the-cni-tests) tell partners to run upstream `e2e.test` directly, with a specific set of `--ginkgo.focus` and `--ginkgo.skip` arguments, which is problematic for various reasons (particularly including the fact that by running `e2e.test` rather than `openshift-tests` they don't get the workarounds for e2e-vs-ocp issues (eg, creating an SCC to allow creating privileged pods)). Also, if we want to change the set of tests to be run, we have to change the focus/skip options, and potentially provide kube-version-specific options...

Anyway, this adds a new suite to openshift-tests, so they can just say `openshift-tests run openshift/network/third-party`. Initially it runs basically the same tests as we currently tell them to run manually, though over time we will likely adjust this, and possibly include some of the openshift-specific tests (eg, router stuff perhaps)

/assign @knobunc 
