### PR TITLE
Bug 1928297: Wait until router pod is ready before checking health

### DIFF
--- a/test/extended/router/oc_copy.go
+++ b/test/extended/router/oc_copy.go
@@ -15,3 +15,13 @@ func IngressConditionStatus(ingress *routev1.RouteIngress, t routev1.RouteIngres
 	}
 	return corev1.ConditionUnknown, routev1.RouteIngressCondition{}
 }
+
+func podConditionStatus(pod *corev1.Pod, t corev1.PodConditionType) corev1.ConditionStatus {
+	for _, condition := range pod.Status.Conditions {
+		if t != condition.Type {
+			continue
+		}
+		return condition.Status
+	}
+	return corev1.ConditionUnknown
+}

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -78,11 +78,10 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 				if err != nil {
 					return false, err
 				}
-				if len(pod.Status.PodIP) == 0 {
-					return false, nil
-				}
 				routerIP = pod.Status.PodIP
-				return true, nil
+				podIsReady := podConditionStatus(pod, corev1.PodReady)
+
+				return len(routerIP) != 0 && podIsReady == corev1.ConditionTrue, nil
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -124,11 +123,10 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 				if err != nil {
 					return false, err
 				}
-				if len(pod.Status.PodIP) == 0 {
-					return false, nil
-				}
 				routerIP = pod.Status.PodIP
-				return true, nil
+				podIsReady := podConditionStatus(pod, corev1.PodReady)
+
+				return len(routerIP) != 0 && podIsReady == corev1.ConditionTrue, nil
 			})
 
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -191,11 +189,10 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 				if err != nil {
 					return false, err
 				}
-				if len(pod.Status.PodIP) == 0 {
-					return false, nil
-				}
 				routerIP = pod.Status.PodIP
-				return true, nil
+				podIsReady := podConditionStatus(pod, corev1.PodReady)
+
+				return len(routerIP) != 0 && podIsReady == corev1.ConditionTrue, nil
 			})
 
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
Avoid a race condition in the tests by checking the status of the pod to ensure it is ready before checking the health.