### PR TITLE
test: Only consider rule evaluation failures in current window

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -363,8 +363,11 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
 
+			// we only consider samples since the beginning of the test
+			testDuration := exutil.DurationSinceStartInSeconds().String()
+
 			tests := map[string]bool{
-				`prometheus_rule_evaluation_failures_total >= 1`: false,
+				fmt.Sprintf(`increase(prometheus_rule_evaluation_failures_total[%s]) >= 1`, testDuration): false,
 			}
 			err := helper.RunQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
Some pre-test conditions like upgrade or disruption could result
in rule evaluation failures, so we should check only over the
relevant interval.

Found while testing 4.6->4.7 full e2e upgrades in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/14666/rehearse-14666-release-openshift-origin-installer-e2e-aws-upgrade-4.6-stable-to-4.7-ci/1348694129546104832