### PR TITLE
[release-3.11] Bug 1884422: Backport router hostindex fixes

### DIFF
--- a/pkg/router/controller/hostindex/activation.go
+++ b/pkg/router/controller/hostindex/activation.go
@@ -126,6 +126,11 @@ func hasExistingMatch(exists []*routev1.Route, route *routev1.Route) bool {
 		if existing.Spec.Path == route.Spec.Path {
 			return true
 		}
+		// Path-based TLS routes cannot have the same host as a
+		// passthrough route.
+		if existing.Spec.TLS != nil && route.Spec.TLS != nil && existing.Spec.TLS.Termination == routev1.TLSTerminationPassthrough {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/router/controller/hostindex/activation.go
+++ b/pkg/router/controller/hostindex/activation.go
@@ -128,7 +128,7 @@ func hasExistingMatch(exists []*routev1.Route, route *routev1.Route) bool {
 		}
 		// Path-based TLS routes cannot have the same host as a
 		// passthrough route.
-		if existing.Spec.TLS != nil && route.Spec.TLS != nil && existing.Spec.TLS.Termination == routev1.TLSTerminationPassthrough {
+		if existing.Spec.TLS != nil && route.Spec.TLS != nil && (existing.Spec.TLS.Termination == routev1.TLSTerminationPassthrough || route.Spec.TLS.Termination == routev1.TLSTerminationPassthrough) {
 			return true
 		}
 	}

--- a/pkg/router/controller/hostindex/hostindex_test.go
+++ b/pkg/router/controller/hostindex/hostindex_test.go
@@ -304,6 +304,18 @@ func Test_hostIndex(t *testing.T) {
 			displaces: map[string]struct{}{"003": {}},
 			inactive:  map[string][]string{"test.com": {"003"}},
 		},
+		{
+			name:       "passthrough route that conflicts with path-based route",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com", TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge}, Path: "/foo"})},
+				{route: newRoute("test", "2", 2, 1, routev1.RouteSpec{Host: "test.com", TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough}})},
+			},
+			newRoute:  true,
+			active:    map[string][]string{"test.com": {"001"}},
+			displaces: map[string]struct{}{"002": {}},
+			inactive:  map[string][]string{"test.com": {"002"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/router/controller/hostindex/hostindex_test.go
+++ b/pkg/router/controller/hostindex/hostindex_test.go
@@ -291,6 +291,19 @@ func Test_hostIndex(t *testing.T) {
 			displaces: map[string]struct{}{"002": {}},
 			inactive:  map[string][]string{"test.com": {"002"}},
 		},
+		{
+			name:       "path-based route that conflicts with passthrough route",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com", TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough}})},
+				{route: newRoute("test", "2", 2, 1, routev1.RouteSpec{Host: "test.com", Path: "/bar"})},
+				{route: newRoute("test", "3", 3, 1, routev1.RouteSpec{Host: "test.com", TLS: &routev1.TLSConfig{Termination: routev1.TLSTerminationEdge}, Path: "/foo"})},
+			},
+			newRoute:  true,
+			active:    map[string][]string{"test.com": {"001", "002"}},
+			displaces: map[string]struct{}{"003": {}},
+			inactive:  map[string][]string{"test.com": {"003"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Backport https://github.com/openshift/router/pull/57 and https://github.com/openshift/router/pull/59.


#### hostindex: Passthrough displaces path-based TLS

Ensure that a passthrough route displaces any path-based TLS routes with the same host, because passthrough is incompatible with path-based routing.

* `pkg/router/controller/hostindex/activation.go` (`hasExistingMatch`): Return true if both routes are TLS and the existing route is a passthrough route.
* `pkg/router/controller/hostindex/hostindex_test.go` (`Test_hostIndex`): Verify that a passthrough route displaces path-based TLS routes with the same host, but does not displace non-TLS routes.


#### hostindex: Path-based TLS displaces passthrough

Just as a passthrough route displaces any path-based TLS routes with the same host, a path-based TLS route displaces any passthrough route with the same host.

* `pkg/router/controller/hostindex/activation.go` (`hasExistingMatch`): Return true if both routes are TLS and *either* route is passthrough.
* `pkg/router/controller/hostindex/hostindex_test.go` (`Test_hostIndex`): Verify that a path-based TLS route displaces passthrough routes with the same host.