### PR TITLE
test: add baremetal provider

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -99,7 +99,7 @@ func decodeProvider(provider string, dryRun, discover bool) (*exutilcloud.Cluste
 		}
 		fallthrough
 
-	case "azure", "aws", "gce", "vsphere":
+	case "azure", "aws", "baremetal", "gce", "vsphere":
 		clientConfig, err := e2e.LoadConfig(true)
 		if err != nil {
 			return nil, err

--- a/test/extended/util/baremetal/provider.go
+++ b/test/extended/util/baremetal/provider.go
@@ -1,0 +1,18 @@
+package baremetal
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func init() {
+	framework.RegisterProvider("baremetal", newProvider)
+}
+
+func newProvider() (framework.ProviderInterface, error) {
+	return &Provider{}, nil
+}
+
+// Provider is a structure to handle baremetal for e2e testing
+type Provider struct {
+	framework.NullProvider
+}


### PR DESCRIPTION
Baremetal IPI tests currently run without any provider set. While we're not so
interested in the cloud specific parts, we at least need a null provider
because loading the config also loads which SDN framework we're using,
and allows us to skip specific tests when using OVN.  Currently the
tests that should be skipped on OVN, aren't -- they're filtered manually
by passing a list of tests to skip.