### PR TITLE
tests: Upgrade tests should always include success output

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -55,6 +55,9 @@ var upgradeSuites = testSuites{
 
 // upgradeTestPreSuite validates the test options.
 func upgradeTestPreSuite(opt *runOptions) error {
+	// Upgrade test output is important for debugging because it shows linear progress
+	// and when the CVO hangs.
+	opt.IncludeSuccessOutput = true
 	return parseUpgradeOptions(opt.TestOptions)
 }
 


### PR DESCRIPTION
Upgrade output shows linear progress of the test and it is important
for understanding when even successful runs may fail to preserve
invariants.