### PR TITLE
cmd: initialize baremetal provider

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -15,6 +15,9 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 	exutilcloud "github.com/openshift/origin/test/extended/util/cloud"
 
+	// Initialize baremetal as a provider
+	_ "github.com/openshift/origin/test/extended/util/baremetal"
+
 	// Initialize ovirt as a provider
 	_ "github.com/openshift/origin/test/extended/util/ovirt"
 


### PR DESCRIPTION
When we created the baremetal provider, it wasn't imported in
provider.go to cause it to be registerd.