### PR TITLE
Bug 1916419: broaden acceptance of scl sample s2i image usage messages

### DIFF
--- a/test/extended/image_ecosystem/scl.go
+++ b/test/extended/image_ecosystem/scl.go
@@ -79,6 +79,15 @@ func defineTest(name string, t tc, oc *exutil.CLI) {
 				if strings.Contains(string(log), "Sample invocation") {
 					return true, nil
 				}
+				if strings.Contains(string(log), "oc new-app") {
+					return true, nil
+				}
+				if strings.Contains(string(log), "OpenShift") {
+					return true, nil
+				}
+				if strings.Contains(string(log), "Openshift") {
+					return true, nil
+				}
 				return false, nil
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
/assign @bparees 
in Adam's absence

@pedjak @jasperchui FYI per our discussion today I got a couple of cycles so I went ahead and threw this up

So the SCL folks recently tweaked the s2i usage message for 2 of their images such that it no longer passes in the test referenced by the associated bugzilla.

That said, at least in my opinion, their usage messages seem good enough to me.  I've pasted them in the associated bugzilla.

So, what to do:
- for now, this PR broadens the acceptance criteria for the images; we could review and iterate and go with some form of this for the test
- during my discussion with @pedjak he brought up a point I'm sure has come up with us before @bparees .... string verifications like this are fragile;  agreed - but conversely, I think making sure they have some sensible usage message is warranted, and in the past at least, that side of the argument as won out .... should that continue
- also during our discussion, @pedjak asked another good question:  do we proscribe somewhere for sample providers requirements for s2i based images' usage messages that the supply to OCP .... I could not recall any at the time.  And looking after the fact, the closest I found was https://github.com/openshift/source-to-image#anatomy-of-a-builder-image where it says the usage script is optional.  Unless you know otherwise, my initial thought in response was we should minimally add some verbiage in the openshift/library readme about what should be there *if* you supply a usage script for s2i.  And since it is optional, maybe that is argument against verifying the message for the SCL images in the first place.

Thoughts?