### PR TITLE
test: Mark kubelet terminates non-gracefully as a flake

### DIFF
--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -33,7 +33,11 @@ func testKubeletToAPIServerGracefulTermination(events []*monitor.EventInterval) 
 				Output: fmt.Sprintf("%d kube-apiserver reports a non-graceful termination.  Probably kubelet or CRI-O is not giving the time to cleanly shut down. This can lead to connection refused and network I/O timeout errors in other components.\n\n%v", len(failures), strings.Join(failures, "\n")),
 			},
 		})
-		pass = false
+
+		// while waiting for https://bugzilla.redhat.com/show_bug.cgi?id=1928946 mark as flake
+		tests[0].FailureOutput.Output = "Marked flake while fix for https://bugzilla.redhat.com/show_bug.cgi?id=1928946 is identified:\n\n" + tests[0].FailureOutput.Output
+		// pass = false
+		tests = append(tests, &ginkgo.JUnitTestCase{Name: testName})
 	} else {
 		tests = append(tests, &ginkgo.JUnitTestCase{Name: testName})
 	}


### PR DESCRIPTION
Now that we have a root cause, mark this a flake until the crio
fix is in place.