### PR TITLE
Bug 1914343: Replacing centos with ubi in image-annotation test.

### DIFF
--- a/test/extended/images/trigger/annotation.go
+++ b/test/extended/images/trigger/annotation.go
@@ -41,8 +41,8 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers] Annotation trigge
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(o.Equal(" "))
 
-		g.By("tagging the docker.io/library/centos:latest as test:v1 image to create ImageStream")
-		out, err := oc.Run("tag").Args("docker.io/library/centos:latest", "test:v1").Output()
+		g.By("tagging the image-registry.openshift-image-registry.svc:5000/openshift/tools:latest as test:v1 image to create ImageStream")
+		out, err := oc.Run("tag").Args("image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "test:v1").Output()
 		framework.Logf("%s", out)
 		o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
Centos is not compatible with s390x, resulting in observed flakeyness when this is run on s390x.