### PR TITLE
test: Node unready should ignore the ns/ in event locator

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -593,7 +593,7 @@ func testNodeUpgradeTransitions(events []*monitor.EventInterval) ([]*ginkgo.JUni
 		var foundEnd bool
 		for i, event := range events {
 			// treat multiple sequential upgrades as distinct test failures
-			if event.Locator == "clusterversion/cluster" && (strings.Contains(event.Message, "reason/UpgradeStarted") || strings.Contains(event.Message, "reason/UpgradeRollback")) {
+			if strings.HasSuffix(event.Locator, "clusterversion/cluster") && (strings.Contains(event.Message, "reason/UpgradeStarted") || strings.Contains(event.Message, "reason/UpgradeRollback")) {
 				text = event.Message
 				events = events[i+1:]
 				foundEnd = true


### PR DESCRIPTION
Events from the upgrade job include the namespace (probably because
I'm holding event sending wrong on cluster scoped events).

For now, simply look at the end of the locator rather than the
beginning.