### PR TITLE
test: Prevent all SCC failures from being allowed during normal e2e

### DIFF
--- a/test/extended/authorization/scc.go
+++ b/test/extended/authorization/scc.go
@@ -20,55 +20,49 @@ var _ = g.Describe("[sig-auth][Feature:SCC][Early]", func() {
 	g.It("should not have pod creation failures during install", func() {
 		kubeClient := oc.AdminKubeClient()
 
-		isFIPS, err := exutil.IsFIPS(kubeClient.CoreV1())
-		o.Expect(err).NotTo(o.HaveOccurred())
-		// deads2k chose five as a number that passes nearly all the time on 4.6.  If this gets worse, we should double check against 4.6.
-		// if I was wrong about 4.6, then adjust this up.  If I am right about 4.6, then fix whatever regressed this.
-		// Because the CVO starts a static pod that races with the cluster-policy-controller, it is impractical to get this value to 0.
-		numFailuresForFail := 5
-		if isFIPS {
-			// for whatever reason, fips fails more frequently.  this isn't good and it's bad practice to have platform
-			// dependent tests, but we need to start the ratchet somewhere to prevent regressions.
-			numFailuresForFail = 10
-		}
+		// we are seeting a few install-time failures, mostly around extremely early pods like CSI drivers, therefore
+		// we allow a few failures here.
+		numFailuresForFail := 2
 
 		events, err := kubeClient.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		denialStrings := []string{}
+		suiteStartTime := exutil.SuiteStartTime()
+		var preTestDenialStrings, duringTestDenialStrings []string
+
 		for _, event := range events.Items {
 			if !strings.Contains(event.Message, "unable to validate against any security context constraint") {
 				continue
 			}
-			// SCCs become accessible to serviceaccounts based on RBAC resources.  We could require that every operator
-			// apply their RBAC in order with respect to their operands by checking SARs against every kube-apiserver endpoint
-			// and ensuring that the "use" for an SCC comes back correctly, but that isn't very useful.
-			// We don't want to delay pods for an excessive period of time, so we will catch those pods that take more
-			// than five seconds to make it through SCC
-			durationPodFailed := event.LastTimestamp.Sub(event.FirstTimestamp.Time)
-			if durationPodFailed < 5*time.Second {
-				continue
-			}
-			// TODO if we need more details, this is a good guess.
-			//eventBytes, err := json.Marshal(event)
-			//if err != nil {
-			//	e2e.Logf("%v", spew.Sdump(event))
-			//} else {
-			//	e2e.Logf("%v", string(eventBytes))
-			//}
+
 			// try with a short summary we can actually read first
 			denialString := fmt.Sprintf("%v for %v.%v/%v -n %v happened %d times", event.Message, event.InvolvedObject.Kind, event.InvolvedObject.APIVersion, event.InvolvedObject.Name, event.InvolvedObject.Namespace, event.Count)
-			denialStrings = append(denialStrings, denialString)
+
+			if event.EventTime.Time.Before(suiteStartTime) {
+				// SCCs become accessible to serviceaccounts based on RBAC resources.  We could require that every operator
+				// apply their RBAC in order with respect to their operands by checking SARs against every kube-apiserver endpoint
+				// and ensuring that the "use" for an SCC comes back correctly, but that isn't very useful.
+				// We don't want to delay pods for an excessive period of time, so we will catch those pods that take more
+				// than five seconds to make it through SCC
+				durationPodFailed := event.LastTimestamp.Sub(event.FirstTimestamp.Time)
+				if durationPodFailed < 5*time.Second {
+					continue
+				}
+				preTestDenialStrings = append(preTestDenialStrings, denialString)
+			} else {
+				// Tests are not allowed to not take SCC propagation time into account, and so every during test SCC failure
+				// is a hard fail so that we don't allow bad tests to get checked in.
+				duringTestDenialStrings = append(duringTestDenialStrings, denialString)
+			}
 		}
 
-		numFailingPods := len(denialStrings)
-		failMessage := fmt.Sprintf("%d pods failed on SCC errors\n%s\n", numFailingPods, strings.Join(denialStrings, "\n"))
-		if numFailingPods > numFailuresForFail {
+		if numFailingPods := len(preTestDenialStrings); numFailingPods > numFailuresForFail {
+			failMessage := fmt.Sprintf("%d pods failed before test on SCC errors\n%s\n", numFailingPods, strings.Join(preTestDenialStrings, "\n"))
 			g.Fail(failMessage)
-			return
 		}
-
-		// given a low threshold, there isn't much space left to mark a flake over a fail.
-		//result.Flakef(failMessage)
+		if numFailingPods := len(duringTestDenialStrings); numFailingPods > 0 {
+			failMessage := fmt.Sprintf("%d pods failed during test on SCC errors\n%s\n", numFailingPods, strings.Join(duringTestDenialStrings, "\n"))
+			g.Fail(failMessage)
+		}
 	})
 })


### PR DESCRIPTION
Tests are required to take into account SCC propagation in order to
not have their own flakes, so during test runs SCC delay is forbidden.