### PR TITLE
 add additional settling debug information

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/test/extended/util/operator"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/onsi/ginkgo/config"
@@ -231,6 +232,13 @@ func (opt *Options) Run(args []string) error {
 	includeSuccess := opt.IncludeSuccessOutput
 	if len(tests) == 1 {
 		includeSuccess = true
+	} else {
+		// if we're running more than one test, check stability before we start.  This doesn't impact test result, but
+		// provides a clear log if we aren't running on a stable cluster.
+		err := operator.WaitForOperatorsToSettleWithDefaultClient(ctx)
+		if err != nil {
+			fmt.Printf("Operators are not yet stable, continuing: %v\n", err)
+		}
 	}
 	status := newTestStatus(opt.Out, includeSuccess, len(tests), timeout, m, opt.AsEnv())
 

--- a/test/extended/util/operator/settle.go
+++ b/test/extended/util/operator/settle.go
@@ -1,0 +1,94 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func WaitForOperatorsToSettleWithDefaultClient(ctx context.Context) error {
+	cfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	clusterConfig, err := cfg.ClientConfig()
+	if err != nil {
+		return fmt.Errorf("could not load client configuration: %v", err)
+	}
+	configClient, err := clientconfigv1.NewForConfig(clusterConfig)
+	if err != nil {
+		return err
+	}
+	return WaitForOperatorsToSettle(ctx, configClient)
+}
+
+// can be overridden for tests
+var nowFn = realNow
+
+func realNow() time.Time {
+	return time.Now()
+}
+
+func WaitForOperatorsToSettle(ctx context.Context, configClient clientconfigv1.Interface) error {
+	framework.Logf("Waiting for operators to settle")
+	unsettledOperatorStatus := []string{}
+	if err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+		coList, err := configClient.ConfigV1().ClusterOperators().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			framework.Logf("error getting ClusterOperators %v", err)
+			return false, nil
+		}
+		unsettledOperatorStatus = unsettledOperators(coList.Items)
+		done := len(unsettledOperatorStatus) == 0
+		return done, nil
+
+	}); err != nil {
+		return fmt.Errorf("ClusterOperators did not settle: \n%v", strings.Join(unsettledOperatorStatus, "\n\t"))
+	}
+	return nil
+}
+
+func unsettledOperators(operators []configv1.ClusterOperator) []string {
+	unsettledOperatorStatus := []string{}
+	for _, co := range operators {
+		available := findCondition(co.Status.Conditions, configv1.OperatorAvailable)
+		degraded := findCondition(co.Status.Conditions, configv1.OperatorDegraded)
+		progressing := findCondition(co.Status.Conditions, configv1.OperatorProgressing)
+		if available.Status == configv1.ConditionTrue &&
+			degraded.Status == configv1.ConditionFalse &&
+			progressing.Status == configv1.ConditionFalse {
+			continue
+		}
+		if available.Status != configv1.ConditionTrue {
+			unsettledOperatorStatus = append(unsettledOperatorStatus, fmt.Sprintf("clusteroperator/%v is not Available for %v because %q", co.Name, nowFn().Sub(available.LastTransitionTime.Time), available.Message))
+		}
+		if degraded.Status != configv1.ConditionFalse {
+			unsettledOperatorStatus = append(unsettledOperatorStatus, fmt.Sprintf("clusteroperator/%v is Degraded for %v because %q", co.Name, nowFn().Sub(degraded.LastTransitionTime.Time), degraded.Message))
+		}
+		if progressing.Status != configv1.ConditionFalse {
+			unsettledOperatorStatus = append(unsettledOperatorStatus, fmt.Sprintf("clusteroperator/%v is Progressing for %v because %q", co.Name, nowFn().Sub(progressing.LastTransitionTime.Time), progressing.Message))
+		}
+	}
+	return unsettledOperatorStatus
+}
+
+func findCondition(conditions []configv1.ClusterOperatorStatusCondition, name configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if name == conditions[i].Type {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func conditionHasStatus(c *configv1.ClusterOperatorStatusCondition, status configv1.ConditionStatus) bool {
+	if c == nil {
+		return false
+	}
+	return c.Status == status
+}

--- a/test/extended/util/operator/settle_test.go
+++ b/test/extended/util/operator/settle_test.go
@@ -1,0 +1,153 @@
+package operator
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func fakeNow() time.Time {
+	fakeNow, err := time.Parse("Mon Jan 2 15:04:05 -0700 MST 2006", "Mon Jan 2 15:04:05 -0700 MST 2006")
+	if err != nil {
+		panic(err)
+	}
+	return fakeNow
+}
+
+func newOperator(name string,
+	available, availableMessage string, availableDuration time.Duration,
+	degraded, degradedMessage string, degradedDuration time.Duration,
+	progressing, progressingMessage string, progressingDuration time.Duration,
+) configv1.ClusterOperator {
+	return configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               "Available",
+					Status:             configv1.ConditionStatus(available),
+					LastTransitionTime: metav1.Time{Time: fakeNow().Add(-1 * availableDuration)},
+					Message:            availableMessage,
+				},
+				{
+					Type:               "Degraded",
+					Status:             configv1.ConditionStatus(degraded),
+					LastTransitionTime: metav1.Time{Time: fakeNow().Add(-1 * degradedDuration)},
+					Message:            degradedMessage,
+				},
+				{
+					Type:               "Progressing",
+					Status:             configv1.ConditionStatus(progressing),
+					LastTransitionTime: metav1.Time{Time: fakeNow().Add(-1 * progressingDuration)},
+					Message:            progressingMessage,
+				},
+			},
+		},
+	}
+}
+
+func TestWaitForOperatorsToSettle(t *testing.T) {
+	nowFn = fakeNow
+	tests := []struct {
+		name      string
+		operators []configv1.ClusterOperator
+		expected  []string
+	}{
+		{
+			name: "all pass",
+			operators: []configv1.ClusterOperator{
+				newOperator("foo",
+					"True", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+				),
+			},
+			expected: []string{},
+		},
+		{
+			name: "one not available",
+			operators: []configv1.ClusterOperator{
+				newOperator("foo",
+					"False", "OH NO", time.Minute,
+					"False", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+				),
+				newOperator("bar",
+					"True", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+				),
+			},
+			expected: []string{
+				`clusteroperator/foo is not Available for 1m0s because "OH NO"`,
+			},
+		},
+		{
+			name: "one degraded, another unavailable",
+			operators: []configv1.ClusterOperator{
+				newOperator("foo",
+					"False", "OH NO", time.Minute,
+					"False", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+				),
+				newOperator("bar",
+					"True", "as expected", time.Minute,
+					"True", "Degraded", 2*time.Minute,
+					"False", "as expected", time.Minute,
+				),
+			},
+			expected: []string{
+				`clusteroperator/foo is not Available for 1m0s because "OH NO"`,
+				`clusteroperator/bar is Degraded for 2m0s because "Degraded"`,
+			},
+		},
+		{
+			name: "one progressing",
+			operators: []configv1.ClusterOperator{
+				newOperator("foo",
+					"True", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+				),
+				newOperator("bar",
+					"True", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+					"True", "rolling out", time.Minute,
+				),
+			},
+			expected: []string{
+				`clusteroperator/bar is Progressing for 1m0s because "rolling out"`,
+			},
+		},
+		{
+			name: "one doing both",
+			operators: []configv1.ClusterOperator{
+				newOperator("foo",
+					"True", "as expected", time.Minute,
+					"True", "Degraded", 2*time.Minute,
+					"True", "rolling out", time.Minute,
+				),
+				newOperator("bar",
+					"True", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+					"False", "as expected", time.Minute,
+				),
+			},
+			expected: []string{
+				`clusteroperator/foo is Degraded for 2m0s because "Degraded"`,
+				`clusteroperator/foo is Progressing for 1m0s because "rolling out"`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := unsettledOperators(tt.operators)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Error(actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We recently had a BZ about operators not achieving a stable level.  This adds extra debugging to the error message so we know which operator and how long it has been unstable.

TRT identified the problem and https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_openshift-apiserver/167/pull-ci-openshift-openshift-apiserver-master-e2e-aws-upgrade/1351976530204430336 is an example.