### PR TITLE
test: Synthetics should only return junit tests instead of a bool

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -202,7 +202,7 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 
 	// any image not in the allowed prefixes is considered a failure, as the user
 	// may have added a new test image without calling the appropriate helpers
-	return func(events monitor.EventIntervals, _ time.Duration) ([]*ginkgo.JUnitTestCase, bool) {
+	return func(events monitor.EventIntervals, _ time.Duration) []*ginkgo.JUnitTestCase {
 		imageStreamPrefixes, err := imagePrefixesFromNamespaceImageStreams("openshift")
 		if err != nil {
 			klog.Errorf("Unable to identify image prefixes from the openshift namespace: %v", err)
@@ -211,7 +211,6 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 
 		allowedPrefixes := allowedPrefixes.List()
 
-		passed := true
 		var tests []*ginkgo.JUnitTestCase
 
 		pulls := make(map[string]sets.String)
@@ -260,10 +259,9 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 					Output: fmt.Sprintf("Cluster accessed images that were not mirrored to the testing repository or already part of the cluster, see test/extended/util/image/README.md in the openshift/origin repo:\n\n%s", buf.String()),
 				},
 			})
-			passed = false
 		}
 
-		return tests, passed
+		return tests
 	}
 }
 

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -11,10 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testKubeletToAPIServerGracefulTermination(events []*monitor.EventInterval) ([]*ginkgo.JUnitTestCase, bool) {
+func testKubeletToAPIServerGracefulTermination(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] kubelet terminates kube-apiserver gracefully"
-
-	pass := true
 
 	var failures []string
 	for _, event := range events {
@@ -36,19 +34,17 @@ func testKubeletToAPIServerGracefulTermination(events []*monitor.EventInterval) 
 
 		// while waiting for https://bugzilla.redhat.com/show_bug.cgi?id=1928946 mark as flake
 		tests[0].FailureOutput.Output = "Marked flake while fix for https://bugzilla.redhat.com/show_bug.cgi?id=1928946 is identified:\n\n" + tests[0].FailureOutput.Output
-		// pass = false
-		tests = append(tests, &ginkgo.JUnitTestCase{Name: testName})
-	} else {
 		tests = append(tests, &ginkgo.JUnitTestCase{Name: testName})
 	}
 
-	return tests, pass
+	if len(tests) == 0 {
+		tests = append(tests, &ginkgo.JUnitTestCase{Name: testName})
+	}
+	return tests
 }
 
-func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) ([]*ginkgo.JUnitTestCase, bool) {
+func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-api-machinery] kube-apiserver terminates within graceful termination period"
-
-	pass := true
 
 	var failures []string
 	for _, event := range events {
@@ -67,11 +63,12 @@ func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) ([]*g
 				Output: fmt.Sprintf("%d kube-apiserver reports a non-graceful termination. This is a bug in kube-apiserver. It probably means that network connections are not closed cleanly, and this leads to network I/O timeout errors in other components.\n\n%v", len(failures), strings.Join(failures, "\n")),
 			},
 		})
-		pass = false
-	} else {
+	}
+
+	if len(tests) == 0 {
 		tests = append(tests, &ginkgo.JUnitTestCase{Name: testName})
 	}
-	return tests, pass
+	return tests
 }
 
 func testPodTransitions(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
@@ -107,7 +104,7 @@ func formatTimes(times []time.Time) []string {
 	return s
 }
 
-func testNodeUpgradeTransitions(events []*monitor.EventInterval) ([]*ginkgo.JUnitTestCase, bool) {
+func testNodeUpgradeTransitions(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] nodes should not go unready after being upgraded and go unready only once"
 
 	var buf bytes.Buffer
@@ -204,9 +201,8 @@ func testNodeUpgradeTransitions(events []*monitor.EventInterval) ([]*ginkgo.JUni
 	}
 	if len(testCases) == 0 {
 		testCases = append(testCases, &ginkgo.JUnitTestCase{Name: testName})
-		return testCases, true
 	}
-	return testCases, false
+	return testCases
 }
 
 func testSystemDTimeout(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -33,7 +33,11 @@ func testKubeletToAPIServerGracefulTermination(events []*monitor.EventInterval) 
 				Output: fmt.Sprintf("%d kube-apiserver reports a non-graceful termination.  Probably kubelet or CRI-O is not giving the time to cleanly shut down. This can lead to connection refused and network I/O timeout errors in other components.\n\n%v", len(failures), strings.Join(failures, "\n")),
 			},
 		})
-		pass = false
+
+		// while waiting for https://bugzilla.redhat.com/show_bug.cgi?id=1928946 mark as flake
+		tests[0].FailureOutput.Output = "Marked flake while fix for https://bugzilla.redhat.com/show_bug.cgi?id=1928946 is identified:\n\n" + tests[0].FailureOutput.Output
+		// pass = false
+		tests = append(tests, &ginkgo.JUnitTestCase{Name: testName})
 	} else {
 		tests = append(tests, &ginkgo.JUnitTestCase{Name: testName})
 	}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -285,11 +285,8 @@ func (opt *Options) Run(suite *TestSuite) error {
 
 		var buf *bytes.Buffer
 		syntheticTestResults, buf, _ = createSyntheticTestsFromMonitor(m, eventsForTests, duration)
-		testCases, passed := syntheticEventTests.JUnitsForEvents(events, duration)
+		testCases := syntheticEventTests.JUnitsForEvents(events, duration)
 		syntheticTestResults = append(syntheticTestResults, testCases...)
-		if !passed {
-			syntheticFailure = true
-		}
 
 		if len(syntheticTestResults) > 0 {
 			// mark any failures by name
@@ -311,6 +308,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 			failing = failing.Difference(flaky)
 			if failing.Len() > 0 {
 				fmt.Fprintf(buf, "Failing invariants:\n\n%s\n\n", strings.Join(failing.List(), "\n"))
+				syntheticFailure = true
 			}
 			if flaky.Len() > 0 {
 				fmt.Fprintf(buf, "Flaky invariants:\n\n%s\n\n", strings.Join(flaky.List(), "\n"))

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -15,13 +15,13 @@ type JUnitsForEvents interface {
 	// JUnitsForEvents returns a set of additional test passes or failures implied by the
 	// events sent during the test suite run. If passed is false, the entire suite is failed.
 	// To set a test as flaky, return a passing and failing JUnitTestCase with the same name.
-	JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) (results []*JUnitTestCase, passed bool)
+	JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) []*JUnitTestCase
 }
 
 // JUnitForEventsFunc converts a function into the JUnitForEvents interface.
-type JUnitForEventsFunc func(events monitor.EventIntervals, duration time.Duration) (results []*JUnitTestCase, passed bool)
+type JUnitForEventsFunc func(events monitor.EventIntervals, duration time.Duration) []*JUnitTestCase
 
-func (fn JUnitForEventsFunc) JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) (results []*JUnitTestCase, passed bool) {
+func (fn JUnitForEventsFunc) JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) []*JUnitTestCase {
 	return fn(events, duration)
 }
 
@@ -29,19 +29,16 @@ func (fn JUnitForEventsFunc) JUnitsForEvents(events monitor.EventIntervals, dura
 // the result of all invocations. It ignores nil interfaces.
 type JUnitsForAllEvents []JUnitsForEvents
 
-func (a JUnitsForAllEvents) JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) (all []*JUnitTestCase, passed bool) {
-	passed = true
+func (a JUnitsForAllEvents) JUnitsForEvents(events monitor.EventIntervals, duration time.Duration) []*JUnitTestCase {
+	var all []*JUnitTestCase
 	for _, obj := range a {
 		if obj == nil {
 			continue
 		}
-		results, testPassed := obj.JUnitsForEvents(events, duration)
-		if !testPassed {
-			passed = false
-		}
+		results := obj.JUnitsForEvents(events, duration)
 		all = append(all, results...)
 	}
-	return all, passed
+	return all
 }
 
 func createEventsForTests(tests []*testCase) []*monitor.EventInterval {


### PR DESCRIPTION
The bool was complex and easy to get wrong, we now simply expect flakes to
be reported with a duplicate junit.