### PR TITLE
Add new tests for baremetal IPI platform

### DIFF
--- a/test/extended/baremetal/OWNERS
+++ b/test/extended/baremetal/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - andfasano
+  - ardaguclu
+  - stbenjam

--- a/test/extended/baremetal/hosts.go
+++ b/test/extended/baremetal/hosts.go
@@ -1,0 +1,69 @@
+package baremetal
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	configv1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+)
+
+func skipIfNotBaremetal(oc *exutil.CLI) {
+	g.By("checking platform type")
+
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	if infra.Status.Platform != configv1.BareMetalPlatformType {
+		e2eskipper.Skipf("No baremetal platform detected")
+	}
+}
+
+func baremetalClient(dc dynamic.Interface) dynamic.ResourceInterface {
+	baremetalClient := dc.Resource(schema.GroupVersionResource{Group: "metal3.io", Resource: "baremetalhosts", Version: "v1alpha1"})
+	return baremetalClient.Namespace("openshift-machine-api")
+}
+
+var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLI("baremetal")
+
+	g.It("have a metal3 deployment", func() {
+		skipIfNotBaremetal(oc)
+
+		c, err := e2e.LoadClientset()
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		metal3, err := c.AppsV1().Deployments("openshift-machine-api").Get(context.Background(), "metal3", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(metal3.Status.AvailableReplicas).To(o.BeEquivalentTo(1))
+	})
+
+	g.It("have baremetalhost resources", func() {
+		skipIfNotBaremetal(oc)
+
+		dc := oc.AdminDynamicClient()
+		bmc := baremetalClient(dc)
+
+		hosts, err := bmc.List(context.Background(), v1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hosts.Items).ToNot(o.BeEmpty())
+
+		for _, h := range hosts.Items {
+			status, found, err := unstructured.NestedString(h.Object, "status", "operationalStatus")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(found).To(o.BeTrue(), "baremetalhost not ready")
+			o.Expect(status).To(o.BeEquivalentTo("OK"))
+		}
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/authentication"
 	_ "github.com/openshift/origin/test/extended/authorization"
 	_ "github.com/openshift/origin/test/extended/authorization/rbac"
+	_ "github.com/openshift/origin/test/extended/baremetal"
 	_ "github.com/openshift/origin/test/extended/bootstrap_user"
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/cli"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1843,6 +1843,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-imageregistry][Serial][Suite:openshift/registry/serial] Image signature workflow can push a signed image to openshift registry and verify it": "can push a signed image to openshift registry and verify it [Suite:openshift/conformance/serial]",
 
+	"[Top Level] [sig-installer][Feature:baremetal] Baremetal platform should have a metal3 deployment": "have a metal3 deployment [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-installer][Feature:baremetal] Baremetal platform should have baremetalhost resources": "have baremetalhost resources [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch": "should check that logs from containers are ingested into Elasticsearch [Disabled:Unimplemented] [Suite:k8s]",
 
 	"[Top Level] [sig-instrumentation] Events API should delete a collection of events [Conformance]": "should delete a collection of events [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",


### PR DESCRIPTION
This PR adds some new basic tests for the baremetal IPI platform, so that it could be possible to integrate them in the current CI/release builds for the baremetal IPI platform.

Tests are referring the following enhancements:
* https://github.com/openshift/enhancements/pull/102
* https://github.com/openshift/enhancements/pull/212

CI baremetal workflow:
* https://github.com/openshift/release/blob/master/ci-operator/step-registry/baremetalds/e2e/baremetalds-e2e-workflow.yaml

This is just an initial PR to begin landing tests for the baremetal IPI platform and clear out the required technical details.

