### PR TITLE
NE-544: DNS: Add new dual-stack service DNS test

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1899,6 +1899,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics": "should start and expose a secured proxy and verify build metrics [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service": "should answer A and AAAA queries for a dual-stack service [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": "should answer endpoint and wildcard queries for the cluster [Disabled:Broken]",
 
 	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should be able to connect to a service that is idled because a GET on the route will unidle it": "should be able to connect to a service that is idled because a GET on the route will unidle it [Suite:openshift/conformance/parallel/minimal]",


### PR DESCRIPTION
test/extended/util/dns/dns.go:

OCP 4.8 now uses CoreDNS v1.8.1, which adds support for dual-stack clusterIP services (https://github.com/coredns/coredns/pull/4339). Add a new test to verify that CoreDNS pods respond to A and AAAA queries for a service URL (ie `<service>.<namespace>.svc`) as well for a service endpointslice URL (ie `<endpointslice_hostname>.<service>.<namespace>.svc`). Note that the other existing test in `dns.go` is disabled since the DNS operator does not support wildcard DNS.

test/extended/util/annotate/generated/zz_generated.annotations.go:
Regenerate

---

This is in support of https://issues.redhat.com/browse/NE-544.