### PR TITLE
test/e2e/upgrade/alert: Extend to testDuration, not just 1m

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -85,7 +85,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	testDuration := exutil.DurationSinceStartInSeconds().String()
 
 	// Query to check for any critical severity alerts that have occurred within the last alertPeriodCheckMinutes.
-	criticalAlertQuery := fmt.Sprintf(`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|KubeAPILatencyHigh",alertstate="firing",severity="critical"}[%ds]) >= 1`, testDuration)
+	criticalAlertQuery := fmt.Sprintf(`count_over_time(ALERTS{alertstate="firing",severity="critical"}[%ds]) >= 1`, testDuration)
 
 	tests := map[string]bool{
 		watchdogQuery:      true,

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -68,7 +68,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 			// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
 			// TODO: remove KubePodCrashLooping subtraction logic once https://bugzilla.redhat.com/show_bug.cgi?id=1842002
 			// is fixed, but for now we are ignoring KubePodCrashLooping alerts in the openshift-kube-controller-manager namespace.
-			fmt.Sprintf(`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|KubeAPILatencyHigh",alertstate="firing",severity!="info"}[%[1]s]) - count_over_time(ALERTS{alertname="KubePodCrashLooping",namespace="openshift-kube-controller-manager",alertstate="firing",severity!="info"}[%[1]s]) >= 1`, testDuration): false,
+			fmt.Sprintf(`count_over_time(ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured",alertstate="firing",severity!="info"}[%[1]s]) - count_over_time(ALERTS{alertname="KubePodCrashLooping",namespace="openshift-kube-controller-manager",alertstate="firing",severity!="info"}[%[1]s]) >= 1`, testDuration): false,
 		}
 		err := helper.RunQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
We're doing better in updates now, and want to ratchet down to bar critical-alert noise during updates.  The old 1m `alertPeriodCheckMinutes` landed with this test in 3b8cb3ca9b (#24786).  `DurationSinceStartInSeconds`, which I'm using now, landed in ace1345c00 (#25784).

I've also dropped some special-cased `alertname` filtering, because we don't want any critical alerts firing.  [Watchdog is `severity=none
`][1].  [AlertmanagerReceiversNotConfigured is `severity=warning`][2].  KubeAPILatencyHigh was dropped in openshift/cluster-monitoring-operator#898, [4.6][3] and was `severity=warning` anyway.

[1]: https://github.com/openshift/cluster-monitoring-operator/blob/776379a9616be1cbea49dd86086d8be8230370ce/assets/prometheus-k8s/rules.yaml#L2326-L2336
[2]: https://github.com/openshift/cluster-monitoring-operator/blob/776379a9616be1cbea49dd86086d8be8230370ce/assets/prometheus-k8s/rules.yaml#L924-L933
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1846805#c13