### PR TITLE
[release-4.6] Bug 1939549: Update tests to use Ruby 2.7

### DIFF
--- a/examples/image-streams/image-streams-centos7.json
+++ b/examples/image-streams/image-streams-centos7.json
@@ -1258,7 +1258,7 @@
             },
             "from": {
               "kind": "ImageStreamTag",
-              "name": "2.5"
+              "name": "2.7"
             },
             "name": "latest",
             "referencePolicy": {
@@ -1267,20 +1267,20 @@
           },
           {
             "annotations": {
-              "description": "Build and run Ruby 2.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+              "description": "Build and run Ruby 2.7 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
               "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.5",
+              "openshift.io/display-name": "Ruby 2.7",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
               "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.5,ruby",
+              "supports": "ruby:2.7,ruby",
               "tags": "builder,ruby",
-              "version": "2.5"
+              "version": "2.7"
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-27-centos7:latest"
             },
-            "name": "2.5",
+            "name": "2.7",
             "referencePolicy": {
               "type": "Local"
             }

--- a/examples/quickstarts/rails-postgresql-persistent.json
+++ b/examples/quickstarts/rails-postgresql-persistent.json
@@ -120,7 +120,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "ruby:2.5",
+                            "name": "ruby:2.7",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -171,7 +171,7 @@ This section covers how to perform all the steps of building, deploying, and upd
             service "frontend" created
             route "route-edge" created
             imagestream "origin-ruby-sample" created
-            imagestream "ruby-25-centos7" created
+            imagestream "ruby-27-centos7" created
             buildconfig "ruby-sample-build" created
             deploymentconfig "frontend" created
             service "database" created

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -83,14 +83,14 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
         "tags": [
           {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "docker.io/centos/ruby-27-centos7:latest"
             },
             "name": "latest"
           }
@@ -143,7 +143,7 @@
           "dockerStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {

--- a/examples/sample-app/application-template-pullspecbuild.json
+++ b/examples/sample-app/application-template-pullspecbuild.json
@@ -83,10 +83,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -134,7 +134,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7:latest"
+              "name": "centos/ruby-27-centos7:latest"
             }
           }
         },

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -83,10 +83,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -138,7 +138,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -194,7 +194,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				g.By("waiting 1s for build controller configuration to propagate")
 				time.Sleep(1 * time.Second)
 				g.By("starting build sample-build and waiting for success")
-				// Image used by sample-build (centos/ruby-25-centos7) is only available on docker.io
+				// Image used by sample-build (centos/ruby-27-centos7) is only available on docker.io
 				br, err := exutil.StartBuildAndWait(oc, "sample-build")
 				o.Expect(err).NotTo(o.HaveOccurred())
 				br.AssertSuccess()

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -25,7 +25,7 @@ FROM image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
 USER 1001
 `
 		testDockerfile2 = `
-FROM image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+FROM image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
 USER 1001
 `
 		testDockerfile3 = `
@@ -109,7 +109,7 @@ USER 1001
 				o.Expect(image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.User).To(o.Equal("1001"))
 
 				g.By("checking for the imported tag")
-				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(context.Background(), "ruby:2.5", metav1.GetOptions{})
+				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(context.Background(), "ruby:2.7", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -97,7 +97,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 				g.By("expecting the pod to contain the file from the input image")
 				out, err := oc.Run("exec").Args(pod.Name, "-c", pod.Spec.Containers[0].Name, "--", "ls", "-R", "-l", "injected/opt/app-root").Output()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(out).To(o.ContainSubstring("bin -> ../../rh/rh-ruby25/root/usr/bin"))
+				o.Expect(out).To(o.ContainSubstring("bin -> ../../rh/6/root/usr/bin"))
 			})
 		})
 		g.Describe("buildconfig with input source image and docker strategy", func() {
@@ -124,7 +124,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 				g.By("expecting the pod to contain the file from the input image")
 				out, err := oc.Run("exec").Args(pod.Name, "-c", pod.Spec.Containers[0].Name, "--", "ls", "-R", "-l", "injected/opt/app-root").Output()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(out).To(o.ContainSubstring("bin -> ../../rh/rh-ruby25/root/usr/bin"))
+				o.Expect(out).To(o.ContainSubstring("bin -> ../../rh/6/root/usr/bin"))
 			})
 		})
 		g.Describe("creating a build with an input source image and s2i strategy", func() {

--- a/test/extended/image_ecosystem/s2i_images.go
+++ b/test/extended/image_ecosystem/s2i_images.go
@@ -29,25 +29,18 @@ type tc struct {
 var s2iImages = map[string][]tc{
 	"ruby": {
 		{
+			Version:    "27",
+			Cmd:        "ruby --version",
+			Expected:   "ruby 2.7",
+			Repository: "rhscl",
+			NonAMD:     true,
+		},
+		{
 			Version:    "26",
 			Cmd:        "ruby --version",
 			Expected:   "ruby 2.6",
 			Repository: "rhscl",
 			NonAMD:     true,
-		},
-		{
-			Version:    "25",
-			Cmd:        "ruby --version",
-			Expected:   "ruby 2.5",
-			Repository: "rhscl",
-			NonAMD:     true,
-		},
-		{
-			Version:    "24",
-			Cmd:        "ruby --version",
-			Expected:   "ruby 2.4",
-			Repository: "rhscl",
-			NonAMD:     false,
 		},
 	},
 	"python": {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -4633,7 +4633,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "ImageStreamTag",
-              "name": "2.5"
+              "name": "2.7"
             },
             "name": "latest",
             "referencePolicy": {
@@ -4642,20 +4642,20 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
           },
           {
             "annotations": {
-              "description": "Build and run Ruby 2.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+              "description": "Build and run Ruby 2.7 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
               "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.5",
+              "openshift.io/display-name": "Ruby 2.7",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
               "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.5,ruby",
+              "supports": "ruby:2.7,ruby",
               "tags": "builder,ruby",
-              "version": "2.5"
+              "version": "2.7"
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-27-centos7:latest"
             },
-            "name": "2.5",
+            "name": "2.7",
             "referencePolicy": {
               "type": "Local"
             }
@@ -6422,14 +6422,14 @@ var _examplesSampleAppApplicationTemplateDockerbuildJson = []byte(`{
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
         "tags": [
           {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "docker.io/centos/ruby-27-centos7:latest"
             },
             "name": "latest"
           }
@@ -6482,7 +6482,7 @@ var _examplesSampleAppApplicationTemplateDockerbuildJson = []byte(`{
           "dockerStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {
@@ -6884,10 +6884,10 @@ var _examplesSampleAppApplicationTemplatePullspecbuildJson = []byte(`{
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -6935,7 +6935,7 @@ var _examplesSampleAppApplicationTemplatePullspecbuildJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-25-centos7:latest"
+              "name": "centos/ruby-27-centos7:latest"
             }
           }
         },
@@ -7381,10 +7381,10 @@ var _examplesSampleAppApplicationTemplateStibuildJson = []byte(`{
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -7436,7 +7436,7 @@ var _examplesSampleAppApplicationTemplateStibuildJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {
@@ -14140,7 +14140,7 @@ var _examplesQuickstartsRailsPostgresqlPersistentJson = []byte(`{
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "ruby:2.5",
+                            "name": "ruby:2.7",
                             "namespace": "${NAMESPACE}"
                         }
                     },
@@ -14629,7 +14629,8 @@ var _examplesQuickstartsRailsPostgresqlPersistentJson = []byte(`{
             "value": ""
         }
     ]
-}`)
+}
+`)
 
 func examplesQuickstartsRailsPostgresqlPersistentJsonBytes() ([]byte, error) {
 	return _examplesQuickstartsRailsPostgresqlPersistentJson, nil
@@ -19928,7 +19929,7 @@ var _testExtendedTestdataBuildsBuildSecretsTestS2iBuildJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
         },
         "env": [
           {
@@ -19945,7 +19946,8 @@ var _testExtendedTestdataBuildsBuildSecretsTestS2iBuildJson = []byte(`{
       }
     }
   }
-}`)
+}
+`)
 
 func testExtendedTestdataBuildsBuildSecretsTestS2iBuildJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataBuildsBuildSecretsTestS2iBuildJson, nil
@@ -20024,7 +20026,7 @@ func testExtendedTestdataBuildsBuildSecretsTestSecretJson() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsBuildTimingDockerfile = []byte(`FROM centos/ruby-25-centos7
+var _testExtendedTestdataBuildsBuildTimingDockerfile = []byte(`FROM centos/ruby-27-centos7
 
 USER root
 `)
@@ -20546,7 +20548,7 @@ var _testExtendedTestdataBuildsIncrementalAuthBuildJson = []byte(`{
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             },
             "incremental": true
           }
@@ -20564,7 +20566,8 @@ var _testExtendedTestdataBuildsIncrementalAuthBuildJson = []byte(`{
   "labels": {
     "template": "application-template-stibuild"
   }
-}`)
+}
+`)
 
 func testExtendedTestdataBuildsIncrementalAuthBuildJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataBuildsIncrementalAuthBuildJson, nil
@@ -20735,7 +20738,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
 `)
 
 func testExtendedTestdataBuildsStatusfailBadcontextdirs2iYamlBytes() ([]byte, error) {
@@ -20827,15 +20830,15 @@ spec:
         paths:
           - destinationDir: injected/opt/app-root/test-links
             sourcePath: /opt/app-root/test-links/.
-          - destinationDir: injected/opt/rh/rh-ruby-25/root/usr/bin
-            sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+          - destinationDir: injected/opt/rh/rh-ruby-27/root/usr/bin
+            sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
 
   strategy:
     type: Docker
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchimagecontentdockerYamlBytes() ([]byte, error) {
@@ -20866,7 +20869,7 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsourcedockerYamlBytes() ([]byte, error) {
@@ -20897,7 +20900,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsources2iYamlBytes() ([]byte, error) {
@@ -20928,7 +20931,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy
@@ -20966,7 +20969,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
       forcePull: true
 `)
 
@@ -21186,14 +21189,14 @@ func testExtendedTestdataBuildsTestBcWithPrRefYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsTestBuildAppDockerfile = []byte(`FROM centos/ruby-25-centos7
+var _testExtendedTestdataBuildsTestBuildAppDockerfile = []byte(`FROM centos/ruby-27-centos7
 USER default
 EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
-RUN scl enable rh-ruby25 "bundle install"
-CMD ["scl", "enable", "rh-ruby25", "./run.sh"]
+RUN scl enable rh-ruby27 "bundle install"
+CMD ["scl", "enable", "rh-ruby27", "./run.sh"]
 
 USER default
 `)
@@ -21386,7 +21389,7 @@ items:
   apiVersion: v1
   metadata:
     name: origin-ruby-sample
-    creationTimestamp: 
+    creationTimestamp:
   spec: {}
   status:
     dockerImageRepository: ''
@@ -21394,7 +21397,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -21420,7 +21423,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-s2i-build-noproxy
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -21447,7 +21450,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-docker-build-noproxy
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -21464,7 +21467,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -21548,7 +21551,7 @@ items:
   apiVersion: v1
   metadata:
     name: origin-ruby-sample
-    creationTimestamp: 
+    creationTimestamp:
   spec: {}
   status:
     dockerImageRepository: ''
@@ -21556,7 +21559,7 @@ items:
   apiVersion: v1
   metadata:
     name: webhooksecret
-    creationTimestamp: 
+    creationTimestamp:
   data:
     WebHookSecretKey: c2VjcmV0dmFsdWUx
   type: Opaque
@@ -21564,7 +21567,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: ImageChange
@@ -21572,7 +21575,7 @@ items:
     - type: Generic
       generic:
         secret: "mysecret"
-        secretReference: 
+        secretReference:
           name: "webhooksecret"
     source:
       type: Git
@@ -21590,7 +21593,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
   status:
     lastVersion: 0
@@ -21598,7 +21601,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-verbose-build
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -21619,7 +21622,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
   status:
     lastVersion: 0
@@ -21627,7 +21630,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build-binary
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -21647,7 +21650,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
   status:
     lastVersion: 0
@@ -21655,7 +21658,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build-github-archive
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -21676,7 +21679,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
   status:
     lastVersion: 0
@@ -21684,7 +21687,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build-binary-invalidnodeselector
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -21704,7 +21707,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -21714,7 +21717,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build-docker-args
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: ImageChange
@@ -21722,9 +21725,9 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM centos/ruby-25-centos7
-        ARG foo
-        RUN echo $foo
+        FROM centos/ruby-27-centos7
+        ARG foofoo
+        RUN echo $foofoo
     strategy:
       type: Docker
       dockerStrategy:
@@ -21733,14 +21736,14 @@ items:
           name: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
     resources: {}
     postCommit: {}
-    nodeSelector: 
+    nodeSelector:
   status:
     lastVersion: 0
 - kind: BuildConfig
   apiVersion: v1
   metadata:
     name: sample-build-docker-args-preset
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: ImageChange
@@ -21748,7 +21751,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM centos/ruby-25-centos7
+        FROM centos/ruby-27-centos7
         ARG foofoo
         RUN echo $foofoo
     strategy:
@@ -21762,7 +21765,7 @@ items:
           value: default
     resources: {}
     postCommit: {}
-    nodeSelector: 
+    nodeSelector:
   status:
     lastVersion: 0
 `)
@@ -22033,7 +22036,7 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
           "git": {
             "uri":"https://github.com/sclorg/s2i-ruby-container"
           },
-          "contextDir": "2.5/test/puma-test-app"
+          "contextDir": "2.7/test/puma-test-app"
         },
         "strategy": {
           "type": "Source",
@@ -22046,7 +22049,7 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             }
           }
         },
@@ -22064,7 +22067,7 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
       "metadata": {
         "name": "test"
       }
-    },    
+    },
     {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
@@ -22442,7 +22445,7 @@ var _testExtendedTestdataBuildsTestEnvBuildJson = []byte(`{
       "sourceStrategy":{
         "from":{
           "kind":"DockerImage",
-          "name":"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5"
+          "name":"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
         }
       }
     },
@@ -22602,7 +22605,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       customStrategy:
         from:
@@ -22649,7 +22652,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       dockerStrategy:
         from:
@@ -22696,7 +22699,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       sourceStrategy:
         from:
@@ -22739,12 +22742,12 @@ items:
         # Bug 1694859: ensure symlinks are followed
         FROM ruby
         RUN mkdir -p /opt/app-root/test-links && \
-            ln -s ../../rh/rh-ruby25/root/usr/bin /opt/app-root/test-links/bin
+            ln -s ../../rh/6/root/usr/bin /opt/app-root/test-links/bin
     strategy:
       dockerStrategy:
-        from: 
+        from:
           kind: ImageStreamTag
-          name: ruby:2.5
+          name: ruby:2.7
           namespace: openshift
 - apiVersion: v1
   kind: BuildConfig
@@ -22768,8 +22771,8 @@ items:
         # Bug 1698152: ensure image source copy behavior is correct
         - destinationDir: injected/opt/app-root/test-links
           sourcePath: /opt/app-root/test-links/.
-        - destinationDir: injected/opt/rh/rh-ruby-25/root/usr/bin
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+        - destinationDir: injected/opt/rh/rh-ruby-27/root/usr/bin
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       sourceStrategy:
         from:
@@ -22798,8 +22801,8 @@ items:
         # Bug 1698152: ensure image source copy behavior is correct
         - destinationDir: injected/opt/app-root/test-links
           sourcePath: /opt/app-root/test-links/.
-        - destinationDir: injected/opt/rh/rh-ruby-25/root/usr/bin
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+        - destinationDir: injected/opt/rh/rh-ruby-27/root/usr/bin
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       dockerStrategy: {}
 
@@ -27436,7 +27439,7 @@ var _testExtendedTestdataClusterQuickstartsRailsPostgresqlJson = []byte(`{
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "ruby:2.5",
+                            "name": "ruby:2.7",
                             "namespace": "${NAMESPACE}"
                         }
                     },
@@ -31244,7 +31247,7 @@ project="$(oc project -q)"
 os::test::junit::declare_suite_start "cmd/builds"
 # This test validates builds and build related commands
 # Disabled because git is required in the container running the test
-#os::cmd::expect_success 'oc new-build centos/ruby-25-centos7 https://github.com/openshift/ruby-hello-world.git'
+#os::cmd::expect_success 'oc new-build centos/ruby-26-centos7 https://github.com/openshift/ruby-hello-world.git'
 #os::cmd::expect_success 'oc get bc/ruby-hello-world'
 
 #os::cmd::expect_success "cat '${OS_ROOT}/examples/hello-openshift/Dockerfile' | oc new-build -D - --name=test"
@@ -31287,8 +31290,8 @@ os::cmd::expect_success 'oc delete is/tests'
 os::cmd::expect_success "oc new-build -D \$'FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest\nENV ok=1' --to origin-name-test --name origin-test2"
 os::cmd::expect_success_and_text "oc get bc/origin-test2 --template '${template}'" '^ImageStreamTag origin-name-test:latest$'
 
-#os::cmd::try_until_text 'oc get is ruby-25-centos7' 'latest'
-#os::cmd::expect_failure_and_text 'oc new-build ruby-25-centos7~https://github.com/sclorg/ruby-ex ruby-25-centos7~https://github.com/sclorg/ruby-ex --to invalid/argument' 'error: only one component with source can be used when specifying an output image reference'
+#os::cmd::try_until_text 'oc get is ruby-26-centos7' 'latest'
+#os::cmd::expect_failure_and_text 'oc new-build ruby-26-centos7~https://github.com/sclorg/ruby-ex ruby-26-centos7~https://github.com/sclorg/ruby-ex --to invalid/argument' 'error: only one component with source can be used when specifying an output image reference'
 
 os::cmd::expect_success 'oc delete all --all'
 
@@ -31305,7 +31308,7 @@ os::cmd::expect_success 'oc get bc'
 os::cmd::expect_success 'oc get builds'
 
 # make sure the imagestream has the latest tag before trying to test it or start a build with it
-os::cmd::try_until_success 'oc get istag ruby-25-centos7:latest'
+os::cmd::try_until_success 'oc get istag ruby-27-centos7:latest'
 
 os::test::junit::declare_suite_start "cmd/builds/patch-anon-fields"
 REAL_OUTPUT_TO=$(oc get bc/ruby-sample-build --template='{{ .spec.output.to.name }}')
@@ -32856,10 +32859,10 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/merge-tags-on-apply"
 os::cmd::expect_success 'oc new-project merge-tags'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/image-streams/image-streams-centos7.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.0 2.2 2.3 2.4 2.5 latest'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 latest'
 os::cmd::expect_success 'oc apply -f ${TEST_DATA}/modified-ruby-imagestream.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.0 2.2 2.3 2.4 2.5 latest newtag'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[3].annotations.version}' '2.4 patched'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 latest newtag'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[0].annotations.version}' '2.7 patched'
 os::cmd::expect_success 'oc delete project merge-tags'
 echo "apply new imagestream tags: ok"
 os::test::junit::declare_suite_end
@@ -33182,7 +33185,7 @@ os::cmd::expect_success 'oc new-app --docker-image=library/perl https://github.c
 os::cmd::try_until_success 'oc get istag perl:latest -n test-imagestreams'
 
 # remove redundant imagestream tag before creating objects
-os::cmd::expect_success_and_text 'oc new-app  openshift/ruby-25-centos7 https://github.com/openshift/ruby-hello-world  --strategy=docker --loglevel=5' 'Removing duplicate tag from object list'
+os::cmd::expect_success_and_text 'oc new-app  openshift/ruby-27-centos7 https://github.com/openshift/ruby-hello-world  --strategy=docker --loglevel=5' 'Removing duplicate tag from object list'
 
 # create imagestream in the correct namespace
 os::cmd::expect_success 'oc new-app --name=mytest --image-stream=mysql --env=MYSQL_USER=test --env=MYSQL_PASSWORD=redhat --env=MYSQL_DATABASE=testdb -l app=mytest'
@@ -33240,7 +33243,7 @@ os::cmd::expect_success 'oc delete all -l app=ruby-ex'
 os::cmd::expect_success_and_not_text 'oc new-app --file ${TEST_DATA}/new-app/invalid-build-strategy.yaml --dry-run' 'invalid memory address or nil pointer dereference'
 
 # test that imagestream references across imagestreams do not cause an error
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.7'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/new-app/imagestream-ref.yaml'
 os::cmd::try_until_success 'oc get imagestreamtags myruby:latest'
 os::cmd::expect_success 'oc new-app myruby~https://github.com/openshift/ruby-hello-world.git --dry-run'
@@ -33510,11 +33513,7 @@ os::cmd::try_until_success 'oc get imagestreamtags python:3.4'
 os::cmd::try_until_success 'oc get imagestreamtags python:3.5'
 os::cmd::try_until_success 'oc get imagestreamtags python:3.6'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:latest'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.2'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.4'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.5'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.7'
 os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest'
 os::cmd::try_until_success 'oc get imagestreamtags wildfly:12.0'
 os::cmd::try_until_success 'oc get imagestreamtags wildfly:11.0'
@@ -33530,10 +33529,10 @@ os::cmd::expect_success_and_text 'oc new-app --search --image-stream=nginx' "Tag
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=nodejs' "Tags:\s+10, 11, 6, 8, 8-RHOAR, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=perl' "Tags:\s+5.24, 5.26, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=php' "Tags:\s+7.0, 7.1, latest"
-os::cmd::expect_success_and_text 'oc new-app --search --image-stream=postgresql' "Tags:\s+10, 9.5, 9.6, latest"
-os::cmd::expect_success_and_text 'oc new-app -S --image-stream=python' "Tags:\s+2.7, 3.5, 3.6, latest"
-os::cmd::expect_success_and_text 'oc new-app -S --image-stream=ruby' "Tags:\s+2.3, 2.4, 2.5, latest"
-os::cmd::expect_success_and_text 'oc new-app -S --image-stream=wildfly' "Tags:\s+10.0, 10.1, 11.0, 12.0, 13.0, 14.0, 15.0, 8.1, 9.0, latest"
+os::cmd::expect_success_and_text 'oc new-app --search --image-stream=postgresql' "Tags:\s+9.5, 9.6, latest"
+os::cmd::expect_success_and_text 'oc new-app -S --image-stream=python' "Tags:\s+2.7, 3.6, latest"
+os::cmd::expect_success_and_text 'oc new-app -S --image-stream=ruby' "Tags:\s+2.6, 2.7, latest"
+os::cmd::expect_success_and_text 'oc new-app -S --image-stream=wildfly' "Tags:\s+20.0, 21.0, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --template=ruby-helloworld-sample' 'ruby-helloworld-sample'
 # check search - no matches
 os::cmd::expect_failure_and_text 'oc new-app -S foo-the-bar' 'no matches found'
@@ -33600,13 +33599,11 @@ os::cmd::expect_success 'oc new-app --image-stream ruby https://github.com/sclor
 # when latest does not exist, there are multiple partial matches (2.2, 2.3, 2.4, 2.5)
 os::cmd::expect_success 'oc delete imagestreamtag ruby:latest'
 os::cmd::expect_failure_and_text 'oc new-app --image-stream ruby https://github.com/sclorg/rails-ex --dry-run' 'error: multiple images or templates matched \"ruby\"'
-# when only 2.5 exists, there is a single partial match (2.5)
-os::cmd::expect_success 'oc delete imagestreamtag ruby:2.2'
-os::cmd::expect_success 'oc delete imagestreamtag ruby:2.3'
-os::cmd::expect_success 'oc delete imagestreamtag ruby:2.4'
+# when only 2.6 exists, there is a single partial match (2.6)
+os::cmd::expect_success 'oc delete imagestreamtag ruby:2.7'
 os::cmd::expect_failure_and_text 'oc new-app --image-stream ruby https://github.com/sclorg/rails-ex --dry-run' 'error: only a partial match was found for \"ruby\":'
 # when the tag is specified explicitly, the operation is successful
-os::cmd::expect_success 'oc new-app --image-stream ruby:2.5 https://github.com/sclorg/rails-ex --dry-run'
+os::cmd::expect_success 'oc new-app --image-stream ruby:2.7 https://github.com/sclorg/rails-ex --dry-run'
 os::cmd::expect_success 'oc delete imagestreams --all'
 
 # newapp does not attempt to create an imagestream that already exists for a container image
@@ -33619,9 +33616,9 @@ os::cmd::expect_success 'oc delete all -l app=testapp1'
 os::cmd::expect_success 'oc delete all -l app=ruby --ignore-not-found'
 os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 # newapp does not attempt to create an imagestream that already exists for a container image
-os::cmd::expect_success 'oc new-app docker.io/ruby:2.2'
+os::cmd::expect_success 'oc new-app docker.io/ruby:2.7'
 # the next one technically fails cause the DC is already created, but we should still see the ist created
-os::cmd::expect_failure_and_text 'oc new-app docker.io/ruby:2.4' 'imagestreamtag.image.openshift.io "ruby:2.4" created'
+os::cmd::expect_failure_and_text 'oc new-app docker.io/ruby:2.7' 'imagestreamtag.image.openshift.io "ruby:2.7" created'
 os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 
 # check that we can create from the template without errors
@@ -33647,7 +33644,7 @@ os::cmd::expect_success_and_text 'oc new-build mysql https://github.com/openshif
 os::cmd::expect_failure_and_text 'oc new-build mysql https://github.com/openshift/ruby-hello-world --binary' 'specifying binary builds and source repositories at the same time is not allowed'
 # binary builds cannot be created unless a builder image is specified.
 os::cmd::expect_failure_and_text 'oc new-build --name mybuild --binary --strategy=source -o yaml' 'you must provide a builder image when using the source strategy with a binary build'
-os::cmd::expect_success_and_text 'oc new-build --name mybuild centos/ruby-25-centos7 --binary --strategy=source -o yaml' 'name: ruby-25-centos7:latest'
+os::cmd::expect_success_and_text 'oc new-build --name mybuild registry.centos.org/centos/ruby-27-centos7 --binary --strategy=source -o yaml' 'name: ruby-27-centos7:latest'
 # binary builds can be created with no builder image if no strategy or docker strategy is specified
 os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary -o yaml' 'type: Binary'
 os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary --strategy=docker -o yaml' 'type: Binary'
@@ -33716,19 +33713,19 @@ os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 
 # new-app different syntax for new-app functionality
 os::cmd::expect_success 'oc new-project new-app-syntax'
-os::cmd::expect_success 'oc import-image openshift/ruby-20-centos7:latest --confirm'
-os::cmd::expect_success 'oc import-image openshift/php-55-centos7:latest --confirm'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest~https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest~./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest ./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest --code ./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest --code ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc import-image registry.centos.org/centos/ruby-27-centos7:latest --confirm'
+os::cmd::expect_success 'oc import-image registry.centos.org/centos/php-70-centos7:latest --confirm'
+os::cmd::expect_success 'oc new-app ruby-27-centos7:latest~https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app ruby-27-centos7:latest~./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-27-centos7:latest https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-27-centos7:latest ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app ruby-27-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app ruby-27-centos7:latest --code ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-27-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-27-centos7:latest --code ./test/testdata/testapp --dry-run'
 
 os::cmd::expect_success 'oc new-app --code ./test/testdata/testapp --name test'
-os::cmd::expect_success_and_text 'oc get bc test --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-25-centos7:latest'
+os::cmd::expect_success_and_text 'oc get bc test --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27-centos7:latest'
 
 os::cmd::expect_success 'oc new-app -i php-55-centos7:latest --code ./test/testdata/testapp --name test2'
 os::cmd::expect_success_and_text 'oc get bc test2 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
@@ -33746,7 +33743,7 @@ os::cmd::expect_success 'oc new-app php-55-centos7:latest --code https://github.
 os::cmd::expect_success_and_text 'oc get bc test6 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
 
 os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-world.git --name test7'
-os::cmd::expect_success_and_text 'oc get bc test7 --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-25-centos7:latest'
+os::cmd::expect_success_and_text 'oc get bc test7 --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27-centos7:latest'
 
 os::cmd::expect_success 'oc new-app php-55-centos7:latest https://github.com/openshift/ruby-hello-world.git --name test8'
 os::cmd::expect_success_and_text 'oc get bc test8 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
@@ -34940,20 +34937,19 @@ os::test::junit::declare_suite_start "cmd/oc/set/image"
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/test-deployment-config.yaml'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/hello-openshift/hello-pod.json'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/image-streams/image-streams-centos7.json'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.7-ubi8'
 
 # test --local flag
-os::cmd::expect_failure_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --local' 'you must specify resources by --filename when --local is set.'
+os::cmd::expect_failure_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --local' 'you must specify resources by --filename when --local is set.'
 # test --dry-run flag with -o formats
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run' 'test-deployment-config'
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run -o name' 'deploymentconfig.apps.openshift.io/test-deployment-config'
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run' 'deploymentconfig.apps.openshift.io/test-deployment-config image updated \(dry run\)'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag --dry-run' 'test-deployment-config'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag --dry-run -o name' 'deploymentconfig.apps.openshift.io/test-deployment-config'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag --dry-run' 'deploymentconfig.apps.openshift.io/test-deployment-config image updated \(dry run\)'
 
-os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.3 --source=istag'
+os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" 'image-registry.openshift-image-registry.svc:5000/cmd-set-image/ruby'
 
-os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag'
+os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" 'image-registry.openshift-image-registry.svc:5000/cmd-set-image/ruby'
 
 os::cmd::expect_failure 'oc set image dc/test-deployment-config ruby-helloworld=ruby:XYZ --source=istag'
@@ -34968,7 +34964,7 @@ os::cmd::expect_success_and_text "oc get pod/hello-openshift -o jsonpath='{.spec
 os::cmd::expect_success 'oc set image pod/hello-openshift hello-openshift=nginx:1.9.1'
 os::cmd::expect_success_and_text "oc get pod/hello-openshift -o jsonpath='{.spec.containers[0].image}'" 'nginx:1.9.1'
 
-os::cmd::expect_success 'oc set image pods,dc *=ruby:2.3 --all --source=imagestreamtag'
+os::cmd::expect_success 'oc set image pods,dc *=ruby:2.7-ubi8 --all --source=imagestreamtag'
 os::cmd::expect_success_and_text "oc get pod/hello-openshift -o jsonpath='{.spec.containers[0].image}'" 'image-registry.openshift-image-registry.svc:5000/cmd-set-image/ruby'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" 'image-registry.openshift-image-registry.svc:5000/cmd-set-image/ruby'
 
@@ -35305,10 +35301,10 @@ os::cmd::expect_success 'oc process ruby-helloworld-sample -o go-template-file=/
 os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o jsonpath --template "{.kind}"' "List"
 os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o jsonpath={.kind}'              "List"
 os::cmd::expect_success 'oc process ruby-helloworld-sample -o jsonpath-file=/dev/null'
-os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o describe' "ruby-25-centos7"
-os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o json'     "ruby-25-centos7"
-os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o yaml'     "ruby-25-centos7"
-os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o name'     "ruby-25-centos7"
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o describe' "ruby-27-centos7"
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o json'     "ruby-27-centos7"
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o yaml'     "ruby-27-centos7"
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o name'     "ruby-27-centos7"
 os::cmd::expect_success_and_text 'oc describe templates ruby-helloworld-sample' "BuildConfig.*ruby-sample-build"
 os::cmd::expect_success 'oc delete templates ruby-helloworld-sample'
 os::cmd::expect_success 'oc get templates'
@@ -39078,7 +39074,7 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateDockerbuildJson = 
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
         "tags": [
@@ -39138,7 +39134,7 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateDockerbuildJson = 
           "dockerStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {
@@ -39540,10 +39536,10 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateStibuildJson = []b
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -39595,7 +39591,7 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateStibuildJson = []b
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {
@@ -40562,36 +40558,18 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
           },
           {
             "annotations": {
-              "description": "Provides a MongoDB 2.4 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mongodb-container/tree/master/2.4/README.md.",
+              "description": "Provides a MongoDB 2.7 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mongodb-container/blob/master/2.7/README.md.",
               "iconClass": "icon-mongodb",
-              "openshift.io/display-name": "MongoDB 2.4",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "tags": "hidden,mongodb",
-              "version": "2.4"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/openshift/mongodb-24-centos7:latest"
-            },
-            "name": "2.4",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Provides a MongoDB 2.6 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mongodb-container/tree/master/2.6/README.md.",
-              "iconClass": "icon-mongodb",
-              "openshift.io/display-name": "MongoDB 2.6",
+              "openshift.io/display-name": "MongoDB 2.7",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
               "tags": "hidden,database,mongodb",
-              "version": "2.6"
+              "version": "2.7"
             },
             "from": {
               "kind": "DockerImage",
               "name": "docker.io/centos/mongodb-26-centos7:latest"
             },
-            "name": "2.6",
+            "name": "2.7",
             "referencePolicy": {
               "type": "Local"
             }
@@ -41552,7 +41530,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "ImageStreamTag",
-              "name": "2.5"
+              "name": "2.7"
             },
             "name": "latest",
             "referencePolicy": {
@@ -41560,101 +41538,23 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             }
           },
           {
+            "name": "2.7-ubi8",
             "annotations": {
-              "description": "Build and run Ruby 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.0/README.md.",
+              "description": "Build and run Ruby 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.7/README.md.",
               "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.0",
+              "openshift.io/display-name": "Ruby 2.7 (UBI 8)",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
               "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.0,ruby",
-              "tags": "hidden,builder,ruby",
-              "version": "2.0"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/openshift/ruby-20-centos7:latest"
-            },
-            "name": "2.0",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run Ruby 2.2 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.2/README.md.",
-              "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.2",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.2,ruby",
-              "tags": "hidden,builder,ruby",
-              "version": "2.2"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-22-centos7:latest"
-            },
-            "name": "2.2",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run Ruby 2.3 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.3/README.md.",
-              "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.3",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.3,ruby",
+              "supports": "ruby:2.7,ruby",
               "tags": "builder,ruby",
-              "version": "2.3"
+              "version": "2.7"
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-23-centos7:latest"
+              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
             },
-            "name": "2.3",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run Ruby 2.4 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.4/README.md.",
-              "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.4",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.4,ruby",
-              "tags": "builder,ruby",
-              "version": "2.4"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-24-centos7:latest"
-            },
-            "name": "2.4",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run Ruby 2.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
-              "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.5",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.5,ruby",
-              "tags": "builder,ruby",
-              "version": "2.5"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
-            },
-            "name": "2.5",
+            "generation": null,
+            "importPolicy": {},
             "referencePolicy": {
               "type": "Local"
             }
@@ -42294,27 +42194,27 @@ var _testExtendedTestdataCmdTestCmdTestdataModifiedRubyImagestreamJson = []byte(
   "spec": {
     "tags": [
       {
-        "name": "2.4",
+        "name": "2.7",
         "annotations": {
           "openshift.io/display-name": "Ruby Patched",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.4 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.4/README.md.",
+          "description": "Build and run Ruby 2.7 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.7/README.md.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
-          "supports": "ruby:2.4,ruby",
-          "version": "2.4 patched",
+          "supports": "ruby:2.7,ruby",
+          "version": "2.7 patched",
           "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "centos/ruby-24-centos7:latest"
+          "name": "registry.centos.org/centos/ruby-27-centos7:latest"
         }
       },
       {
         "name": "newtag",
         "from": {
           "kind": "DockerImage",
-          "name": "centos/ruby-24-centos7:latest"
+          "name": "registry.centos.org/centos/ruby-27-centos7:latest"
         }
       }
     ]
@@ -42452,7 +42352,7 @@ func testExtendedTestdataCmdTestCmdTestdataNewAppBcFromImagestreamimageJson() (*
 	return a, nil
 }
 
-var _testExtendedTestdataCmdTestCmdTestdataNewAppBuildArgDockerfileDockerfile = []byte(`FROM centos/ruby-25-centos7
+var _testExtendedTestdataCmdTestCmdTestdataNewAppBuildArgDockerfileDockerfile = []byte(`FROM centos/ruby-27-centos7
 ARG foo
 RUN echo $foo
 `)
@@ -42561,12 +42461,12 @@ spec:
   tags:
   - from:
       kind: ImageStreamTag
-      name: "2.3"
+      name: "2.7"
     name: "latest"
   - from:
       kind: ImageStreamTag
-      name: ruby:2.3
-    name: "2.3"
+      name: ruby:2.7
+    name: "2.7"
 `)
 
 func testExtendedTestdataCmdTestCmdTestdataNewAppImagestreamRefYamlBytes() ([]byte, error) {
@@ -42831,11 +42731,11 @@ var _testExtendedTestdataCmdTestCmdTestdataNewAppTemplateWithAppLabelJson = []by
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7",
+        "name": "ruby-27-centos7",
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -42885,7 +42785,7 @@ var _testExtendedTestdataCmdTestCmdTestdataNewAppTemplateWithAppLabelJson = []by
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {
@@ -43494,11 +43394,11 @@ var _testExtendedTestdataCmdTestCmdTestdataNewAppTemplateWithoutAppLabelJson = [
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7",
+        "name": "ruby-27-centos7",
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -43547,7 +43447,7 @@ var _testExtendedTestdataCmdTestCmdTestdataNewAppTemplateWithoutAppLabelJson = [
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {
@@ -45102,7 +45002,7 @@ spec:
     spec:
       containers:
       - name: testapp
-        image: centos/ruby-25-centos7:latest
+        image: centos/ruby-27-centos7:latest
         command:
         - /bin/sleep
         args:
@@ -46056,7 +45956,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-25-centos7
+        name: centos/ruby-27-centos7
     type: Source
   triggers: []
 status:
@@ -46368,7 +46268,7 @@ var _testExtendedTestdataCmdTestCmdTestdataTestImageJson = []byte(`{
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "openshift/ruby-19-centos:latest",
+  "dockerImageReference": "registry.redhat.io/rhscl/ruby-27-rhel7:latest",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",
@@ -46725,7 +46625,7 @@ project="$(oc project -q)"
 os::test::junit::declare_suite_start "cmd/triggers"
 # This test validates triggers
 
-os::cmd::expect_success 'oc new-app centos/ruby-25-centos7~https://github.com/openshift/ruby-hello-world.git'
+os::cmd::expect_success 'oc new-app centos/ruby-27-centos7~https://github.com/openshift/ruby-hello-world.git'
 os::cmd::expect_success 'oc get bc/ruby-hello-world'
 
 os::cmd::expect_success "oc new-build --name=scratch --docker-image=scratch --dockerfile='FROM scratch'"
@@ -46738,7 +46638,7 @@ os::cmd::expect_failure_and_text 'oc set triggers bc/ruby-hello-world --remove -
 os::cmd::expect_failure_and_text 'oc set triggers bc/ruby-hello-world --auto --manual' 'at most one of --auto or --manual'
 # print
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'config.*true'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:latest.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:latest.*true'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'webhook'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'github'
 # note, oc new-app currently does not set up gitlab or bitbucket webhooks by default
@@ -46755,7 +46655,7 @@ os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --remove-a
 
 os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'webhook|github'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'config.*false'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:latest.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:latest.*false'
 # set github hook
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-github' 'updated'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'github'
@@ -46782,18 +46682,18 @@ os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'bitbucke
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --remove --from-bitbucket' 'updated'
 os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'bitbucket'
 # set from-image
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-25-centos7:other' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:other.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other.*true'
 # manual and remove both clear build configs
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-25-centos7:other --manual' 'updated'
-os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:other.*false'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-25-centos7:other' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-25-centos7:other --remove' 'updated'
-os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:other'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other --manual' 'updated'
+os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other --remove' 'updated'
+os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other'
 # test --all
-os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-25-centos7:latest.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-27-centos7:latest.*false'
 os::cmd::expect_success_and_text 'oc set triggers bc --all --auto' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-25-centos7:latest.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-27-centos7:latest.*true'
 # set a trigger on a build that doesn't have an imagestream strategy.from-image
 os::cmd::expect_success_and_text 'oc set triggers bc/scratch --from-image=test:latest' 'updated'
 
@@ -47625,7 +47525,7 @@ run Proc.new { |env|
 EOF
 
 cat > Dockerfile <<- EOF
-FROM centos/ruby-25-centos7
+FROM centos/ruby-27-centos7
 ENV SECRET_FILE /opt/openshift/src/dockercfg
 COPY dockercfg ./
 COPY config.ru ./
@@ -50542,7 +50442,7 @@ var _testExtendedTestdataImageTestImageJson = []byte(`{
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "registry.redhat.io/rhscl/ruby-25-rhel7:latest",
+  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",
@@ -51898,7 +51798,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             }
           }
         ]
@@ -51916,7 +51816,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             }
           }
         ]
@@ -51934,7 +51834,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             }
           }
         ]
@@ -53210,7 +53110,7 @@ func testExtendedTestdataLdapLdapserverServiceYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataLong_namesDockerfile = []byte(`FROM centos/ruby-25-centos7
+var _testExtendedTestdataLong_namesDockerfile = []byte(`FROM centos/ruby-27-centos7
 
 CMD ["/bin/sh", "-c", "echo", "hello"]
 `)
@@ -53258,7 +53158,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
                         }
                     }
                 }
@@ -53287,14 +53187,15 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
                         }
                     }
                 }
             }
         }
     ]
-}`)
+}
+`)
 
 func testExtendedTestdataLong_namesFixtureJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataLong_namesFixtureJson, nil
@@ -56523,41 +56424,40 @@ var _testExtendedTestdataRun_policyParallelBcYaml = []byte(`---
   kind: "List"
   apiVersion: "v1"
   metadata: {}
-  items: 
-    - 
+  items:
+    -
       kind: "ImageStream"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "origin-ruby-sample"
         creationTimestamp: null
       spec: {}
-      status: 
+      status:
         dockerImageRepository: ""
-    - 
+    -
       kind: "BuildConfig"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "sample-parallel-build"
-      spec: 
+      spec:
         runPolicy: "Parallel"
-        triggers: 
-          - 
+        triggers:
+          -
             type: "imageChange"
             imageChange: {}
-        source: 
+        source:
           type: "Git"
-          git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
-        strategy: 
+          git:
+            uri: "https://github.com/openshift/ruby-hello-world.git"
+        strategy:
           type: "Source"
-          sourceStrategy: 
-            from: 
+          sourceStrategy:
+            from:
               kind: "DockerImage"
-              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
         resources: {}
-      status: 
+      status:
         lastVersion: 0
-
 `)
 
 func testExtendedTestdataRun_policyParallelBcYamlBytes() ([]byte, error) {
@@ -56579,49 +56479,49 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
   kind: "List"
   apiVersion: "v1"
   metadata: {}
-  items: 
-    - 
+  items:
+    -
       kind: "BuildConfig"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "sample-serial-build"
-      spec: 
+      spec:
         runPolicy: "Serial"
-        triggers: 
-          - 
+        triggers:
+          -
             type: "imageChange"
             imageChange: {}
-        source: 
+        source:
           type: "Git"
-          git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
-        strategy: 
+          git:
+            uri: "https://github.com/openshift/ruby-hello-world.git"
+        strategy:
           type: "Source"
-          sourceStrategy: 
-            from: 
+          sourceStrategy:
+            from:
               kind: "DockerImage"
-              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
-    - 
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
+    -
       kind: "BuildConfig"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "sample-serial-build-fail"
-      spec: 
+      spec:
         runPolicy: "Serial"
-        triggers: 
-          - 
+        triggers:
+          -
             type: "imageChange"
             imageChange: {}
-        source: 
+        source:
           type: "Git"
-          git: 
-            uri: "git://github.com/openshift/invalidrepo.git"
-        strategy: 
+          git:
+            uri: "https://github.com/openshift/invalidrepo.git"
+        strategy:
           type: "Source"
-          sourceStrategy: 
-            from: 
+          sourceStrategy:
+            from:
               kind: "DockerImage"
-              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
 `)
 
 func testExtendedTestdataRun_policySerialBcYamlBytes() ([]byte, error) {
@@ -56643,32 +56543,31 @@ var _testExtendedTestdataRun_policySerialLatestOnlyBcYaml = []byte(`---
   kind: "List"
   apiVersion: "v1"
   metadata: {}
-  items: 
-    - 
+  items:
+    -
       kind: "BuildConfig"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "sample-serial-latest-only-build"
-      spec: 
+      spec:
         runPolicy: "SerialLatestOnly"
-        triggers: 
-          - 
+        triggers:
+          -
             type: "imageChange"
             imageChange: {}
-        source: 
+        source:
           type: "Git"
-          git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
-        strategy: 
+          git:
+            uri: "https://github.com/openshift/ruby-hello-world.git"
+        strategy:
           type: "Source"
-          sourceStrategy: 
-            from: 
+          sourceStrategy:
+            from:
               kind: "DockerImage"
-              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
         resources: {}
-      status: 
+      status:
         lastVersion: 0
-
 `)
 
 func testExtendedTestdataRun_policySerialLatestOnlyBcYamlBytes() ([]byte, error) {
@@ -56739,7 +56638,7 @@ func testExtendedTestdataS2iDropcapsRootAccessBuildYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataS2iDropcapsRootableRubyDockerfile = []byte(`FROM centos/ruby-25-centos7:latest
+var _testExtendedTestdataS2iDropcapsRootableRubyDockerfile = []byte(`FROM centos/ruby-27-centos7:latest
 USER root
 RUN rm -f /usr/bin/ls
 RUN echo "root:redhat" | chpasswd

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -21726,8 +21726,8 @@ items:
       type: Dockerfile
       dockerfile: |-
         FROM centos/ruby-27-centos7
-        ARG foofoo
-        RUN echo $foofoo
+        ARG foo
+        RUN echo $foo
     strategy:
       type: Docker
       dockerStrategy:
@@ -30523,7 +30523,7 @@ os::cmd::expect_success 'oc process -f ${TEST_DATA}/application-template-stibuil
 # Test both the type/name resource syntax and the fact that istag/origin-ruby-sample:latest is still
 # not created but due to a buildConfig pointing to it, we get back its graph of deps.
 os::cmd::expect_success_and_text 'oc adm build-chain istag/origin-ruby-sample' 'istag/origin-ruby-sample:latest'
-os::cmd::expect_success_and_text 'oc adm build-chain ruby-25-centos7 -o dot' 'digraph "ruby-25-centos7:latest"'
+os::cmd::expect_success_and_text 'oc adm build-chain ruby-27-centos7 -o dot' 'digraph "ruby-27-centos7:latest"'
 os::cmd::expect_success 'oc delete all -l build=sti'
 echo "ex build-chain: ok"
 os::test::junit::declare_suite_end

--- a/test/extended/testdata/builds/build-secrets/test-s2i-build.json
+++ b/test/extended/testdata/builds/build-secrets/test-s2i-build.json
@@ -45,7 +45,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/build-timing/Dockerfile
+++ b/test/extended/testdata/builds/build-timing/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos/ruby-25-centos7
+FROM centos/ruby-27-centos7
 
 USER root

--- a/test/extended/testdata/builds/incremental-auth-build.json
+++ b/test/extended/testdata/builds/incremental-auth-build.json
@@ -48,7 +48,7 @@
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             },
             "incremental": true
           }

--- a/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
+++ b/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
@@ -12,4 +12,4 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7

--- a/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
@@ -11,12 +11,12 @@ spec:
         paths:
           - destinationDir: injected/opt/app-root/test-links
             sourcePath: /opt/app-root/test-links/.
-          - destinationDir: injected/opt/rh/rh-ruby-25/root/usr/bin
-            sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+          - destinationDir: injected/opt/rh/rh-ruby-27/root/usr/bin
+            sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
 
   strategy:
     type: Docker
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7

--- a/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
@@ -11,4 +11,4 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7

--- a/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
@@ -11,4 +11,4 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7

--- a/test/extended/testdata/builds/statusfail-genericreason.yaml
+++ b/test/extended/testdata/builds/statusfail-genericreason.yaml
@@ -11,7 +11,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy

--- a/test/extended/testdata/builds/statusfail-oomkilled.yaml
+++ b/test/extended/testdata/builds/statusfail-oomkilled.yaml
@@ -14,5 +14,5 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
       forcePull: true

--- a/test/extended/testdata/builds/test-build-app/Dockerfile
+++ b/test/extended/testdata/builds/test-build-app/Dockerfile
@@ -1,10 +1,10 @@
-FROM centos/ruby-25-centos7
+FROM centos/ruby-27-centos7
 USER default
 EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
-RUN scl enable rh-ruby25 "bundle install"
-CMD ["scl", "enable", "rh-ruby25", "./run.sh"]
+RUN scl enable rh-ruby27 "bundle install"
+CMD ["scl", "enable", "rh-ruby27", "./run.sh"]
 
 USER default

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -6,7 +6,7 @@ items:
   apiVersion: v1
   metadata:
     name: origin-ruby-sample
-    creationTimestamp: 
+    creationTimestamp:
   spec: {}
   status:
     dockerImageRepository: ''
@@ -14,7 +14,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -40,7 +40,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-s2i-build-noproxy
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -67,7 +67,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-docker-build-noproxy
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -84,7 +84,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -6,7 +6,7 @@ items:
   apiVersion: v1
   metadata:
     name: origin-ruby-sample
-    creationTimestamp: 
+    creationTimestamp:
   spec: {}
   status:
     dockerImageRepository: ''
@@ -14,7 +14,7 @@ items:
   apiVersion: v1
   metadata:
     name: webhooksecret
-    creationTimestamp: 
+    creationTimestamp:
   data:
     WebHookSecretKey: c2VjcmV0dmFsdWUx
   type: Opaque
@@ -22,7 +22,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: ImageChange
@@ -30,7 +30,7 @@ items:
     - type: Generic
       generic:
         secret: "mysecret"
-        secretReference: 
+        secretReference:
           name: "webhooksecret"
     source:
       type: Git
@@ -48,7 +48,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
   status:
     lastVersion: 0
@@ -56,7 +56,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-verbose-build
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -77,7 +77,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
   status:
     lastVersion: 0
@@ -85,7 +85,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build-binary
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -105,7 +105,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
   status:
     lastVersion: 0
@@ -113,7 +113,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build-github-archive
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -134,7 +134,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
   status:
     lastVersion: 0
@@ -142,7 +142,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build-binary-invalidnodeselector
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: imageChange
@@ -162,7 +162,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -172,7 +172,7 @@ items:
   apiVersion: v1
   metadata:
     name: sample-build-docker-args
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: ImageChange
@@ -180,9 +180,9 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM centos/ruby-25-centos7
-        ARG foo
-        RUN echo $foo
+        FROM centos/ruby-27-centos7
+        ARG foofoo
+        RUN echo $foofoo
     strategy:
       type: Docker
       dockerStrategy:
@@ -191,14 +191,14 @@ items:
           name: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
     resources: {}
     postCommit: {}
-    nodeSelector: 
+    nodeSelector:
   status:
     lastVersion: 0
 - kind: BuildConfig
   apiVersion: v1
   metadata:
     name: sample-build-docker-args-preset
-    creationTimestamp: 
+    creationTimestamp:
   spec:
     triggers:
     - type: ImageChange
@@ -206,7 +206,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM centos/ruby-25-centos7
+        FROM centos/ruby-27-centos7
         ARG foofoo
         RUN echo $foofoo
     strategy:
@@ -220,6 +220,6 @@ items:
           value: default
     resources: {}
     postCommit: {}
-    nodeSelector: 
+    nodeSelector:
   status:
     lastVersion: 0

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -181,8 +181,8 @@ items:
       type: Dockerfile
       dockerfile: |-
         FROM centos/ruby-27-centos7
-        ARG foofoo
-        RUN echo $foofoo
+        ARG foo
+        RUN echo $foo
     strategy:
       type: Docker
       dockerStrategy:

--- a/test/extended/testdata/builds/test-context-build.json
+++ b/test/extended/testdata/builds/test-context-build.json
@@ -42,7 +42,7 @@
           "git": {
             "uri":"https://github.com/sclorg/s2i-ruby-container"
           },
-          "contextDir": "2.5/test/puma-test-app"
+          "contextDir": "2.7/test/puma-test-app"
         },
         "strategy": {
           "type": "Source",
@@ -55,7 +55,7 @@
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             }
           }
         },
@@ -73,7 +73,7 @@
       "metadata": {
         "name": "test"
       }
-    },    
+    },
     {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",

--- a/test/extended/testdata/builds/test-env-build.json
+++ b/test/extended/testdata/builds/test-env-build.json
@@ -17,7 +17,7 @@
       "sourceStrategy":{
         "from":{
           "kind":"DockerImage",
-          "name":"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5"
+          "name":"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
         }
       }
     },

--- a/test/extended/testdata/builds/test-imageresolution-custom-build.yaml
+++ b/test/extended/testdata/builds/test-imageresolution-custom-build.yaml
@@ -22,7 +22,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       customStrategy:
         from:

--- a/test/extended/testdata/builds/test-imageresolution-docker-build.yaml
+++ b/test/extended/testdata/builds/test-imageresolution-docker-build.yaml
@@ -22,7 +22,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       dockerStrategy:
         from:

--- a/test/extended/testdata/builds/test-imageresolution-s2i-build.yaml
+++ b/test/extended/testdata/builds/test-imageresolution-s2i-build.yaml
@@ -22,7 +22,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       sourceStrategy:
         from:

--- a/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
+++ b/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
@@ -18,12 +18,12 @@ items:
         # Bug 1694859: ensure symlinks are followed
         FROM ruby
         RUN mkdir -p /opt/app-root/test-links && \
-            ln -s ../../rh/rh-ruby25/root/usr/bin /opt/app-root/test-links/bin
+            ln -s ../../rh/6/root/usr/bin /opt/app-root/test-links/bin
     strategy:
       dockerStrategy:
-        from: 
+        from:
           kind: ImageStreamTag
-          name: ruby:2.5
+          name: ruby:2.7
           namespace: openshift
 - apiVersion: v1
   kind: BuildConfig
@@ -47,8 +47,8 @@ items:
         # Bug 1698152: ensure image source copy behavior is correct
         - destinationDir: injected/opt/app-root/test-links
           sourcePath: /opt/app-root/test-links/.
-        - destinationDir: injected/opt/rh/rh-ruby-25/root/usr/bin
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+        - destinationDir: injected/opt/rh/rh-ruby-27/root/usr/bin
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       sourceStrategy:
         from:
@@ -77,8 +77,8 @@ items:
         # Bug 1698152: ensure image source copy behavior is correct
         - destinationDir: injected/opt/app-root/test-links
           sourcePath: /opt/app-root/test-links/.
-        - destinationDir: injected/opt/rh/rh-ruby-25/root/usr/bin
-          sourcePath: /opt/rh/rh-ruby25/root/usr/bin/ruby
+        - destinationDir: injected/opt/rh/rh-ruby-27/root/usr/bin
+          sourcePath: /opt/rh/rh-ruby27/root/usr/bin/ruby
     strategy:
       dockerStrategy: {}
 

--- a/test/extended/testdata/cluster/quickstarts/rails-postgresql.json
+++ b/test/extended/testdata/cluster/quickstarts/rails-postgresql.json
@@ -120,7 +120,7 @@
                         ],
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "ruby:2.5",
+                            "name": "ruby:2.7",
                             "namespace": "${NAMESPACE}"
                         }
                     },

--- a/test/extended/testdata/cmd/test/cmd/admin.sh
+++ b/test/extended/testdata/cmd/test/cmd/admin.sh
@@ -226,7 +226,7 @@ os::cmd::expect_success 'oc process -f ${TEST_DATA}/application-template-stibuil
 # Test both the type/name resource syntax and the fact that istag/origin-ruby-sample:latest is still
 # not created but due to a buildConfig pointing to it, we get back its graph of deps.
 os::cmd::expect_success_and_text 'oc adm build-chain istag/origin-ruby-sample' 'istag/origin-ruby-sample:latest'
-os::cmd::expect_success_and_text 'oc adm build-chain ruby-25-centos7 -o dot' 'digraph "ruby-25-centos7:latest"'
+os::cmd::expect_success_and_text 'oc adm build-chain ruby-27-centos7 -o dot' 'digraph "ruby-27-centos7:latest"'
 os::cmd::expect_success 'oc delete all -l build=sti'
 echo "ex build-chain: ok"
 os::test::junit::declare_suite_end

--- a/test/extended/testdata/cmd/test/cmd/builds.sh
+++ b/test/extended/testdata/cmd/test/cmd/builds.sh
@@ -16,7 +16,7 @@ project="$(oc project -q)"
 os::test::junit::declare_suite_start "cmd/builds"
 # This test validates builds and build related commands
 # Disabled because git is required in the container running the test
-#os::cmd::expect_success 'oc new-build centos/ruby-25-centos7 https://github.com/openshift/ruby-hello-world.git'
+#os::cmd::expect_success 'oc new-build centos/ruby-26-centos7 https://github.com/openshift/ruby-hello-world.git'
 #os::cmd::expect_success 'oc get bc/ruby-hello-world'
 
 #os::cmd::expect_success "cat '${OS_ROOT}/examples/hello-openshift/Dockerfile' | oc new-build -D - --name=test"
@@ -59,8 +59,8 @@ os::cmd::expect_success 'oc delete is/tests'
 os::cmd::expect_success "oc new-build -D \$'FROM image-registry.openshift-image-registry.svc:5000/openshift/tests:latest\nENV ok=1' --to origin-name-test --name origin-test2"
 os::cmd::expect_success_and_text "oc get bc/origin-test2 --template '${template}'" '^ImageStreamTag origin-name-test:latest$'
 
-#os::cmd::try_until_text 'oc get is ruby-25-centos7' 'latest'
-#os::cmd::expect_failure_and_text 'oc new-build ruby-25-centos7~https://github.com/sclorg/ruby-ex ruby-25-centos7~https://github.com/sclorg/ruby-ex --to invalid/argument' 'error: only one component with source can be used when specifying an output image reference'
+#os::cmd::try_until_text 'oc get is ruby-26-centos7' 'latest'
+#os::cmd::expect_failure_and_text 'oc new-build ruby-26-centos7~https://github.com/sclorg/ruby-ex ruby-26-centos7~https://github.com/sclorg/ruby-ex --to invalid/argument' 'error: only one component with source can be used when specifying an output image reference'
 
 os::cmd::expect_success 'oc delete all --all'
 
@@ -77,7 +77,7 @@ os::cmd::expect_success 'oc get bc'
 os::cmd::expect_success 'oc get builds'
 
 # make sure the imagestream has the latest tag before trying to test it or start a build with it
-os::cmd::try_until_success 'oc get istag ruby-25-centos7:latest'
+os::cmd::try_until_success 'oc get istag ruby-27-centos7:latest'
 
 os::test::junit::declare_suite_start "cmd/builds/patch-anon-fields"
 REAL_OUTPUT_TO=$(oc get bc/ruby-sample-build --template='{{ .spec.output.to.name }}')

--- a/test/extended/testdata/cmd/test/cmd/images.sh
+++ b/test/extended/testdata/cmd/test/cmd/images.sh
@@ -307,10 +307,10 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/merge-tags-on-apply"
 os::cmd::expect_success 'oc new-project merge-tags'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/image-streams/image-streams-centos7.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.0 2.2 2.3 2.4 2.5 latest'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 latest'
 os::cmd::expect_success 'oc apply -f ${TEST_DATA}/modified-ruby-imagestream.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.0 2.2 2.3 2.4 2.5 latest newtag'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[3].annotations.version}' '2.4 patched'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 latest newtag'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[0].annotations.version}' '2.7 patched'
 os::cmd::expect_success 'oc delete project merge-tags'
 echo "apply new imagestream tags: ok"
 os::test::junit::declare_suite_end

--- a/test/extended/testdata/cmd/test/cmd/newapp.sh
+++ b/test/extended/testdata/cmd/test/cmd/newapp.sh
@@ -43,7 +43,7 @@ os::cmd::expect_success 'oc new-app --docker-image=library/perl https://github.c
 os::cmd::try_until_success 'oc get istag perl:latest -n test-imagestreams'
 
 # remove redundant imagestream tag before creating objects
-os::cmd::expect_success_and_text 'oc new-app  openshift/ruby-25-centos7 https://github.com/openshift/ruby-hello-world  --strategy=docker --loglevel=5' 'Removing duplicate tag from object list'
+os::cmd::expect_success_and_text 'oc new-app  openshift/ruby-27-centos7 https://github.com/openshift/ruby-hello-world  --strategy=docker --loglevel=5' 'Removing duplicate tag from object list'
 
 # create imagestream in the correct namespace
 os::cmd::expect_success 'oc new-app --name=mytest --image-stream=mysql --env=MYSQL_USER=test --env=MYSQL_PASSWORD=redhat --env=MYSQL_DATABASE=testdb -l app=mytest'
@@ -101,7 +101,7 @@ os::cmd::expect_success 'oc delete all -l app=ruby-ex'
 os::cmd::expect_success_and_not_text 'oc new-app --file ${TEST_DATA}/new-app/invalid-build-strategy.yaml --dry-run' 'invalid memory address or nil pointer dereference'
 
 # test that imagestream references across imagestreams do not cause an error
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.7'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/new-app/imagestream-ref.yaml'
 os::cmd::try_until_success 'oc get imagestreamtags myruby:latest'
 os::cmd::expect_success 'oc new-app myruby~https://github.com/openshift/ruby-hello-world.git --dry-run'
@@ -371,11 +371,7 @@ os::cmd::try_until_success 'oc get imagestreamtags python:3.4'
 os::cmd::try_until_success 'oc get imagestreamtags python:3.5'
 os::cmd::try_until_success 'oc get imagestreamtags python:3.6'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:latest'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.2'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.4'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.5'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.7'
 os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest'
 os::cmd::try_until_success 'oc get imagestreamtags wildfly:12.0'
 os::cmd::try_until_success 'oc get imagestreamtags wildfly:11.0'
@@ -391,10 +387,10 @@ os::cmd::expect_success_and_text 'oc new-app --search --image-stream=nginx' "Tag
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=nodejs' "Tags:\s+10, 11, 6, 8, 8-RHOAR, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=perl' "Tags:\s+5.24, 5.26, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=php' "Tags:\s+7.0, 7.1, latest"
-os::cmd::expect_success_and_text 'oc new-app --search --image-stream=postgresql' "Tags:\s+10, 9.5, 9.6, latest"
-os::cmd::expect_success_and_text 'oc new-app -S --image-stream=python' "Tags:\s+2.7, 3.5, 3.6, latest"
-os::cmd::expect_success_and_text 'oc new-app -S --image-stream=ruby' "Tags:\s+2.3, 2.4, 2.5, latest"
-os::cmd::expect_success_and_text 'oc new-app -S --image-stream=wildfly' "Tags:\s+10.0, 10.1, 11.0, 12.0, 13.0, 14.0, 15.0, 8.1, 9.0, latest"
+os::cmd::expect_success_and_text 'oc new-app --search --image-stream=postgresql' "Tags:\s+9.5, 9.6, latest"
+os::cmd::expect_success_and_text 'oc new-app -S --image-stream=python' "Tags:\s+2.7, 3.6, latest"
+os::cmd::expect_success_and_text 'oc new-app -S --image-stream=ruby' "Tags:\s+2.6, 2.7, latest"
+os::cmd::expect_success_and_text 'oc new-app -S --image-stream=wildfly' "Tags:\s+20.0, 21.0, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --template=ruby-helloworld-sample' 'ruby-helloworld-sample'
 # check search - no matches
 os::cmd::expect_failure_and_text 'oc new-app -S foo-the-bar' 'no matches found'
@@ -461,13 +457,11 @@ os::cmd::expect_success 'oc new-app --image-stream ruby https://github.com/sclor
 # when latest does not exist, there are multiple partial matches (2.2, 2.3, 2.4, 2.5)
 os::cmd::expect_success 'oc delete imagestreamtag ruby:latest'
 os::cmd::expect_failure_and_text 'oc new-app --image-stream ruby https://github.com/sclorg/rails-ex --dry-run' 'error: multiple images or templates matched \"ruby\"'
-# when only 2.5 exists, there is a single partial match (2.5)
-os::cmd::expect_success 'oc delete imagestreamtag ruby:2.2'
-os::cmd::expect_success 'oc delete imagestreamtag ruby:2.3'
-os::cmd::expect_success 'oc delete imagestreamtag ruby:2.4'
+# when only 2.6 exists, there is a single partial match (2.6)
+os::cmd::expect_success 'oc delete imagestreamtag ruby:2.7'
 os::cmd::expect_failure_and_text 'oc new-app --image-stream ruby https://github.com/sclorg/rails-ex --dry-run' 'error: only a partial match was found for \"ruby\":'
 # when the tag is specified explicitly, the operation is successful
-os::cmd::expect_success 'oc new-app --image-stream ruby:2.5 https://github.com/sclorg/rails-ex --dry-run'
+os::cmd::expect_success 'oc new-app --image-stream ruby:2.7 https://github.com/sclorg/rails-ex --dry-run'
 os::cmd::expect_success 'oc delete imagestreams --all'
 
 # newapp does not attempt to create an imagestream that already exists for a container image
@@ -480,9 +474,9 @@ os::cmd::expect_success 'oc delete all -l app=testapp1'
 os::cmd::expect_success 'oc delete all -l app=ruby --ignore-not-found'
 os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 # newapp does not attempt to create an imagestream that already exists for a container image
-os::cmd::expect_success 'oc new-app docker.io/ruby:2.2'
+os::cmd::expect_success 'oc new-app docker.io/ruby:2.7'
 # the next one technically fails cause the DC is already created, but we should still see the ist created
-os::cmd::expect_failure_and_text 'oc new-app docker.io/ruby:2.4' 'imagestreamtag.image.openshift.io "ruby:2.4" created'
+os::cmd::expect_failure_and_text 'oc new-app docker.io/ruby:2.7' 'imagestreamtag.image.openshift.io "ruby:2.7" created'
 os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 
 # check that we can create from the template without errors
@@ -508,7 +502,7 @@ os::cmd::expect_success_and_text 'oc new-build mysql https://github.com/openshif
 os::cmd::expect_failure_and_text 'oc new-build mysql https://github.com/openshift/ruby-hello-world --binary' 'specifying binary builds and source repositories at the same time is not allowed'
 # binary builds cannot be created unless a builder image is specified.
 os::cmd::expect_failure_and_text 'oc new-build --name mybuild --binary --strategy=source -o yaml' 'you must provide a builder image when using the source strategy with a binary build'
-os::cmd::expect_success_and_text 'oc new-build --name mybuild centos/ruby-25-centos7 --binary --strategy=source -o yaml' 'name: ruby-25-centos7:latest'
+os::cmd::expect_success_and_text 'oc new-build --name mybuild registry.centos.org/centos/ruby-27-centos7 --binary --strategy=source -o yaml' 'name: ruby-27-centos7:latest'
 # binary builds can be created with no builder image if no strategy or docker strategy is specified
 os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary -o yaml' 'type: Binary'
 os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary --strategy=docker -o yaml' 'type: Binary'
@@ -577,19 +571,19 @@ os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 
 # new-app different syntax for new-app functionality
 os::cmd::expect_success 'oc new-project new-app-syntax'
-os::cmd::expect_success 'oc import-image openshift/ruby-20-centos7:latest --confirm'
-os::cmd::expect_success 'oc import-image openshift/php-55-centos7:latest --confirm'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest~https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest~./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest ./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest --code ./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest --code ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc import-image registry.centos.org/centos/ruby-27-centos7:latest --confirm'
+os::cmd::expect_success 'oc import-image registry.centos.org/centos/php-70-centos7:latest --confirm'
+os::cmd::expect_success 'oc new-app ruby-27-centos7:latest~https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app ruby-27-centos7:latest~./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-27-centos7:latest https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-27-centos7:latest ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app ruby-27-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app ruby-27-centos7:latest --code ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-27-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-27-centos7:latest --code ./test/testdata/testapp --dry-run'
 
 os::cmd::expect_success 'oc new-app --code ./test/testdata/testapp --name test'
-os::cmd::expect_success_and_text 'oc get bc test --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-25-centos7:latest'
+os::cmd::expect_success_and_text 'oc get bc test --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27-centos7:latest'
 
 os::cmd::expect_success 'oc new-app -i php-55-centos7:latest --code ./test/testdata/testapp --name test2'
 os::cmd::expect_success_and_text 'oc get bc test2 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
@@ -607,7 +601,7 @@ os::cmd::expect_success 'oc new-app php-55-centos7:latest --code https://github.
 os::cmd::expect_success_and_text 'oc get bc test6 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
 
 os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-world.git --name test7'
-os::cmd::expect_success_and_text 'oc get bc test7 --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-25-centos7:latest'
+os::cmd::expect_success_and_text 'oc get bc test7 --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27-centos7:latest'
 
 os::cmd::expect_success 'oc new-app php-55-centos7:latest https://github.com/openshift/ruby-hello-world.git --name test8'
 os::cmd::expect_success_and_text 'oc get bc test8 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'

--- a/test/extended/testdata/cmd/test/cmd/set-image.sh
+++ b/test/extended/testdata/cmd/test/cmd/set-image.sh
@@ -14,20 +14,19 @@ os::test::junit::declare_suite_start "cmd/oc/set/image"
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/test-deployment-config.yaml'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/hello-openshift/hello-pod.json'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/image-streams/image-streams-centos7.json'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.7-ubi8'
 
 # test --local flag
-os::cmd::expect_failure_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --local' 'you must specify resources by --filename when --local is set.'
+os::cmd::expect_failure_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --local' 'you must specify resources by --filename when --local is set.'
 # test --dry-run flag with -o formats
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run' 'test-deployment-config'
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run -o name' 'deploymentconfig.apps.openshift.io/test-deployment-config'
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run' 'deploymentconfig.apps.openshift.io/test-deployment-config image updated \(dry run\)'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag --dry-run' 'test-deployment-config'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag --dry-run -o name' 'deploymentconfig.apps.openshift.io/test-deployment-config'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag --dry-run' 'deploymentconfig.apps.openshift.io/test-deployment-config image updated \(dry run\)'
 
-os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.3 --source=istag'
+os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" 'image-registry.openshift-image-registry.svc:5000/cmd-set-image/ruby'
 
-os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag'
+os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.7-ubi8 --source=istag'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" 'image-registry.openshift-image-registry.svc:5000/cmd-set-image/ruby'
 
 os::cmd::expect_failure 'oc set image dc/test-deployment-config ruby-helloworld=ruby:XYZ --source=istag'
@@ -42,7 +41,7 @@ os::cmd::expect_success_and_text "oc get pod/hello-openshift -o jsonpath='{.spec
 os::cmd::expect_success 'oc set image pod/hello-openshift hello-openshift=nginx:1.9.1'
 os::cmd::expect_success_and_text "oc get pod/hello-openshift -o jsonpath='{.spec.containers[0].image}'" 'nginx:1.9.1'
 
-os::cmd::expect_success 'oc set image pods,dc *=ruby:2.3 --all --source=imagestreamtag'
+os::cmd::expect_success 'oc set image pods,dc *=ruby:2.7-ubi8 --all --source=imagestreamtag'
 os::cmd::expect_success_and_text "oc get pod/hello-openshift -o jsonpath='{.spec.containers[0].image}'" 'image-registry.openshift-image-registry.svc:5000/cmd-set-image/ruby'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" 'image-registry.openshift-image-registry.svc:5000/cmd-set-image/ruby'
 

--- a/test/extended/testdata/cmd/test/cmd/templates.sh
+++ b/test/extended/testdata/cmd/test/cmd/templates.sh
@@ -30,10 +30,10 @@ os::cmd::expect_success 'oc process ruby-helloworld-sample -o go-template-file=/
 os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o jsonpath --template "{.kind}"' "List"
 os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o jsonpath={.kind}'              "List"
 os::cmd::expect_success 'oc process ruby-helloworld-sample -o jsonpath-file=/dev/null'
-os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o describe' "ruby-25-centos7"
-os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o json'     "ruby-25-centos7"
-os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o yaml'     "ruby-25-centos7"
-os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o name'     "ruby-25-centos7"
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o describe' "ruby-27-centos7"
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o json'     "ruby-27-centos7"
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o yaml'     "ruby-27-centos7"
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample -o name'     "ruby-27-centos7"
 os::cmd::expect_success_and_text 'oc describe templates ruby-helloworld-sample' "BuildConfig.*ruby-sample-build"
 os::cmd::expect_success 'oc delete templates ruby-helloworld-sample'
 os::cmd::expect_success 'oc get templates'

--- a/test/extended/testdata/cmd/test/cmd/testdata/application-template-dockerbuild.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/application-template-dockerbuild.json
@@ -83,7 +83,7 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
         "tags": [
@@ -143,7 +143,7 @@
           "dockerStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {

--- a/test/extended/testdata/cmd/test/cmd/testdata/application-template-stibuild.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/application-template-stibuild.json
@@ -83,10 +83,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7"
+        "name": "ruby-27-centos7"
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -138,7 +138,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {

--- a/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
@@ -268,36 +268,18 @@
           },
           {
             "annotations": {
-              "description": "Provides a MongoDB 2.4 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mongodb-container/tree/master/2.4/README.md.",
+              "description": "Provides a MongoDB 2.7 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mongodb-container/blob/master/2.7/README.md.",
               "iconClass": "icon-mongodb",
-              "openshift.io/display-name": "MongoDB 2.4",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "tags": "hidden,mongodb",
-              "version": "2.4"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/openshift/mongodb-24-centos7:latest"
-            },
-            "name": "2.4",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Provides a MongoDB 2.6 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mongodb-container/tree/master/2.6/README.md.",
-              "iconClass": "icon-mongodb",
-              "openshift.io/display-name": "MongoDB 2.6",
+              "openshift.io/display-name": "MongoDB 2.7",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
               "tags": "hidden,database,mongodb",
-              "version": "2.6"
+              "version": "2.7"
             },
             "from": {
               "kind": "DockerImage",
               "name": "docker.io/centos/mongodb-26-centos7:latest"
             },
-            "name": "2.6",
+            "name": "2.7",
             "referencePolicy": {
               "type": "Local"
             }
@@ -1258,7 +1240,7 @@
             },
             "from": {
               "kind": "ImageStreamTag",
-              "name": "2.5"
+              "name": "2.7"
             },
             "name": "latest",
             "referencePolicy": {
@@ -1266,101 +1248,23 @@
             }
           },
           {
+            "name": "2.7-ubi8",
             "annotations": {
-              "description": "Build and run Ruby 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.0/README.md.",
+              "description": "Build and run Ruby 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.7/README.md.",
               "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.0",
+              "openshift.io/display-name": "Ruby 2.7 (UBI 8)",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
               "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.0,ruby",
-              "tags": "hidden,builder,ruby",
-              "version": "2.0"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/openshift/ruby-20-centos7:latest"
-            },
-            "name": "2.0",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run Ruby 2.2 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.2/README.md.",
-              "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.2",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.2,ruby",
-              "tags": "hidden,builder,ruby",
-              "version": "2.2"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-22-centos7:latest"
-            },
-            "name": "2.2",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run Ruby 2.3 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.3/README.md.",
-              "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.3",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.3,ruby",
+              "supports": "ruby:2.7,ruby",
               "tags": "builder,ruby",
-              "version": "2.3"
+              "version": "2.7"
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-23-centos7:latest"
+              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
             },
-            "name": "2.3",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run Ruby 2.4 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.4/README.md.",
-              "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.4",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.4,ruby",
-              "tags": "builder,ruby",
-              "version": "2.4"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-24-centos7:latest"
-            },
-            "name": "2.4",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run Ruby 2.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
-              "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 2.5",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:2.5,ruby",
-              "tags": "builder,ruby",
-              "version": "2.5"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
-            },
-            "name": "2.5",
+            "generation": null,
+            "importPolicy": {},
             "referencePolicy": {
               "type": "Local"
             }

--- a/test/extended/testdata/cmd/test/cmd/testdata/modified-ruby-imagestream.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/modified-ruby-imagestream.json
@@ -10,27 +10,27 @@
   "spec": {
     "tags": [
       {
-        "name": "2.4",
+        "name": "2.7",
         "annotations": {
           "openshift.io/display-name": "Ruby Patched",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.4 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.4/README.md.",
+          "description": "Build and run Ruby 2.7 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.7/README.md.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
-          "supports": "ruby:2.4,ruby",
-          "version": "2.4 patched",
+          "supports": "ruby:2.7,ruby",
+          "version": "2.7 patched",
           "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "centos/ruby-24-centos7:latest"
+          "name": "registry.centos.org/centos/ruby-27-centos7:latest"
         }
       },
       {
         "name": "newtag",
         "from": {
           "kind": "DockerImage",
-          "name": "centos/ruby-24-centos7:latest"
+          "name": "registry.centos.org/centos/ruby-27-centos7:latest"
         }
       }
     ]

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/build-arg-dockerfile/Dockerfile
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/build-arg-dockerfile/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos/ruby-25-centos7
+FROM centos/ruby-27-centos7
 ARG foo
 RUN echo $foo

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/imagestream-ref.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/imagestream-ref.yaml
@@ -6,9 +6,9 @@ spec:
   tags:
   - from:
       kind: ImageStreamTag
-      name: "2.3"
+      name: "2.7"
     name: "latest"
   - from:
       kind: ImageStreamTag
-      name: ruby:2.3
-    name: "2.3"
+      name: ruby:2.7
+    name: "2.7"

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/template-with-app-label.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/template-with-app-label.json
@@ -73,11 +73,11 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7",
+        "name": "ruby-27-centos7",
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -127,7 +127,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/template-without-app-label.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/template-without-app-label.json
@@ -77,11 +77,11 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "ruby-25-centos7",
+        "name": "ruby-27-centos7",
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "centos/ruby-25-centos7"
+        "dockerImageRepository": "centos/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -130,7 +130,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby-25-centos7:latest"
+              "name": "ruby-27-centos7:latest"
             },
             "env": [
               {

--- a/test/extended/testdata/cmd/test/cmd/testdata/statefulset.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/statefulset.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: testapp
-        image: centos/ruby-25-centos7:latest
+        image: centos/ruby-27-centos7:latest
         command:
         - /bin/sleep
         args:

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-bc.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-bc.yaml
@@ -14,7 +14,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: centos/ruby-25-centos7
+        name: centos/ruby-27-centos7
     type: Source
   triggers: []
 status:

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-image.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-image.json
@@ -5,7 +5,7 @@
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "openshift/ruby-19-centos:latest",
+  "dockerImageReference": "registry.redhat.io/rhscl/ruby-27-rhel7:latest",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",

--- a/test/extended/testdata/cmd/test/cmd/triggers.sh
+++ b/test/extended/testdata/cmd/test/cmd/triggers.sh
@@ -16,7 +16,7 @@ project="$(oc project -q)"
 os::test::junit::declare_suite_start "cmd/triggers"
 # This test validates triggers
 
-os::cmd::expect_success 'oc new-app centos/ruby-25-centos7~https://github.com/openshift/ruby-hello-world.git'
+os::cmd::expect_success 'oc new-app centos/ruby-27-centos7~https://github.com/openshift/ruby-hello-world.git'
 os::cmd::expect_success 'oc get bc/ruby-hello-world'
 
 os::cmd::expect_success "oc new-build --name=scratch --docker-image=scratch --dockerfile='FROM scratch'"
@@ -29,7 +29,7 @@ os::cmd::expect_failure_and_text 'oc set triggers bc/ruby-hello-world --remove -
 os::cmd::expect_failure_and_text 'oc set triggers bc/ruby-hello-world --auto --manual' 'at most one of --auto or --manual'
 # print
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'config.*true'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:latest.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:latest.*true'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'webhook'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'github'
 # note, oc new-app currently does not set up gitlab or bitbucket webhooks by default
@@ -46,7 +46,7 @@ os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --remove-a
 
 os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'webhook|github'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'config.*false'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:latest.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:latest.*false'
 # set github hook
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-github' 'updated'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'github'
@@ -73,18 +73,18 @@ os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'bitbucke
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --remove --from-bitbucket' 'updated'
 os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'bitbucket'
 # set from-image
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-25-centos7:other' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:other.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other.*true'
 # manual and remove both clear build configs
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-25-centos7:other --manual' 'updated'
-os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:other.*false'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-25-centos7:other' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-25-centos7:other --remove' 'updated'
-os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-25-centos7:other'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other --manual' 'updated'
+os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other --remove' 'updated'
+os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other'
 # test --all
-os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-25-centos7:latest.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-27-centos7:latest.*false'
 os::cmd::expect_success_and_text 'oc set triggers bc --all --auto' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-25-centos7:latest.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-27-centos7:latest.*true'
 # set a trigger on a build that doesn't have an imagestream strategy.from-image
 os::cmd::expect_success_and_text 'oc set triggers bc/scratch --from-image=test:latest' 'updated'
 

--- a/test/extended/testdata/custom-secret-builder/build.sh
+++ b/test/extended/testdata/custom-secret-builder/build.sh
@@ -35,7 +35,7 @@ run Proc.new { |env|
 EOF
 
 cat > Dockerfile <<- EOF
-FROM centos/ruby-25-centos7
+FROM centos/ruby-27-centos7
 ENV SECRET_FILE /opt/openshift/src/dockercfg
 COPY dockercfg ./
 COPY config.ru ./

--- a/test/extended/testdata/image/test-image.json
+++ b/test/extended/testdata/image/test-image.json
@@ -5,7 +5,7 @@
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "registry.redhat.io/rhscl/ruby-25-rhel7:latest",
+  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",

--- a/test/extended/testdata/jenkins-plugin/multitag-template.json
+++ b/test/extended/testdata/jenkins-plugin/multitag-template.json
@@ -18,7 +18,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             }
           }
         ]
@@ -36,7 +36,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             }
           }
         ]
@@ -54,7 +54,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
             }
           }
         ]

--- a/test/extended/testdata/long_names/Dockerfile
+++ b/test/extended/testdata/long_names/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos/ruby-25-centos7
+FROM centos/ruby-27-centos7
 
 CMD ["/bin/sh", "-c", "echo", "hello"]

--- a/test/extended/testdata/long_names/fixture.json
+++ b/test/extended/testdata/long_names/fixture.json
@@ -26,7 +26,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
                         }
                     }
                 }
@@ -55,7 +55,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
                         }
                     }
                 }

--- a/test/extended/testdata/run_policy/parallel-bc.yaml
+++ b/test/extended/testdata/run_policy/parallel-bc.yaml
@@ -2,38 +2,37 @@
   kind: "List"
   apiVersion: "v1"
   metadata: {}
-  items: 
-    - 
+  items:
+    -
       kind: "ImageStream"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "origin-ruby-sample"
         creationTimestamp: null
       spec: {}
-      status: 
+      status:
         dockerImageRepository: ""
-    - 
+    -
       kind: "BuildConfig"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "sample-parallel-build"
-      spec: 
+      spec:
         runPolicy: "Parallel"
-        triggers: 
-          - 
+        triggers:
+          -
             type: "imageChange"
             imageChange: {}
-        source: 
+        source:
           type: "Git"
-          git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
-        strategy: 
+          git:
+            uri: "https://github.com/openshift/ruby-hello-world.git"
+        strategy:
           type: "Source"
-          sourceStrategy: 
-            from: 
+          sourceStrategy:
+            from:
               kind: "DockerImage"
-              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
         resources: {}
-      status: 
+      status:
         lastVersion: 0
-

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -2,46 +2,46 @@
   kind: "List"
   apiVersion: "v1"
   metadata: {}
-  items: 
-    - 
+  items:
+    -
       kind: "BuildConfig"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "sample-serial-build"
-      spec: 
+      spec:
         runPolicy: "Serial"
-        triggers: 
-          - 
+        triggers:
+          -
             type: "imageChange"
             imageChange: {}
-        source: 
+        source:
           type: "Git"
-          git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
-        strategy: 
+          git:
+            uri: "https://github.com/openshift/ruby-hello-world.git"
+        strategy:
           type: "Source"
-          sourceStrategy: 
-            from: 
+          sourceStrategy:
+            from:
               kind: "DockerImage"
-              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
-    - 
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
+    -
       kind: "BuildConfig"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "sample-serial-build-fail"
-      spec: 
+      spec:
         runPolicy: "Serial"
-        triggers: 
-          - 
+        triggers:
+          -
             type: "imageChange"
             imageChange: {}
-        source: 
+        source:
           type: "Git"
-          git: 
-            uri: "git://github.com/openshift/invalidrepo.git"
-        strategy: 
+          git:
+            uri: "https://github.com/openshift/invalidrepo.git"
+        strategy:
           type: "Source"
-          sourceStrategy: 
-            from: 
+          sourceStrategy:
+            from:
               kind: "DockerImage"
-              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"

--- a/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
@@ -2,29 +2,28 @@
   kind: "List"
   apiVersion: "v1"
   metadata: {}
-  items: 
-    - 
+  items:
+    -
       kind: "BuildConfig"
       apiVersion: "v1"
-      metadata: 
+      metadata:
         name: "sample-serial-latest-only-build"
-      spec: 
+      spec:
         runPolicy: "SerialLatestOnly"
-        triggers: 
-          - 
+        triggers:
+          -
             type: "imageChange"
             imageChange: {}
-        source: 
+        source:
           type: "Git"
-          git: 
-            uri: "git://github.com/openshift/ruby-hello-world.git"
-        strategy: 
+          git:
+            uri: "https://github.com/openshift/ruby-hello-world.git"
+        strategy:
           type: "Source"
-          sourceStrategy: 
-            from: 
+          sourceStrategy:
+            from:
               kind: "DockerImage"
-              name: "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7"
         resources: {}
-      status: 
+      status:
         lastVersion: 0
-

--- a/test/extended/testdata/s2i-dropcaps/rootable-ruby/Dockerfile
+++ b/test/extended/testdata/s2i-dropcaps/rootable-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-25-centos7:latest
+FROM centos/ruby-27-centos7:latest
 USER root
 RUN rm -f /usr/bin/ls
 RUN echo "root:redhat" | chpasswd

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1615,11 +1615,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"registry.redhat.io/rhscl/python-36-rhel7\" should print the usage": "\"registry.redhat.io/rhscl/python-36-rhel7\" should print the usage",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"registry.redhat.io/rhscl/ruby-24-rhel7\" should print the usage": "\"registry.redhat.io/rhscl/ruby-24-rhel7\" should print the usage",
-
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"registry.redhat.io/rhscl/ruby-25-rhel7\" should print the usage": "\"registry.redhat.io/rhscl/ruby-25-rhel7\" should print the usage",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"registry.redhat.io/rhscl/ruby-26-rhel7\" should print the usage": "\"registry.redhat.io/rhscl/ruby-26-rhel7\" should print the usage",
+
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"registry.redhat.io/rhscl/ruby-27-rhel7\" should print the usage": "\"registry.redhat.io/rhscl/ruby-27-rhel7\" should print the usage",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"registry.redhat.io/rhscl/nodejs-10-rhel7\" should be SCL enabled": "\"registry.redhat.io/rhscl/nodejs-10-rhel7\" should be SCL enabled",
 
@@ -1635,11 +1633,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"registry.redhat.io/rhscl/python-36-rhel7\" should be SCL enabled": "\"registry.redhat.io/rhscl/python-36-rhel7\" should be SCL enabled",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"registry.redhat.io/rhscl/ruby-24-rhel7\" should be SCL enabled": "\"registry.redhat.io/rhscl/ruby-24-rhel7\" should be SCL enabled",
-
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"registry.redhat.io/rhscl/ruby-25-rhel7\" should be SCL enabled": "\"registry.redhat.io/rhscl/ruby-25-rhel7\" should be SCL enabled",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"registry.redhat.io/rhscl/ruby-26-rhel7\" should be SCL enabled": "\"registry.redhat.io/rhscl/ruby-26-rhel7\" should be SCL enabled",
+
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"registry.redhat.io/rhscl/ruby-27-rhel7\" should be SCL enabled": "\"registry.redhat.io/rhscl/ruby-27-rhel7\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][php] test php images with cakephp-ex db repo  Building cakephp-mysql app from new-app should build a cakephp-mysql image and run it in a pod": "should build a cakephp-mysql image and run it in a pod",
 


### PR DESCRIPTION
Ruby 2.5 is now EOL, and github.com/openshift/ruby-hello-world was updated to use Ruby 2.7