### PR TITLE
Bug 1929110: test: add vsphere to unsupported platforms for LB service

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -49,7 +49,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	// ovirt does not support service type loadbalancer because it doesn't program a cloud.
-	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.KubevirtPlatformType || infra.Status.PlatformStatus.Type == configv1.LibvirtPlatformType {
+	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.KubevirtPlatformType || infra.Status.PlatformStatus.Type == configv1.LibvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType {
 		t.unsupportedPlatform = true
 	}
 	if t.unsupportedPlatform {


### PR DESCRIPTION
Required to pass tests in vsphere upgrade workflow.

Ref: https://issues.redhat.com/browse/OTA-308