### PR TITLE
Bug 1900989: test/extended/router: add idle/unidle e2e test

### DIFF
--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -1,0 +1,147 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	unidlingapi "github.com/openshift/api/unidling/v1alpha1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/url"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		configPath = exutil.FixturePath("testdata", "router", "router-idle.yaml")
+		oc         = exutil.NewCLI("router-idling")
+	)
+
+	// this hook must be registered before the framework namespace teardown
+	// hook
+	g.AfterEach(func() {
+		if g.CurrentGinkgoTestDescription().Failed {
+			exutil.DumpPodLogsStartingWithInNamespace("router", "openshift-ingress", oc.AsAdmin())
+		}
+	})
+
+	g.Describe("The HAProxy router", func() {
+		g.It("should be able to connect to a service that is idled because a GET on the route will unidle it", func() {
+			// timeout for kube GET polling operations
+			timeout := 3 * time.Minute
+
+			// timout for GET requests
+			urlTimeout := 1 * time.Minute
+
+			g.By(fmt.Sprintf("creating test fixture from a config file %q", configPath))
+			err := oc.Run("new-app").Args("-f", configPath).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			urlTester := url.NewTester(oc.AdminKubeClient(), oc.Namespace()).WithErrorPassthrough(true)
+			defer urlTester.Close()
+			hostname := getHostnameForRoute(oc, "idle-test")
+			urlTester.Within(urlTimeout, url.Expect("GET", "http://"+hostname).Through(hostname).HasStatusCode(200))
+
+			g.By("Idling the service")
+			_, err = oc.Run("idle").Args("idle-test").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			var annotations map[string]string
+
+			g.By("Fetching the endpoints and checking the idle annotations are present")
+			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+				endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(context.Background(), "idle-test", metav1.GetOptions{})
+				if err != nil {
+					e2e.Logf("Error getting endpoints: %v", err)
+					return false, nil
+				}
+				annotations = endpoints.Annotations
+				_, idledAt := annotations[unidlingapi.IdledAtAnnotation]
+				_, unidleTarget := annotations[unidlingapi.UnidleTargetAnnotation]
+				return idledAt && unidleTarget, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			checkIdleAnnotationValues(annotations)
+
+			g.By("Fetching the service and checking the idle annotations are present")
+			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+				service, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(context.Background(), "idle-test", metav1.GetOptions{})
+				if err != nil {
+					e2e.Logf("Error getting service: %v", err)
+					return false, nil
+				}
+				annotations = service.Annotations
+				_, idledAt := annotations[unidlingapi.IdledAtAnnotation]
+				_, unidleTarget := annotations[unidlingapi.UnidleTargetAnnotation]
+				return idledAt && unidleTarget, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			checkIdleAnnotationValues(annotations)
+
+			g.By("Unidling up the service by making a GET request on the route")
+			urlTester.Within(urlTimeout, url.Expect("GET", "http://"+hostname).Through(hostname).HasStatusCode(200))
+
+			g.By("Validating that the idle annotations have been removed from the endpoints")
+			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+				endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(context.Background(), "idle-test", metav1.GetOptions{})
+				if err != nil {
+					e2e.Logf("Error getting endpoints: %v", err)
+					return false, nil
+				}
+				_, idledAt := endpoints.Annotations[unidlingapi.IdledAtAnnotation]
+				_, unidleTarget := endpoints.Annotations[unidlingapi.UnidleTargetAnnotation]
+				return !idledAt && !unidleTarget, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Validating that the idle annotations have been removed from the service")
+			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+				service, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(context.Background(), "idle-test", metav1.GetOptions{})
+				if err != nil {
+					e2e.Logf("Error getting service: %v", err)
+					return false, nil
+				}
+				_, idledAt := service.Annotations[unidlingapi.IdledAtAnnotation]
+				_, unidleTarget := service.Annotations[unidlingapi.UnidleTargetAnnotation]
+				return !idledAt && !unidleTarget, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+	})
+})
+
+func checkIdleAnnotationValues(annotations map[string]string) {
+	o.Expect(annotations).To(o.HaveKey(unidlingapi.IdledAtAnnotation))
+	o.Expect(annotations).To(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
+
+	idledAtAnnotation := annotations[unidlingapi.IdledAtAnnotation]
+	idledAtTime, err := time.Parse(time.RFC3339, idledAtAnnotation)
+	o.Expect(err).ToNot(o.HaveOccurred())
+	o.Expect(idledAtTime).To(o.BeTemporally("~", time.Now(), 5*time.Minute))
+
+	g.By("Checking the idle targets")
+	unidleTargetAnnotation := annotations[unidlingapi.UnidleTargetAnnotation]
+	var unidleTargets []unidlingapi.RecordedScaleReference
+	err = json.Unmarshal([]byte(unidleTargetAnnotation), &unidleTargets)
+	o.Expect(err).ToNot(o.HaveOccurred())
+	o.Expect(unidleTargets).To(o.Equal([]unidlingapi.RecordedScaleReference{
+		{
+			Replicas: 1,
+			CrossGroupObjectReference: unidlingapi.CrossGroupObjectReference{
+				Kind:  "Deployment",
+				Group: "apps",
+				Name:  "idle-test",
+			},
+		},
+	}))
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -456,6 +456,7 @@
 // test/extended/testdata/router/router-h2spec.yaml
 // test/extended/testdata/router/router-http-echo-server.yaml
 // test/extended/testdata/router/router-http2.yaml
+// test/extended/testdata/router/router-idle.yaml
 // test/extended/testdata/router/router-metrics.yaml
 // test/extended/testdata/router/router-override-domains.yaml
 // test/extended/testdata/router/router-override.yaml
@@ -50602,6 +50603,83 @@ func testExtendedTestdataRouterRouterHttp2Yaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataRouterRouterIdleYaml = []byte(`apiVersion: v1
+kind: Template
+objects:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: idle-test
+    labels:
+      app: idle-test
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: idle-test
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: idle-test
+    labels:
+      app: idle-test
+  spec:
+    selector:
+      app: idle-test
+    ports:
+      - port: 8080
+        name: 8080-http
+        targetPort: 8080
+        protocol: TCP
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: idle-test
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        name: idle-test
+        labels:
+          app: idle-test
+      spec:
+        containers:
+        - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          name: idle-test
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          command:
+            - /usr/bin/socat
+            - TCP4-LISTEN:8080,reuseaddr,fork
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+    selector:
+      matchLabels:
+        app: idle-test
+`)
+
+func testExtendedTestdataRouterRouterIdleYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterRouterIdleYaml, nil
+}
+
+func testExtendedTestdataRouterRouterIdleYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterRouterIdleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/router-idle.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataRouterRouterMetricsYaml = []byte(`apiVersion: v1
 kind: List
 items:
@@ -53906,6 +53984,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/router/router-h2spec.yaml":                                                       testExtendedTestdataRouterRouterH2specYaml,
 	"test/extended/testdata/router/router-http-echo-server.yaml":                                             testExtendedTestdataRouterRouterHttpEchoServerYaml,
 	"test/extended/testdata/router/router-http2.yaml":                                                        testExtendedTestdataRouterRouterHttp2Yaml,
+	"test/extended/testdata/router/router-idle.yaml":                                                         testExtendedTestdataRouterRouterIdleYaml,
 	"test/extended/testdata/router/router-metrics.yaml":                                                      testExtendedTestdataRouterRouterMetricsYaml,
 	"test/extended/testdata/router/router-override-domains.yaml":                                             testExtendedTestdataRouterRouterOverrideDomainsYaml,
 	"test/extended/testdata/router/router-override.yaml":                                                     testExtendedTestdataRouterRouterOverrideYaml,
@@ -54653,6 +54732,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"router-h2spec.yaml":           {testExtendedTestdataRouterRouterH2specYaml, map[string]*bintree{}},
 					"router-http-echo-server.yaml": {testExtendedTestdataRouterRouterHttpEchoServerYaml, map[string]*bintree{}},
 					"router-http2.yaml":            {testExtendedTestdataRouterRouterHttp2Yaml, map[string]*bintree{}},
+					"router-idle.yaml":             {testExtendedTestdataRouterRouterIdleYaml, map[string]*bintree{}},
 					"router-metrics.yaml":          {testExtendedTestdataRouterRouterMetricsYaml, map[string]*bintree{}},
 					"router-override-domains.yaml": {testExtendedTestdataRouterRouterOverrideDomainsYaml, map[string]*bintree{}},
 					"router-override.yaml":         {testExtendedTestdataRouterRouterOverrideYaml, map[string]*bintree{}},

--- a/test/extended/testdata/router/router-idle.yaml
+++ b/test/extended/testdata/router/router-idle.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Template
+objects:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: idle-test
+    labels:
+      app: idle-test
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: idle-test
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: idle-test
+    labels:
+      app: idle-test
+  spec:
+    selector:
+      app: idle-test
+    ports:
+      - port: 8080
+        name: 8080-http
+        targetPort: 8080
+        protocol: TCP
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: idle-test
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        name: idle-test
+        labels:
+          app: idle-test
+      spec:
+        containers:
+        - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          name: idle-test
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          command:
+            - /usr/bin/socat
+            - TCP4-LISTEN:8080,reuseaddr,fork
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+    selector:
+      matchLabels:
+        app: idle-test

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1891,6 +1891,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": "should answer endpoint and wildcard queries for the cluster [Disabled:Broken]",
 
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should be able to connect to a service that is idled because a GET on the route will unidle it": "should be able to connect to a service that is idled because a GET on the route will unidle it [Suite:openshift/conformance/parallel/minimal]",
+
 	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the gRPC interoperability tests": "should pass the gRPC interoperability tests [Suite:openshift/conformance/parallel/minimal]",
 
 	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the h2spec conformance tests": "should pass the h2spec conformance tests [Suite:openshift/conformance/parallel/minimal]",


### PR DESCRIPTION
 An explicit test to assert that a service that is idled will be
 unidled when a GET request occurs on the route.