### PR TITLE
tests/extended: Add a basic sanity test for CoreOS bootimages

### DIFF
--- a/test/extended/coreos/coreos.go
+++ b/test/extended/coreos/coreos.go
@@ -1,0 +1,42 @@
+package coreos
+
+import (
+	"context"
+	"encoding/json"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	mcoNamespace = "openshift-machine-config-operator"
+	cmName       = "coreos-bootimages"
+	cmKey        = "stream"
+)
+
+// stream is a subset of https://github.com/coreos/stream-metadata-go
+// in the future we could vendor that, but it doesn't matter much
+// right now, we're just sanity checking the config exists.
+type stream struct {
+	Stream string `json:"stream"`
+}
+
+// This test validates https://github.com/openshift/enhancements/pull/679
+var _ = g.Describe("[sig-coreos] [Conformance] CoreOS bootimages", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithoutNamespace("coreos")
+	g.It("TestBootimagesPresent", func() {
+		client := oc.AdminKubeClient()
+		cm, err := client.CoreV1().ConfigMaps(mcoNamespace).Get(context.Background(), cmName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		d, ok := cm.Data[cmKey]
+		o.Expect(ok).To(o.BeTrue())
+		var st stream
+		err = json.Unmarshal([]byte(d), &st)
+		o.Expect(err).To(o.BeNil())
+		o.Expect(len(st.Stream)).ToNot(o.BeZero())
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/cluster"
 	_ "github.com/openshift/origin/test/extended/cmd"
 	_ "github.com/openshift/origin/test/extended/controller_manager"
+	_ "github.com/openshift/origin/test/extended/coreos"
 	_ "github.com/openshift/origin/test/extended/crdvalidation"
 	_ "github.com/openshift/origin/test/extended/csrapprover"
 	_ "github.com/openshift/origin/test/extended/deployments"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1647,6 +1647,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously": "grow and decrease when scaling different machineSets simultaneously [Suite:openshift/conformance/serial]",
 
+	"[Top Level] [sig-coreos] [Conformance] CoreOS bootimages TestBootimagesPresent": "TestBootimagesPresent [Suite:openshift/conformance/parallel/minimal]",
+
 	"[Top Level] [sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations": "run sample related validations [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:10\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:10\" should print the usage",


### PR DESCRIPTION
This validates https://github.com/openshift/installer/pull/4760
until we have an in-cluster consumer.