### PR TITLE
test: Calculate leader elections over individual metrics

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
 		g.By("Examining the number of etcd leadership changes over the run")
-		result, _, err := prometheus.Query(context.Background(), fmt.Sprintf("increase(max(max by (pod,job) (etcd_server_leader_changes_seen_total))[%s:1s])", testDuration), time.Now())
+		result, _, err := prometheus.Query(context.Background(), fmt.Sprintf("max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total[%s])))", testDuration), time.Now())
 		o.Expect(err).ToNot(o.HaveOccurred())
 		leaderChanges := result.(model.Vector)[0].Value
 		if leaderChanges != 0 {


### PR DESCRIPTION
The change to calculation worked when the metric was new (because the serial test cleared the PV data) but not when it was restarted.

Simplify the metric with the new data from when we have preserved the change.