### PR TITLE
Bug 1899941: Add e2e test for liveness override annotation

### DIFF
--- a/test/extended/pods/liveness_override.go
+++ b/test/extended/pods/liveness_override.go
@@ -1,0 +1,49 @@
+package pods
+
+import (
+	"strconv"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	"github.com/openshift/library-go/pkg/build/naming"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	e2ecommon "k8s.io/kubernetes/test/e2e/common"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+var _ = g.Describe("[sig-node]", func() {
+	defer g.GinkgoRecover()
+
+	f := framework.NewDefaultFramework("liveness-probe-override")
+
+	// upstream e2e will test normal grace period on shutdown
+	g.It("should override timeoutGracePeriodSeconds when annotation is set", func() {
+		g.By("creating the pod")
+		podName := naming.GetPodName("pod-liveness-override", string(uuid.NewUUID()))
+		pod := e2epod.NewAgnhostPod(f.Namespace.Name, podName, nil, nil, nil, "bash", "-c", "sleep 1000")
+		gracePeriod := int64(500)
+		pod.Spec.TerminationGracePeriodSeconds = &gracePeriod
+
+		// liveness probe will fail since pod has no http endpoints
+		pod.Spec.Containers[0].LivenessProbe = &v1.Probe{
+			Handler: v1.Handler{
+				HTTPGet: &v1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.FromInt(8080),
+				},
+			},
+			InitialDelaySeconds: 10, // wait a bit or else it might restart too soon
+			FailureThreshold:    1,
+		}
+
+		gracePeriodOverride := 5
+		pod.ObjectMeta.Annotations = map[string]string{
+			"unsupported.do-not-use.openshift.io/override-liveness-grace-period-seconds": strconv.Itoa(gracePeriodOverride),
+		}
+		// 10s delay + 10s period + 5s grace period = 25s < 30s << pod-level timeout 500
+		e2ecommon.RunLivenessTest(f, pod, 1, time.Second*30)
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2405,6 +2405,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with scheduling without taints ": "should run a Pod requesting a RuntimeClass with scheduling without taints  [Disabled:Broken] [Suite:k8s]",
 
+	"[Top Level] [sig-node] should override timeoutGracePeriodSeconds when annotation is set": "should override timeoutGracePeriodSeconds when annotation is set [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [Local]": "should propagate requested groups to the container [Local]",
 
 	"[Top Level] [sig-node][Late] should not have pod creation failures due to systemd timeouts": "should not have pod creation failures due to systemd timeouts [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1899941
Tests https://github.com/openshift/kubernetes/pull/527

Add an e2e test that verifies the liveness override annotation works.

Ran the test 103 times in a while loop on a nightly cluster to tune parameters and verify the fix.

Analyzed data on time elapsed, in seconds:

min | 25% | 50% | 75% | max
-- | -- | -- | -- | --
2.022462378 | 2.0259687905 | 2.030493038 | 16.127785352 | 24.317637698

I had the timeout threshold set at 25s before but upped to 30s just to be super safe given the max...

/cc @rphillips 