### PR TITLE
test: Synthetic failures were not failing the job

### DIFF
--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -35,8 +35,8 @@ func (a JUnitsForAllEvents) JUnitsForEvents(events monitor.EventIntervals, durat
 		if obj == nil {
 			continue
 		}
-		results, passed := obj.JUnitsForEvents(events, duration)
-		if !passed {
+		results, testPassed := obj.JUnitsForEvents(events, duration)
+		if !testPassed {
 			passed = false
 		}
 		all = append(all, results...)


### PR DESCRIPTION
A local variable was shadowed and prevented synthetic failures from
propagating.