### PR TITLE
Bug 1931864: test: add vsphere and libvirt to unsupported platforms for LB service

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -49,7 +49,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	// ovirt does not support service type loadbalancer because it doesn't program a cloud.
-	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType {
+	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.LibvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType {
 		t.unsupportedPlatform = true
 	}
 	if t.unsupportedPlatform {


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/origin/pull/25900 on `release-4.6`