### PR TITLE
remove unused initiatedAt in favor of a single At for monitor events

### DIFF
--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -68,10 +68,10 @@ func E2ETestsRunningBetween(events []*EventInterval, start, end time.Time) map[s
 		for _, event := range events {
 			switch {
 			case event.Message == "started":
-				currInterval.start = event.InitiatedAt
+				currInterval.start = event.From
 				currInterval.events = append(currInterval.events, event)
 			case strings.HasPrefix(event.Message, "finishedStatus/"):
-				currInterval.end = event.InitiatedAt
+				currInterval.end = event.From
 				currInterval.events = append(currInterval.events, event)
 				runningIntervals = append(runningIntervals, currInterval)
 

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -141,7 +141,7 @@ func (m *Monitor) Events(from, to time.Time) EventIntervals {
 		}
 
 		to := events[i].At
-		from := events[i].InitiatedAt
+		from := events[i].At
 		if from.IsZero() {
 			from = to
 		}

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -54,8 +54,6 @@ type Condition struct {
 
 	Locator string
 	Message string
-
-	InitiatedAt time.Time
 }
 
 type EventInterval struct {

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -100,11 +100,11 @@ func testOperatorState(interestingCondition configv1.ClusterStatusConditionType,
 
 			startTime := time.Now().Add(4 * time.Hour)
 			if previousEvent != nil {
-				startTime = previousEvent.InitiatedAt
+				startTime = previousEvent.From
 			}
-			failedTests := monitor.FindFailedTestsActiveBetween(e2eEvents, startTime, event.InitiatedAt)
+			failedTests := monitor.FindFailedTestsActiveBetween(e2eEvents, startTime, event.From)
 			if len(failedTests) > 0 {
-				failures = append(failures, fmt.Sprintf("%d tests failed during this blip (%v to %v): %v", len(failedTests), startTime, event.InitiatedAt, strings.Join(failedTests, ",")))
+				failures = append(failures, fmt.Sprintf("%d tests failed during this blip (%v to %v): %v", len(failedTests), startTime, event.From, strings.Join(failedTests, ",")))
 			}
 		}
 	}


### PR DESCRIPTION
We only ever set At near as I can tell.  And I coded in a bug because of this before. :(