### PR TITLE
Bug 1935707: [release-4.7] test: Detect when the master pool is still updating after upgrade 

### DIFF
--- a/test/extended/dr/common.go
+++ b/test/extended/dr/common.go
@@ -83,7 +83,8 @@ func clusterNodes(oc *exutil.CLI) (masters, workers []*corev1.Node) {
 func waitForMastersToUpdate(oc *exutil.CLI, mcps dynamic.NamespaceableResourceInterface) {
 	e2elog.Logf("Waiting for MachineConfig master to finish rolling out")
 	err := wait.Poll(30*time.Second, 30*time.Minute, func() (done bool, err error) {
-		return upgrade.IsPoolUpdated(mcps, "master")
+		done, _ = upgrade.IsPoolUpdated(mcps, "master")
+		return done, nil
 	})
 	o.Expect(err).NotTo(o.HaveOccurred())
 }


### PR DESCRIPTION
The MCO is required to roll out the master config pool prior to
reporting level, and thus CVO should never reach Available at a
new version without the master pool being updated. Add an extra
check to the pool rollout - if we see the master pool with an
Updating condition flag it and fail the upgrade job. Also handle
paused pools in the wait loop (a paused pool is effectively "we
will not deal with this pool" and so we will exit early and log).

Cherr-pick of #25922 on release-4.7