### PR TITLE
test: Ensure nodes stay ready during upgrades after reboot

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -31,7 +31,8 @@ var upgradeSuites = testSuites{
 				}
 				return strings.Contains(name, "[Feature:ClusterUpgrade]") && !strings.Contains(name, "[Suite:k8s]")
 			},
-			TestTimeout: 240 * time.Minute,
+			TestTimeout:         240 * time.Minute,
+			SyntheticEventTests: ginkgo.JUnitForEventsFunc(systemUpgradeEventInvariants),
 		},
 		PreSuite: upgradeTestPreSuite,
 	},
@@ -47,7 +48,8 @@ var upgradeSuites = testSuites{
 				}
 				return strings.Contains(name, "[Feature:ClusterUpgrade]") && !strings.Contains(name, "[Suite:k8s]")
 			},
-			TestTimeout: 240 * time.Minute,
+			TestTimeout:         240 * time.Minute,
+			SyntheticEventTests: ginkgo.JUnitForEventsFunc(systemUpgradeEventInvariants),
 		},
 		PreSuite: upgradeTestPreSuite,
 	},

--- a/pkg/monitor/node.go
+++ b/pkg/monitor/node.go
@@ -25,7 +25,7 @@ func startNodeMonitoring(ctx context.Context, m Recorder, client kubernetes.Inte
 					conditions = append(conditions, Condition{
 						Level:   Warning,
 						Locator: locateNode(node),
-						Message: fmt.Sprintf("condition %s changed", c.Type),
+						Message: fmt.Sprintf("condition/%s status/%s reason/%s changed", c.Type, c.Status, c.Reason),
 					})
 				}
 			}


### PR DESCRIPTION
A node should go down, get upgraded, and come back up ready exactly
once per upgrade. Test that condition.