### PR TITLE
Bug 1902054: Update multicast test image for use in release-4.6

### DIFF
--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -167,7 +167,7 @@ func launchTestMulticastPod(f *e2e.Framework, nodeName string, podName string) e
 			Containers: []kapiv1.Container{
 				{
 					Name:    contName,
-					Image:   "openshift/test-multicast",
+					Image:   "quay.io/openshift/community-e2e-images:e2e-docker-io-openshift-test-multicast-latest-4AxcBBxKg_prX34z",
 					Command: []string{"sleep", "1000"},
 				},
 			},


### PR DESCRIPTION
In order to get around docker rate limiting, the e2e tests
need to pull images off either quay or the local image
registry. This change updates the multicast image to be
pulled from the local image registry.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>