### PR TITLE
Added openshift-image-registry to single node topology test allowedToFail list

### DIFF
--- a/test/extended/single_node/topology.go
+++ b/test/extended/single_node/topology.go
@@ -105,6 +105,9 @@ func isAllowedToFail(deployment appsv1.Deployment) bool {
 			"console",
 			"downloads",
 		},
+		"openshift-image-registry": {
+			"image-registry",
+		},
 		"openshift-monitoring": {
 			"prometheus-adapter",
 			"thanos-querier",


### PR DESCRIPTION
It also creates 2 replicas for now so it's allowed to fail