### PR TITLE
Bug 1909875: upgrade/upgrade.go: Enhance upgrade ack time out error

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -319,6 +319,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 				return err
 			}
 			updated = cv
+			var observedGeneration int64
 
 			// wait until the cluster acknowledges the update
 			if err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
@@ -326,10 +327,13 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 				if err != nil || cv == nil {
 					return false, err
 				}
+				observedGeneration = cv.Status.ObservedGeneration
 				return cv.Status.ObservedGeneration >= updated.Generation, nil
 
 			}); err != nil {
-				return fmt.Errorf("timed out waiting for cluster to acknowledge upgrade: %v", err)
+				return fmt.Errorf(
+					"Timed out waiting for cluster to acknowledge upgrade: %v; observedGeneration: %d; updated.Generation: %d",
+					err, observedGeneration, updated.Generation)
 			}
 			return nil
 		},


### PR DESCRIPTION
To include values of observed generation and updated generation to help
diagnose issue [1].

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1909875