### PR TITLE
test/extended/etcd: fix leader change test

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -26,7 +26,17 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		g.By("Examining the number of etcd leadership changes over the run")
 		result, _, err := prometheus.Query(context.Background(), fmt.Sprintf("max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total[%s])))", testDuration), time.Now())
 		o.Expect(err).ToNot(o.HaveOccurred())
-		leaderChanges := result.(model.Vector)[0].Value
+
+		vec, ok := result.(model.Vector)
+		if !ok {
+			o.Expect(fmt.Errorf("expecting Prometheus query to return a vector, got %s instead", vec.Type())).ToNot(o.HaveOccurred())
+		}
+
+		if len(vec) == 0 {
+			o.Expect(fmt.Errorf("expecting Prometheus query to return at least one item, got 0 instead")).ToNot(o.HaveOccurred())
+		}
+
+		leaderChanges := vec[0].Value
 		if leaderChanges != 0 {
 			o.Expect(fmt.Errorf("Observed %s leader changes in %s: Leader changes are a result of stopping the etcd leader process or from latency (disk or network), review etcd performance metrics", leaderChanges, testDuration)).ToNot(o.HaveOccurred())
 		}


### PR DESCRIPTION
The test would panic if Prometheus returns no result.

Spotted in https://github.com/openshift/cluster-monitoring-operator/pull/1044

Signed-off-by: Simon Pasquier <spasquie@redhat.com>