### PR TITLE
Re-enable test/extended/idling

### DIFF
--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -197,8 +197,9 @@ func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]s
 		{
 			Replicas: 2,
 			CrossGroupObjectReference: unidlingapi.CrossGroupObjectReference{
-				Name: resources[resourceName][0],
-				Kind: kind,
+				Name:  resources[resourceName][0],
+				Kind:  kind,
+				Group: "apps.openshift.io",
 			},
 		},
 	}))

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -211,7 +211,6 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling] Idling and unidling", fun
 		oc                  = exutil.NewCLI("cli-idling").Verbose()
 		echoServerFixture   = exutil.FixturePath("testdata", "idling-echo-server.yaml")
 		echoServerRcFixture = exutil.FixturePath("testdata", "idling-echo-server-rc.yaml")
-		framework           = oc.KubeFramework()
 	)
 
 	// path to the fixture
@@ -258,7 +257,6 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling] Idling and unidling", fun
 	g.Describe("idling [Local]", func() {
 		g.Context("with a single service and DeploymentConfig", func() {
 			g.BeforeEach(func() {
-				framework.BeforeEach()
 				fixture = echoServerFixture
 			})
 
@@ -269,7 +267,6 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling] Idling and unidling", fun
 
 		g.Context("with a single service and ReplicationController", func() {
 			g.BeforeEach(func() {
-				framework.BeforeEach()
 				fixture = echoServerRcFixture
 			})
 
@@ -281,7 +278,6 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling] Idling and unidling", fun
 
 	g.Describe("unidling", func() {
 		g.BeforeEach(func() {
-			framework.BeforeEach()
 			fixture = echoServerFixture
 		})
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1897,7 +1897,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the http2 tests": "should pass the http2 tests [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling idling [Local] with a single service and DeploymentConfig should idle the service and DeploymentConfig properly": "should idle the service and DeploymentConfig properly [Disabled:Broken]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling idling [Local] with a single service and DeploymentConfig should idle the service and DeploymentConfig properly": "should idle the service and DeploymentConfig properly",
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling idling [Local] with a single service and ReplicationController should idle the service and ReplicationController properly": "should idle the service and ReplicationController properly",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -30,7 +30,6 @@ var (
 		// tests that are known broken and need to be fixed upstream or in openshift
 		// always add an issue here
 		"[Disabled:Broken]": {
-			`should idle the service and DeploymentConfig properly`,       // idling with a single service and DeploymentConfig
 			`should answer endpoint and wildcard queries for the cluster`, // currently not supported by dns operator https://github.com/openshift/cluster-dns-operator/issues/43
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1908677
 			`SCTP \[Feature:SCTP\] \[LinuxOnly\] should create a Pod with SCTP HostPort`,


### PR DESCRIPTION
The gist of this was to verify that, if this had been enabled, we would have noticed that idling was broken in the router, see https://bugzilla.redhat.com/show_bug.cgi?id=1900989. However this test doesn't exercise a route and we would have still missed the regression in BZ#1900989.

TODO/TBD:
- land this as is
- extend this to also exercise a route