### PR TITLE
test: etcd leader changes should be measured over the test, not the run

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -16,15 +16,19 @@ import (
 var _ = g.Describe("[sig-etcd] etcd", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("etcd-leader-change").AsAdmin()
-	g.It("leader changes are not excessive", func() {
+	g.It("leader changes are not excessive [Late]", func() {
 		prometheus, err := client.NewE2EPrometheusRouterClient(oc)
 		o.Expect(err).ToNot(o.HaveOccurred())
-		g.By("Examining the rate of increase in the number of etcd leadership changes for last five minutes")
-		result, _, err := prometheus.Query(context.Background(), "increase((max by (job) (etcd_server_leader_changes_seen_total) or 0*absent(etcd_server_leader_changes_seen_total))[15m:1m])", time.Now())
+
+		// we only consider series sent since the beginning of the test
+		testDuration := exutil.DurationSinceStartInSeconds().String()
+
+		g.By("Examining the number of etcd leadership changes over the run")
+		result, _, err := prometheus.Query(context.Background(), fmt.Sprintf("increase((max(max by (job) (etcd_server_leader_changes_seen_total)) or 0*absent(etcd_server_leader_changes_seen_total))[%s:15s])", testDuration), time.Now())
 		o.Expect(err).ToNot(o.HaveOccurred())
-		leaderChangeLastFiveMinutes := result.(model.Vector)[0].Value
-		if leaderChangeLastFiveMinutes != 0 {
-			o.Expect(fmt.Errorf("Leader changes observed last 5m %q: Leader changes are a result of stopping the etcd leader process or from latency (disk or network), review etcd performance metrics", leaderChangeLastFiveMinutes)).ToNot(o.HaveOccurred())
+		leaderChanges := result.(model.Vector)[0].Value
+		if leaderChanges != 0 {
+			o.Expect(fmt.Errorf("Observed %s leader changes in %s: Leader changes are a result of stopping the etcd leader process or from latency (disk or network), review etcd performance metrics", leaderChanges, testDuration)).ToNot(o.HaveOccurred())
 		}
 	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1735,7 +1735,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker security test  should pass security tests": "should pass security tests [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-etcd] etcd leader changes are not excessive": "leader changes are not excessive [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-etcd] etcd leader changes are not excessive [Late]": "leader changes are not excessive [Late] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [Serial]",
 


### PR DESCRIPTION
Our guarantee is that no leader changes should occur during test runs,
not during installation or scenarios prior to the test. Use the new
test duration to constrain the metric by time. Verified against a cluster
that the resulting query is correct.