### PR TITLE
indicate which tests correspond to an operator outage

### DIFF
--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -2,8 +2,116 @@ package monitor
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 )
 
 func E2ETestLocator(testName string) string {
 	return fmt.Sprintf("e2e-test/%q", testName)
+}
+
+func E2ETestFromLocator(locator string) (string, bool) {
+	if !strings.HasPrefix(locator, "e2e-test/") {
+		return "", false
+	}
+	parts := strings.SplitN(locator, "/", 2)
+	quotedTestName := parts[1]
+	testName, err := strconv.Unquote(quotedTestName)
+	if err != nil {
+		return "", false
+	}
+	return testName, true
+}
+
+// EventsByE2ETest returns map keyed by e2e test name (may contain spaces).
+func EventsByE2ETest(events []*EventInterval) map[string][]*EventInterval {
+	eventsByE2ETest := map[string][]*EventInterval{}
+	for _, event := range events {
+		if !strings.Contains(event.Locator, "e2e-test/") {
+			continue
+		}
+		testName, ok := E2ETestFromLocator(event.Locator)
+		if !ok {
+			continue
+		}
+		eventsByE2ETest[testName] = append(eventsByE2ETest[testName], event)
+	}
+	return eventsByE2ETest
+}
+
+// E2ETestEvents returns only events for e2e tests
+func E2ETestEvents(events []*EventInterval) []*EventInterval {
+	e2eEvents := []*EventInterval{}
+	for i := range events {
+		event := events[i]
+		if !strings.Contains(event.Locator, "e2e-test/") {
+			continue
+		}
+		e2eEvents = append(e2eEvents, event)
+	}
+	return e2eEvents
+}
+
+// E2ETestsRunningBetween returns names of e2e test that were active during the timeframe
+func E2ETestsRunningBetween(events []*EventInterval, start, end time.Time) map[string][]*EventInterval {
+	activeTests := map[string][]*EventInterval{}
+	e2eTestsToEvents := EventsByE2ETest(events)
+	type activeInterval struct {
+		start  time.Time
+		end    time.Time
+		events []*EventInterval
+	}
+	for testName, events := range e2eTestsToEvents {
+		runningIntervals := []activeInterval{}
+		currInterval := activeInterval{}
+		for _, event := range events {
+			switch {
+			case event.Message == "started":
+				currInterval.start = event.InitiatedAt
+				currInterval.events = append(currInterval.events, event)
+			case strings.HasPrefix(event.Message, "finishedStatus/"):
+				currInterval.end = event.InitiatedAt
+				currInterval.events = append(currInterval.events, event)
+				runningIntervals = append(runningIntervals, currInterval)
+
+				// reset
+				currInterval = activeInterval{}
+			}
+		}
+
+		// now check each interval (you can have more than one for flakes and repeats)
+		for _, interval := range runningIntervals {
+			if interval.start.After(end) {
+				continue
+			}
+			if interval.end.Before(start) {
+				continue
+			}
+			// if the test started before the end and ended after the start, then it was active during this time.
+			activeTests[testName] = append(activeTests[testName], interval.events...)
+		}
+	}
+	return activeTests
+}
+
+func FindFailedTestsActiveBetween(events []*EventInterval, start, end time.Time) []string {
+	e2eTestEvents := E2ETestEvents(events)
+	e2eTestsActive := E2ETestsRunningBetween(e2eTestEvents, start, end)
+
+	failedTests := []string{}
+	for testName, e2eEvents := range e2eTestsActive {
+		for _, event := range e2eEvents {
+			if !strings.HasPrefix(event.Message, "finishedStatus/") {
+				continue
+			}
+			parts := strings.Split(event.Message, " ")
+			parts = strings.Split(parts[0], "/")
+			if parts[1] != "Passed" && parts[1] != "Skipped" {
+				failedTests = append(failedTests, testName)
+			}
+		}
+	}
+
+	return failedTests
 }

--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -1,0 +1,9 @@
+package monitor
+
+import (
+	"fmt"
+)
+
+func E2ETestLocator(testName string) string {
+	return fmt.Sprintf("e2e-test/%q", testName)
+}

--- a/pkg/monitor/noop.go
+++ b/pkg/monitor/noop.go
@@ -1,0 +1,11 @@
+package monitor
+
+type noOpMonitor struct {
+}
+
+func NewNoOpMonitor() Recorder {
+	return &noOpMonitor{}
+}
+
+func (*noOpMonitor) Record(conditions ...Condition) {}
+func (*noOpMonitor) AddSampler(fn SamplerFunc)      {}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -155,7 +155,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 	}
 
 	if opt.PrintCommands {
-		status := newTestStatus(opt.Out, true, len(tests), time.Minute, &monitor.Monitor{}, opt.AsEnv())
+		status := newTestStatus(opt.Out, true, len(tests), time.Minute, &monitor.Monitor{}, monitor.NewNoOpMonitor(), opt.AsEnv())
 		newParallelTestQueue().Execute(context.Background(), tests, 1, status.OutputCommand)
 		return nil
 	}
@@ -237,7 +237,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 	}
 	expectedTestCount += len(normal)
 
-	status := newTestStatus(opt.Out, includeSuccess, expectedTestCount, timeout, m, opt.AsEnv())
+	status := newTestStatus(opt.Out, includeSuccess, expectedTestCount, timeout, m, m, opt.AsEnv())
 	testCtx := ctx
 	if opt.FailFast {
 		var cancelFn context.CancelFunc
@@ -333,7 +333,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 		}
 
 		q := newParallelTestQueue()
-		status := newTestStatus(ioutil.Discard, opt.IncludeSuccessOutput, len(retries), timeout, m, opt.AsEnv())
+		status := newTestStatus(ioutil.Discard, opt.IncludeSuccessOutput, len(retries), timeout, m, m, opt.AsEnv())
 		q.Execute(testCtx, retries, parallelism, status.Run)
 		var flaky []string
 		var repeatFailures []*testCase

--- a/pkg/test/ginkgo/queue.go
+++ b/pkg/test/ginkgo/queue.go
@@ -92,7 +92,7 @@ func (q *parallelByFileTestQueue) Take(ctx context.Context, fn TestFunc) bool {
 	}
 }
 
-func (q *parallelByFileTestQueue) Execute(ctx context.Context, tests []*testCase, parallelism int, fn TestFunc) {
+func (q *parallelByFileTestQueue) Execute(ctx context.Context, tests []*testCase, parallelism int, testFn TestFunc) {
 	defer q.Close()
 
 	if ctx.Err() != nil {
@@ -113,7 +113,9 @@ func (q *parallelByFileTestQueue) Execute(ctx context.Context, tests []*testCase
 	for i := 0; i < parallelism; i++ {
 		go func(i int) {
 			defer wg.Done()
-			for q.Take(ctx, func(ctx context.Context, test *testCase) { fn(ctx, test) }) {
+			for q.Take(ctx, func(ctx context.Context, test *testCase) {
+				testFn(ctx, test)
+			}) {
 				if ctx.Err() != nil {
 					return
 				}
@@ -126,7 +128,7 @@ func (q *parallelByFileTestQueue) Execute(ctx context.Context, tests []*testCase
 		if ctx.Err() != nil {
 			return
 		}
-		fn(ctx, test)
+		testFn(ctx, test)
 	}
 }
 

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -28,6 +28,7 @@ type testCase struct {
 	out      []byte
 	success  bool
 	failed   bool
+	timedOut bool
 	skipped  bool
 	flake    bool
 


### PR DESCRIPTION
To be expanded next to reflect tests failing during an apiserver availability outage, but that's a little more surgery.

This also adds monitor events for running tests, so we should see those in the monitor now.