### PR TITLE
Bug 1915907: replace test/cmd/builds.sh direct/indirect docker.io refs with imagestream image refs

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -30833,8 +30833,8 @@ os::test::junit::declare_suite_start "cmd/builds"
 template='{{with .spec.output.to}}{{.kind}} {{.name}}{{end}}'
 
 # Build from Dockerfile with output to ImageStreamTag
-os::cmd::expect_success "oc new-build --dockerfile=\$'FROM centos:7\nRUN yum install -y httpd'"
-os::cmd::expect_success_and_text "oc get bc/centos --template '${template}'" '^ImageStreamTag centos:latest$'
+os::cmd::expect_success "oc new-build --to=tests:custom --dockerfile=\$'FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest\nRUN yum install -y httpd'"
+os::cmd::expect_success_and_text "oc get bc/tests --template '${template}'" '^ImageStreamTag tests:custom$'
 
 # Build from a binary with no inputs requires name
 os::cmd::expect_failure_and_text "oc new-build --binary" "you must provide a --name"
@@ -30843,28 +30843,28 @@ os::cmd::expect_failure_and_text "oc new-build --binary" "you must provide a --n
 os::cmd::expect_success "oc new-build --binary --name=binary-test"
 os::cmd::expect_success_and_text "oc get bc/binary-test" 'Binary'
 
-os::cmd::expect_success 'oc delete is/binary-test bc/binary-test bc/centos'
+os::cmd::expect_success 'oc delete is/binary-test bc/binary-test bc/tests'
 
 # Build from Dockerfile with output to DockerImage
-os::cmd::expect_success "oc new-build -D \$'FROM centos:7' --to-docker"
-os::cmd::expect_success_and_text "oc get bc/centos --template '${template}'" '^DockerImage centos:latest$'
+os::cmd::expect_success "oc new-build -D \$'FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest' --to-docker"
+os::cmd::expect_success_and_text "oc get bc/tests --template '${template}'" '^DockerImage tests:latest$'
 
-os::cmd::expect_success 'oc delete is/centos bc/centos'
+os::cmd::expect_success 'oc delete is/tests bc/tests'
 
 # Build from Dockerfile with given output ImageStreamTag spec
-os::cmd::expect_success "oc new-build -D \$'FROM centos:7\nENV ok=1' --to origin-test:v1.1"
+os::cmd::expect_success "oc new-build -D \$'FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest\nENV ok=1' --to origin-test:v1.1"
 os::cmd::expect_success_and_text "oc get bc/origin-test --template '${template}'" '^ImageStreamTag origin-test:v1.1$'
 
-os::cmd::expect_success 'oc delete is/centos bc/origin-test'
+os::cmd::expect_success 'oc delete is/tests bc/origin-test'
 
 # Build from Dockerfile with given output DockerImage spec
-os::cmd::expect_success "oc new-build -D \$'FROM centos:7\nENV ok=1' --to-docker --to openshift/origin:v1.1-test"
+os::cmd::expect_success "oc new-build -D \$'FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest\nENV ok=1' --to-docker --to openshift/origin:v1.1-test"
 os::cmd::expect_success_and_text "oc get bc/origin --template '${template}'" '^DockerImage openshift/origin:v1.1-test$'
 
-os::cmd::expect_success 'oc delete is/centos'
+os::cmd::expect_success 'oc delete is/tests'
 
 # Build from Dockerfile with custom name and given output ImageStreamTag spec
-os::cmd::expect_success "oc new-build -D \$'FROM centos:7\nENV ok=1' --to origin-name-test --name origin-test2"
+os::cmd::expect_success "oc new-build -D \$'FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest\nENV ok=1' --to origin-name-test --name origin-test2"
 os::cmd::expect_success_and_text "oc get bc/origin-test2 --template '${template}'" '^ImageStreamTag origin-name-test:latest$'
 
 #os::cmd::try_until_text 'oc get is ruby-25-centos7' 'latest'
@@ -30872,11 +30872,11 @@ os::cmd::expect_success_and_text "oc get bc/origin-test2 --template '${template}
 
 os::cmd::expect_success 'oc delete all --all'
 
-os::cmd::expect_success "oc new-build -D \$'FROM centos:7' --no-output"
-os::cmd::expect_success_and_not_text 'oc get bc/centos -o=jsonpath="{.spec.output.to}"' '.'
+os::cmd::expect_success "oc new-build -D \$'FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest' --no-output"
+os::cmd::expect_success_and_not_text 'oc get bc/tests -o=jsonpath="{.spec.output.to}"' '.'
 
 # Ensure output is valid JSON
-#os::cmd::expect_success 'oc new-build -D "FROM centos:7" -o json | python -m json.tool'
+#os::cmd::expect_success 'oc new-build -D "FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest" -o json | python -m json.tool'
 
 os::cmd::expect_success 'oc delete all --all'
 os::cmd::expect_success 'oc process -f ${TEST_DATA}/application-template-dockerbuild.json -l build=docker | oc create -f -'
@@ -30932,9 +30932,9 @@ os::cmd::expect_success 'oc create -f ${TEST_DATA}/test-buildcli.json'
 # the build should use the image field as defined in the buildconfig
 # Use basename to transform "build/build-name" into "build-name"
 started="$(basename $(oc start-build -o=name ruby-sample-build-invalidtag))"
-os::cmd::expect_success_and_text "oc describe build ${started}" 'centos/ruby-25-centos7$'
+os::cmd::expect_success_and_text "oc describe build ${started}" 'openshift/ruby$'
 frombuild="$(basename $(oc start-build -o=name --from-build="${started}"))"
-os::cmd::expect_success_and_text "oc describe build ${frombuild}" 'centos/ruby-25-centos7$'
+os::cmd::expect_success_and_text "oc describe build ${frombuild}" 'openshift/ruby$'
 os::cmd::expect_failure_and_text "oc start-build ruby-sample-build-invalid-tag --from-dir=. --from-build=${started}" "cannot use '--from-build' flag with binary builds"
 os::cmd::expect_failure_and_text "oc start-build ruby-sample-build-invalid-tag --from-file=. --from-build=${started}" "cannot use '--from-build' flag with binary builds"
 os::cmd::expect_failure_and_text "oc start-build ruby-sample-build-invalid-tag --from-repo=. --from-build=${started}" "cannot use '--from-build' flag with binary builds"
@@ -35372,7 +35372,7 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateDockerbuildJson = 
           {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:latest"
             },
             "name": "latest"
           }
@@ -42098,7 +42098,7 @@ var _testExtendedTestdataCmdTestCmdTestdataTestBuildcliJson = []byte(`{
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7",
+        "dockerImageRepository": "image-registry.openshift-image-registry.svc:5000/openshift/ruby",
         "tags": [
           {
             "name": "valid"
@@ -42134,7 +42134,7 @@ var _testExtendedTestdataCmdTestCmdTestdataTestBuildcliJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby"
             },
             "incremental": true
           }
@@ -42176,7 +42176,7 @@ var _testExtendedTestdataCmdTestCmdTestdataTestBuildcliJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby"
             },
             "incremental": true
           }
@@ -42551,7 +42551,7 @@ var _testExtendedTestdataCmdTestCmdTestdataTestS2iBuildJson = []byte(`{
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/test-build-simples2i:latest"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/nodejs:latest"
         }
       }
     },

--- a/test/extended/testdata/cmd/test/cmd/testdata/application-template-dockerbuild.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/application-template-dockerbuild.json
@@ -90,7 +90,7 @@
           {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:latest"
             },
             "name": "latest"
           }

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-buildcli.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-buildcli.json
@@ -11,7 +11,7 @@
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7",
+        "dockerImageRepository": "image-registry.openshift-image-registry.svc:5000/openshift/ruby",
         "tags": [
           {
             "name": "valid"
@@ -47,7 +47,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby"
             },
             "incremental": true
           }
@@ -89,7 +89,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby"
             },
             "incremental": true
           }

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-s2i-build.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-s2i-build.json
@@ -26,7 +26,7 @@
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/test-build-simples2i:latest"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/nodejs:latest"
         }
       }
     },


### PR DESCRIPTION
note at least some of these files were touched by clayton's huge refactor, but a few refs slipped the cracks

/assign @bparees 
(in Adam's absence)

thanks @dmage for the heads up