### PR TITLE
Bug 1921088: don't wait for PV removal in volumes.sh

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -42910,7 +42910,7 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates,pv,pvc --all
+  oc delete all,templates,pvc --all
   exit 0
 ) &>/dev/null
 

--- a/test/extended/testdata/cmd/test/cmd/volumes.sh
+++ b/test/extended/testdata/cmd/test/cmd/volumes.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates,pv,pvc --all
+  oc delete all,templates,pvc --all
   exit 0
 ) &>/dev/null
 


### PR DESCRIPTION
We were unnecessarily waiting for PV removal in `volumes.sh` test which caused this particular test to stuck for removal of a PV which it didn't create in the first place. 