### PR TITLE
Bug 1928856: Skip tests that rely on Machine API when Machine API is not installed

### DIFF
--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -29,6 +29,10 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed clu
 		dc, err := dynamic.NewForConfig(cfg)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		g.By("checking for the openshift machine api operator")
+		// TODO: skip if platform != aws
+		skipUnlessMachineAPIOperator(c.CoreV1().Namespaces())
+
 		g.By("getting MachineSet list")
 		machineSetClient := dc.Resource(schema.GroupVersionResource{Group: "machine.openshift.io", Resource: "machinesets", Version: "v1beta1"})
 		msList, err := machineSetClient.List(context.Background(), metav1.ListOptions{})

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed clu
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(c.CoreV1().Namespaces())
+		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
 
 		g.By("getting MachineSet list")
 		machineSetClient := dc.Resource(schema.GroupVersionResource{Group: "machine.openshift.io", Resource: "machinesets", Version: "v1beta1"})

--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -21,8 +21,6 @@ import (
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
-
-	"github.com/openshift/origin/test/extended/util/ibmcloud"
 )
 
 const (
@@ -33,9 +31,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 	defer g.GinkgoRecover()
 
 	g.It("have machine resources", func() {
-		if e2e.TestContext.Provider == ibmcloud.ProviderName {
-			e2eskipper.Skipf("IBM Cloud clusters do not contain machine resources")
-		}
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()

--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(c.CoreV1().Namespaces())
+		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
 
 		g.By("ensuring every node is linked to a machine api resource")
 		allNodes, err := c.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
@@ -102,8 +102,33 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 	})
 })
 
-func skipUnlessMachineAPIOperator(c coreclient.NamespaceInterface) {
+// skipUnlessMachineAPI is used to deterine if the Machine API is installed and running in a cluster.
+// It is expected to skip the test if it determines that the Machine API is not installed/running.
+// Use this early in a test that relies on Machine API functionality.
+//
+// It checks to see if the machine custom resource is installed in the cluster.
+// If machines are not installed it skips the test case.
+// It then checks to see if the `openshift-machine-api` namespace is installed.
+// If the namespace is not present it skips the test case.
+func skipUnlessMachineAPIOperator(dc dynamic.Interface, c coreclient.NamespaceInterface) {
+	machineClient := dc.Resource(schema.GroupVersionResource{Group: "machine.openshift.io", Resource: "machines", Version: "v1beta1"})
+
 	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+		// Listing the resource will return an IsNotFound error when the CRD has not been installed.
+		// Otherwise it would return an empty list.
+		_, err := machineClient.List(context.Background(), metav1.ListOptions{})
+		if err == nil {
+			return true, nil
+		}
+		if errors.IsNotFound(err) {
+			e2eskipper.Skipf("The cluster does not support machine instances")
+		}
+		e2e.Logf("Unable to check for machine api operator: %v", err)
+		return false, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 		_, err := c.Get(context.Background(), "openshift-machine-api", metav1.GetOptions{})
 		if err == nil {
 			return true, nil

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -167,7 +167,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(c.CoreV1().Namespaces())
+		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
 
 		g.By("fetching worker machineSets")
 		machineSets, err := listWorkerMachineSets(dc)

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -8,7 +8,6 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	"github.com/openshift/origin/test/extended/util/ibmcloud"
 	"github.com/stretchr/objx"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,10 +139,6 @@ func scaleMachineSet(name string, replicas int) error {
 
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should", func() {
 	g.It("grow and decrease when scaling different machineSets simultaneously", func() {
-		if e2e.TestContext.Provider == ibmcloud.ProviderName {
-			e2eskipper.Skipf("IBM Cloud clusters do not contain machineset resources")
-		}
-
 		// expect new nodes to come up for machineSet
 		verifyNodeScalingFunc := func(c *kubernetes.Clientset, dc dynamic.Interface, expectedScaleOut int, machineSet objx.Map) bool {
 			nodes, err := getNodesFromMachineSet(c, dc, machineName(machineSet))
@@ -169,6 +164,10 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 		o.Expect(err).NotTo(o.HaveOccurred())
 		dc, err := dynamic.NewForConfig(cfg)
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("checking for the openshift machine api operator")
+		// TODO: skip if platform != aws
+		skipUnlessMachineAPIOperator(c.CoreV1().Namespaces())
 
 		g.By("fetching worker machineSets")
 		machineSets, err := listWorkerMachineSets(dc)

--- a/test/extended/machines/workers.go
+++ b/test/extended/machines/workers.go
@@ -129,7 +129,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Manage
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(c.CoreV1().Namespaces())
+		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
 
 		g.By("validating node and machine invariants")
 		// fetch all machines


### PR DESCRIPTION
We have a number of tests that use the Machine API, but also topologies of deploying OpenShift that do not install the Machine API (eg IBM). To be able to support this going forward, ensure that all tests check for the presence of Machine API before starting the test. If the Machine API namespace doesn't exist, skip the test.

This should mean that all tests that rely on the Machine API check before starting that the Machine API is installed.
@csrwng I've removed the IBM checks that you added as I was trying to minimize the special cases, do you think the current approach will still work for IBM or do they have the Machine API namespace created even though they have no machines on the cluster?