### PR TITLE
pkg/synthetictests/operators: Include the reason string in testOperatorState

### DIFF
--- a/pkg/monitor/operator_test.go
+++ b/pkg/monitor/operator_test.go
@@ -65,29 +65,43 @@ func TestGetOperatorConditionStatus(t *testing.T) {
 	tests := []struct {
 		name    string
 		message string
-		want    string
-		want1   bool
-		want3   string
+		want    *configv1.ClusterOperatorStatusCondition
 	}{
 		{
 			name:    "simple",
 			message: "condition/Degraded status/True reason/DNSDegraded changed: DNS default is degraded",
-			want:    "Degraded",
-			want1:   true,
-			want3:   "DNS default is degraded",
+			want: &configv1.ClusterOperatorStatusCondition{
+				Type:    configv1.OperatorDegraded,
+				Status:  configv1.ConditionTrue,
+				Reason:  "DNSDegraded",
+				Message: "DNS default is degraded",
+			},
+		},
+		{
+			name:    "unknown",
+			message: "condition/Upgradeable status/Unknown reason/NoData changed: blah blah",
+			want: &configv1.ClusterOperatorStatusCondition{
+				Type:    configv1.OperatorUpgradeable,
+				Status:  configv1.ConditionUnknown,
+				Reason:  "NoData",
+				Message: "blah blah",
+			},
+		},
+		{
+			name:    "repeat reason",
+			message: "condition/Available status/True reason/AsExpected changed: reason/again",
+			want: &configv1.ClusterOperatorStatusCondition{
+				Type:    configv1.OperatorAvailable,
+				Status:  configv1.ConditionTrue,
+				Reason:  "AsExpected",
+				Message: "reason/again",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got3 := GetOperatorConditionStatus(tt.message)
-			if got != tt.want {
+			if got := GetOperatorConditionStatus(tt.message); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetOperatorConditionStatus() got = %v, want %v", got, tt.want)
-			}
-			if got1 != tt.want1 {
-				t.Errorf("GetOperatorConditionStatus() got1 = %v, want %v", got1, tt.want1)
-			}
-			if got3 != tt.want3 {
-				t.Errorf("GetOperatorConditionStatus() got3 = %v, want %v", got3, tt.want3)
 			}
 		})
 	}


### PR DESCRIPTION
Extending the the logic from 6ec446bad7 (#25918) to include the reason, since that slug both makes it easier to find the relevant operator code and makes it easier to match CI flakes with seen-in-the-wild Telemetry (where we get the status and reason, but not the message).

I'm also moving some string types into structured config/v1 types. Narrowly, this makes it easier for `GetOperatorConditionStatus` to return all its metadata without a big-list-of-strings API.  More broadly, this drops things like "assume status is a boolean, and neglect `Unknown` and unrecognized values".  This also means that we can't use `!status` to guess at what the previous status was, so I've dropped that and now only talk about the data we actually have.