### PR TITLE
Bug 1924128: Allow RHE7 /run contents for build fs test

### DIFF
--- a/test/extended/builds/run_fs_verification.go
+++ b/test/extended/builds/run_fs_verification.go
@@ -102,6 +102,31 @@ secrets
 
 /run/secrets:
 `
+		lsRSlashRunRhel7 = `
+/run:
+lock
+rhsm
+secrets
+
+/run/lock:
+
+/run/rhsm:
+
+/run/secrets:
+rhsm
+
+/run/secrets/rhsm:
+ca
+logging.conf
+rhsm.conf
+syspurpose
+
+/run/secrets/rhsm/ca:
+redhat-uep.pem
+
+/run/secrets/rhsm/syspurpose:
+valid_fields.json
+`
 	)
 
 	g.Context("", func() {
@@ -132,7 +157,11 @@ secrets
 				logs, err := br.LogsNoTimestamp()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				hasRightListing := false
-				if strings.Contains(logs, lsRSlashRun) || strings.Contains(logs, lsRSlashRunFIPS) || strings.Contains(logs, lsRSlashRunOKD) {
+				if strings.Contains(logs, lsRSlashRun) ||
+					strings.Contains(logs, lsRSlashRunFIPS) ||
+					strings.Contains(logs, lsRSlashRunOKD) ||
+					strings.Contains(logs, lsRSlashRunRhel7) {
+
 					hasRightListing = true
 				}
 				o.Expect(hasRightListing).To(o.BeTrue())


### PR DESCRIPTION
On RHEL7 workers /run contents for build fs test are different from all the other variants we are checking, which makes test fail on RHEL7 workers as seen in this bug: https://bugzilla.redhat.com/show_bug.cgi?id=1924128
Adding correct string from RHEL7 worker to the list of checked contents should help.