### PR TITLE
Bug 1900989: idle.sh: Drop endpoints mocks from idle tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -29987,36 +29987,15 @@ setup_idling_resources() {
     dc_name=$(basename $(oc create -f ${TEST_DATA}/idling-dc.yaml -o name))  # ` + "`" + `basename type/name` + "`" + ` --> name
     os::cmd::expect_success "oc describe deploymentconfigs '${dc_name}'"
     os::cmd::try_until_success 'oc describe endpoints idling-echo'
-    local endpoints_json
-    endpoints_json="$(oc get endpoints idling-echo -o json)"
-    os::cmd::expect_success 'oc delete service idling-echo'
-    os::cmd::expect_success "echo '${endpoints_json}' | oc create -f -"
-    os::cmd::expect_success 'oc describe endpoints idling-echo'
+
     # deployer pod won't work, so just scale up the rc ourselves
     os::cmd::try_until_success "oc get replicationcontroller ${dc_name}-1"
     os::cmd::expect_success "oc scale replicationcontroller ${dc_name}-1 --replicas=2"
     os::cmd::try_until_text "oc get pod -l app=idling-echo -o go-template='{{ len .items }}'" "2"
-    local pod_name
-    pod_name="$(oc get pod -l app=idling-echo -o go-template='{{ (index .items 0).metadata.name }}')"
-    fake_endpoints_patch=$(cat <<EOF
-{
-    "subsets": [{
-        "addresses": [{
-            "ip": "1.2.3.4",
-            "targetRef": {
-                "kind": "Pod",
-                "name": "${pod_name}",
-                "namespace": "${project}"
-            }
-        }],
-        "ports": [{"name": "foo", "port": 80}]
-    }]
-}
-EOF
-)
 
-    os::cmd::expect_success "oc patch endpoints idling-echo -p '${fake_endpoints_patch}'"
-    os::cmd::try_until_text 'oc get endpoints idling-echo -o go-template="{{ len .subsets }}"' '1'
+    # wait for endpoints to populate. Ensure subset exists first to avoid nil dereference.
+    os::cmd::try_until_success "oc get endpoints idling-echo -o go-template='{{ index .subsets 0 }}'"
+    os::cmd::try_until_text "oc get endpoints idling-echo -o go-template='{{ len (index .subsets 0).addresses }}'" "2"
 }
 
 os::test::junit::declare_suite_start "cmd/idle/by-name"


### PR DESCRIPTION
**test/extended/testdata/cmd/test/cmd/idle.sh:**
Remove the need for deleting the test service by removing the custom
runtime-created endpoints. Instead, block test setup on the number of
endpoint addresses actually available in the test endpoint resource.
By being able to keep the service, this test is now compatible with
recent changes to `oc idle`, in which `oc idle` annotates a service
directly (in addition to available endpoints).

**test/extended/testdata/bindata.go:**
Regenerate

---

This PR should unblock CI for https://github.com/openshift/oc/pull/720