### PR TITLE
Change registry.svc.ci.openshift.org to registry.ci.openshift.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/deps.mk \
 )
 
-IMAGE_REGISTRY :=registry.svc.ci.openshift.org
+IMAGE_REGISTRY :=registry.ci.openshift.org
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name

--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 		Before(oc)
 		defer After(oc)
 
-		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i"))
+		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.ci.openshift.org/ocp/4.7:test-build-roots2i"))
 		err := oc.Run("new-app").Args(firstArgString, "--name", "nodejsfail").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 		roleBinding, err = oc.AdminKubeClient().RbacV1().RoleBindings(oc.Namespace()).Create(context.Background(), roleBinding, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i"))
+		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.ci.openshift.org/ocp/4.7:test-build-roots2i"))
 		err = oc.Run("new-build").Args(firstArgString, "--name", "nodejspass").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -22,7 +22,7 @@ func init() {
 
 		// used by build s2i e2e's to verify that builder with USER root are not allowed
 		// the github.com/openshift/build-test-images repo is built out of github.com/openshift/release
-		"registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i": -1,
+		"registry.ci.openshift.org/ocp/4.7:test-build-roots2i": -1,
 
 		// moved to GCR
 		"k8s.gcr.io/sig-storage/csi-attacher:v2.2.0":              -1,

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -50,4 +50,4 @@ k8s.gcr.io/sig-storage/livenessprobe:v1.1.0 quay.io/openshift/community-e2e-imag
 k8s.gcr.io/sig-storage/mock-driver:v4.0.2 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-mock-driver-v4-0-2-GE9vfPm7mdvjzZh_
 k8s.gcr.io/sig-storage/nfs-provisioner:v2.2.2 quay.io/openshift/community-e2e-images:e2e-22-k8s-gcr-io-sig-storage-nfs-provisioner-v2-2-2-dbgtOCwYmEGggl01
 k8s.gcr.io/sig-storage/snapshot-controller:v2.1.1 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-snapshot-controller-v2-1-1-n5BM_jX2npV3RxHM
-registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-svc-ci-openshift-org-ocp-4-7-test-build-roots2i-ZzDWhWn0wPB9cLFM
+registry.ci.openshift.org/ocp/4.7:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-ci-openshift-org-ocp-4-7-test-build-roots2i-tG08qb6aSmDhxBBy


### PR DESCRIPTION
While mirroring image for https://github.com/openshift/origin/pull/25862 I've noticed we're still pointing to deprecated images in registry.svc.ci.openshift.org. I've updated them during mirroring but here is the actual PR fixing those.

/assign @adambkaplan 

since you own those bits. 