### PR TITLE
test: Require no alerts during upgrades

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -42,7 +42,8 @@ func (UpgradeTest) DisplayName() string {
 func (t *UpgradeTest) Setup(f *framework.Framework) {
 	g.By("Setting up post-upgrade alert test")
 
-	url, bearerToken, oc, ok := helper.ExpectPrometheus(f)
+	oc := exutil.NewCLIWithFramework(f)
+	url, _, bearerToken, ok := helper.LocatePrometheus(oc)
 	if !ok {
 		framework.Failf("Prometheus could not be located on this cluster, failing test %s", t.Name())
 	}

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -66,7 +66,7 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 	)
 	g.BeforeEach(func() {
 		var ok bool
-		url, bearerToken, ok = prometheus.LocatePrometheus(oc)
+		url, _, bearerToken, ok = prometheus.LocatePrometheus(oc)
 		if !ok {
 			e2e.Failf("Prometheus could not be located on this cluster, failing prometheus test")
 		}

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus
 	)
 	g.BeforeEach(func() {
 		var ok bool
-		url, bearerToken, ok = helper.LocatePrometheus(oc)
+		url, _, bearerToken, ok = helper.LocatePrometheus(oc)
 		if !ok {
 			e2eskipper.Skipf("Prometheus could not be located on this cluster, skipping prometheus test")
 		}

--- a/test/extended/prometheus/storage.go
+++ b/test/extended/prometheus/storage.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-storage][Late] Metrics", func() {
 
 	g.BeforeEach(func() {
 		var ok bool
-		url, bearerToken, ok = helper.LocatePrometheus(oc)
+		url, _, bearerToken, ok = helper.LocatePrometheus(oc)
 		if !ok {
 			e2e.Failf("Prometheus could not be located on this cluster, failing prometheus test")
 		}


### PR DESCRIPTION
It is unacceptable to fire alerts during normal upgrades. Tighten
the constraints on the upgrade tests to ensure that any alerts
fail the upgrade test. If the test is skipped, continue to report
which alerts fired. Test over the entire duration of the test like
we do in the post-run variation.