### PR TITLE
test/ginkgo: When --count is used tests all fail together

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -147,13 +147,16 @@ func (opt *Options) Run(args []string) error {
 	}
 
 	count := opt.Count
-	if count == 0 {
+	if count < 1 {
 		count = suite.Count
 	}
 	if count > 1 {
 		var newTests []*testCase
 		for i := 0; i < count; i++ {
-			newTests = append(newTests, tests...)
+			for _, t := range tests {
+				copied := *t
+				newTests = append(newTests, &copied)
+			}
 		}
 		tests = newTests
 	}

--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -96,16 +96,6 @@ func (s *testStatus) Run(ctx context.Context, test *testCase) {
 		case test.failed:
 			s.out.Write(test.out)
 			fmt.Fprintln(s.out)
-			// only write the monitor output for a test if there is more than two tests being run (otherwise it's redundant)
-			if s.monitor != nil && s.total > 2 {
-				events := s.monitor.Events(test.start, test.end)
-				if len(events) > 0 {
-					for _, event := range events {
-						fmt.Fprintln(s.out, event.String())
-					}
-					fmt.Fprintln(s.out)
-				}
-			}
 			fmt.Fprintf(s.out, "failed: (%s) %s %q\n\n", test.duration, test.end.UTC().Format("2006-01-02T15:04:05"), test.name)
 			s.Failure()
 		}


### PR DESCRIPTION
--count results in each test being run over and over and the last test
result is printed. Instead, each test should be unique.