### PR TITLE
tests: Synthetic tests moved up and out of test infra

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	"k8s.io/kubectl/pkg/util/templates"
 
+	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/test/ginkgo"
 
 	_ "github.com/openshift/origin/test/extended"
 	_ "github.com/openshift/origin/test/extended/util/annotate/generated"
+	"github.com/openshift/origin/test/extended/util/disruption"
 )
 
 func isDisabled(name string) bool {
@@ -26,7 +29,8 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Suite:openshift/conformance/")
 		},
-		Parallelism: 30,
+		Parallelism:         30,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/conformance/parallel",
@@ -38,6 +42,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		},
 		Parallelism:          30,
 		MaximumAllowedFlakes: 15,
+		SyntheticEventTests:  ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/conformance/serial",
@@ -47,6 +52,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Suite:openshift/conformance/serial")
 		},
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/disruptive",
@@ -57,7 +63,8 @@ var staticSuites = []*ginkgo.TestSuite{
 			return !isDisabled(name) && (strings.Contains(name, "[Feature:EtcdRecovery]") || strings.Contains(name, "[Feature:NodeRecovery]")) &&
 				!strings.Contains(name, "[Skipped:Disruptive]")
 		},
-		TestTimeout: 60 * time.Minute,
+		TestTimeout:         60 * time.Minute,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(systemEventInvariants),
 	},
 	{
 		Name: "kubernetes/conformance",
@@ -67,7 +74,8 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Suite:k8s]") && strings.Contains(name, "[Conformance]")
 		},
-		Parallelism: 30,
+		Parallelism:         30,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/build",
@@ -81,7 +89,8 @@ var staticSuites = []*ginkgo.TestSuite{
 		// TODO: Builds are really flaky right now, remove when we land perf updates and fix io on workers
 		MaximumAllowedFlakes: 3,
 		// Jenkins tests can take a really long time
-		TestTimeout: 60 * time.Minute,
+		TestTimeout:         60 * time.Minute,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/templates",
@@ -91,7 +100,8 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Feature:Templates]")
 		},
-		Parallelism: 1,
+		Parallelism:         1,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/image-registry",
@@ -101,6 +111,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[sig-imageregistry]") && !strings.Contains(name, "[Local]")
 		},
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/image-ecosystem",
@@ -110,8 +121,9 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Feature:ImageEcosystem]") && !strings.Contains(name, "[Local]")
 		},
-		Parallelism: 7,
-		TestTimeout: 20 * time.Minute,
+		Parallelism:         7,
+		TestTimeout:         20 * time.Minute,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/jenkins-e2e",
@@ -121,8 +133,9 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Feature:Jenkins]")
 		},
-		Parallelism: 4,
-		TestTimeout: 20 * time.Minute,
+		Parallelism:         4,
+		TestTimeout:         20 * time.Minute,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/jenkins-e2e-rhel-only",
@@ -132,9 +145,11 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Feature:JenkinsRHELImagesOnly]")
 		},
-		Parallelism: 4,
-		TestTimeout: 20 * time.Minute,
-	}, {
+		Parallelism:         4,
+		TestTimeout:         20 * time.Minute,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
+	},
+	{
 		Name: "openshift/scalability",
 		Description: templates.LongDesc(`
 		Tests that verify the scalability characteristics of the cluster. Currently this is focused on core performance behaviors and preventing regressions.
@@ -153,6 +168,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && !strings.Contains(name, "[Suite:openshift/conformance/")
 		},
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/test-cmd",
@@ -162,6 +178,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Feature:LegacyCommandTests]")
 		},
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/csi",
@@ -173,6 +190,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "External Storage [Driver:") && !strings.Contains(name, "[Disruptive]")
 		},
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "openshift/network/stress",
@@ -182,9 +200,10 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return !isDisabled(name) && strings.Contains(name, "[Suite:openshift/conformance/") && strings.Contains(name, "[sig-network]")
 		},
-		Parallelism: 30,
-		Count:       15,
-		TestTimeout: 20 * time.Minute,
+		Parallelism:         30,
+		Count:               15,
+		TestTimeout:         20 * time.Minute,
+		SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 	},
 	{
 		Name: "all",
@@ -195,4 +214,290 @@ var staticSuites = []*ginkgo.TestSuite{
 			return true
 		},
 	},
+}
+
+const (
+	// Max. duration of API server unreachability, in fraction of total test duration.
+	tolerateDisruptionPercent = 0.01
+)
+
+// stableSystemEventInvariants are invariants that should hold true when a cluster is in
+// steady state (not being changed externally). Use these with suites that assume the
+// cluster is under no adversarial change (config changes, induced disruption to nodes,
+// etcd, or apis).
+func stableSystemEventInvariants(events monitor.EventIntervals, duration time.Duration) (results []*ginkgo.JUnitTestCase, passed bool) {
+	tests, _ := systemEventInvariants(events, duration)
+	results = append(results, tests...)
+	results = append(results, testKubeAPIServerGracefulTermination(events)...)
+	results = append(results, testServerAvailability(monitor.LocatorKubeAPIServerNewConnection, events, duration)...)
+	results = append(results, testServerAvailability(monitor.LocatorOpenshiftAPIServerNewConnection, events, duration)...)
+	results = append(results, testServerAvailability(monitor.LocatorOAuthAPIServerNewConnection, events, duration)...)
+	results = append(results, testServerAvailability(monitor.LocatorKubeAPIServerReusedConnection, events, duration)...)
+	results = append(results, testServerAvailability(monitor.LocatorOpenshiftAPIServerReusedConnection, events, duration)...)
+	results = append(results, testServerAvailability(monitor.LocatorOAuthAPIServerReusedConnection, events, duration)...)
+	return results, true
+}
+
+// systemEventInvariants are invariants tested against events that should hold true in any cluster,
+// even one undergoing disruption. These are usually focused on things that must be true on a single
+// machine, even if the machine crashes.
+func systemEventInvariants(events monitor.EventIntervals, duration time.Duration) (results []*ginkgo.JUnitTestCase, passed bool) {
+	results = append(results, testPodTransitions(events)...)
+	results = append(results, testSystemDTimeout(events)...)
+	results = append(results, testPodSandboxCreation(events)...)
+	return results, true
+}
+
+func testServerAvailability(locator string, events []*monitor.EventInterval, duration time.Duration) []*ginkgo.JUnitTestCase {
+	errDuration, errMessages := disruption.GetDisruption(events, locator)
+
+	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)
+	successTest := &ginkgo.JUnitTestCase{
+		Name:     testName,
+		Duration: duration.Seconds(),
+	}
+	if percent := float64(errDuration) / float64(duration); percent > tolerateDisruptionPercent {
+		test := &ginkgo.JUnitTestCase{
+			Name:     testName,
+			Duration: duration.Seconds(),
+			FailureOutput: &ginkgo.FailureOutput{
+				Output: fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Truncate(time.Second), 100*percent),
+			},
+			SystemOut: strings.Join(errMessages, "\n"),
+		}
+		// Return *two* tests results to pretend this is a flake not to fail whole testsuite.
+		return []*ginkgo.JUnitTestCase{test, successTest}
+	} else {
+		successTest.SystemOut = fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Truncate(time.Second), 100*percent)
+		return []*ginkgo.JUnitTestCase{successTest}
+	}
+}
+
+func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+	const testName = "[sig-node] kubelet terminates kube-apiserver gracefully"
+	success := &ginkgo.JUnitTestCase{Name: testName}
+
+	failures := []string{}
+	for _, event := range events {
+		// from https://github.com/openshift/kubernetes/blob/1f35e4f63be8fbb19e22c9ff1df31048f6b42ddf/cmd/watch-termination/main.go#L96
+		if strings.Contains(event.Message, "did not terminate gracefully") {
+			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
+		}
+	}
+	if len(failures) == 0 {
+		return []*ginkgo.JUnitTestCase{success}
+	}
+
+	failure := &ginkgo.JUnitTestCase{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &ginkgo.FailureOutput{
+			Output: fmt.Sprintf("%d kube-apiserver reports a non-graceful termination. Probably kubelet or CRI-O is not giving the time to cleanly shut down. This can lead to connection refused and network I/O timeout errors in other components.\n\n%v", len(failures), strings.Join(failures, "\n")),
+		},
+	}
+
+	// This should fail a CI run, not flake it.
+	return []*ginkgo.JUnitTestCase{failure}
+
+}
+
+func testPodTransitions(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+	const testName = "[sig-node] pods should never transition back to pending"
+	success := &ginkgo.JUnitTestCase{Name: testName}
+
+	failures := []string{}
+	for _, event := range events {
+		if strings.Contains(event.Message, "pod should not transition") || strings.Contains(event.Message, "pod moved back to Pending") {
+			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
+		}
+	}
+	if len(failures) == 0 {
+		return []*ginkgo.JUnitTestCase{success}
+	}
+
+	failure := &ginkgo.JUnitTestCase{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &ginkgo.FailureOutput{
+			Output: fmt.Sprintf("%d pods illegally transitioned to Pending\n\n%v", len(failures), strings.Join(failures, "\n")),
+		},
+	}
+
+	// TODO an upgrade job that starts before 4.6 may need to make this test flake instead of fail.  This will depend on which `openshift-tests`
+	//  is used to run that upgrade test.  I recommend waiting to a flake until we know and even then find a way to constrain it.
+	return []*ginkgo.JUnitTestCase{failure}
+}
+
+func testSystemDTimeout(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+	const testName = "[sig-node] pods should not fail on systemd timeouts"
+	success := &ginkgo.JUnitTestCase{Name: testName}
+
+	failures := []string{}
+	for _, event := range events {
+		if strings.Contains(event.Message, "systemd timed out for pod") {
+			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
+		}
+	}
+	if len(failures) == 0 {
+		return []*ginkgo.JUnitTestCase{success}
+	}
+
+	failure := &ginkgo.JUnitTestCase{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &ginkgo.FailureOutput{
+			Output: fmt.Sprintf("%d systemd timed out for pod occurrences\n\n%v", len(failures), strings.Join(failures, "\n")),
+		},
+	}
+
+	// write a passing test to trigger detection of this issue as a flake. Doing this first to try to see how frequent the issue actually is
+	return []*ginkgo.JUnitTestCase{failure, success}
+}
+
+type testCategorizer struct {
+	by        string
+	substring string
+}
+
+func testPodSandboxCreation(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+	const testName = "[sig-network] pods should successfully create sandboxes"
+	// we can further refine this signal by subdividing different failure modes if it is pertinent.  Right now I'm seeing
+	// 1. error reading container (probably exited) json message: EOF
+	// 2. dial tcp 10.0.76.225:6443: i/o timeout
+	// 3. error getting pod: pods "terminate-cmd-rpofb45fa14c-96bb-40f7-bd9e-346721740cac" not found
+	// 4. write child: broken pipe
+	bySubStrings := []testCategorizer{
+		{by: " by reading container", substring: "error reading container (probably exited) json message: EOF"},
+		{by: " by not timing out", substring: "i/o timeout"},
+		{by: " by writing network status", substring: "error setting the networks status"},
+		{by: " by getting pod", substring: " error getting pod: pods"},
+		{by: " by writing child", substring: "write child: broken pipe"},
+		{by: " by other", substring: " "}, // always matches
+	}
+
+	failures := []string{}
+	flakes := []string{}
+	eventsForPods := getEventsByPod(events)
+	for _, event := range events {
+		if !strings.Contains(event.Message, "reason/FailedCreatePodSandBox Failed to create pod sandbox") {
+			continue
+		}
+		deletionTime := getPodDeletionTime(eventsForPods[event.Locator], event.Locator)
+		if deletionTime == nil {
+			// this indicates a failure to create the sandbox that should not happen
+			failures = append(failures, fmt.Sprintf("%v - never deleted - %v", event.Locator, event.Message))
+		} else {
+			timeBetweenDeleteAndFailure := event.From.Sub(*deletionTime)
+			switch {
+			case timeBetweenDeleteAndFailure < 1*time.Second:
+				// nothing here, one second is close enough to be ok, the kubelet and CNI just didn't know
+			case timeBetweenDeleteAndFailure < 5*time.Second:
+				// withing five seconds, it ought to be long enough to know, but it's close enough to flake and not fail
+				flakes = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator, timeBetweenDeleteAndFailure.Seconds(), event.Message))
+			case deletionTime.Before(event.From):
+				// something went wrong.  More than five seconds after the pod ws deleted, the CNI is trying to set up pod sandboxes and can't
+				failures = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator, timeBetweenDeleteAndFailure.Seconds(), event.Message))
+			default:
+				// something went wrong.  deletion happend after we had a failure to create the pod sandbox
+				failures = append(failures, fmt.Sprintf("%v - deletion came AFTER sandbox failure - %v", event.Locator, event.Message))
+			}
+		}
+	}
+	if len(failures) == 0 && len(flakes) == 0 {
+		successes := []*ginkgo.JUnitTestCase{}
+		for _, by := range bySubStrings {
+			successes = append(successes, &ginkgo.JUnitTestCase{Name: testName + by.by})
+		}
+		return successes
+	}
+
+	ret := []*ginkgo.JUnitTestCase{}
+	failuresBySubtest, flakesBySubtest := categorizeBySubset(bySubStrings, failures, flakes)
+
+	// now iterate the individual failures to create failure entries
+	for by, subFailures := range failuresBySubtest {
+		failure := &ginkgo.JUnitTestCase{
+			Name:      testName + by,
+			SystemOut: strings.Join(subFailures, "\n"),
+			FailureOutput: &ginkgo.FailureOutput{
+				Output: fmt.Sprintf("%d failures to create the sandbox\n\n%v", len(subFailures), strings.Join(subFailures, "\n")),
+			},
+		}
+		ret = append(ret, failure)
+	}
+	for by, subFlakes := range flakesBySubtest {
+		flake := &ginkgo.JUnitTestCase{
+			Name:      testName + by,
+			SystemOut: strings.Join(subFlakes, "\n"),
+			FailureOutput: &ginkgo.FailureOutput{
+				Output: fmt.Sprintf("%d failures to create the sandbox\n\n%v", len(subFlakes), strings.Join(subFlakes, "\n")),
+			},
+		}
+		ret = append(ret, flake)
+		// write a passing test to trigger detection of this issue as a flake. Doing this first to try to see how frequent the issue actually is
+		success := &ginkgo.JUnitTestCase{
+			Name: testName + by,
+		}
+		ret = append(ret, success)
+	}
+
+	return append(ret)
+}
+
+// categorizeBySubset returns a map keyed by category for failures and flakes.  If a category is present in both failures and flakes, all are listed under failures.
+func categorizeBySubset(categorizers []testCategorizer, failures, flakes []string) (map[string][]string, map[string][]string) {
+	failuresBySubtest := map[string][]string{}
+	flakesBySubtest := map[string][]string{}
+	for _, failure := range failures {
+		for _, by := range categorizers {
+			if strings.Contains(failure, by.substring) {
+				failuresBySubtest[by.by] = append(failuresBySubtest[by.by], failure)
+				break // break after first match so we only add each failure one bucket
+			}
+		}
+	}
+
+	for _, flake := range flakes {
+		for _, by := range categorizers {
+			if strings.Contains(flake, by.substring) {
+				if _, isFailure := failuresBySubtest[by.by]; isFailure {
+					failuresBySubtest[by.by] = append(failuresBySubtest[by.by], flake)
+				} else {
+					flakesBySubtest[by.by] = append(flakesBySubtest[by.by], flake)
+				}
+				break // break after first match so we only add each failure one bucket
+			}
+		}
+	}
+	return failuresBySubtest, flakesBySubtest
+}
+
+func getPodCreationTime(events []*monitor.EventInterval, podLocator string) *time.Time {
+	for _, event := range events {
+		if event.Locator == podLocator && event.Message == "reason/Created" {
+			return &event.From
+		}
+	}
+	return nil
+}
+
+func getPodDeletionTime(events []*monitor.EventInterval, podLocator string) *time.Time {
+	for _, event := range events {
+		if event.Locator == podLocator && event.Message == "reason/Deleted" {
+			return &event.From
+		}
+	}
+	return nil
+}
+
+// getEventsByPod returns map keyed by pod locator with all events associated with it.
+func getEventsByPod(events []*monitor.EventInterval) map[string][]*monitor.EventInterval {
+	eventsByPods := map[string][]*monitor.EventInterval{}
+	for _, event := range events {
+		if !strings.Contains(event.Locator, "pod/") {
+			continue
+		}
+		eventsByPods[event.Locator] = append(eventsByPods[event.Locator], event)
+	}
+	return eventsByPods
 }

--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -171,7 +172,7 @@ func verifyImagesWithoutEnv() error {
 // local cluster registry, any repository referenced by the image streams in the cluster's 'openshift'
 // namespace, or the location that input images are cloned from. Only namespaces prefixed with 'e2e-'
 // are checked.
-func pulledInvalidImages(fromRepository string) func(events monitor.EventIntervals) ([]*ginkgo.JUnitTestCase, bool) {
+func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 	// static allowed images
 	allowedImages := sets.NewString("image/webserver:404")
 	allowedPrefixes := sets.NewString(
@@ -207,7 +208,7 @@ func pulledInvalidImages(fromRepository string) func(events monitor.EventInterva
 
 	// any image not in the allowed prefixes is considered a failure, as the user
 	// may have added a new test image without calling the appropriate helpers
-	return func(events monitor.EventIntervals) ([]*ginkgo.JUnitTestCase, bool) {
+	return func(events monitor.EventIntervals, _ time.Duration) ([]*ginkgo.JUnitTestCase, bool) {
 		allowedPrefixes := allowedPrefixes.List()
 
 		passed := true

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -229,7 +229,7 @@ func newRunCommand() *cobra.Command {
 					return err
 				}
 				opt.MatchFn = matchFn
-				opt.AdditionalJUnitsFn = pulledInvalidImages(opt.FromRepository)
+				opt.SyntheticEventTests = pulledInvalidImages(opt.FromRepository)
 
 				err = opt.Run(args)
 				if !opt.DryRun && len(args) > 0 && strings.HasPrefix(args[0], "openshift/csi") {
@@ -311,7 +311,7 @@ func newRunUpgradeCommand() *cobra.Command {
 					return err
 				}
 				opt.MatchFn = matchFn
-				opt.AdditionalJUnitsFn = pulledInvalidImages(opt.FromRepository)
+				opt.SyntheticEventTests = pulledInvalidImages(opt.FromRepository)
 				return opt.Run(args)
 			})
 		},

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -4,17 +4,45 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor"
-	"github.com/openshift/origin/test/extended/util/disruption"
 )
 
-const (
-	// Max. duration of API server unreachability, in fraction of total test duration.
-	tolerateDisruptionPercent = 0.01
-)
+// JUnitsForEvents returns a set of JUnit results for the provided events encountered
+// during a test suite run.
+type JUnitsForEvents interface {
+	// JUnitsForEvents returns a set of additional test passes or failures implied by the
+	// events sent during the test suite run. If passed is false, the entire suite is failed.
+	// To set a test as flaky, return a passing and failing JUnitTestCase with the same name.
+	JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) (results []*JUnitTestCase, passed bool)
+}
+
+// JUnitForEventsFunc converts a function into the JUnitForEvents interface.
+type JUnitForEventsFunc func(events monitor.EventIntervals, duration time.Duration) (results []*JUnitTestCase, passed bool)
+
+func (fn JUnitForEventsFunc) JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) (results []*JUnitTestCase, passed bool) {
+	return fn(events, duration)
+}
+
+// JUnitsForAllEvents aggregates multiple JUnitsForEvent interfaces and returns
+// the result of all invocations. It ignores nil interfaces.
+type JUnitsForAllEvents []JUnitsForEvents
+
+func (a JUnitsForAllEvents) JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) (all []*JUnitTestCase, passed bool) {
+	passed = true
+	for _, obj := range a {
+		if obj == nil {
+			continue
+		}
+		results, passed := obj.JUnitsForEvents(events, duration)
+		if !passed {
+			passed = false
+		}
+		all = append(all, results...)
+	}
+	return all, passed
+}
 
 func createEventsForTests(tests []*testCase) []*monitor.EventInterval {
 	eventsForTests := []*monitor.EventInterval{}
@@ -85,281 +113,5 @@ func createSyntheticTestsFromMonitor(m *monitor.Monitor, eventsForTests []*monit
 		)
 	}
 
-	// check events
-	syntheticTestResults = append(syntheticTestResults, testKubeAPIServerGracefulTermination(events)...)
-	syntheticTestResults = append(syntheticTestResults, testPodTransitions(events)...)
-	syntheticTestResults = append(syntheticTestResults, testSystemDTimeout(events)...)
-	syntheticTestResults = append(syntheticTestResults, testPodSandboxCreation(events)...)
-	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorKubeAPIServerNewConnection, events, monitorDuration)...)
-	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOpenshiftAPIServerNewConnection, events, monitorDuration)...)
-	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOAuthAPIServerNewConnection, events, monitorDuration)...)
-	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorKubeAPIServerReusedConnection, events, monitorDuration)...)
-	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOpenshiftAPIServerReusedConnection, events, monitorDuration)...)
-	syntheticTestResults = append(syntheticTestResults, testServerAvailability(monitor.LocatorOAuthAPIServerReusedConnection, events, monitorDuration)...)
-
-	fmt.Fprintln(buf, "Synthetic test results:")
-	for _, test := range syntheticTestResults {
-		status := "passed"
-		if test.FailureOutput != nil {
-			status = "failed"
-		}
-		fmt.Fprintf(buf, "%s: %s\n", status, test.Name)
-	}
-	fmt.Fprintln(buf, "(duplicates are used to mark some failures as flake and not to fail the whole suite")
-	fmt.Fprintln(buf)
 	return syntheticTestResults, buf, errBuf
-}
-
-func testServerAvailability(locator string, events []*monitor.EventInterval, duration time.Duration) []*JUnitTestCase {
-	errDuration, errMessages := disruption.GetDisruption(events, locator)
-
-	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)
-	successTest := &JUnitTestCase{
-		Name:     testName,
-		Duration: duration.Seconds(),
-	}
-	if percent := float64(errDuration) / float64(duration); percent > tolerateDisruptionPercent {
-		test := &JUnitTestCase{
-			Name:     testName,
-			Duration: duration.Seconds(),
-			FailureOutput: &FailureOutput{
-				Output: fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Truncate(time.Second), 100*percent),
-			},
-			SystemOut: strings.Join(errMessages, "\n"),
-		}
-		// Return *two* tests results to pretend this is a flake not to fail whole testsuite.
-		return []*JUnitTestCase{test, successTest}
-	} else {
-		successTest.SystemOut = fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Truncate(time.Second), 100*percent)
-		return []*JUnitTestCase{successTest}
-	}
-}
-
-func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) []*JUnitTestCase {
-	const testName = "[sig-node] kubelet terminates kube-apiserver gracefully"
-	success := &JUnitTestCase{Name: testName}
-
-	failures := []string{}
-	for _, event := range events {
-		// from https://github.com/openshift/kubernetes/blob/1f35e4f63be8fbb19e22c9ff1df31048f6b42ddf/cmd/watch-termination/main.go#L96
-		if strings.Contains(event.Message, "did not terminate gracefully") {
-			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
-		}
-	}
-	if len(failures) == 0 {
-		return []*JUnitTestCase{success}
-	}
-
-	failure := &JUnitTestCase{
-		Name:      testName,
-		SystemOut: strings.Join(failures, "\n"),
-		FailureOutput: &FailureOutput{
-			Output: fmt.Sprintf("%d kube-apiserver reports a non-graceful termination. Probably kubelet or CRI-O is not giving the time to cleanly shut down. This can lead to connection refused and network I/O timeout errors in other components.\n\n%v", len(failures), strings.Join(failures, "\n")),
-		},
-	}
-
-	// This should fail a CI run, not flake it.
-	return []*JUnitTestCase{failure}
-
-}
-
-func testPodTransitions(events []*monitor.EventInterval) []*JUnitTestCase {
-	const testName = "[sig-node] pods should never transition back to pending"
-	success := &JUnitTestCase{Name: testName}
-
-	failures := []string{}
-	for _, event := range events {
-		if strings.Contains(event.Message, "pod should not transition") || strings.Contains(event.Message, "pod moved back to Pending") {
-			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
-		}
-	}
-	if len(failures) == 0 {
-		return []*JUnitTestCase{success}
-	}
-
-	failure := &JUnitTestCase{
-		Name:      testName,
-		SystemOut: strings.Join(failures, "\n"),
-		FailureOutput: &FailureOutput{
-			Output: fmt.Sprintf("%d pods illegally transitioned to Pending\n\n%v", len(failures), strings.Join(failures, "\n")),
-		},
-	}
-
-	// TODO an upgrade job that starts before 4.6 may need to make this test flake instead of fail.  This will depend on which `openshift-tests`
-	//  is used to run that upgrade test.  I recommend waiting to a flake until we know and even then find a way to constrain it.
-	return []*JUnitTestCase{failure}
-}
-
-func testSystemDTimeout(events []*monitor.EventInterval) []*JUnitTestCase {
-	const testName = "[sig-node] pods should not fail on systemd timeouts"
-	success := &JUnitTestCase{Name: testName}
-
-	failures := []string{}
-	for _, event := range events {
-		if strings.Contains(event.Message, "systemd timed out for pod") {
-			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
-		}
-	}
-	if len(failures) == 0 {
-		return []*JUnitTestCase{success}
-	}
-
-	failure := &JUnitTestCase{
-		Name:      testName,
-		SystemOut: strings.Join(failures, "\n"),
-		FailureOutput: &FailureOutput{
-			Output: fmt.Sprintf("%d systemd timed out for pod occurrences\n\n%v", len(failures), strings.Join(failures, "\n")),
-		},
-	}
-
-	// write a passing test to trigger detection of this issue as a flake. Doing this first to try to see how frequent the issue actually is
-	return []*JUnitTestCase{failure, success}
-}
-
-type testCategorizer struct {
-	by        string
-	substring string
-}
-
-func testPodSandboxCreation(events []*monitor.EventInterval) []*JUnitTestCase {
-	const testName = "[sig-network] pods should successfully create sandboxes"
-	// we can further refine this signal by subdividing different failure modes if it is pertinent.  Right now I'm seeing
-	// 1. error reading container (probably exited) json message: EOF
-	// 2. dial tcp 10.0.76.225:6443: i/o timeout
-	// 3. error getting pod: pods "terminate-cmd-rpofb45fa14c-96bb-40f7-bd9e-346721740cac" not found
-	// 4. write child: broken pipe
-	bySubStrings := []testCategorizer{
-		{by: " by reading container", substring: "error reading container (probably exited) json message: EOF"},
-		{by: " by not timing out", substring: "i/o timeout"},
-		{by: " by writing network status", substring: "error setting the networks status"},
-		{by: " by getting pod", substring: " error getting pod: pods"},
-		{by: " by writing child", substring: "write child: broken pipe"},
-		{by: " by other", substring: " "}, // always matches
-	}
-
-	failures := []string{}
-	flakes := []string{}
-	eventsForPods := getEventsByPod(events)
-	for _, event := range events {
-		if !strings.Contains(event.Message, "reason/FailedCreatePodSandBox Failed to create pod sandbox") {
-			continue
-		}
-		deletionTime := getPodDeletionTime(eventsForPods[event.Locator], event.Locator)
-		if deletionTime == nil {
-			// this indicates a failure to create the sandbox that should not happen
-			failures = append(failures, fmt.Sprintf("%v - never deleted - %v", event.Locator, event.Message))
-		} else {
-			timeBetweenDeleteAndFailure := event.From.Sub(*deletionTime)
-			switch {
-			case timeBetweenDeleteAndFailure < 1*time.Second:
-				// nothing here, one second is close enough to be ok, the kubelet and CNI just didn't know
-			case timeBetweenDeleteAndFailure < 5*time.Second:
-				// withing five seconds, it ought to be long enough to know, but it's close enough to flake and not fail
-				flakes = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator, timeBetweenDeleteAndFailure.Seconds(), event.Message))
-			case deletionTime.Before(event.From):
-				// something went wrong.  More than five seconds after the pod ws deleted, the CNI is trying to set up pod sandboxes and can't
-				failures = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator, timeBetweenDeleteAndFailure.Seconds(), event.Message))
-			default:
-				// something went wrong.  deletion happend after we had a failure to create the pod sandbox
-				failures = append(failures, fmt.Sprintf("%v - deletion came AFTER sandbox failure - %v", event.Locator, event.Message))
-			}
-		}
-	}
-	if len(failures) == 0 && len(flakes) == 0 {
-		successes := []*JUnitTestCase{}
-		for _, by := range bySubStrings {
-			successes = append(successes, &JUnitTestCase{Name: testName + by.by})
-		}
-		return successes
-	}
-
-	ret := []*JUnitTestCase{}
-	failuresBySubtest, flakesBySubtest := categorizeBySubset(bySubStrings, failures, flakes)
-
-	// now iterate the individual failures to create failure entries
-	for by, subFailures := range failuresBySubtest {
-		failure := &JUnitTestCase{
-			Name:      testName + by,
-			SystemOut: strings.Join(subFailures, "\n"),
-			FailureOutput: &FailureOutput{
-				Output: fmt.Sprintf("%d failures to create the sandbox\n\n%v", len(subFailures), strings.Join(subFailures, "\n")),
-			},
-		}
-		ret = append(ret, failure)
-	}
-	for by, subFlakes := range flakesBySubtest {
-		flake := &JUnitTestCase{
-			Name:      testName + by,
-			SystemOut: strings.Join(subFlakes, "\n"),
-			FailureOutput: &FailureOutput{
-				Output: fmt.Sprintf("%d failures to create the sandbox\n\n%v", len(subFlakes), strings.Join(subFlakes, "\n")),
-			},
-		}
-		ret = append(ret, flake)
-		// write a passing test to trigger detection of this issue as a flake. Doing this first to try to see how frequent the issue actually is
-		success := &JUnitTestCase{
-			Name: testName + by,
-		}
-		ret = append(ret, success)
-	}
-
-	return append(ret)
-}
-
-// categorizeBySubset returns a map keyed by category for failures and flakes.  If a category is present in both failures and flakes, all are listed under failures.
-func categorizeBySubset(categorizers []testCategorizer, failures, flakes []string) (map[string][]string, map[string][]string) {
-	failuresBySubtest := map[string][]string{}
-	flakesBySubtest := map[string][]string{}
-	for _, failure := range failures {
-		for _, by := range categorizers {
-			if strings.Contains(failure, by.substring) {
-				failuresBySubtest[by.by] = append(failuresBySubtest[by.by], failure)
-				break // break after first match so we only add each failure one bucket
-			}
-		}
-	}
-
-	for _, flake := range flakes {
-		for _, by := range categorizers {
-			if strings.Contains(flake, by.substring) {
-				if _, isFailure := failuresBySubtest[by.by]; isFailure {
-					failuresBySubtest[by.by] = append(failuresBySubtest[by.by], flake)
-				} else {
-					flakesBySubtest[by.by] = append(flakesBySubtest[by.by], flake)
-				}
-				break // break after first match so we only add each failure one bucket
-			}
-		}
-	}
-	return failuresBySubtest, flakesBySubtest
-}
-
-func getPodCreationTime(events []*monitor.EventInterval, podLocator string) *time.Time {
-	for _, event := range events {
-		if event.Locator == podLocator && event.Message == "reason/Created" {
-			return &event.From
-		}
-	}
-	return nil
-}
-
-func getPodDeletionTime(events []*monitor.EventInterval, podLocator string) *time.Time {
-	for _, event := range events {
-		if event.Locator == podLocator && event.Message == "reason/Deleted" {
-			return &event.From
-		}
-	}
-	return nil
-}
-
-// getEventsByPod returns map keyed by pod locator with all events associated with it.
-func getEventsByPod(events []*monitor.EventInterval) map[string][]*monitor.EventInterval {
-	eventsByPods := map[string][]*monitor.EventInterval{}
-	for _, event := range events {
-		if !strings.Contains(event.Locator, "pod/") {
-			continue
-		}
-		eventsByPods[event.Locator] = append(eventsByPods[event.Locator], event)
-	}
-	return eventsByPods
 }

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -74,6 +74,9 @@ type TestSuite struct {
 	// The number of flakes that may occur before this test is marked as a failure.
 	MaximumAllowedFlakes int
 
+	// SyntheticEventTests is a set of suite level synthetics applied
+	SyntheticEventTests JUnitsForEvents
+
 	TestTimeout time.Duration
 }
 


### PR DESCRIPTION
The disruption suite needs to skip many of the synthetics because
the invariants aren't expected to be maintained. Hoist those use
cases up and out of the code.