### PR TITLE
tests: Double up the network stress test pressure

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -314,8 +314,8 @@ var staticSuites = testSuites{
 				}
 				return (strings.Contains(name, "[Suite:openshift/conformance/") && strings.Contains(name, "[sig-network]")) || isStandardEarlyOrLateTest(name)
 			},
-			Parallelism:         30,
-			Count:               15,
+			Parallelism:         60,
+			Count:               12,
 			TestTimeout:         20 * time.Minute,
 			SyntheticEventTests: ginkgo.JUnitForEventsFunc(stableSystemEventInvariants),
 		},

--- a/test/extended/oauth/server_headers.go
+++ b/test/extended/oauth/server_headers.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers]", func() {
 		// deploy oauth server
 		var newRequestTokenOptions oauthserver.NewRequestTokenOptionsFunc
 		newRequestTokenOptions, oauthServerCleanup, err = deployOAuthServer(oc)
-		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(err).ToNot(o.HaveOccurred(), "while attempting to deploy the oauth server")
 		oauthServerAddr = newRequestTokenOptions("", "").Issuer
 	})
 


### PR DESCRIPTION
Double parallelism, cut repetitions 20% to 12.