### PR TITLE
Bug 1930663: test/e2e/upgrade: skip paused worker pools when checking for update to complete

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -505,6 +505,15 @@ func IsPoolUpdated(dc dynamic.NamespaceableResourceInterface, name string) (bool
 		framework.Logf("error getting pool %s: %v", name, err)
 		return false, nil
 	}
+	paused, found, err := unstructured.NestedBool(pool.Object, "spec", "paused")
+	if err != nil || !found {
+		return false, nil
+	}
+	if paused && (name == "worker") {
+		framework.Logf("worker pool paused, considering it to be updated")
+		return true, nil
+	}
+
 	conditions, found, err := unstructured.NestedFieldNoCopy(pool.Object, "status", "conditions")
 	if err != nil || !found {
 		return false, nil


### PR DESCRIPTION
Upgrade test ensures all pool updates are complete during upgrade tests. In order to test  EUS upgrade testing with minimal worker pool disruption steps would set paused in the spec. Upgrade test should consider those updated as it would be verified on later stages.

Ref: https://issues.redhat.com/browse/OTA-359