### PR TITLE
allow separating monitor event identification from monitor event generation

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -9,17 +9,14 @@ import (
 	"strings"
 	"time"
 
+	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo"
+	"github.com/openshift/origin/test/extended/util/image"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
-
-	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
-	"github.com/openshift/library-go/pkg/image/reference"
-
-	"github.com/openshift/origin/pkg/monitor"
-	"github.com/openshift/origin/pkg/test/ginkgo"
-	"github.com/openshift/origin/test/extended/util/image"
-
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	k8simage "k8s.io/kubernetes/test/utils/image"
 )
@@ -202,7 +199,7 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 
 	// any image not in the allowed prefixes is considered a failure, as the user
 	// may have added a new test image without calling the appropriate helpers
-	return func(events monitor.EventIntervals, _ time.Duration) []*ginkgo.JUnitTestCase {
+	return func(events monitorapi.EventIntervals, _ time.Duration) []*ginkgo.JUnitTestCase {
 		imageStreamPrefixes, err := imagePrefixesFromNamespaceImageStreams("openshift")
 		if err != nil {
 			klog.Errorf("Unable to identify image prefixes from the openshift namespace: %v", err)

--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -250,10 +250,6 @@ func locatePod(pod *corev1.Pod) string {
 	return fmt.Sprintf("ns/%s pod/%s node/%s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 }
 
-func locateNode(node *corev1.Node) string {
-	return fmt.Sprintf("node/%s", node.Name)
-}
-
 func locatePodContainer(pod *corev1.Pod, containerName string) string {
 	return fmt.Sprintf("ns/%s pod/%s node/%s container/%s", pod.Namespace, pod.Name, pod.Spec.NodeName, containerName)
 }

--- a/pkg/monitor/cmd.go
+++ b/pkg/monitor/cmd.go
@@ -54,7 +54,7 @@ func (opt *Options) Run() error {
 			case <-ctx.Done():
 				done = true
 			}
-			events := m.Events(last, time.Time{})
+			events := m.EventIntervals(last, time.Time{})
 			if len(events) > 0 {
 				for _, event := range events {
 					if !event.From.Equal(event.To) {

--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
 func E2ETestLocator(testName string) string {
@@ -30,8 +32,8 @@ func E2ETestFromLocator(locator string) (string, bool) {
 }
 
 // EventsByE2ETest returns map keyed by e2e test name (may contain spaces).
-func EventsByE2ETest(events []*EventInterval) map[string][]*EventInterval {
-	eventsByE2ETest := map[string][]*EventInterval{}
+func EventsByE2ETest(events []*monitorapi.EventInterval) map[string][]*monitorapi.EventInterval {
+	eventsByE2ETest := map[string][]*monitorapi.EventInterval{}
 	for _, event := range events {
 		if !strings.Contains(event.Locator, "e2e-test/") {
 			continue
@@ -46,8 +48,8 @@ func EventsByE2ETest(events []*EventInterval) map[string][]*EventInterval {
 }
 
 // E2ETestEvents returns only events for e2e tests
-func E2ETestEvents(events []*EventInterval) []*EventInterval {
-	e2eEvents := []*EventInterval{}
+func E2ETestEvents(events []*monitorapi.EventInterval) []*monitorapi.EventInterval {
+	e2eEvents := []*monitorapi.EventInterval{}
 	for i := range events {
 		event := events[i]
 		if !strings.Contains(event.Locator, "e2e-test/") {
@@ -59,13 +61,13 @@ func E2ETestEvents(events []*EventInterval) []*EventInterval {
 }
 
 // E2ETestsRunningBetween returns names of e2e test that were active during the timeframe
-func E2ETestsRunningBetween(events []*EventInterval, start, end time.Time) map[string][]*EventInterval {
-	activeTests := map[string][]*EventInterval{}
+func E2ETestsRunningBetween(events []*monitorapi.EventInterval, start, end time.Time) map[string][]*monitorapi.EventInterval {
+	activeTests := map[string][]*monitorapi.EventInterval{}
 	e2eTestsToEvents := EventsByE2ETest(events)
 	type activeInterval struct {
 		start  time.Time
 		end    time.Time
-		events []*EventInterval
+		events []*monitorapi.EventInterval
 	}
 	for testName, events := range e2eTestsToEvents {
 		runningIntervals := []activeInterval{}
@@ -100,7 +102,7 @@ func E2ETestsRunningBetween(events []*EventInterval, start, end time.Time) map[s
 	return activeTests
 }
 
-func FindFailedTestsActiveBetween(events []*EventInterval, start, end time.Time) []string {
+func FindFailedTestsActiveBetween(events []*monitorapi.EventInterval, start, end time.Time) []string {
 	e2eTestEvents := E2ETestEvents(events)
 	e2eTestsActive := E2ETestsRunningBetween(e2eTestEvents, start, end)
 

--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -1,35 +1,11 @@
 package monitor
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
-
-func E2ETestLocator(testName string) string {
-	return fmt.Sprintf("e2e-test/%q", testName)
-}
-
-func IsE2ETest(locator string) bool {
-	_, ret := E2ETestFromLocator(locator)
-	return ret
-}
-
-func E2ETestFromLocator(locator string) (string, bool) {
-	if !strings.HasPrefix(locator, "e2e-test/") {
-		return "", false
-	}
-	parts := strings.SplitN(locator, "/", 2)
-	quotedTestName := parts[1]
-	testName, err := strconv.Unquote(quotedTestName)
-	if err != nil {
-		return "", false
-	}
-	return testName, true
-}
 
 // EventsByE2ETest returns map keyed by e2e test name (may contain spaces).
 func EventsByE2ETest(events []*monitorapi.EventInterval) map[string][]*monitorapi.EventInterval {
@@ -38,7 +14,7 @@ func EventsByE2ETest(events []*monitorapi.EventInterval) map[string][]*monitorap
 		if !strings.Contains(event.Locator, "e2e-test/") {
 			continue
 		}
-		testName, ok := E2ETestFromLocator(event.Locator)
+		testName, ok := monitorapi.E2ETestFromLocator(event.Locator)
 		if !ok {
 			continue
 		}

--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -68,10 +68,10 @@ func E2ETestsRunningBetween(events []*EventInterval, start, end time.Time) map[s
 		for _, event := range events {
 			switch {
 			case event.Message == "started":
-				currInterval.start = event.InitiatedAt
+				currInterval.start = event.From
 				currInterval.events = append(currInterval.events, event)
 			case strings.HasPrefix(event.Message, "finishedStatus/"):
-				currInterval.end = event.InitiatedAt
+				currInterval.end = event.From
 				currInterval.events = append(currInterval.events, event)
 				runningIntervals = append(runningIntervals, currInterval)
 

--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -11,6 +11,11 @@ func E2ETestLocator(testName string) string {
 	return fmt.Sprintf("e2e-test/%q", testName)
 }
 
+func IsE2ETest(locator string) bool {
+	_, ret := E2ETestFromLocator(locator)
+	return ret
+}
+
 func E2ETestFromLocator(locator string) (string, bool) {
 	if !strings.HasPrefix(locator, "e2e-test/") {
 		return "", false

--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,13 +93,13 @@ func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Int
 							default:
 								message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
 							}
-							condition := Condition{
-								Level:   Info,
+							condition := monitorapi.Condition{
+								Level:   monitorapi.Info,
 								Locator: locateEvent(obj),
 								Message: message,
 							}
 							if obj.Type == corev1.EventTypeWarning {
-								condition.Level = Warning
+								condition.Level = monitorapi.Warning
 							}
 							m.Record(condition)
 						case watch.Error:
@@ -111,8 +113,8 @@ func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Int
 							} else {
 								message = fmt.Sprintf("event object was not a Status: %T", event.Object)
 							}
-							m.Record(Condition{
-								Level:   Info,
+							m.Record(monitorapi.Condition{
+								Level:   monitorapi.Info,
 								Locator: "kube-apiserver",
 								Message: fmt.Sprintf("received an error while watching events: %s", message),
 							})

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -141,7 +141,7 @@ func (m *Monitor) Events(from, to time.Time) EventIntervals {
 		}
 
 		to := events[i].At
-		from := events[i].InitiatedAt
+		from := events[i].At
 		if from.IsZero() {
 			from = to
 		}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -128,7 +128,7 @@ func (m *Monitor) Conditions(from, to time.Time) EventIntervals {
 // Events returns all events that occur between from and to, including
 // any sampled conditions that were encountered during that period.
 // EventIntervals are returned in order of their occurrence.
-func (m *Monitor) Events(from, to time.Time) EventIntervals {
+func (m *Monitor) EventIntervals(from, to time.Time) EventIntervals {
 	samples, events := m.snapshot()
 	intervals := filterSamples(samples, from, to)
 	events = filterEvents(events, from, to)

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func TestMonitor_Newlines(t *testing.T) {
-	evt := &Event{Condition: Condition{Message: "a\nb\n"}}
+	evt := &monitorapi.Event{Condition: monitorapi.Condition{Message: "a\nb\n"}}
 	expected := "Jan 01 00:00:00.000 I  a\\nb\\n"
 	if evt.String() != expected {
 		t.Fatalf("unexpected:\n%s\n%s", expected, evt.String())
@@ -19,74 +21,74 @@ func TestMonitor_Newlines(t *testing.T) {
 func TestMonitor_Events(t *testing.T) {
 	tests := []struct {
 		name    string
-		events  []*Event
+		events  []*monitorapi.Event
 		samples []*sample
 		from    time.Time
 		to      time.Time
-		want    EventIntervals
+		want    monitorapi.EventIntervals
 	}{
 		{
-			events: []*Event{
-				{Condition{Message: "1"}, time.Unix(1, 0)},
-				{Condition{Message: "2"}, time.Unix(2, 0)},
+			events: []*monitorapi.Event{
+				{monitorapi.Condition{Message: "1"}, time.Unix(1, 0)},
+				{monitorapi.Condition{Message: "2"}, time.Unix(2, 0)},
 			},
-			want: EventIntervals{
-				{&Condition{Message: "1"}, time.Unix(1, 0), time.Unix(1, 0)},
-				{&Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
+			want: monitorapi.EventIntervals{
+				{&monitorapi.Condition{Message: "1"}, time.Unix(1, 0), time.Unix(1, 0)},
+				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
 			},
 		},
 		{
-			events: []*Event{
-				{Condition{Message: "1"}, time.Unix(1, 0)},
-				{Condition{Message: "2"}, time.Unix(2, 0)},
+			events: []*monitorapi.Event{
+				{monitorapi.Condition{Message: "1"}, time.Unix(1, 0)},
+				{monitorapi.Condition{Message: "2"}, time.Unix(2, 0)},
 			},
 			from: time.Unix(1, 0),
-			want: EventIntervals{
-				{&Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
+			want: monitorapi.EventIntervals{
+				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
 			},
 		},
 		{
-			events: []*Event{
-				{Condition{Message: "1"}, time.Unix(1, 0)},
-				{Condition{Message: "2"}, time.Unix(2, 0)},
+			events: []*monitorapi.Event{
+				{monitorapi.Condition{Message: "1"}, time.Unix(1, 0)},
+				{monitorapi.Condition{Message: "2"}, time.Unix(2, 0)},
 			},
 			from: time.Unix(1, 0),
 			to:   time.Unix(2, 0),
-			want: EventIntervals{
-				{&Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
+			want: monitorapi.EventIntervals{
+				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
 			},
 		},
 		{
-			events: []*Event{
-				{Condition{Message: "1"}, time.Unix(1, 0)},
-				{Condition{Message: "2"}, time.Unix(2, 0)},
+			events: []*monitorapi.Event{
+				{monitorapi.Condition{Message: "1"}, time.Unix(1, 0)},
+				{monitorapi.Condition{Message: "2"}, time.Unix(2, 0)},
 			},
 			from: time.Unix(2, 0),
 			want: nil,
 		},
 		{
 			samples: []*sample{
-				{time.Unix(1, 0), []*Condition{{Message: "1"}, {Message: "A"}}},
-				{time.Unix(2, 0), []*Condition{{Message: "2"}}},
-				{time.Unix(3, 0), []*Condition{{Message: "2"}, {Message: "A"}}},
+				{time.Unix(1, 0), []*monitorapi.Condition{{Message: "1"}, {Message: "A"}}},
+				{time.Unix(2, 0), []*monitorapi.Condition{{Message: "2"}}},
+				{time.Unix(3, 0), []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
 			},
 			from: time.Unix(1, 0),
-			want: EventIntervals{
-				{&Condition{Message: "2"}, time.Unix(2, 0), time.Unix(3, 0)},
-				{&Condition{Message: "A"}, time.Unix(3, 0), time.Unix(3, 0)},
+			want: monitorapi.EventIntervals{
+				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(3, 0)},
+				{&monitorapi.Condition{Message: "A"}, time.Unix(3, 0), time.Unix(3, 0)},
 			},
 		},
 		{
 			samples: []*sample{
-				{time.Unix(1, 0), []*Condition{{Message: "1"}, {Message: "A"}}},
-				{time.Unix(2, 0), []*Condition{{Message: "2"}}},
-				{time.Unix(3, 0), []*Condition{{Message: "2"}, {Message: "A"}}},
+				{time.Unix(1, 0), []*monitorapi.Condition{{Message: "1"}, {Message: "A"}}},
+				{time.Unix(2, 0), []*monitorapi.Condition{{Message: "2"}}},
+				{time.Unix(3, 0), []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
 			},
-			want: EventIntervals{
-				{&Condition{Message: "1"}, time.Unix(1, 0), time.Unix(1, 0)},
-				{&Condition{Message: "A"}, time.Unix(1, 0), time.Unix(1, 0)},
-				{&Condition{Message: "2"}, time.Unix(2, 0), time.Unix(3, 0)},
-				{&Condition{Message: "A"}, time.Unix(3, 0), time.Unix(3, 0)},
+			want: monitorapi.EventIntervals{
+				{&monitorapi.Condition{Message: "1"}, time.Unix(1, 0), time.Unix(1, 0)},
+				{&monitorapi.Condition{Message: "A"}, time.Unix(1, 0), time.Unix(1, 0)},
+				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(3, 0)},
+				{&monitorapi.Condition{Message: "A"}, time.Unix(3, 0), time.Unix(3, 0)},
 			},
 		},
 	}

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -29,66 +29,66 @@ func TestMonitor_Events(t *testing.T) {
 	}{
 		{
 			events: []*monitorapi.Event{
-				{monitorapi.Condition{Message: "1"}, time.Unix(1, 0)},
-				{monitorapi.Condition{Message: "2"}, time.Unix(2, 0)},
+				{Condition: monitorapi.Condition{Message: "1"}, At: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
 			},
 			want: monitorapi.EventIntervals{
-				{&monitorapi.Condition{Message: "1"}, time.Unix(1, 0), time.Unix(1, 0)},
-				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
+				{Condition: &monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
 			events: []*monitorapi.Event{
-				{monitorapi.Condition{Message: "1"}, time.Unix(1, 0)},
-				{monitorapi.Condition{Message: "2"}, time.Unix(2, 0)},
+				{Condition: monitorapi.Condition{Message: "1"}, At: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
 			},
 			from: time.Unix(1, 0),
 			want: monitorapi.EventIntervals{
-				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
+				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
 			events: []*monitorapi.Event{
-				{monitorapi.Condition{Message: "1"}, time.Unix(1, 0)},
-				{monitorapi.Condition{Message: "2"}, time.Unix(2, 0)},
+				{Condition: monitorapi.Condition{Message: "1"}, At: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
 			},
 			from: time.Unix(1, 0),
 			to:   time.Unix(2, 0),
 			want: monitorapi.EventIntervals{
-				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(2, 0)},
+				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
 			events: []*monitorapi.Event{
-				{monitorapi.Condition{Message: "1"}, time.Unix(1, 0)},
-				{monitorapi.Condition{Message: "2"}, time.Unix(2, 0)},
+				{Condition: monitorapi.Condition{Message: "1"}, At: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
 			},
 			from: time.Unix(2, 0),
 			want: nil,
 		},
 		{
 			samples: []*sample{
-				{time.Unix(1, 0), []*monitorapi.Condition{{Message: "1"}, {Message: "A"}}},
-				{time.Unix(2, 0), []*monitorapi.Condition{{Message: "2"}}},
-				{time.Unix(3, 0), []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
+				{at: time.Unix(1, 0), conditions: []*monitorapi.Condition{{Message: "1"}, {Message: "A"}}},
+				{at: time.Unix(2, 0), conditions: []*monitorapi.Condition{{Message: "2"}}},
+				{at: time.Unix(3, 0), conditions: []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
 			},
 			from: time.Unix(1, 0),
 			want: monitorapi.EventIntervals{
-				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(3, 0)},
-				{&monitorapi.Condition{Message: "A"}, time.Unix(3, 0), time.Unix(3, 0)},
+				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
+				{Condition: &monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
 			},
 		},
 		{
 			samples: []*sample{
-				{time.Unix(1, 0), []*monitorapi.Condition{{Message: "1"}, {Message: "A"}}},
-				{time.Unix(2, 0), []*monitorapi.Condition{{Message: "2"}}},
-				{time.Unix(3, 0), []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
+				{at: time.Unix(1, 0), conditions: []*monitorapi.Condition{{Message: "1"}, {Message: "A"}}},
+				{at: time.Unix(2, 0), conditions: []*monitorapi.Condition{{Message: "2"}}},
+				{at: time.Unix(3, 0), conditions: []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
 			},
 			want: monitorapi.EventIntervals{
-				{&monitorapi.Condition{Message: "1"}, time.Unix(1, 0), time.Unix(1, 0)},
-				{&monitorapi.Condition{Message: "A"}, time.Unix(1, 0), time.Unix(1, 0)},
-				{&monitorapi.Condition{Message: "2"}, time.Unix(2, 0), time.Unix(3, 0)},
-				{&monitorapi.Condition{Message: "A"}, time.Unix(3, 0), time.Unix(3, 0)},
+				{Condition: &monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: &monitorapi.Condition{Message: "A"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
+				{Condition: &monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
 			},
 		},
 	}

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -96,7 +96,7 @@ func TestMonitor_Events(t *testing.T) {
 				events:  tt.events,
 				samples: tt.samples,
 			}
-			if got := m.Events(tt.from, tt.to); !reflect.DeepEqual(got, tt.want) {
+			if got := m.EventIntervals(tt.from, tt.to); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%s", diff.ObjectReflectDiff(tt.want, got))
 			}
 		})

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -1,0 +1,63 @@
+package monitorapi
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func E2ETestLocator(testName string) string {
+	return fmt.Sprintf("e2e-test/%q", testName)
+}
+
+func IsE2ETest(locator string) bool {
+	_, ret := E2ETestFromLocator(locator)
+	return ret
+}
+
+func E2ETestFromLocator(locator string) (string, bool) {
+	if !strings.HasPrefix(locator, "e2e-test/") {
+		return "", false
+	}
+	parts := strings.SplitN(locator, "/", 2)
+	quotedTestName := parts[1]
+	testName, err := strconv.Unquote(quotedTestName)
+	if err != nil {
+		return "", false
+	}
+	return testName, true
+}
+
+func NodeLocator(testName string) string {
+	return fmt.Sprintf("node/%v", testName)
+}
+
+func IsNode(locator string) bool {
+	_, ret := NodeFromLocator(locator)
+	return ret
+}
+
+func NodeFromLocator(locator string) (string, bool) {
+	if !strings.HasPrefix(locator, "node/") {
+		return "", false
+	}
+	parts := strings.SplitN(locator, "/", 2)
+	return parts[1], true
+}
+
+func OperatorLocator(testName string) string {
+	return fmt.Sprintf("clusteroperator/%v", testName)
+}
+
+func IsOperator(locator string) bool {
+	_, ret := OperatorFromLocator(locator)
+	return ret
+}
+
+func OperatorFromLocator(locator string) (string, bool) {
+	if !strings.HasPrefix(locator, "clusteroperator/") {
+		return "", false
+	}
+	parts := strings.SplitN(locator, "/", 2)
+	return parts[1], true
+}

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -1,0 +1,82 @@
+package monitorapi
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type EventLevel string
+
+const (
+	Info    EventLevel = "Info"
+	Warning EventLevel = "Warning"
+	Error   EventLevel = "Error"
+)
+
+var eventString = map[EventLevel]string{
+	Info:    "I",
+	Warning: "W",
+	Error:   "E",
+}
+
+type Event struct {
+	Condition
+
+	At time.Time
+}
+
+func (e *Event) String() string {
+	return fmt.Sprintf("%s.%03d %s %s %s", e.At.Format("Jan 02 15:04:05"), e.At.Nanosecond()/1000000, eventString[e.Level], e.Locator, strings.Replace(e.Message, "\n", "\\n", -1))
+}
+
+type Condition struct {
+	Level EventLevel
+
+	Locator string
+	Message string
+}
+
+type EventInterval struct {
+	*Condition
+
+	From time.Time
+	To   time.Time
+}
+
+func (i *EventInterval) String() string {
+	if i.From.Equal(i.To) {
+		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
+	}
+	duration := i.To.Sub(i.From)
+	if duration < time.Second {
+		return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Millisecond))+"ms", eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
+	}
+	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Second))+"s", eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
+}
+
+type EventIntervals []*EventInterval
+
+var _ sort.Interface = EventIntervals{}
+
+func (intervals EventIntervals) Less(i, j int) bool {
+	switch d := intervals[i].From.Sub(intervals[j].From); {
+	case d < 0:
+		return true
+	case d > 0:
+		return false
+	}
+	switch d := intervals[i].To.Sub(intervals[j].To); {
+	case d < 0:
+		return true
+	case d > 0:
+		return false
+	}
+	return intervals[i].Message < intervals[j].Message
+}
+func (intervals EventIntervals) Len() int { return len(intervals) }
+func (intervals EventIntervals) Swap(i, j int) {
+	intervals[i], intervals[j] = intervals[j], intervals[i]
+}

--- a/pkg/monitor/node.go
+++ b/pkg/monitor/node.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,6 +11,19 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
+
+func IsNode(locator string) bool {
+	_, ret := NodeFromLocator(locator)
+	return ret
+}
+
+func NodeFromLocator(locator string) (string, bool) {
+	if !strings.HasPrefix(locator, "node/") {
+		return "", false
+	}
+	parts := strings.SplitN(locator, "/", 2)
+	return parts[1], true
+}
 
 func startNodeMonitoring(ctx context.Context, m Recorder, client kubernetes.Interface) {
 	nodeChangeFns := []func(node, oldNode *corev1.Node) []Condition{

--- a/pkg/monitor/noop.go
+++ b/pkg/monitor/noop.go
@@ -1,5 +1,7 @@
 package monitor
 
+import "github.com/openshift/origin/pkg/monitor/monitorapi"
+
 type noOpMonitor struct {
 }
 
@@ -7,5 +9,5 @@ func NewNoOpMonitor() Recorder {
 	return &noOpMonitor{}
 }
 
-func (*noOpMonitor) Record(conditions ...Condition) {}
-func (*noOpMonitor) AddSampler(fn SamplerFunc)      {}
+func (*noOpMonitor) Record(conditions ...monitorapi.Condition) {}
+func (*noOpMonitor) AddSampler(fn SamplerFunc)                 {}

--- a/pkg/monitor/operator.go
+++ b/pkg/monitor/operator.go
@@ -15,6 +15,19 @@ import (
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 )
 
+func IsOperator(locator string) bool {
+	_, ret := OperatorFromLocator(locator)
+	return ret
+}
+
+func OperatorFromLocator(locator string) (string, bool) {
+	if !strings.HasPrefix(locator, "clusteroperator/") {
+		return "", false
+	}
+	parts := strings.SplitN(locator, "/", 2)
+	return parts[1], true
+}
+
 // condition/Degraded status/True reason/DNSDegraded changed: DNS default is degraded
 func GetOperatorConditionStatus(message string) *configv1.ClusterOperatorStatusCondition {
 	if !strings.HasPrefix(message, "condition/") {

--- a/pkg/monitor/sampler.go
+++ b/pkg/monitor/sampler.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
 type ConditionalSampler interface {
-	ConditionWhenFailing(*Condition) SamplerFunc
+	ConditionWhenFailing(*monitorapi.Condition) SamplerFunc
 }
 
 type sampler struct {
@@ -15,7 +17,7 @@ type sampler struct {
 	available bool
 }
 
-func StartSampling(ctx context.Context, recorder Recorder, interval time.Duration, sampleFn func(previous bool) (*Condition, bool)) ConditionalSampler {
+func StartSampling(ctx context.Context, recorder Recorder, interval time.Duration, sampleFn func(previous bool) (*monitorapi.Condition, bool)) ConditionalSampler {
 	s := &sampler{
 		available: true,
 	}
@@ -53,11 +55,11 @@ func (s *sampler) setAvailable(b bool) {
 	s.available = b
 }
 
-func (s *sampler) ConditionWhenFailing(condition *Condition) SamplerFunc {
-	return func(_ time.Time) []*Condition {
+func (s *sampler) ConditionWhenFailing(condition *monitorapi.Condition) SamplerFunc {
+	return func(_ time.Time) []*monitorapi.Condition {
 		if s.isAvailable() {
 			return nil
 		}
-		return []*Condition{condition}
+		return []*monitorapi.Condition{condition}
 	}
 }

--- a/pkg/monitor/sampler_test.go
+++ b/pkg/monitor/sampler_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
@@ -17,31 +19,31 @@ func TestStartSampling(t *testing.T) {
 
 	doneCh := make(chan struct{})
 	var count int
-	m.AddSampler(StartSampling(ctx, m, 21*time.Millisecond, func(previous bool) (condition *Condition, next bool) {
+	m.AddSampler(StartSampling(ctx, m, 21*time.Millisecond, func(previous bool) (condition *monitorapi.Condition, next bool) {
 		defer func() { count++ }()
 		switch {
 		case count <= 5:
 			return nil, true
 		case count == 6:
-			return &Condition{Level: Error, Locator: "tester", Message: "dying"}, false
+			return &monitorapi.Condition{Level: monitorapi.Error, Locator: "tester", Message: "dying"}, false
 		case count == 7:
-			return &Condition{Level: Info, Locator: "tester", Message: "recovering"}, true
+			return &monitorapi.Condition{Level: monitorapi.Info, Locator: "tester", Message: "recovering"}, true
 		case count <= 12:
 			return nil, true
 		case count == 13:
-			return &Condition{Level: Error, Locator: "tester", Message: "dying 2"}, false
+			return &monitorapi.Condition{Level: monitorapi.Error, Locator: "tester", Message: "dying 2"}, false
 		case count <= 16:
 			return nil, false
 		case count == 17:
-			return &Condition{Level: Info, Locator: "tester", Message: "recovering 2"}, true
+			return &monitorapi.Condition{Level: monitorapi.Info, Locator: "tester", Message: "recovering 2"}, true
 		case count <= 20:
 			return nil, true
 		default:
 			doneCh <- struct{}{}
 			return nil, true
 		}
-	}).ConditionWhenFailing(&Condition{
-		Level:   Error,
+	}).ConditionWhenFailing(&monitorapi.Condition{
+		Level:   monitorapi.Error,
 		Locator: "tester",
 		Message: "down",
 	}))

--- a/pkg/monitor/sampler_test.go
+++ b/pkg/monitor/sampler_test.go
@@ -52,7 +52,7 @@ func TestStartSampling(t *testing.T) {
 
 	var describe []string
 	var log []string
-	events := m.Events(time.Time{}, time.Time{})
+	events := m.EventIntervals(time.Time{}, time.Time{})
 	for _, interval := range events {
 		i := interval.To.Sub(interval.From)
 		describe = append(describe, fmt.Sprintf("%v %s", *interval.Condition, i))

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -1,99 +1,24 @@
 package monitor
 
 import (
-	"fmt"
-	"sort"
-	"strconv"
-	"strings"
 	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
-type SamplerFunc func(time.Time) []*Condition
+type SamplerFunc func(time.Time) []*monitorapi.Condition
 
 type Interface interface {
-	EventIntervals(from, to time.Time) EventIntervals
-	Conditions(from, to time.Time) EventIntervals
+	EventIntervals(from, to time.Time) monitorapi.EventIntervals
+	Conditions(from, to time.Time) monitorapi.EventIntervals
 }
 
 type Recorder interface {
-	Record(conditions ...Condition)
+	Record(conditions ...monitorapi.Condition)
 	AddSampler(fn SamplerFunc)
-}
-
-type EventLevel int
-
-const (
-	Info EventLevel = iota
-	Warning
-	Error
-)
-
-var eventString = []string{
-	"I",
-	"W",
-	"E",
-}
-
-type Event struct {
-	Condition
-
-	At time.Time
-}
-
-func (e *Event) String() string {
-	return fmt.Sprintf("%s.%03d %s %s %s", e.At.Format("Jan 02 15:04:05"), e.At.Nanosecond()/1000000, eventString[e.Level], e.Locator, strings.Replace(e.Message, "\n", "\\n", -1))
 }
 
 type sample struct {
 	at         time.Time
-	conditions []*Condition
-}
-
-type Condition struct {
-	Level EventLevel
-
-	Locator string
-	Message string
-}
-
-type EventInterval struct {
-	*Condition
-
-	From time.Time
-	To   time.Time
-}
-
-func (i *EventInterval) String() string {
-	if i.From.Equal(i.To) {
-		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
-	}
-	duration := i.To.Sub(i.From)
-	if duration < time.Second {
-		return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Millisecond))+"ms", eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
-	}
-	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Second))+"s", eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
-}
-
-type EventIntervals []*EventInterval
-
-var _ sort.Interface = EventIntervals{}
-
-func (intervals EventIntervals) Less(i, j int) bool {
-	switch d := intervals[i].From.Sub(intervals[j].From); {
-	case d < 0:
-		return true
-	case d > 0:
-		return false
-	}
-	switch d := intervals[i].To.Sub(intervals[j].To); {
-	case d < 0:
-		return true
-	case d > 0:
-		return false
-	}
-	return intervals[i].Message < intervals[j].Message
-}
-func (intervals EventIntervals) Len() int { return len(intervals) }
-func (intervals EventIntervals) Swap(i, j int) {
-	intervals[i], intervals[j] = intervals[j], intervals[i]
+	conditions []*monitorapi.Condition
 }

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -11,7 +11,7 @@ import (
 type SamplerFunc func(time.Time) []*Condition
 
 type Interface interface {
-	Events(from, to time.Time) EventIntervals
+	EventIntervals(from, to time.Time) EventIntervals
 	Conditions(from, to time.Time) EventIntervals
 }
 

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -54,8 +54,6 @@ type Condition struct {
 
 	Locator string
 	Message string
-
-	InitiatedAt time.Time
 }
 
 type EventInterval struct {

--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/openshift/origin/pkg/test/ginkgo"
 	"github.com/openshift/origin/test/extended/util/disruption"
 )
@@ -15,7 +16,7 @@ const (
 	tolerateDisruptionPercent = 0.01
 )
 
-func testServerAvailability(locator string, events []*monitor.EventInterval, duration time.Duration) []*ginkgo.JUnitTestCase {
+func testServerAvailability(locator string, events []*monitorapi.EventInterval, duration time.Duration) []*ginkgo.JUnitTestCase {
 	errDuration, errMessages := disruption.GetDisruption(events, locator)
 
 	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -3,6 +3,8 @@ package synthetictests
 import (
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/test/ginkgo"
 )
@@ -11,7 +13,7 @@ import (
 // steady state (not being changed externally). Use these with suites that assume the
 // cluster is under no adversarial change (config changes, induced disruption to nodes,
 // etcd, or apis).
-func StableSystemEventInvariants(events monitor.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
+func StableSystemEventInvariants(events monitorapi.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
 	tests = SystemEventInvariants(events, duration)
 	tests = append(tests, testKubeAPIServerGracefulTermination(events)...)
 	tests = append(tests, testKubeletToAPIServerGracefulTermination(events)...)
@@ -30,7 +32,7 @@ func StableSystemEventInvariants(events monitor.EventIntervals, duration time.Du
 
 // systemUpgradeEventInvariants are invariants tested against events that should hold true in a cluster
 // that is being upgraded without induced disruption
-func SystemUpgradeEventInvariants(events monitor.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
+func SystemUpgradeEventInvariants(events monitorapi.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
 	tests = SystemEventInvariants(events, duration)
 	tests = append(tests, testKubeAPIServerGracefulTermination(events)...)
 	tests = append(tests, testKubeletToAPIServerGracefulTermination(events)...)
@@ -43,7 +45,7 @@ func SystemUpgradeEventInvariants(events monitor.EventIntervals, duration time.D
 // systemEventInvariants are invariants tested against events that should hold true in any cluster,
 // even one undergoing disruption. These are usually focused on things that must be true on a single
 // machine, even if the machine crashes.
-func SystemEventInvariants(events monitor.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
+func SystemEventInvariants(events monitorapi.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
 	tests = append(tests, testSystemDTimeout(events)...)
 	return tests
 }

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/test/ginkgo"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testKubeletToAPIServerGracefulTermination(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+func testKubeletToAPIServerGracefulTermination(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] kubelet terminates kube-apiserver gracefully"
 
 	var failures []string
@@ -43,7 +45,7 @@ func testKubeletToAPIServerGracefulTermination(events []*monitor.EventInterval) 
 	return tests
 }
 
-func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+func testKubeAPIServerGracefulTermination(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-api-machinery] kube-apiserver terminates within graceful termination period"
 
 	var failures []string
@@ -71,7 +73,7 @@ func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) []*gi
 	return tests
 }
 
-func testPodTransitions(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+func testPodTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] pods should never transition back to pending"
 	success := &ginkgo.JUnitTestCase{Name: testName}
 
@@ -104,7 +106,7 @@ func formatTimes(times []time.Time) []string {
 	return s
 }
 
-func testNodeUpgradeTransitions(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+func testNodeUpgradeTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] nodes should not go unready after being upgraded and go unready only once"
 
 	var buf bytes.Buffer
@@ -205,7 +207,7 @@ func testNodeUpgradeTransitions(events []*monitor.EventInterval) []*ginkgo.JUnit
 	return testCases
 }
 
-func testSystemDTimeout(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+func testSystemDTimeout(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] pods should not fail on systemd timeouts"
 	success := &ginkgo.JUnitTestCase{Name: testName}
 

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 
-	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/test/ginkgo"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -127,13 +126,13 @@ func testNodeUpgradeTransitions(events []*monitorapi.EventInterval) []*ginkgo.JU
 				fmt.Fprintf(&buf, "DEBUG: found upgrade start event: %v\n", event.String())
 				break
 			}
-			if !monitor.IsNode(event.Locator) {
+			if !monitorapi.IsNode(event.Locator) {
 				continue
 			}
 			if !strings.HasPrefix(event.Message, "condition/Ready ") || !strings.HasSuffix(event.Message, " changed") {
 				continue
 			}
-			node, _ := monitor.NodeFromLocator(event.Locator)
+			node, _ := monitorapi.NodeFromLocator(event.Locator)
 			if strings.Contains(event.Message, " status/True ") {
 				if currentNodeReady[node] {
 					failures = append(failures, fmt.Sprintf("Node %s was reported ready twice in a row, this should be impossible", node))

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -125,13 +125,13 @@ func testNodeUpgradeTransitions(events []*monitor.EventInterval) []*ginkgo.JUnit
 				fmt.Fprintf(&buf, "DEBUG: found upgrade start event: %v\n", event.String())
 				break
 			}
-			if !strings.HasPrefix(event.Locator, "node/") {
+			if !monitor.IsNode(event.Locator) {
 				continue
 			}
 			if !strings.HasPrefix(event.Message, "condition/Ready ") || !strings.HasSuffix(event.Message, " changed") {
 				continue
 			}
-			node := strings.TrimPrefix(event.Locator, "node/")
+			node, _ := monitor.NodeFromLocator(event.Locator)
 			if strings.Contains(event.Message, " status/True ") {
 				if currentNodeReady[node] {
 					failures = append(failures, fmt.Sprintf("Node %s was reported ready twice in a row, this should be impossible", node))

--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/openshift/origin/pkg/test/ginkgo"
 )
 
@@ -14,7 +15,7 @@ type testCategorizer struct {
 	substring string
 }
 
-func testPodSandboxCreation(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+func testPodSandboxCreation(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-network] pods should successfully create sandboxes"
 	// we can further refine this signal by subdividing different failure modes if it is pertinent.  Right now I'm seeing
 	// 1. error reading container (probably exited) json message: EOF
@@ -128,8 +129,8 @@ func categorizeBySubset(categorizers []testCategorizer, failures, flakes []strin
 }
 
 // getEventsByPod returns map keyed by pod locator with all events associated with it.
-func getEventsByPod(events []*monitor.EventInterval) map[string][]*monitor.EventInterval {
-	eventsByPods := map[string][]*monitor.EventInterval{}
+func getEventsByPod(events []*monitorapi.EventInterval) map[string][]*monitorapi.EventInterval {
+	eventsByPods := map[string][]*monitorapi.EventInterval{}
 	for _, event := range events {
 		if !strings.Contains(event.Locator, "pod/") {
 			continue
@@ -139,7 +140,7 @@ func getEventsByPod(events []*monitor.EventInterval) map[string][]*monitor.Event
 	return eventsByPods
 }
 
-func getPodDeletionTime(events []*monitor.EventInterval, podLocator string) *time.Time {
+func getPodDeletionTime(events []*monitorapi.EventInterval, podLocator string) *time.Time {
 	for _, event := range events {
 		if event.Locator == podLocator && event.Message == "reason/Deleted" {
 			return &event.From

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -5,13 +5,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/test/ginkgo"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testOperatorStateTransitions(events []*monitor.EventInterval) []*ginkgo.JUnitTestCase {
+func testOperatorStateTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
 	ret := []*ginkgo.JUnitTestCase{}
 
 	knownOperators := allOperators(events)
@@ -48,7 +50,7 @@ func testOperatorStateTransitions(events []*monitor.EventInterval) []*ginkgo.JUn
 	return ret
 }
 
-func allOperators(events []*monitor.EventInterval) sets.String {
+func allOperators(events []*monitorapi.EventInterval) sets.String {
 	// start with a list of known values
 	knownOperators := sets.NewString(KnownOperators.List()...)
 
@@ -64,8 +66,8 @@ func allOperators(events []*monitor.EventInterval) sets.String {
 }
 
 // getEventsByOperator returns map keyed by operator locator with all events associated with it.
-func getEventsByOperator(events []*monitor.EventInterval) map[string][]*monitor.EventInterval {
-	eventsByClusterOperator := map[string][]*monitor.EventInterval{}
+func getEventsByOperator(events []*monitorapi.EventInterval) map[string][]*monitorapi.EventInterval {
+	eventsByClusterOperator := map[string][]*monitorapi.EventInterval{}
 	for _, event := range events {
 		operatorName, ok := monitor.OperatorFromLocator(event.Locator)
 		if !ok {
@@ -76,12 +78,12 @@ func getEventsByOperator(events []*monitor.EventInterval) map[string][]*monitor.
 	return eventsByClusterOperator
 }
 
-func testOperatorState(interestingCondition configv1.ClusterStatusConditionType, events []*monitor.EventInterval, e2eEvents []*monitor.EventInterval) []string {
+func testOperatorState(interestingCondition configv1.ClusterStatusConditionType, events []*monitorapi.EventInterval, e2eEvents []*monitorapi.EventInterval) []string {
 	failures := []string{}
 
 	clusterOperatorToEvents := getEventsByOperator(events)
 
-	var previousEvent *monitor.EventInterval
+	var previousEvent *monitorapi.EventInterval
 
 	for clusterOperator, events := range clusterOperatorToEvents {
 		for _, event := range events {

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -69,7 +69,7 @@ func allOperators(events []*monitorapi.EventInterval) sets.String {
 func getEventsByOperator(events []*monitorapi.EventInterval) map[string][]*monitorapi.EventInterval {
 	eventsByClusterOperator := map[string][]*monitorapi.EventInterval{}
 	for _, event := range events {
-		operatorName, ok := monitor.OperatorFromLocator(event.Locator)
+		operatorName, ok := monitorapi.OperatorFromLocator(event.Locator)
 		if !ok {
 			continue
 		}

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -67,11 +67,10 @@ func allOperators(events []*monitor.EventInterval) sets.String {
 func getEventsByOperator(events []*monitor.EventInterval) map[string][]*monitor.EventInterval {
 	eventsByClusterOperator := map[string][]*monitor.EventInterval{}
 	for _, event := range events {
-		if !strings.Contains(event.Locator, "clusteroperator/") {
+		operatorName, ok := monitor.OperatorFromLocator(event.Locator)
+		if !ok {
 			continue
 		}
-		operators := strings.Split(event.Locator, "/")
-		operatorName := operators[1]
 		eventsByClusterOperator[operatorName] = append(eventsByClusterOperator[operatorName], event)
 	}
 	return eventsByClusterOperator

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -100,11 +100,11 @@ func testOperatorState(interestingCondition configv1.ClusterStatusConditionType,
 
 			startTime := time.Now().Add(4 * time.Hour)
 			if previousEvent != nil {
-				startTime = previousEvent.InitiatedAt
+				startTime = previousEvent.From
 			}
-			failedTests := monitor.FindFailedTestsActiveBetween(e2eEvents, startTime, event.InitiatedAt)
+			failedTests := monitor.FindFailedTestsActiveBetween(e2eEvents, startTime, event.From)
 			if len(failedTests) > 0 {
-				failures = append(failures, fmt.Sprintf("%d tests failed during this blip (%v to %v): %v", len(failedTests), startTime, event.InitiatedAt, strings.Join(failedTests, ",")))
+				failures = append(failures, fmt.Sprintf("%d tests failed during this blip (%v to %v): %v", len(failedTests), startTime, event.From, strings.Join(failedTests, ",")))
 			}
 		}
 	}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -280,7 +280,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 	// monitor the cluster while the tests are running and report any detected anomalies
 	var syntheticTestResults []*JUnitTestCase
 	var syntheticFailure bool
-	if events := m.Events(time.Time{}, time.Time{}); len(events) > 0 {
+	if events := m.EventIntervals(time.Time{}, time.Time{}); len(events) > 0 {
 		eventsForTests := createEventsForTests(tests)
 
 		var buf *bytes.Buffer

--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/openshift/origin/pkg/monitor"
 )
 
@@ -76,7 +78,7 @@ func (s *testStatus) finalizeTest(test *testCase) {
 	}
 
 	eventMessage := "finishedStatus/Unknown reason/Unknown"
-	eventLevel := monitor.Warning
+	eventLevel := monitorapi.Warning
 	// output the status of the test
 	switch {
 	case test.flake:
@@ -84,7 +86,7 @@ func (s *testStatus) finalizeTest(test *testCase) {
 		fmt.Fprintln(s.out)
 		fmt.Fprintf(s.out, "flaked: (%s) %s %q\n\n", test.duration, test.end.UTC().Format("2006-01-02T15:04:05"), test.name)
 		eventMessage = "finishedStatus/Flaked"
-		eventLevel = monitor.Error
+		eventLevel = monitorapi.Error
 	case test.success:
 		if s.includeSuccessfulOutput {
 			s.out.Write(test.out)
@@ -92,7 +94,7 @@ func (s *testStatus) finalizeTest(test *testCase) {
 		}
 		fmt.Fprintf(s.out, "passed: (%s) %s %q\n\n", test.duration, test.end.UTC().Format("2006-01-02T15:04:05"), test.name)
 		eventMessage = "finishedStatus/Passed"
-		eventLevel = monitor.Info
+		eventLevel = monitorapi.Info
 	case test.skipped:
 		if s.includeSuccessfulOutput {
 			s.out.Write(test.out)
@@ -106,20 +108,20 @@ func (s *testStatus) finalizeTest(test *testCase) {
 		}
 		fmt.Fprintf(s.out, "skipped: (%s) %s %q\n\n", test.duration, test.end.UTC().Format("2006-01-02T15:04:05"), test.name)
 		eventMessage = "finishedStatus/Skipped"
-		eventLevel = monitor.Info
+		eventLevel = monitorapi.Info
 	case test.failed:
 		s.failures++
 		s.out.Write(test.out)
 		fmt.Fprintln(s.out)
 		fmt.Fprintf(s.out, "failed: (%s) %s %q\n\n", test.duration, test.end.UTC().Format("2006-01-02T15:04:05"), test.name)
 		eventMessage = "finishedStatus/Failed"
-		eventLevel = monitor.Error
+		eventLevel = monitorapi.Error
 		if test.timedOut {
 			eventMessage = "finishedStatus/Failed  reason/Timeout"
 		}
 	}
 
-	s.monitorRecorder.Record(monitor.Condition{
+	s.monitorRecorder.Record(monitorapi.Condition{
 		Level:   eventLevel,
 		Locator: monitor.E2ETestLocator(test.name),
 		Message: eventMessage,
@@ -138,8 +140,8 @@ func (s *testStatus) OutputCommand(ctx context.Context, test *testCase) {
 }
 
 func (s *testStatus) Run(ctx context.Context, test *testCase) {
-	s.monitorRecorder.Record(monitor.Condition{
-		Level:   monitor.Info,
+	s.monitorRecorder.Record(monitorapi.Condition{
+		Level:   monitorapi.Info,
 		Locator: monitor.E2ETestLocator(test.name),
 		Message: "started",
 	})

--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -123,7 +123,7 @@ func (s *testStatus) finalizeTest(test *testCase) {
 
 	s.monitorRecorder.Record(monitorapi.Condition{
 		Level:   eventLevel,
-		Locator: monitor.E2ETestLocator(test.name),
+		Locator: monitorapi.E2ETestLocator(test.name),
 		Message: eventMessage,
 	})
 }
@@ -142,7 +142,7 @@ func (s *testStatus) OutputCommand(ctx context.Context, test *testCase) {
 func (s *testStatus) Run(ctx context.Context, test *testCase) {
 	s.monitorRecorder.Record(monitorapi.Condition{
 		Level:   monitorapi.Info,
-		Locator: monitor.E2ETestLocator(test.name),
+		Locator: monitorapi.E2ETestLocator(test.name),
 		Message: "started",
 	})
 	defer s.finalizeTest(test)

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -74,7 +74,7 @@ func createEventsForTests(tests []*testCase) []*monitor.EventInterval {
 func createSyntheticTestsFromMonitor(m *monitor.Monitor, eventsForTests []*monitor.EventInterval, monitorDuration time.Duration) ([]*JUnitTestCase, *bytes.Buffer, *bytes.Buffer) {
 	var syntheticTestResults []*JUnitTestCase
 
-	events := m.Events(time.Time{}, time.Time{})
+	events := m.EventIntervals(time.Time{}, time.Time{})
 	events = append(events, eventsForTests...)
 	sort.Sort(events)
 

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/onsi/ginkgo"
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -184,7 +186,7 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 	}
 
 	m.AddSampler(
-		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
 			resp, err := continuousClient.Get(url)
 			if err == nil {
 				defer resp.Body.Close()
@@ -195,16 +197,16 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 			}
 			switch {
 			case err == nil && !previous:
-				condition = &monitor.Condition{
-					Level:   monitor.Info,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Info,
 					Locator: locateService(svc),
 					Message: "Service started responding to GET requests on reused connections",
 				}
 			case err != nil && previous:
 				framework.Logf("Service %s is unreachable on reused connections: %v", svc.Name, err)
 				r.Eventf(&v1.ObjectReference{Kind: "Service", Namespace: "kube-system", Name: "service-upgrade-test"}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on reused connections")
-				condition = &monitor.Condition{
-					Level:   monitor.Error,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Error,
 					Locator: locateService(svc),
 					Message: "Service stopped responding to GET requests on reused connections",
 				}
@@ -212,8 +214,8 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 				framework.Logf("Service %s is unreachable on reused connections: %v", svc.Name, err)
 			}
 			return condition, err == nil
-		}).ConditionWhenFailing(&monitor.Condition{
-			Level:   monitor.Error,
+		}).ConditionWhenFailing(&monitorapi.Condition{
+			Level:   monitorapi.Error,
 			Locator: locateService(svc),
 			Message: "Service is not responding to GET requests on reused connections",
 		}),
@@ -233,7 +235,7 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 		},
 	}
 	m.AddSampler(
-		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
 			resp, err := client.Get(url)
 			if err == nil {
 				defer resp.Body.Close()
@@ -244,16 +246,16 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 			}
 			switch {
 			case err == nil && !previous:
-				condition = &monitor.Condition{
-					Level:   monitor.Info,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Info,
 					Locator: locateService(svc),
 					Message: "Service started responding to GET requests over new connections",
 				}
 			case err != nil && previous:
 				framework.Logf("Service %s is unreachable on new connections: %v", svc.Name, err)
 				r.Eventf(&v1.ObjectReference{Kind: "Service", Namespace: "kube-system", Name: "service-upgrade-test"}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on new connections")
-				condition = &monitor.Condition{
-					Level:   monitor.Error,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Error,
 					Locator: locateService(svc),
 					Message: "Service stopped responding to GET requests over new connections",
 				}
@@ -261,8 +263,8 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Se
 				framework.Logf("Service %s is unreachable on new connections: %v", svc.Name, err)
 			}
 			return condition, err == nil
-		}).ConditionWhenFailing(&monitor.Condition{
-			Level:   monitor.Error,
+		}).ConditionWhenFailing(&monitorapi.Condition{
+			Level:   monitorapi.Error,
 			Locator: locateService(svc),
 			Message: "Service is not responding to GET requests over new connections",
 		}),

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -152,7 +152,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.02, end.Sub(start), m.Events(time.Time{}, time.Time{}), "Service was unreachable during disruption")
+	disruption.ExpectNoDisruption(f, 0.02, end.Sub(start), m.EventIntervals(time.Time{}, time.Time{}), "Service was unreachable during disruption")
 
 	// verify finalizer behavior
 	defer func() {

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -115,7 +115,7 @@ func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	if framework.ProviderIs("aws", "azure") {
 		toleratedDisruption = 0
 	}
-	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Events(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption", t.name))
+	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.EventIntervals(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption", t.name))
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	g "github.com/onsi/ginkgo"
 
 	"k8s.io/kubernetes/test/e2e/chaosmonkey"
@@ -21,8 +23,6 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 	"k8s.io/kubernetes/test/utils/junit"
-
-	"github.com/openshift/origin/pkg/monitor"
 )
 
 // testWithDisplayName is implemented by tests that want more descriptive test names
@@ -279,7 +279,7 @@ func createTestFrameworks(tests []upgrades.Test) map[string]*framework.Framework
 // ExpectNoDisruption fails if the sum of the duration of all events exceeds tolerate as a fraction ([0-1]) of total, reports a
 // disruption flake if any disruption occurs, and uses reason to prefix the message. I.e. tolerate 0.1 of 10m total will fail
 // if the sum of the intervals is greater than 1m, or report a flake if any interval is found.
-func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Duration, events monitor.EventIntervals, reason string) {
+func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Duration, events monitorapi.EventIntervals, reason string) {
 	duration, describe := GetDisruption(events, "")
 	if percent := float64(duration) / float64(total); percent > tolerate {
 		framework.Failf("%s for at least %s of %s (%0.0f%%):\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
@@ -290,7 +290,7 @@ func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Dur
 
 // GetDisruption returns total duration of all error events and array of event description for printing.
 // When requiredLocator is specified (non-empty), only events matching this locator are considered.
-func GetDisruption(events monitor.EventIntervals, requiredLocator string) (time.Duration, []string) {
+func GetDisruption(events monitorapi.EventIntervals, requiredLocator string) (time.Duration, []string) {
 	var duration time.Duration
 	var describe []string
 	for _, interval := range events {
@@ -302,7 +302,7 @@ func GetDisruption(events monitor.EventIntervals, requiredLocator string) (time.
 		if i < time.Second {
 			i = time.Second
 		}
-		if interval.Condition.Level > monitor.Info {
+		if interval.Condition.Level > monitorapi.Info {
 			duration += i
 		}
 	}

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/onsi/ginkgo"
 
 	v1 "k8s.io/api/core/v1"
@@ -131,23 +133,23 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, frontend F
 		return err
 	}
 	m.AddSampler(
-		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
 			data, err := continuousClient.Get().AbsPath(frontend.Path).DoRaw(ctx)
 			if err == nil && !bytes.Contains(data, []byte(frontend.Expect)) {
 				err = fmt.Errorf("route returned success but did not contain the correct body contents: %q", string(data))
 			}
 			switch {
 			case err == nil && !previous:
-				condition = &monitor.Condition{
-					Level:   monitor.Info,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Info,
 					Locator: locateRoute(frontend.Namespace, frontend.Name),
 					Message: "Route started responding to GET requests on reused connections",
 				}
 			case err != nil && previous:
 				framework.Logf("Route %s is unreachable on reused connections: %v", frontend.Name, err)
 				r.Eventf(&v1.ObjectReference{Kind: "Route", Namespace: "kube-system", Name: frontend.Name}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on reused connections")
-				condition = &monitor.Condition{
-					Level:   monitor.Error,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Error,
 					Locator: locateRoute(frontend.Namespace, frontend.Name),
 					Message: "Route stopped responding to GET requests on reused connections",
 				}
@@ -155,8 +157,8 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, frontend F
 				framework.Logf("Route %s is unreachable on reused connections: %v", frontend.Name, err)
 			}
 			return condition, err == nil
-		}).ConditionWhenFailing(&monitor.Condition{
-			Level:   monitor.Error,
+		}).ConditionWhenFailing(&monitorapi.Condition{
+			Level:   monitorapi.Error,
 			Locator: locateRoute(frontend.Namespace, frontend.Name),
 			Message: "Route is not responding to GET requests on reused connections",
 		}),
@@ -184,7 +186,7 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, frontend F
 		return err
 	}
 	m.AddSampler(
-		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
 			data, err := client.Get().AbsPath(frontend.Path).DoRaw(ctx)
 			switch {
 			case err == nil && len(frontend.Expect) != 0 && !bytes.Contains(data, []byte(frontend.Expect)):
@@ -194,16 +196,16 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, frontend F
 			}
 			switch {
 			case err == nil && !previous:
-				condition = &monitor.Condition{
-					Level:   monitor.Info,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Info,
 					Locator: locateRoute(frontend.Namespace, frontend.Name),
 					Message: "Route started responding to GET requests over new connections",
 				}
 			case err != nil && previous:
 				framework.Logf("Route %s is unreachable on new connections: %v", frontend.Name, err)
 				r.Eventf(&v1.ObjectReference{Kind: "Route", Namespace: "kube-system", Name: frontend.Name}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on new connections")
-				condition = &monitor.Condition{
-					Level:   monitor.Error,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Error,
 					Locator: locateRoute(frontend.Namespace, frontend.Name),
 					Message: "Route stopped responding to GET requests over new connections",
 				}
@@ -211,8 +213,8 @@ func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, frontend F
 				framework.Logf("Route %s is unreachable on new connections: %v", frontend.Name, err)
 			}
 			return condition, err == nil
-		}).ConditionWhenFailing(&monitor.Condition{
-			Level:   monitor.Error,
+		}).ConditionWhenFailing(&monitorapi.Condition{
+			Level:   monitorapi.Error,
 			Locator: locateRoute(frontend.Namespace, frontend.Name),
 			Message: "Route is not responding to GET requests over new connections",
 		}),

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -103,7 +103,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.Events(time.Time{}, time.Time{}), "Frontends were unreachable during disruption")
+	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.EventIntervals(time.Time{}, time.Time{}), "Frontends were unreachable during disruption")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/extended/util/disruption/imageregistry/imageregistry.go
+++ b/test/extended/util/disruption/imageregistry/imageregistry.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/onsi/ginkgo"
 
 	corev1 "k8s.io/api/core/v1"
@@ -161,20 +163,20 @@ func (t *AvailableTest) startEndpointMonitoring(ctx context.Context, m *monitor.
 		return err
 	}
 	m.AddSampler(
-		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
 			_, err := continuousClient.Get().AbsPath(path).DoRaw(ctx)
 			switch {
 			case err == nil && !previous:
-				condition = &monitor.Condition{
-					Level:   monitor.Info,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Info,
 					Locator: locator,
 					Message: "Route started responding to GET requests on reused connections",
 				}
 			case err != nil && previous:
 				framework.Logf("Route for image-registry is unreachable on reused connections: %v", err)
 				r.Eventf(t.routeRef, nil, corev1.EventTypeWarning, "Unreachable", "detected", "on reused connections")
-				condition = &monitor.Condition{
-					Level:   monitor.Error,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Error,
 					Locator: locator,
 					Message: "Route stopped responding to GET requests on reused connections",
 				}
@@ -182,8 +184,8 @@ func (t *AvailableTest) startEndpointMonitoring(ctx context.Context, m *monitor.
 				framework.Logf("Route for image-registry is unreachable on reused connections: %v", err)
 			}
 			return condition, err == nil
-		}).ConditionWhenFailing(&monitor.Condition{
-			Level:   monitor.Error,
+		}).ConditionWhenFailing(&monitorapi.Condition{
+			Level:   monitorapi.Error,
 			Locator: locator,
 			Message: "Route is not responding to GET requests on reused connections",
 		}),
@@ -211,20 +213,20 @@ func (t *AvailableTest) startEndpointMonitoring(ctx context.Context, m *monitor.
 		return err
 	}
 	m.AddSampler(
-		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitor.Condition, next bool) {
+		monitor.StartSampling(ctx, m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
 			_, err := client.Get().AbsPath(path).DoRaw(ctx)
 			switch {
 			case err == nil && !previous:
-				condition = &monitor.Condition{
-					Level:   monitor.Info,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Info,
 					Locator: locator,
 					Message: "Route started responding to GET requests over new connections",
 				}
 			case err != nil && previous:
 				framework.Logf("Route for image-registry is unreachable on new connections: %v", err)
 				r.Eventf(t.routeRef, nil, corev1.EventTypeWarning, "Unreachable", "detected", "on new connections")
-				condition = &monitor.Condition{
-					Level:   monitor.Error,
+				condition = &monitorapi.Condition{
+					Level:   monitorapi.Error,
 					Locator: locator,
 					Message: "Route stopped responding to GET requests over new connections",
 				}
@@ -232,8 +234,8 @@ func (t *AvailableTest) startEndpointMonitoring(ctx context.Context, m *monitor.
 				framework.Logf("Route for image-registry is unreachable on new connections: %v", err)
 			}
 			return condition, err == nil
-		}).ConditionWhenFailing(&monitor.Condition{
-			Level:   monitor.Error,
+		}).ConditionWhenFailing(&monitorapi.Condition{
+			Level:   monitorapi.Error,
 			Locator: locator,
 			Message: "Route is not responding to GET requests over new connections",
 		}),

--- a/test/extended/util/disruption/imageregistry/imageregistry.go
+++ b/test/extended/util/disruption/imageregistry/imageregistry.go
@@ -119,7 +119,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.Events(time.Time{}, time.Time{}), "Image registry was unreachable during disruption")
+	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.EventIntervals(time.Time{}, time.Time{}), "Image registry was unreachable during disruption")
 }
 
 // Teardown cleans up any remaining resources.


### PR DESCRIPTION
This avoids package dep cycles we try to build analysis layers. The monitor event generation should not be relied upon directly by analysis built on top.