### PR TITLE
Bug 1945091: Refactor openshift-tests a bit, add more network-test-autodetecting support

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -401,13 +401,13 @@ func suiteWithInitializedProviderPreSuite(opt *runOptions) error {
 }
 
 // suiteWithProviderPreSuite ensures that the suite filters out tests from providers
-// that aren't relevant (see getProviderMatchFn) by loading the provider info from the
-// cluster or flags.
+// that aren't relevant (see exutilcluster.ClusterConfig.MatchFn) by loading the
+// provider info from the cluster or flags.
 func suiteWithProviderPreSuite(opt *runOptions) error {
 	if err := suiteWithInitializedProviderPreSuite(opt); err != nil {
 		return err
 	}
-	opt.MatchFn = getProviderMatchFn(opt.config)
+	opt.MatchFn = opt.config.MatchFn()
 	return nil
 }
 

--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -390,7 +390,7 @@ func isStandardEarlyOrLateTest(name string) bool {
 // suiteWithInitializedProviderPreSuite loads the provider info, but does not
 // exclude any tests specific to that provider.
 func suiteWithInitializedProviderPreSuite(opt *runOptions) error {
-	config, err := decodeProvider(opt.Provider, opt.DryRun, true)
+	config, err := decodeProvider(opt.Provider, opt.DryRun, true, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -29,7 +29,7 @@ import (
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	"github.com/openshift/origin/pkg/version"
 	exutil "github.com/openshift/origin/test/extended/util"
-	"github.com/openshift/origin/test/extended/util/cloud"
+	"github.com/openshift/origin/test/extended/util/cluster"
 )
 
 func main() {
@@ -204,7 +204,7 @@ type runOptions struct {
 	TestOptions  []string
 
 	// Shared by initialization code
-	config *cloud.ClusterConfiguration
+	config *cluster.ClusterConfiguration
 }
 
 func (opt *runOptions) AsEnv() []string {

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -406,7 +406,7 @@ func newRunTestCommand() *cobra.Command {
 			ginkgo.GlobalSuite().ClearBeforeSuiteNode()
 			ginkgo.GlobalSuite().ClearAfterSuiteNode()
 
-			config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false)
+			config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -28,8 +27,6 @@ import (
 	_ "k8s.io/kubernetes/test/e2e"
 	_ "k8s.io/kubernetes/test/e2e/lifecycle"
 )
-
-type TestNameMatchesFunc func(name string) bool
 
 func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster.ClusterConfiguration, dryRun bool) error {
 	// update context with loaded config
@@ -65,29 +62,6 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster
 	e2e.AfterReadingAllFlags(context)
 	context.DumpLogsOnFailure = true
 	return nil
-}
-
-func getProviderMatchFn(config *exutilcluster.ClusterConfiguration) TestNameMatchesFunc {
-	// given the configuration we have loaded, skip tests that our provider, disconnected status,
-	// or our network plugin should exclude
-	var skips []string
-	skips = append(skips, fmt.Sprintf("[Skipped:%s]", config.ProviderName))
-	for _, id := range config.NetworkPluginIDs {
-		skips = append(skips, fmt.Sprintf("[Skipped:Network/%s]", id))
-	}
-	if config.Disconnected {
-		skips = append(skips, "[Skipped:Disconnected]")
-	}
-
-	matchFn := func(name string) bool {
-		for _, skip := range skips {
-			if strings.Contains(name, skip) {
-				return false
-			}
-		}
-		return true
-	}
-	return matchFn
 }
 
 func decodeProvider(provider string, dryRun, discover bool, clusterState *exutilcluster.ClusterState) (*exutilcluster.ClusterConfiguration, error) {

--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -13,7 +13,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
-	exutilcloud "github.com/openshift/origin/test/extended/util/cloud"
+	exutilcluster "github.com/openshift/origin/test/extended/util/cluster"
 
 	// Initialize baremetal as a provider
 	_ "github.com/openshift/origin/test/extended/util/baremetal"
@@ -31,7 +31,7 @@ import (
 
 type TestNameMatchesFunc func(name string) bool
 
-func initializeTestFramework(context *e2e.TestContextType, config *exutilcloud.ClusterConfiguration, dryRun bool) error {
+func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster.ClusterConfiguration, dryRun bool) error {
 	// update context with loaded config
 	context.Provider = config.ProviderName
 	context.CloudConfig = e2e.CloudConfig{
@@ -67,7 +67,7 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcloud.C
 	return nil
 }
 
-func getProviderMatchFn(config *exutilcloud.ClusterConfiguration) TestNameMatchesFunc {
+func getProviderMatchFn(config *exutilcluster.ClusterConfiguration) TestNameMatchesFunc {
 	// given the configuration we have loaded, skip tests that our provider, disconnected status,
 	// or our network plugin should exclude
 	var skips []string
@@ -90,19 +90,19 @@ func getProviderMatchFn(config *exutilcloud.ClusterConfiguration) TestNameMatche
 	return matchFn
 }
 
-func decodeProvider(provider string, dryRun, discover bool, clusterState *exutilcloud.ClusterState) (*exutilcloud.ClusterConfiguration, error) {
+func decodeProvider(provider string, dryRun, discover bool, clusterState *exutilcluster.ClusterState) (*exutilcluster.ClusterConfiguration, error) {
 	switch provider {
 	case "none":
-		return &exutilcloud.ClusterConfiguration{ProviderName: "skeleton"}, nil
+		return &exutilcluster.ClusterConfiguration{ProviderName: "skeleton"}, nil
 
 	case "":
 		if _, ok := os.LookupEnv("KUBE_SSH_USER"); ok {
 			if _, ok := os.LookupEnv("LOCAL_SSH_KEY"); ok {
-				return &exutilcloud.ClusterConfiguration{ProviderName: "local"}, nil
+				return &exutilcluster.ClusterConfiguration{ProviderName: "local"}, nil
 			}
 		}
 		if dryRun {
-			return &exutilcloud.ClusterConfiguration{ProviderName: "skeleton"}, nil
+			return &exutilcluster.ClusterConfiguration{ProviderName: "skeleton"}, nil
 		}
 		fallthrough
 
@@ -112,12 +112,12 @@ func decodeProvider(provider string, dryRun, discover bool, clusterState *exutil
 			if err != nil {
 				return nil, err
 			}
-			clusterState, err = exutilcloud.DiscoverClusterState(clientConfig)
+			clusterState, err = exutilcluster.DiscoverClusterState(clientConfig)
 			if err != nil {
 				return nil, err
 			}
 		}
-		config, err := exutilcloud.LoadConfig(clusterState)
+		config, err := exutilcluster.LoadConfig(clusterState)
 		if err != nil {
 			return nil, err
 		}
@@ -140,19 +140,19 @@ func decodeProvider(provider string, dryRun, discover bool, clusterState *exutil
 		}
 		// attempt to load the default config, then overwrite with any values from the passed
 		// object that can be overridden
-		var config *exutilcloud.ClusterConfiguration
+		var config *exutilcluster.ClusterConfiguration
 		if discover {
 			if clusterState == nil {
 				if clientConfig, err := e2e.LoadConfig(true); err == nil {
-					clusterState, _ = exutilcloud.DiscoverClusterState(clientConfig)
+					clusterState, _ = exutilcluster.DiscoverClusterState(clientConfig)
 				}
 			}
 			if clusterState != nil {
-				config, _ = exutilcloud.LoadConfig(clusterState)
+				config, _ = exutilcluster.LoadConfig(clusterState)
 			}
 		}
 		if config == nil {
-			config = &exutilcloud.ClusterConfiguration{
+			config = &exutilcluster.ClusterConfiguration{
 				ProviderName: providerInfo.Type,
 				ProjectID:    providerInfo.ProjectID,
 				Region:       providerInfo.Region,

--- a/cmd/openshift-tests/provider_test.go
+++ b/cmd/openshift-tests/provider_test.go
@@ -172,7 +172,7 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: noPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  sdnConfig,
-			expectedConfig:     `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":0,"MultiMaster":false,"MultiZone":false,"Zones":null,"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			expectedConfig:     `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online"),
 		},
 		{
@@ -191,7 +191,7 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: noPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  sdnConfig,
-			expectedConfig:     `{"type":"openstack","ProjectID":"","Region":"","Zone":"","NumNodes":0,"MultiMaster":false,"MultiZone":false,"Zones":null,"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			expectedConfig:     `{"type":"openstack","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online"),
 		},
 		{
@@ -218,7 +218,7 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: noPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  ovnKubernetesConfig,
-			expectedConfig:     `{"type":"none","ProjectID":"","Region":"","Zone":"","NumNodes":0,"MultiMaster":false,"MultiZone":false,"Zones":null,"ConfigFile":"","Disconnected":true,"NetworkPluginIDs":["OVNKubernetes"]}`,
+			expectedConfig:     `{"type":"none","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":true,"NetworkPluginIDs":["OVNKubernetes"]}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-sdn", "not-multitenant"),
 		},
 	}

--- a/cmd/openshift-tests/provider_test.go
+++ b/cmd/openshift-tests/provider_test.go
@@ -247,7 +247,7 @@ func TestDecodeProvider(t *testing.T) {
 			if configJSON != tc.expectedConfig {
 				t.Fatalf("Generated config:\n%s\ndoes not match expected:\n%s\n", configJSON, tc.expectedConfig)
 			}
-			matchFn := getProviderMatchFn(config)
+			matchFn := config.MatchFn()
 
 			runTests := sets.NewString()
 			for name, tags := range e2eTests {

--- a/cmd/openshift-tests/provider_test.go
+++ b/cmd/openshift-tests/provider_test.go
@@ -154,7 +154,7 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: gcePlatform,
 			discoveredMasters:  gceMasters,
 			discoveredNetwork:  sdnConfig,
-			expectedConfig:     `{"type":"gce","ProjectID":"openshift-gce-devel-ci","Region":"us-east1","Zone":"us-east1-a","NumNodes":3,"MultiMaster":true,"MultiZone":true,"Zones":["us-east1-a","us-east1-b","us-east1-c"],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			expectedConfig:     `{"type":"gce","ProjectID":"openshift-gce-devel-ci","Region":"us-east1","Zone":"us-east1-a","NumNodes":3,"MultiMaster":true,"MultiZone":true,"Zones":["us-east1-a","us-east1-b","us-east1-c"],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"OpenShiftSDN"}`,
 			runTests:           sets.NewString("everyone", "not-aws", "not-multitenant", "online"),
 		},
 		{
@@ -163,7 +163,7 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: gcePlatform,
 			discoveredMasters:  gceMasters,
 			discoveredNetwork:  multitenantConfig,
-			expectedConfig:     `{"type":"gce","ProjectID":"openshift-gce-devel-ci","Region":"us-east1","Zone":"us-east1-a","NumNodes":3,"MultiMaster":true,"MultiZone":true,"Zones":["us-east1-a","us-east1-b","us-east1-c"],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN","OpenShiftSDN/Multitenant"]}`,
+			expectedConfig:     `{"type":"gce","ProjectID":"openshift-gce-devel-ci","Region":"us-east1","Zone":"us-east1-a","NumNodes":3,"MultiMaster":true,"MultiZone":true,"Zones":["us-east1-a","us-east1-b","us-east1-c"],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"OpenShiftSDN","NetworkPluginMode":"Multitenant"}`,
 			runTests:           sets.NewString("everyone", "not-aws", "online"),
 		},
 		{
@@ -172,7 +172,7 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: noPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  sdnConfig,
-			expectedConfig:     `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			expectedConfig:     `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"OpenShiftSDN"}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online"),
 		},
 		{
@@ -182,7 +182,7 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  sdnConfig,
 			// NB: It does not actually use the passed-in Provider value
-			expectedConfig: `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			expectedConfig: `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"OpenShiftSDN"}`,
 			runTests:       sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online"),
 		},
 		{
@@ -191,7 +191,7 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: noPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  sdnConfig,
-			expectedConfig:     `{"type":"openstack","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			expectedConfig:     `{"type":"openstack","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"OpenShiftSDN"}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online"),
 		},
 		{
@@ -200,14 +200,14 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: awsPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  ovnKubernetesConfig,
-			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"us-east-2a","NumNodes":3,"MultiMaster":false,"MultiZone":true,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OVNKubernetes"]}`,
+			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"us-east-2a","NumNodes":3,"MultiMaster":false,"MultiZone":true,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"OVNKubernetes"}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-sdn", "not-multitenant", "online"),
 		},
 		{
 			name:               "complex override without discovery",
 			provider:           `{"type":"aws","region":"us-east-2","zone":"us-east-2a","multimaster":false,"multizone":true}`,
 			discoveredPlatform: nil,
-			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"us-east-2a","NumNodes":0,"MultiMaster":false,"MultiZone":true,"Zones":null,"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":null}`,
+			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"us-east-2a","NumNodes":0,"MultiMaster":false,"MultiZone":true,"Zones":null,"ConfigFile":"","Disconnected":false,"NetworkPlugin":""}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-sdn", "not-multitenant", "online"),
 		},
 		{
@@ -216,16 +216,16 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: noPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  ovnKubernetesConfig,
-			expectedConfig:     `{"type":"none","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":true,"NetworkPluginIDs":["OVNKubernetes"]}`,
+			expectedConfig:     `{"type":"none","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":true,"NetworkPlugin":"OVNKubernetes"}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-sdn", "not-multitenant"),
 		},
 		{
 			name:               "override network plugin",
-			provider:           `{"type":"aws","networkPluginIDs":["Calico"]}`,
+			provider:           `{"type":"aws","networkPlugin":"Calico"}`,
 			discoveredPlatform: awsPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  ovnKubernetesConfig,
-			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["Calico"]}`,
+			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"Calico"}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-sdn", "not-multitenant", "online"),
 		},
 	}

--- a/cmd/openshift-tests/provider_test.go
+++ b/cmd/openshift-tests/provider_test.go
@@ -200,10 +200,8 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredPlatform: awsPlatform,
 			discoveredMasters:  simpleMasters,
 			discoveredNetwork:  ovnKubernetesConfig,
-			// NB: MultiMaster and MultiZone are set from discovery, with the
-			// JSON being ignored
-			expectedConfig: `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"us-east-2a","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OVNKubernetes"]}`,
-			runTests:       sets.NewString("everyone", "not-gce", "not-sdn", "not-multitenant", "online"),
+			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"us-east-2a","NumNodes":3,"MultiMaster":false,"MultiZone":true,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OVNKubernetes"]}`,
+			runTests:           sets.NewString("everyone", "not-gce", "not-sdn", "not-multitenant", "online"),
 		},
 		{
 			name:               "complex override without discovery",
@@ -220,6 +218,15 @@ func TestDecodeProvider(t *testing.T) {
 			discoveredNetwork:  ovnKubernetesConfig,
 			expectedConfig:     `{"type":"none","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":true,"NetworkPluginIDs":["OVNKubernetes"]}`,
 			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-sdn", "not-multitenant"),
+		},
+		{
+			name:               "override network plugin",
+			provider:           `{"type":"aws","networkPluginIDs":["Calico"]}`,
+			discoveredPlatform: awsPlatform,
+			discoveredMasters:  simpleMasters,
+			discoveredNetwork:  ovnKubernetesConfig,
+			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["Calico"]}`,
+			runTests:           sets.NewString("everyone", "not-gce", "not-sdn", "not-multitenant", "online"),
 		},
 	}
 

--- a/cmd/openshift-tests/provider_test.go
+++ b/cmd/openshift-tests/provider_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	exutilcloud "github.com/openshift/origin/test/extended/util/cloud"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var gcePlatform = &configv1.PlatformStatus{
+	Type: configv1.GCPPlatformType,
+	GCP: &configv1.GCPPlatformStatus{
+		ProjectID: "openshift-gce-devel-ci",
+		Region:    "us-east1",
+	},
+}
+
+var awsPlatform = &configv1.PlatformStatus{
+	Type: configv1.AWSPlatformType,
+	AWS: &configv1.AWSPlatformStatus{
+		Region: "us-east-2",
+	},
+}
+
+var vspherePlatform = &configv1.PlatformStatus{
+	Type: configv1.VSpherePlatformType,
+}
+
+var noPlatform = &configv1.PlatformStatus{
+	Type: configv1.NonePlatformType,
+}
+
+var gceMasters = &corev1.NodeList{
+	Items: []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-1",
+				Labels: map[string]string{
+					"failure-domain.beta.kubernetes.io/zone": "us-east1-a",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-2",
+				Labels: map[string]string{
+					"failure-domain.beta.kubernetes.io/zone": "us-east1-b",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-3",
+				Labels: map[string]string{
+					"failure-domain.beta.kubernetes.io/zone": "us-east1-c",
+				},
+			},
+		},
+	},
+}
+
+var simpleMasters = &corev1.NodeList{
+	Items: []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-2",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "master-3",
+			},
+		},
+	},
+}
+
+var nonMasters = &corev1.NodeList{
+	Items: []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker-1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker-2",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker-3",
+			},
+		},
+	},
+}
+
+var sdnConfig = &operatorv1.NetworkSpec{
+	DefaultNetwork: operatorv1.DefaultNetworkDefinition{
+		Type:               operatorv1.NetworkTypeOpenShiftSDN,
+		OpenShiftSDNConfig: &operatorv1.OpenShiftSDNConfig{},
+	},
+}
+
+var multitenantConfig = &operatorv1.NetworkSpec{
+	DefaultNetwork: operatorv1.DefaultNetworkDefinition{
+		Type: operatorv1.NetworkTypeOpenShiftSDN,
+		OpenShiftSDNConfig: &operatorv1.OpenShiftSDNConfig{
+			Mode: operatorv1.SDNModeMultitenant,
+		},
+	},
+}
+
+var ovnKubernetesConfig = &operatorv1.NetworkSpec{
+	DefaultNetwork: operatorv1.DefaultNetworkDefinition{
+		Type: operatorv1.NetworkTypeOVNKubernetes,
+	},
+}
+
+var e2eTests = map[string]string{
+	"everyone":        "[Skipped:Wednesday]",
+	"not-gce":         "[Skipped:gce]",
+	"not-aws":         "[Skipped:aws]",
+	"not-sdn":         "[Skipped:Network/OpenShiftSDN]",
+	"not-multitenant": "[Skipped:Network/OpenShiftSDN/Multitenant]",
+	"online":          "[Skipped:Disconnected]",
+}
+
+func TestDecodeProvider(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		provider string
+
+		discoveredPlatform *configv1.PlatformStatus
+		discoveredMasters  *corev1.NodeList
+		discoveredNetwork  *operatorv1.NetworkSpec
+
+		expectedConfig string
+		runTests       sets.String
+	}{
+		{
+			name:               "simple GCE",
+			provider:           "",
+			discoveredPlatform: gcePlatform,
+			discoveredMasters:  gceMasters,
+			discoveredNetwork:  sdnConfig,
+			expectedConfig:     `{"type":"gce","ProjectID":"openshift-gce-devel-ci","Region":"us-east1","Zone":"us-east1-a","NumNodes":3,"MultiMaster":true,"MultiZone":true,"Zones":["us-east1-a","us-east1-b","us-east1-c"],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			runTests:           sets.NewString("everyone", "not-aws", "not-multitenant", "online"),
+		},
+		{
+			name:               "GCE multitenant",
+			provider:           "",
+			discoveredPlatform: gcePlatform,
+			discoveredMasters:  gceMasters,
+			discoveredNetwork:  multitenantConfig,
+			expectedConfig:     `{"type":"gce","ProjectID":"openshift-gce-devel-ci","Region":"us-east1","Zone":"us-east1-a","NumNodes":3,"MultiMaster":true,"MultiZone":true,"Zones":["us-east1-a","us-east1-b","us-east1-c"],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN","OpenShiftSDN/Multitenant"]}`,
+			runTests:           sets.NewString("everyone", "not-aws", "online"),
+		},
+		{
+			name:               "simple non-cloud",
+			provider:           "",
+			discoveredPlatform: noPlatform,
+			discoveredMasters:  simpleMasters,
+			discoveredNetwork:  sdnConfig,
+			expectedConfig:     `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":0,"MultiMaster":false,"MultiZone":false,"Zones":null,"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online"),
+		},
+		{
+			name:               "simple override",
+			provider:           "vsphere",
+			discoveredPlatform: vspherePlatform,
+			discoveredMasters:  simpleMasters,
+			discoveredNetwork:  sdnConfig,
+			// NB: It does not actually use the passed-in Provider value
+			expectedConfig: `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			runTests:       sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online"),
+		},
+		{
+			name:               "json simple override",
+			provider:           `{"type": "openstack"}`,
+			discoveredPlatform: noPlatform,
+			discoveredMasters:  simpleMasters,
+			discoveredNetwork:  sdnConfig,
+			expectedConfig:     `{"type":"openstack","ProjectID":"","Region":"","Zone":"","NumNodes":0,"MultiMaster":false,"MultiZone":false,"Zones":null,"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OpenShiftSDN"]}`,
+			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online"),
+		},
+		{
+			name:               "complex override",
+			provider:           `{"type":"aws","region":"us-east-2","zone":"us-east-2a","multimaster":false,"multizone":true}`,
+			discoveredPlatform: awsPlatform,
+			discoveredMasters:  simpleMasters,
+			discoveredNetwork:  ovnKubernetesConfig,
+			// NB: MultiMaster and MultiZone are set from discovery, with the
+			// JSON being ignored
+			expectedConfig: `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"us-east-2a","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":["OVNKubernetes"]}`,
+			runTests:       sets.NewString("everyone", "not-gce", "not-sdn", "not-multitenant", "online"),
+		},
+		{
+			name:               "complex override without discovery",
+			provider:           `{"type":"aws","region":"us-east-2","zone":"us-east-2a","multimaster":false,"multizone":true}`,
+			discoveredPlatform: nil,
+			expectedConfig:     `{"type":"aws","ProjectID":"","Region":"us-east-2","Zone":"us-east-2a","NumNodes":0,"MultiMaster":false,"MultiZone":true,"Zones":null,"ConfigFile":"","Disconnected":false,"NetworkPluginIDs":null}`,
+			runTests:           sets.NewString("everyone", "not-gce", "not-sdn", "not-multitenant", "online"),
+		},
+		{
+			name:               "disconnected",
+			provider:           `{"type":"none","disconnected":true}`,
+			discoveredPlatform: noPlatform,
+			discoveredMasters:  simpleMasters,
+			discoveredNetwork:  ovnKubernetesConfig,
+			expectedConfig:     `{"type":"none","ProjectID":"","Region":"","Zone":"","NumNodes":0,"MultiMaster":false,"MultiZone":false,"Zones":null,"ConfigFile":"","Disconnected":true,"NetworkPluginIDs":["OVNKubernetes"]}`,
+			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-sdn", "not-multitenant"),
+		},
+	}
+
+	// Unset these to keep decodeProvider from returning "local"
+	os.Unsetenv("KUBE_SSH_USER")
+	os.Unsetenv("LOCAL_SSH_KEY")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			discover := tc.discoveredPlatform != nil
+			var testState *exutilcloud.ClusterState
+			if discover {
+				testState = &exutilcloud.ClusterState{
+					PlatformStatus: tc.discoveredPlatform,
+					Masters:        tc.discoveredMasters,
+					NonMasters:     nonMasters,
+					NetworkSpec:    tc.discoveredNetwork,
+				}
+			}
+			config, err := decodeProvider(tc.provider, false, discover, testState)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			configJSON := config.ToJSONString()
+			if configJSON != tc.expectedConfig {
+				t.Fatalf("Generated config:\n%s\ndoes not match expected:\n%s\n", configJSON, tc.expectedConfig)
+			}
+			matchFn := getProviderMatchFn(config)
+
+			runTests := sets.NewString()
+			for name, tags := range e2eTests {
+				if matchFn(name + " " + tags) {
+					runTests.Insert(name)
+				}
+			}
+			if !runTests.Equal(tc.runTests) {
+				t.Fatalf("Matched tests:\n%v\ndid not match expected:\n%v\n", runTests.List(), tc.runTests.List())
+			}
+		})
+	}
+}

--- a/cmd/openshift-tests/provider_test.go
+++ b/cmd/openshift-tests/provider_test.go
@@ -6,7 +6,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	exutilcloud "github.com/openshift/origin/test/extended/util/cloud"
+	exutilcluster "github.com/openshift/origin/test/extended/util/cluster"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -230,9 +230,9 @@ func TestDecodeProvider(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			discover := tc.discoveredPlatform != nil
-			var testState *exutilcloud.ClusterState
+			var testState *exutilcluster.ClusterState
 			if discover {
-				testState = &exutilcloud.ClusterState{
+				testState = &exutilcluster.ClusterState{
 					PlatformStatus: tc.discoveredPlatform,
 					Masters:        tc.discoveredMasters,
 					NonMasters:     nonMasters,

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	k8s.io/kubelet v0.20.0
 	k8s.io/kubernetes v1.20.0
 	k8s.io/legacy-cloud-providers v0.20.0
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/test/extended/util/cluster/cluster.go
+++ b/test/extended/util/cluster/cluster.go
@@ -1,4 +1,4 @@
-package cloud
+package cluster
 
 import (
 	"context"

--- a/test/extended/util/cluster/cluster.go
+++ b/test/extended/util/cluster/cluster.go
@@ -112,12 +112,6 @@ func LoadConfig(state *ClusterState) (*ClusterConfiguration, error) {
 		networkPluginIDs = append(networkPluginIDs, string(state.NetworkSpec.DefaultNetwork.Type)+"/"+string(state.NetworkSpec.DefaultNetwork.OpenShiftSDNConfig.Mode))
 	}
 
-	if state.PlatformStatus.Type == configv1.NonePlatformType {
-		return &ClusterConfiguration{
-			NetworkPluginIDs: networkPluginIDs,
-		}, nil
-	}
-
 	zones := sets.NewString()
 	for _, node := range state.Masters.Items {
 		zones.Insert(node.Labels["failure-domain.beta.kubernetes.io/zone"])

--- a/test/extended/util/cluster/cluster.go
+++ b/test/extended/util/cluster/cluster.go
@@ -23,7 +23,8 @@ import (
 type ClusterConfiguration struct {
 	ProviderName string `json:"type"`
 
-	// These fields chosen to match the e2e configuration we fill
+	// These fields (and the "type" tag for ProviderName) chosen to match
+	// upstream's e2e.CloudConfig.
 	ProjectID   string
 	Region      string
 	Zone        string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2870,6 +2870,7 @@ k8s.io/mount-utils
 k8s.io/sample-apiserver/pkg/apis/wardle
 k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1
 # k8s.io/utils v0.0.0-20201110183641-67b214c5f920
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/exec


### PR DESCRIPTION
Currently we are unconditionally skipping all single-stack-IPv6, dual-stack, and SCTP tests, regardless of cluster configuration. This is no good.

This PR extends the existing network-plugin-detection code to also detect network IP configuration and automatically skip IPv4-only, IPv6-only, and dual-stack-only tests as appropriate.

It also kind of adds support for detecting and skipping SCTP tests, except we can't really easily detect whether SCTP is available in the cluster at this point, so in reality it only works if you manually override the SCTP detection via `--provider`/`TEST_PROVIDER`. But we might be able to improve on that in the future. (And being able to unskip the SCTP tests at all is an improvement over the current situation.)

This will require a followup PR to openshift/kubernetes to stop skipping these tags. Thus, for the moment, this PR should have no effect on the tests that actually get run.

Also, until https://issues.redhat.com/browse/KNIDEPLOY-4090 is fixed, the `e2e-metal-ipi-ovn-ipv6` and `e2e-metal-ipi-ovn-dualstack` suites won't actually run any of the "fun" test cases anyway...
