### PR TITLE
test: Mark pod transition back to pending as a flake for now

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -37,6 +37,7 @@ func SystemUpgradeEventInvariants(events monitor.EventIntervals, duration time.D
 	results, kubeAPIOk := testKubeAPIServerGracefulTermination(events)
 	tests = append(tests, results...)
 	results, kubeletOk := testKubeletToAPIServerGracefulTermination(events)
+	tests = append(tests, results...)
 	tests = append(tests, testPodTransitions(events)...)
 	tests = append(tests, testPodSandboxCreation(events)...)
 	results, nodeUpgradeOk := testNodeUpgradeTransitions(events)

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -88,13 +88,11 @@ func testPodTransitions(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase
 		Name:      testName,
 		SystemOut: strings.Join(failures, "\n"),
 		FailureOutput: &ginkgo.FailureOutput{
-			Output: fmt.Sprintf("%d pods illegally transitioned to Pending\n\n%v", len(failures), strings.Join(failures, "\n")),
+			Output: fmt.Sprintf("Marked as flake until https://bugzilla.redhat.com/show_bug.cgi?id=1933760 is fixed\n\n%d pods illegally transitioned to Pending\n\n%v", len(failures), strings.Join(failures, "\n")),
 		},
 	}
-
-	// TODO an upgrade job that starts before 4.6 may need to make this test flake instead of fail.  This will depend on which `openshift-tests`
-	//  is used to run that upgrade test.  I recommend waiting to a flake until we know and even then find a way to constrain it.
-	return []*ginkgo.JUnitTestCase{failure}
+	// TODO: temporarily marked flaky since it is continously failing
+	return []*ginkgo.JUnitTestCase{failure, success}
 }
 
 func formatTimes(times []time.Time) []string {


### PR DESCRIPTION
It is continuously failing and blocking merges is unnecessary because
it is a symptom and we have an urgent bug.