### PR TITLE
test: External image test was silently failing

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -217,11 +217,11 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 		pulls := make(map[string]sets.String)
 		for _, event := range events {
 			// only messages that include a Pulled reason
-			if !strings.Contains(event.Message, " reason/Pulled ") {
+			if !strings.Contains(" "+event.Message, " reason/Pulled ") {
 				continue
 			}
 			// only look at pull events from an e2e-* namespace
-			if !strings.Contains(event.Locator, " ns/e2e-") {
+			if !strings.Contains(" "+event.Locator, " ns/e2e-") {
 				continue
 			}
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -34484,7 +34484,7 @@ var _testExtendedTestdataCmdTestCmdTestdataHelloOpenshiftHelloPodJson = []byte(`
     "containers": [
       {
         "name": "hello-openshift",
-        "image": "k8s.gcr.io/e2e-test-images/agnhost:2.20",
+        "image": "k8s.gcr.io/e2e-test-images/agnhost:2.21",
         "args": ["netexec"],
         "ports": [
           {
@@ -36059,7 +36059,7 @@ items:
           run: v1-job
       spec:
         containers:
-        - image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.21
           name: hello-container
         restartPolicy: Never
 
@@ -38701,7 +38701,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       - kind: Route
         apiVersion: v1
         metadata:
@@ -49054,7 +49054,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -49072,7 +49072,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -49305,7 +49305,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -49467,7 +49467,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -50762,7 +50762,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -50780,7 +50780,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -51120,7 +51120,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -51138,7 +51138,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -51156,7 +51156,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -52554,7 +52554,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.21
 `)
 
 func testExtendedTestdataTemplatesTemplateinstance_badobjectYamlBytes() ([]byte, error) {
@@ -52614,7 +52614,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       - kind: Route
         apiVersion: v1
         metadata:

--- a/test/extended/testdata/cmd/test/cmd/testdata/hello-openshift/hello-pod.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/hello-openshift/hello-pod.json
@@ -12,7 +12,7 @@
     "containers": [
       {
         "name": "hello-openshift",
-        "image": "k8s.gcr.io/e2e-test-images/agnhost:2.20",
+        "image": "k8s.gcr.io/e2e-test-images/agnhost:2.21",
         "args": ["netexec"],
         "ports": [
           {

--- a/test/extended/testdata/cmd/test/cmd/testdata/mixed-api-versions.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/mixed-api-versions.yaml
@@ -34,7 +34,7 @@ items:
           run: v1-job
       spec:
         containers:
-        - image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.21
           name: hello-container
         restartPolicy: Never
 

--- a/test/extended/testdata/cmd/test/cmd/testdata/templateinstance_objectkinds.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/templateinstance_objectkinds.yaml
@@ -40,7 +40,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       - kind: Route
         apiVersion: v1
         metadata:

--- a/test/extended/testdata/router/ingress.yaml
+++ b/test/extended/testdata/router/ingress.yaml
@@ -79,7 +79,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -97,7 +97,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/router/router-common.yaml
+++ b/test/extended/testdata/router/router-common.yaml
@@ -99,7 +99,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/router/router-config-manager.yaml
+++ b/test/extended/testdata/router/router-config-manager.yaml
@@ -136,7 +136,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/router/router-metrics.yaml
+++ b/test/extended/testdata/router/router-metrics.yaml
@@ -80,7 +80,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -98,7 +98,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/router/weighted-router.yaml
+++ b/test/extended/testdata/router/weighted-router.yaml
@@ -122,7 +122,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -140,7 +140,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -158,7 +158,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/templates/templateinstance_badobject.yaml
+++ b/test/extended/testdata/templates/templateinstance_badobject.yaml
@@ -28,4 +28,4 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.21

--- a/test/extended/testdata/templates/templateinstance_objectkinds.yaml
+++ b/test/extended/testdata/templates/templateinstance_objectkinds.yaml
@@ -40,7 +40,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.20
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.21
       - kind: Route
         apiVersion: v1
         metadata:


### PR DESCRIPTION
As a result we were not catching images that had not been mirrored.