### PR TITLE
test: Detect when the master pool is still updating after upgrade

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -414,6 +414,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 		return err
 	}
 
+	var errMasterUpdating error
 	if err := disruption.RecordJUnit(
 		f,
 		"[sig-mco] Machine config pools complete upgrade",
@@ -432,12 +433,14 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 				}
 				allUpdated := true
 				for _, p := range pools.Items {
-					updated, err := IsPoolUpdated(mcps, p.GetName())
-					if err != nil {
-						framework.Logf("error checking pool %s: %v", p.GetName(), err)
-						return false, nil
-					}
+					updated, requiresUpdate := IsPoolUpdated(mcps, p.GetName())
 					allUpdated = allUpdated && updated
+
+					// Invariant: when CVO reaches level, MCO is required to have rolled out control plane updates
+					if p.GetName() == "master" && requiresUpdate && errMasterUpdating == nil {
+						errMasterUpdating = fmt.Errorf("the %q pool should be updated before the CVO reports available at the new version", p.GetName())
+						framework.Logf("Invariant violation detected: %s", errMasterUpdating)
+					}
 				}
 				return allUpdated, nil
 			}); err != nil {
@@ -449,6 +452,11 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 	); err != nil {
 		recordClusterEvent(kubeClient, uid, "Upgrade", "UpgradeFailed", fmt.Sprintf("failed to upgrade nodes: %v", err), true)
 		return err
+	}
+
+	if errMasterUpdating != nil {
+		recordClusterEvent(kubeClient, uid, "Upgrade", "UpgradeFailed", fmt.Sprintf("master was updating after cluster version reached level: %v", errMasterUpdating), true)
+		return errMasterUpdating
 	}
 
 	if err := disruption.RecordJUnit(
@@ -499,33 +507,39 @@ func recordClusterEvent(client kubernetes.Interface, uid, action, reason, note s
 }
 
 // TODO(runcom): drop this when MCO types are in openshift/api and we can use the typed client directly
-func IsPoolUpdated(dc dynamic.NamespaceableResourceInterface, name string) (bool, error) {
+func IsPoolUpdated(dc dynamic.NamespaceableResourceInterface, name string) (poolUpToDate bool, poolIsUpdating bool) {
 	pool, err := dc.Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		framework.Logf("error getting pool %s: %v", name, err)
-		return false, nil
+		return false, false
 	}
+
+	paused, found, err := unstructured.NestedBool(pool.Object, "spec", "paused")
+	if err != nil || !found {
+		return false, false
+	}
+
 	conditions, found, err := unstructured.NestedFieldNoCopy(pool.Object, "status", "conditions")
 	if err != nil || !found {
-		return false, nil
+		return false, false
 	}
 	original, ok := conditions.([]interface{})
 	if !ok {
-		return false, nil
+		return false, false
 	}
 	var updated, updating, degraded bool
 	for _, obj := range original {
 		o, ok := obj.(map[string]interface{})
 		if !ok {
-			return false, nil
+			return false, false
 		}
 		t, found, err := unstructured.NestedString(o, "type")
 		if err != nil || !found {
-			return false, nil
+			return false, false
 		}
 		s, found, err := unstructured.NestedString(o, "status")
 		if err != nil || !found {
-			return false, nil
+			return false, false
 		}
 		if t == "Updated" && s == "True" {
 			updated = true
@@ -537,9 +551,13 @@ func IsPoolUpdated(dc dynamic.NamespaceableResourceInterface, name string) (bool
 			degraded = true
 		}
 	}
+	if paused {
+		framework.Logf("Pool %s is paused, treating as up-to-date (Updated: %v, Updating: %v, Degraded: %v)", name, updated, updating, degraded)
+		return true, updating
+	}
 	if updated && !updating && !degraded {
-		return true, nil
+		return true, updating
 	}
 	framework.Logf("Pool %s is still reporting (Updated: %v, Updating: %v, Degraded: %v)", name, updated, updating, degraded)
-	return false, nil
+	return false, updating
 }

--- a/test/extended/dr/common.go
+++ b/test/extended/dr/common.go
@@ -86,7 +86,8 @@ func clusterNodes(oc *exutil.CLI) (masters, workers []*corev1.Node) {
 func waitForMastersToUpdate(oc *exutil.CLI, mcps dynamic.NamespaceableResourceInterface) {
 	e2elog.Logf("Waiting for MachineConfig master to finish rolling out")
 	err := wait.Poll(30*time.Second, 30*time.Minute, func() (done bool, err error) {
-		return upgrade.IsPoolUpdated(mcps, "master")
+		done, _ = upgrade.IsPoolUpdated(mcps, "master")
+		return done, nil
 	})
 	o.Expect(err).NotTo(o.HaveOccurred())
 }


### PR DESCRIPTION
The MCO is required to roll out the master config pool prior to reporting level, and thus CVO should never reach Available at a
new version without the master pool being updated. Add an extra check to the pool rollout - if we see the master pool with an
Updating condition flag it and fail the upgrade job. Also handle paused pools in the wait loop (a paused pool is effectively "we
will not deal with this pool" and so we will exit early and log).

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-network-operator/988/pull-ci-openshift-cluster-network-operator-master-e2e-gcp-ovn-upgrade/1364259570968432640 had a possible case where this happened, tighten the test.

```
Feb 23 18:43:19.284: INFO: cluster upgrade is Progressing: Working towards 4.8.0-0.ci.test-2021-02-23-170859-ci-op-m36h5d5b: 666 of 669 done (99% complete)
Feb 23 18:43:29.285: INFO: Completed upgrade to registry.build01.ci.openshift.org/ci-op-m36h5d5b/release@sha256:7884e2856b8e4f2a71dbcaf8333adc36ac7805315726b31d7c075b961a163a94
Feb 23 18:43:29.313: INFO: Waiting on pools to be upgraded
Feb 23 18:43:29.351: INFO: Pool master is still reporting (Updated: false, Updating: true, Degraded: false)
```

^ no, bad