### PR TITLE
Bug 1924953: Allow prometheus state clear to pass etcd leader change test

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
 		g.By("Examining the number of etcd leadership changes over the run")
-		result, _, err := prometheus.Query(context.Background(), fmt.Sprintf("increase((max(max by (job) (etcd_server_leader_changes_seen_total)) or 0*absent(etcd_server_leader_changes_seen_total))[%s:15s])", testDuration), time.Now())
+		result, _, err := prometheus.Query(context.Background(), fmt.Sprintf("increase(max(max by (pod,job) (etcd_server_leader_changes_seen_total))[%s:1s])", testDuration), time.Now())
 		o.Expect(err).ToNot(o.HaveOccurred())
 		leaderChanges := result.(model.Vector)[0].Value
 		if leaderChanges != 0 {


### PR DESCRIPTION
If the prometheus process on a conformant cluster has no PVs, the
data in prometheus is lost and the current query will flag that as
a leader election (new prometheus scrapes the old etcd and sees the
increase). The tightened tolerance turned out to be too tight for
serial tests, where we allow the machine set test to replace one
of the workers. If we were using PVs for prometheus in all machine
set clusters this would be ok, but it's valid today to have a
machine set cluster with no PV provisioning.

The test now ignores restarts that happen before the beginning of
prometheus history, and only looks at leader changes over the time
prometheus is up and running with the latest data.