### PR TITLE
Bug 1922991: allow OKD /run contents for build fs test

### DIFF
--- a/test/extended/builds/run_fs_verification.go
+++ b/test/extended/builds/run_fs_verification.go
@@ -23,13 +23,16 @@ metadata:
 spec:
   runPolicy: Serial
   source:
-    dockerfile: "FROM %s\nRUN chmod -R uga+rwx /run\nUSER 1001"
-    type: Dockerfile
+    dockerfile: |-
+      FROM %s
+      RUN chmod -R uga+rwx /run
+      USER 1001
+  type: Dockerfile
   strategy:
     dockerStrategy:
       env:
-      - name: BUILD_LOGLEVEL
-        value: "10"
+        - name: BUILD_LOGLEVEL
+          value: "10"
       imageOptimizationPolicy: SkipLayers
     type: Docker
 `, image.ShellImage())
@@ -41,13 +44,16 @@ metadata:
 spec:
   runPolicy: Serial
   source:
-    dockerfile: "FROM %s\nRUN ls -R /run\nUSER 1001"
-    type: Dockerfile
+    dockerfile: |-
+      FROM %s
+      RUN ls -R /run
+      USER 1001
+  type: Dockerfile
   strategy:
     dockerStrategy:
       env:
-      - name: BUILD_LOGLEVEL
-        value: "10"
+        - name: BUILD_LOGLEVEL
+          value: "10"
       imageOptimizationPolicy: SkipLayers
     type: Docker
 `, image.ShellImage())
@@ -84,6 +90,18 @@ secrets
 /run/secrets:
 system-fips
 `
+		lsRSlashRunOKD = `
+/run:
+lock
+rhsm
+secrets
+
+/run/lock:
+
+/run/rhsm:
+
+/run/secrets:
+`
 	)
 
 	g.Context("", func() {
@@ -114,7 +132,7 @@ system-fips
 				logs, err := br.LogsNoTimestamp()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				hasRightListing := false
-				if strings.Contains(logs, lsRSlashRun) || strings.Contains(logs, lsRSlashRunFIPS) {
+				if strings.Contains(logs, lsRSlashRun) || strings.Contains(logs, lsRSlashRunFIPS) || strings.Contains(logs, lsRSlashRunOKD) {
 					hasRightListing = true
 				}
 				o.Expect(hasRightListing).To(o.BeTrue())


### PR DESCRIPTION
addresses 

https://storage.googleapis.com/origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.7/1355560957442527232/build-log.txt

@vrutkovs 

can you open a BZ to facilitate this FIX?
and is there any pre-merge OKD validation we can/should do?

/assign @adambkaplan 

@adambkaplan - I believe I also addressed some nit but merge anyway comments in this new file that you had ... `dockerfile: |-` for better readability