### PR TITLE
[WIP] Bug 1882486: Add proxy settings to router testers when needed

### DIFF
--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -53,6 +53,12 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 
 		tester := exurl.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)
 
+		proxy, err := exutil.GetClusterProxy(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if len(proxy.Status.HTTPProxy) > 0 {
+			tester = tester.WithProxy(proxy.Status.HTTPProxy)
+		}
+
 		tests := []*exurl.Test{}
 
 		routes := []struct {

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -89,6 +89,12 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			g.By("verifying accessing the host returns a 200 status code")
 			for i := 0; i < len(routeTypeTests); i++ {
 				urlTester := url.NewTester(oc.AdminKubeClient(), oc.KubeFramework().Namespace.Name).WithErrorPassthrough(true)
+				proxy, err := exutil.GetClusterProxy(oc)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				if len(proxy.Status.HTTPProxy) > 0 {
+					urlTester = urlTester.WithProxy(proxy.Status.HTTPProxy)
+				}
+
 				defer urlTester.Close()
 				hostname := getHostnameForRoute(oc, fmt.Sprintf("h2spec-haproxy-%s", routeTypeTests[i].routeType))
 				urlTester.Within(30*time.Second, url.Expect("GET", "https://"+hostname).Through(hostname).SkipTLSVerification().HasStatusCode(200))

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -149,6 +149,11 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 
 				// check readiness probe is accessible
 				urlTester := url.NewTester(oc.AdminKubeClient(), oc.KubeFramework().Namespace.Name).WithErrorPassthrough(true)
+				proxy, err := exutil.GetClusterProxy(oc)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				if len(proxy.Status.HTTPProxy) > 0 {
+					urlTester = urlTester.WithProxy(proxy.Status.HTTPProxy)
+				}
 				defer urlTester.Close()
 				hostname := getHostnameForRoute(oc, tc.route)
 				urlTester.Within(30*time.Second, url.Expect("GET", "https://"+hostname+"/healthz").Through(hostname).SkipTLSVerification().HasStatusCode(200))

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -59,6 +59,12 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	g.Describe("The HAProxy router", func() {
 		g.It("should respond with 503 to unrecognized hosts", func() {
 			t := url.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)
+			proxy, err := exutil.GetClusterProxy(oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if len(proxy.Status.HTTPProxy) > 0 {
+				t = t.WithProxy(proxy.Status.HTTPProxy)
+			}
+
 			defer t.Close()
 			t.Within(
 				time.Minute,
@@ -85,6 +91,13 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 
 			g.By("verifying the router reports the correct behavior")
 			t := url.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)
+
+			proxy, err := exutil.GetClusterProxy(oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if len(proxy.Status.HTTPProxy) > 0 {
+				t = t.WithProxy(proxy.Status.HTTPProxy)
+			}
+
 			defer t.Close()
 			t.Within(
 				3*time.Minute,

--- a/test/extended/util/jenkins/ref.go
+++ b/test/extended/util/jenkins/ref.go
@@ -70,13 +70,21 @@ func NewRef(oc *exutil.CLI) *JenkinsRef {
 	token, err := oc.Run("whoami").Args("-t").Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
+	tester := exurl.NewTester(oc.AdminKubeClient(), oc.Namespace())
+
+	proxy, err := exutil.GetClusterProxy(oc)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if len(proxy.Status.HTTPProxy) > 0 {
+		tester = tester.WithProxy(proxy.Status.HTTPProxy)
+	}
+
 	j := &JenkinsRef{
 		oc:         oc,
 		host:       serviceIP,
 		port:       port,
 		namespace:  oc.Namespace(),
 		token:      token,
-		uri_tester: exurl.NewTester(oc.AdminKubeClient(), oc.Namespace()),
+		uri_tester: tester,
 	}
 	return j
 }

--- a/test/extended/util/proxy.go
+++ b/test/extended/util/proxy.go
@@ -3,18 +3,29 @@ package util
 import (
 	"context"
 
+	v1 "github.com/openshift/api/config/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // IsClusterProxyEnabled returns true if the cluster has a global proxy enabled
 func IsClusterProxyEnabled(oc *CLI) (bool, error) {
-	proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
-	if kerrors.IsNotFound(err) {
-		return false, nil
-	}
+	proxy, err := GetClusterProxy(oc)
 	if err != nil {
 		return false, err
 	}
 	return len(proxy.Status.HTTPProxy) > 0 || len(proxy.Status.HTTPSProxy) > 0, nil
+}
+
+func GetClusterProxy(oc *CLI) (*v1.Proxy, error) {
+	proxy := &v1.Proxy{}
+	proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		return proxy, nil
+	}
+	if err != nil {
+		return proxy, err
+	}
+
+	return proxy, nil
 }


### PR DESCRIPTION
**util: Add proxy options to URL Tester.**

test/extended/util/proxy.go: Update url.go
to take into account clusters with a cluster-wide
proxy configured. Pass a proxy URL to the execpod's
curl client when required via the `http_proxy` & `HTTP_PROXY`
container env variables.

test/extended/util/proxy.go: Add a new proxy helper function,
`GetClusterProxy`. Use this function in `IsClusterProxyEnabled`
to avoid duplicate code in `proxy.go`.

**test/extended: Update URL Tester calling sites.**

Update `url.NewTester` callers to pass an oc CLI rather
than an admin kube client.

**Router: Plumb curl proxy env vars to exec pod tests.**

test/extended/router/<headers,reencrypt>.go:

Add a proxy settings `tweak` function so that execpods
created via `exutil.CreateExecPodOrFail` have the necessary env
vars for test curl calls in `waitForRouterOKResponseExec(...)`
when appropriate.

---

These commits resolve https://bugzilla.redhat.com/show_bug.cgi?id=1882486.