### PR TITLE
tests: Introduce the openshift/node/conformance e2e suite

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -347,6 +347,18 @@ var staticSuites = testSuites{
 	},
 	{
 		TestSuite: ginkgo.TestSuite{
+			Name: "openshift/node/conformance",
+			Description: templates.LongDesc(`
+		Run only the node conformance tests.
+		`),
+			Matches: func(name string) bool {
+				return !isDisabled(name) && strings.Contains(name, "[NodeConformance]")
+			},
+		},
+		PreSuite: suiteWithProviderPreSuite,
+	},
+	{
+		TestSuite: ginkgo.TestSuite{
 			Name: "all",
 			Description: templates.LongDesc(`
 		Run all tests.


### PR DESCRIPTION
This adds the openshift/node/conformance suite which runs only the node conformance tests.

It is a replacement on openshift-tests side of the https://github.com/openshift/release/pull/16350 which will allow us to run just the node conformance tests on the Kata Containers job on openshift-ci.

cc @smarterclayton @snir911 @mrunalp 