### PR TITLE
Bug 1926146: test/extended/router/idle: address flakes/failures seen in CI 

### DIFF
--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
@@ -14,7 +16,6 @@ import (
 
 	unidlingapi "github.com/openshift/api/unidling/v1alpha1"
 	exutil "github.com/openshift/origin/test/extended/util"
-	"github.com/openshift/origin/test/extended/util/url"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -37,24 +38,24 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should be able to connect to a service that is idled because a GET on the route will unidle it", func() {
-			// timeout for kube GET polling operations
-			timeout := 3 * time.Minute
-
-			// timout for GET requests
-			urlTimeout := 1 * time.Minute
+			timeout := 15 * time.Minute
 
 			g.By(fmt.Sprintf("creating test fixture from a config file %q", configPath))
 			err := oc.Run("new-app").Args("-f", configPath).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to create test fixture")
 
-			urlTester := url.NewTester(oc.AdminKubeClient(), oc.Namespace()).WithErrorPassthrough(true)
-			defer urlTester.Close()
+			g.By("Waiting for pods to be running")
+			err = waitForRunningPods(oc, 1, exutil.ParseLabelsOrDie("app=idle-test"), timeout)
+			o.Expect(err).NotTo(o.HaveOccurred(), "pods not running")
+
+			g.By("Getting a 200 status code when accessing the route")
 			hostname := getHostnameForRoute(oc, "idle-test")
-			urlTester.Within(urlTimeout, url.Expect("GET", "http://"+hostname).Through(hostname).HasStatusCode(200))
+			err = waitHTTPGetStatus(hostname, http.StatusOK, timeout)
+			o.Expect(err).NotTo(o.HaveOccurred(), "expected status 200 from the GET request")
 
 			g.By("Idling the service")
 			_, err = oc.Run("idle").Args("idle-test").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to idle the service")
 
 			var annotations map[string]string
 
@@ -70,8 +71,8 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 				_, unidleTarget := annotations[unidlingapi.UnidleTargetAnnotation]
 				return idledAt && unidleTarget, nil
 			})
-			o.Expect(err).NotTo(o.HaveOccurred())
-			checkIdleAnnotationValues(annotations)
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to fetch the endpoints")
+			mustVerifyIdleAnnotationValues(annotations)
 
 			g.By("Fetching the service and checking the idle annotations are present")
 			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
@@ -85,11 +86,12 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 				_, unidleTarget := annotations[unidlingapi.UnidleTargetAnnotation]
 				return idledAt && unidleTarget, nil
 			})
-			o.Expect(err).NotTo(o.HaveOccurred())
-			checkIdleAnnotationValues(annotations)
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to fetch the service")
+			mustVerifyIdleAnnotationValues(annotations)
 
-			g.By("Unidling up the service by making a GET request on the route")
-			urlTester.Within(urlTimeout, url.Expect("GET", "http://"+hostname).Through(hostname).HasStatusCode(200))
+			g.By("Unidling the service by making a GET request on the route")
+			err = waitHTTPGetStatus(hostname, http.StatusOK, timeout)
+			o.Expect(err).NotTo(o.HaveOccurred(), "expected status 200 from the GET request")
 
 			g.By("Validating that the idle annotations have been removed from the endpoints")
 			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
@@ -102,7 +104,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 				_, unidleTarget := endpoints.Annotations[unidlingapi.UnidleTargetAnnotation]
 				return !idledAt && !unidleTarget, nil
 			})
-			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred(), "idle annotations not removed from endpoints")
 
 			g.By("Validating that the idle annotations have been removed from the service")
 			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
@@ -115,12 +117,12 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 				_, unidleTarget := service.Annotations[unidlingapi.UnidleTargetAnnotation]
 				return !idledAt && !unidleTarget, nil
 			})
-			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred(), "idle annotations not removed from service")
 		})
 	})
 })
 
-func checkIdleAnnotationValues(annotations map[string]string) {
+func mustVerifyIdleAnnotationValues(annotations map[string]string) {
 	o.Expect(annotations).To(o.HaveKey(unidlingapi.IdledAtAnnotation))
 	o.Expect(annotations).To(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
 
@@ -144,4 +146,57 @@ func checkIdleAnnotationValues(annotations map[string]string) {
 			},
 		},
 	}))
+}
+
+// waitForRunningPods waits for podCount pods matching podSelector are
+// in the running state. It retries the request every second and will
+// return an error if the conditions are not met after the specified
+// timeout.
+func waitForRunningPods(oc *exutil.CLI, podCount int, podLabels labels.Selector, timeout time.Duration) error {
+	ns := oc.KubeFramework().Namespace.Name
+
+	if err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		podList, err := oc.AdminKubeClient().CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{LabelSelector: podLabels.String()})
+		if err != nil {
+			e2e.Logf("Error listing pods: %v", err)
+			return false, nil
+		}
+		return len(podList.Items) == podCount, nil
+	}); err != nil {
+		return fmt.Errorf("failed to list pods: %v", err)
+	}
+
+	e2e.Logf("Waiting for %d pods in namespace %s", podCount, ns)
+	c := oc.AdminKubeClient()
+	pods, err := exutil.WaitForPods(c.CoreV1().Pods(ns), podLabels, exutil.CheckPodIsRunning, podCount, timeout)
+	if err != nil {
+		return fmt.Errorf("error in pod wait: %v", err)
+	} else if len(pods) < podCount {
+		return fmt.Errorf("only got %v out of %v pods in %s (timeout)", len(pods), podCount, timeout)
+	}
+
+	e2e.Logf("All expected pods in namespace %s are running", ns)
+	return nil
+}
+
+// waitHTTPGetStatus repeatedly makes a HTTP GET request to hostname
+// until the GET response equals statusCode. It retries every second
+// and will return an error if the conditions are not met after the
+// specified timeout.
+func waitHTTPGetStatus(hostname string, statusCode int, timeout time.Duration) error {
+	client := makeHTTPClient(false, timeout)
+
+	var attempt int
+
+	return wait.Poll(time.Second, timeout, func() (bool, error) {
+		attempt += 1
+		url := "http://" + hostname
+		resp, err := client.Get(url)
+		if err != nil {
+			e2e.Logf("GET#%v %q error=%v", attempt, url, err)
+			return false, nil // could be 503 if service not ready
+		}
+		e2e.Logf("GET#%v %q status=%v", attempt, url, resp.StatusCode)
+		return resp.StatusCode == statusCode, nil
+	})
 }


### PR DESCRIPTION
Fixes for failures/flakes seen in CI runs:

- increase timeout for polling operations to 15 mins

- wait for PODs to be running after the fixture has been created

This also switches from using URLTester to making a direct connection
to the route's hostname. This reduces the need for an execpod and will
make the test run faster.

The changes here will also make the test pass for the proxy CI job.
