### PR TITLE
[release-3.11] Bug 1884421: Try to promote inactive routes following route deletion

### DIFF
--- a/pkg/router/controller/hostindex/hostindex.go
+++ b/pkg/router/controller/hostindex/hostindex.go
@@ -284,7 +284,7 @@ func (r *hostRules) add(route *routev1.Route, fn RouteActivationFunc, changes *r
 func (r *hostRules) removeActive(i int, fn RouteActivationFunc, changes *routeChanges) {
 	r.active = append(r.active[0:i], r.active[i+1:]...)
 	// attempt to promote all inactive routes
-	if len(r.active) == 0 || i == 0 {
+	if len(r.inactive) > 0 {
 		r.reset(fn, changes)
 		return
 	}


### PR DESCRIPTION
Backport https://github.com/openshift/router/pull/126 (modulo potentially incompatible changes related to unit tests).

#### Try to promote inactive routes following route deletion

Before this patch, inactive routes were not being promoted when the conflicting routes were deleted. Fix it so that when deletes happen, all inactive routes are given a chance to be promoted.