### PR TITLE
Bug 1921720: fix sig-cli flakes

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -19,8 +19,9 @@ import (
 )
 
 var (
-	cliInterval = 5 * time.Second
-	cliTimeout  = 1 * time.Minute
+	cliInterval        = 5 * time.Second
+	cliTimeout         = 1 * time.Minute
+	extendedCliTimeout = 2 * time.Minute
 )
 
 var _ = g.Describe("[sig-cli] oc adm", func() {
@@ -398,7 +399,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(oc.Run("adm", "policy", "add-role-to-user").Args("--rolebinding-name=admin", "admin", "adduser", "-n", "ui-test-project").Execute()).To(o.Succeed())
 
 		// Make sure project can be listed by oc (after auth cache syncs)
-		err := wait.Poll(cliInterval, cliTimeout, func() (bool, error) {
+		err := wait.Poll(cliInterval, extendedCliTimeout, func() (bool, error) {
 			err := ocns.Run("get").Args("project/ui-test-project").Execute()
 			return err == nil, nil
 		})

--- a/test/extended/cli/observe.go
+++ b/test/extended/cli/observe.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-cli] oc observe", func() {
 
 		out, err = oc.Run("observe").Args("serviceaccounts", "--once").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("Sync ended"))
+		o.Expect(out).To(o.Or(o.ContainSubstring("Sync ended"), o.ContainSubstring("Nothing to sync")))
 
 		out, err = oc.Run("observe").Args("daemonsets", "--once").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/rsh.go
+++ b/test/extended/cli/rsh.go
@@ -18,7 +18,7 @@ var _ = g.Describe("[sig-cli] oc rsh", func() {
 		podsLabel              = exutil.ParseLabelsOrDie("name=hello-centos")
 	)
 
-	g.Describe("rsh specific flags", func() {
+	g.Describe("specific flags", func() {
 		g.It("should work well when access to a remote shell", func() {
 			namespace := oc.Namespace()
 			g.By("Creating pods with multi containers")

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1537,7 +1537,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc observe works as expected": "works as expected [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc rsh rsh specific flags should work well when access to a remote shell": "should work well when access to a remote shell [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc rsh specific flags should work well when access to a remote shell": "should work well when access to a remote shell [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/annotations.sh": "test/cmd/annotations.sh",
 


### PR DESCRIPTION
This fixes two most frequently failing problems in our CI:
1. oc observe can spit 'Nothing to sync' if it doesn't find anything and that is equally valid as 'Sync ended'
2. oc adm new-project frequently fails on timeout when waiting for project deletion, so I'm bumping this to 2m.

/assign @ingvagabund 