### PR TITLE
[WIP] DO NOT MERGE: debug proxy test failures with more verbose failure output

### DIFF
--- a/test/extended/util/url/url.go
+++ b/test/extended/util/url/url.go
@@ -157,8 +157,19 @@ func createExecPod(clientset kclientset.Interface, ns, name string) (string, err
 					ImagePullPolicy: v1.PullIfNotPresent,
 				},
 			},
-			HostNetwork:                   false,
+			HostNetwork: false,
+			// Testing control plane vs workload nodes
+			NodeSelector: map[string]string{
+				"node-role.kubernetes.io/master": "",
+			},
 			TerminationGracePeriodSeconds: &immediate,
+			Tolerations: []v1.Toleration{
+				{
+					Effect:   v1.TaintEffectNoSchedule,
+					Key:      "node-role.kubernetes.io/master",
+					Operator: v1.TolerationOpExists,
+				},
+			},
 		},
 	}
 	client := clientset.CoreV1()


### PR DESCRIPTION
Iterating on https://bugzilla.redhat.com/show_bug.cgi?id=1882486 by shimming some quick dig and curl tests into the currently broken router tests.

the `/test e2e-aws-proxy` job has the test skips enabled, so this is the best way to test these sorts of things for now.