### PR TITLE
operators: prevent panic in no crashlooping pods in core namespaces

### DIFF
--- a/test/extended/operators/cluster.go
+++ b/test/extended/operators/cluster.go
@@ -137,7 +137,7 @@ func crashloopingContainerCheck(podFilters ...podFilter) {
 			e2e.Logf("Pod status %s/%s ignored for being pending", pod.Namespace, pod.Name)
 			continue
 		}
-		if pod.Status.StartTime.After(testStartTime) {
+		if pod.Status.StartTime != nil && pod.Status.StartTime.After(testStartTime) {
 			// At this point lastPending has a list of pods that were pending a few seconds ago, but those pods
 			// could have been created a few seconds before that.  What we really want is to know which pods are
 			// pending for longer than a predetermined threshold of time.  This test implies that the intent is


### PR DESCRIPTION
Fixes:

```
[It] have no crashlooping pods in core namespaces over four minutes [Suite:openshift/conformance/parallel]
  github.com/openshift/origin/test/extended/operators/cluster.go:46

	github.com/onsi/ginkgo@v4.7.0-origin.0+incompatible/internal/leafnodes/runner.go:107 +0x76
panic(0x52dfc20, 0x917e2d0)
	runtime/panic.go:969 +0x1b9
github.com/openshift/origin/test/extended/operators.crashloopingContainerCheck(0xc001678b70, 0x2, 0x2)
	github.com/openshift/origin/test/extended/operators/cluster.go:140 +0xac4
github.com/openshift/origin/test/extended/operators.glob..func2.1()
	github.com/openshift/origin/test/extended/operators/cluster.go:47 +0x6b
```

The pod status should be logged and investigated properly.