### PR TITLE
DO NOT MERGE: Test whether multi-az test is impacted by deleting pods

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -205,8 +205,8 @@ func skipTestNamespaceCustomization() bool {
 
 // createTestingNS ensures that kubernetes e2e tests have their service accounts in the privileged and anyuid SCCs
 func createTestingNS(baseName string, c kclientset.Interface, labels map[string]string) (*kapiv1.Namespace, error) {
-	if !strings.HasPrefix(baseName, "e2e-") {
-		baseName = "e2e-" + baseName
+	if !strings.HasPrefix(baseName, "e2e-test-") {
+		baseName = "e2e-test-" + baseName
 	}
 
 	ns, err := e2e.CreateTestingNS(baseName, c, labels)
@@ -215,7 +215,7 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 	}
 
 	// Add anyuid and privileged permissions for upstream tests
-	if strings.HasPrefix(baseName, "e2e-k8s-") || (isKubernetesE2ETest() && !skipTestNamespaceCustomization()) {
+	if isKubernetesE2ETest() {
 		clientConfig, err := getClientConfig(KubeConfigPath())
 		if err != nil {
 			return ns, err

--- a/vendor/k8s.io/kubernetes/test/e2e/scheduling/ubernetes_lite.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/scheduling/ubernetes_lite.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -58,6 +58,12 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 		cs := f.ClientSet
 		e2enode.WaitForTotalHealthy(cs, time.Minute)
 		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
+
+		// ensure no terminating pods still remain on nodes, which ensures the
+		// balanced pods we create next are still accurate when the time the test
+		// starts
+		err = framework.CheckTestingNSDeletedExcept(f.ClientSet, f.Namespace.Name)
 		framework.ExpectNoError(err)
 
 		// make the nodes have balanced cpu,mem usage


### PR DESCRIPTION
Working hypothesis is that deleting pods are being taken into account by
the createBalancedPodForNodes method and then the nodes are left slightly
unbalanced, which results in workloads being steered to the less utilized
nodes. Observed 6 pods on each node that were from previous tests, so
there's a good chance that this reduces the potential for churn.

Will test with this repeatedly.

Depends on:

   test: Use a consistent namespace prefix for all tests

   Simplify the test for kubernetes namespaces.