### PR TITLE
Bug 1915912: Fix CSI snapshotter image version

### DIFF
--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -35,6 +35,7 @@ func init() {
 		"k8s.gcr.io/sig-storage/csi-resizer:v0.5.0":               -1,
 		"k8s.gcr.io/sig-storage/csi-snapshotter:v2.0.1":           -1,
 		"k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.0":           -1,
+		"k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.2":           -1,
 		"k8s.gcr.io/sig-storage/hostpathplugin:v1.4.0":            -1,
 		"k8s.gcr.io/sig-storage/livenessprobe:v1.1.0":             -1,
 		"k8s.gcr.io/sig-storage/mock-driver:v4.0.2":               -1,

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -45,6 +45,7 @@ k8s.gcr.io/sig-storage/csi-resizer:v0.4.0 quay.io/openshift/community-e2e-images
 k8s.gcr.io/sig-storage/csi-resizer:v0.5.0 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-csi-resizer-v0-5-0-O79EW2-1fDT39X15
 k8s.gcr.io/sig-storage/csi-snapshotter:v2.0.1 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-csi-snapshotter-v2-0-1-NIPtB_SC-LRqBaeq
 k8s.gcr.io/sig-storage/csi-snapshotter:v2.1.0 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-csi-snapshotter-v2-1-0-1kbgyjhsZ5sWpBwq
+k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.2 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-csi-snapshotter-v3-0-2-xM4zaRecqro9vBr7
 k8s.gcr.io/sig-storage/hostpathplugin:v1.4.0 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-hostpathplugin-v1-4-0-AfY5JyX6DsfCefAR
 k8s.gcr.io/sig-storage/livenessprobe:v1.1.0 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-livenessprobe-v1-1-0-d49j-mlARufXkhrZ
 k8s.gcr.io/sig-storage/mock-driver:v4.0.2 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-mock-driver-v4-0-2-GE9vfPm7mdvjzZh_


### PR DESCRIPTION
This fixes some niche e2e tests, see the BZ.

In addition, this is pre-requisite for enabling snapshot e2e tests, which we disabled during rebase and forgot to enable in https://bugzilla.redhat.com/show_bug.cgi?id=1906518.

I filed https://bugzilla.redhat.com/show_bug.cgi?id=1925493 for enabling those tests.