### PR TITLE
flake on operator state changes during e2e

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -436,6 +436,8 @@ func stableSystemEventInvariants(events monitor.EventIntervals, duration time.Du
 	tests = append(tests, testServerAvailability(monitor.LocatorKubeAPIServerReusedConnection, events, duration)...)
 	tests = append(tests, testServerAvailability(monitor.LocatorOpenshiftAPIServerReusedConnection, events, duration)...)
 	tests = append(tests, testServerAvailability(monitor.LocatorOAuthAPIServerReusedConnection, events, duration)...)
+	tests = append(tests, testOperatorStateTransitions(events)...)
+
 	return tests, true
 }
 
@@ -820,4 +822,66 @@ func getEventsByPod(events []*monitor.EventInterval) map[string][]*monitor.Event
 		eventsByPods[event.Locator] = append(eventsByPods[event.Locator], event)
 	}
 	return eventsByPods
+}
+
+func testOperatorStateTransitions(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+	// if this starts tripping too much, or tripping on the same actors, feel free to split into tests
+	// for every operator with independent pass/fails
+	available := testOperatorState("Available", events)
+	degraded := testOperatorState("Degraded", events)
+	progressing := testOperatorState("Progressing", events)
+
+	ret := []*ginkgo.JUnitTestCase{}
+	ret = append(ret, operatorStateTestCases("[sig-cluster-lifecycle] operators should never go unavailable", available)...)
+	ret = append(ret, operatorStateTestCases("[sig-cluster-lifecycle] operators should never go degraded", degraded)...)
+	ret = append(ret, operatorStateTestCases("[sig-cluster-lifecycle] operators should never go progressing", progressing)...)
+	return ret
+}
+
+func operatorStateTestCases(testName string, failures []string) []*ginkgo.JUnitTestCase {
+	success := &ginkgo.JUnitTestCase{Name: testName}
+
+	if len(failures) == 0 {
+		return []*ginkgo.JUnitTestCase{success}
+	}
+
+	failure := &ginkgo.JUnitTestCase{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &ginkgo.FailureOutput{
+			Output: fmt.Sprintf("%d unexpected clusteroperator state transitions \n\n%v", len(failures), strings.Join(failures, "\n")),
+		},
+	}
+
+	// write a passing test to trigger detection of this issue as a flake. Doing this first to try to see how frequent the issue actually is
+	return []*ginkgo.JUnitTestCase{failure, success}
+}
+
+func testOperatorState(interestingCondition string, events []*monitor.EventInterval) []string {
+	failures := []string{}
+
+	clusterOperatorToEvents := getEventsByOperator(events)
+	for clusterOperator, events := range clusterOperatorToEvents {
+		for _, event := range events {
+			condition, status, message := monitor.GetOperatorConditionStatus(event.Message)
+			if condition != interestingCondition {
+				continue
+			}
+			// if there was any switch, it was wrong/unexpected at some point
+			failures = append(failures, fmt.Sprintf("%v was %v=%v, but became %v=%v at %v -- %v", clusterOperator, condition, !status, condition, status, event.From, message))
+		}
+	}
+	return failures
+}
+
+// getEventsByOperator returns map keyed by operator locator with all events associated with it.
+func getEventsByOperator(events []*monitor.EventInterval) map[string][]*monitor.EventInterval {
+	eventsByClusterOperator := map[string][]*monitor.EventInterval{}
+	for _, event := range events {
+		if !strings.Contains(event.Locator, "clusteroperator/") {
+			continue
+		}
+		eventsByClusterOperator[event.Locator] = append(eventsByClusterOperator[event.Locator], event)
+	}
+	return eventsByClusterOperator
 }

--- a/pkg/monitor/operator_test.go
+++ b/pkg/monitor/operator_test.go
@@ -60,3 +60,35 @@ func Test_findOperatorVersionChange(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOperatorConditionStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    string
+		want1   bool
+		want3   string
+	}{
+		{
+			name:    "simple",
+			message: "condition/Degraded status/True reason/DNSDegraded changed: DNS default is degraded",
+			want:    "Degraded",
+			want1:   true,
+			want3:   "DNS default is degraded",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, got3 := GetOperatorConditionStatus(tt.message)
+			if got != tt.want {
+				t.Errorf("GetOperatorConditionStatus() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetOperatorConditionStatus() got1 = %v, want %v", got1, tt.want1)
+			}
+			if got3 != tt.want3 {
+				t.Errorf("GetOperatorConditionStatus() got3 = %v, want %v", got3, tt.want3)
+			}
+		})
+	}
+}

--- a/pkg/synthetictests/operator_mapping.go
+++ b/pkg/synthetictests/operator_mapping.go
@@ -1,0 +1,178 @@
+package synthetictests
+
+import (
+	"fmt"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	ValidBugzillaComponents = sets.NewString(
+		"apiserver-auth",
+		"assisted-installer",
+		"Bare Metal Hardware Provisioning",
+		"Build",
+		"Cloud Compute",
+		"Cloud Credential Operator",
+		"Cluster Loader",
+		"Cluster Version Operator",
+		"CNF Variant Validation",
+		"Compliance Operator",
+		"config-operator",
+		"Console Kubevirt Plugin",
+		"Console Metal3 Plugin",
+		"Console Storage Plugin",
+		"Containers",
+		"crc",
+		"Dev Console",
+		"DNS",
+		"Documentation",
+		"Etcd",
+		"Federation",
+		"File Integrity Operator",
+		"Fuse",
+		"Hawkular",
+		"ibm-roks-toolkit",
+		"Image",
+		"Image Registry",
+		"Insights Operator",
+		"Installer",
+		"ISV Operators",
+		"Jenkins",
+		"kata-containers",
+		"kube-apiserver",
+		"kube-controller-manager",
+		"kube-scheduler",
+		"kube-storage-version-migrator",
+		"Logging",
+		"Machine Config Operator",
+		"Management Console",
+		"Metering Operator",
+		"Migration Tooling",
+		"Monitoring",
+		"Multi-Arch",
+		"Multi-cluster-management",
+		"Networking",
+		"Node",
+		"Node Feature Discovery Operator",
+		"Node Tuning Operator",
+		"oauth-apiserver",
+		"oauth-proxy",
+		"oc",
+		"OLM",
+		"openshift-apiserver",
+		"openshift-controller-manager",
+		"Operator SDK",
+		"Performance Addon Operator",
+		"Reference Architecture",
+		"Registry Console",
+		"Release",
+		"RHCOS",
+		"RHMI Monitoring",
+		"Routing",
+		"Samples",
+		"Security",
+		"Service Broker",
+		"Service Catalog",
+		"service-ca",
+		"Special Resources Operator",
+		"Storage",
+		"Templates",
+		"Test Infrastructure",
+		"Unknown",
+		"Windows Containers",
+	)
+
+	// nothing fancy, I just copied the listing
+	KnownOperators = sets.NewString(
+		"authentication",
+		"cloud-credential",
+		"cluster-autoscaler",
+		"config-operator",
+		"console",
+		"csi-snapshot-controller",
+		"dns",
+		"etcd",
+		"ingress",
+		"image-registry",
+		"insights",
+		"kube-apiserver",
+		"kube-controller-manager",
+		"kube-scheduler",
+		"kube-storage-version-migrator",
+		"machine-api",
+		"machine-approver",
+		"machine-config",
+		"marketplace",
+		"monitoring",
+		"network",
+		"node-tuning",
+		"openshift-apiserver",
+		"openshift-controller-manager",
+		"openshift-samples",
+		"operator-lifecycle-manager",
+		"operator-lifecycle-manager-catalog",
+		"operator-lifecycle-manager-packageserver",
+		"service-ca",
+		"storage",
+	)
+
+	operatorToBugzillaComponent = map[string]string{}
+)
+
+func init() {
+	utilruntime.Must(addOperatorMapping("authentication", "apiserver-auth"))
+	utilruntime.Must(addOperatorMapping("cloud-credential", "Cloud Credential Operator"))
+	utilruntime.Must(addOperatorMapping("cluster-autoscaler", "Cloud Compute"))
+	utilruntime.Must(addOperatorMapping("config-operator", "config-operator"))
+	utilruntime.Must(addOperatorMapping("console", "Management Console"))
+	utilruntime.Must(addOperatorMapping("csi-snapshot-controller", "Storage"))
+	utilruntime.Must(addOperatorMapping("dns", "DNS"))
+	utilruntime.Must(addOperatorMapping("etcd", "Etcd"))
+	utilruntime.Must(addOperatorMapping("ingress", "Routing"))
+	utilruntime.Must(addOperatorMapping("image-registry", "Image Registry"))
+	utilruntime.Must(addOperatorMapping("insights", "Insights Operator"))
+	utilruntime.Must(addOperatorMapping("kube-apiserver", "kube-apiserver"))
+	utilruntime.Must(addOperatorMapping("kube-controller-manager", "kube-controller-manager"))
+	utilruntime.Must(addOperatorMapping("kube-scheduler", "kube-scheduler"))
+	utilruntime.Must(addOperatorMapping("kube-storage-version-migrator", "kube-storage-version-migrator"))
+	utilruntime.Must(addOperatorMapping("machine-api", "Cloud Compute"))
+	utilruntime.Must(addOperatorMapping("machine-approver", "Cloud Compute"))
+	utilruntime.Must(addOperatorMapping("machine-config", "Machine Config Operator"))
+	utilruntime.Must(addOperatorMapping("marketplace", "OLM"))
+	utilruntime.Must(addOperatorMapping("monitoring", "Monitoring"))
+	utilruntime.Must(addOperatorMapping("network", "Networking"))
+	utilruntime.Must(addOperatorMapping("node-tuning", "Node Tuning Operator"))
+	utilruntime.Must(addOperatorMapping("openshift-apiserver", "openshift-apiserver"))
+	utilruntime.Must(addOperatorMapping("openshift-controller-manager", "openshift-controller-manager"))
+	utilruntime.Must(addOperatorMapping("openshift-samples", "Samples"))
+	utilruntime.Must(addOperatorMapping("operator-lifecycle-manager", "OLM"))
+	utilruntime.Must(addOperatorMapping("operator-lifecycle-manager-catalog", "OLM"))
+	utilruntime.Must(addOperatorMapping("operator-lifecycle-manager-packageserver", "OLM"))
+	utilruntime.Must(addOperatorMapping("service-ca", "service-ca"))
+	utilruntime.Must(addOperatorMapping("storage", "Storage"))
+
+	for _, name := range KnownOperators.List() {
+		if bz := GetBugzillaComponentForOperator(name); bz == "Unknown" {
+			panic(fmt.Sprintf("%q missing a bugzilla mapping", name))
+		}
+	}
+
+}
+
+func GetBugzillaComponentForOperator(operator string) string {
+	ret, ok := operatorToBugzillaComponent[operator]
+	if !ok {
+		return "Unknown"
+	}
+	return ret
+}
+
+func addOperatorMapping(operator, bugzillaComponent string) error {
+	if !ValidBugzillaComponents.Has(bugzillaComponent) {
+		return fmt.Errorf("%q is not a valid bugzilla component", bugzillaComponent)
+	}
+	operatorToBugzillaComponent[operator] = bugzillaComponent
+	return nil
+}


### PR DESCRIPTION
If any operator changes available, degraded, or progressing on non-disruptive, non-upgrade jobs, then fail.  It's easy to apply elsewhere and easy to make fail, but let's see where we are.