### PR TITLE
test: remove apk add tcpdump to internal ports test

### DIFF
--- a/test/extended/networking/internal_ports.go
+++ b/test/extended/networking/internal_ports.go
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe("[sig-network] Internal connectivity", func() {
 							{
 								Name:    "webserver",
 								Image:   e2enetwork.NetexecImageName,
-								Command: []string{"/bin/bash", "-c", fmt.Sprintf("#!/bin/bash\napk add -q --update tcpdump\n./agnhost netexec --http-port=%v --udp-port=%v &\nexec tcpdump -i any port %v or port %v -n", nodeTCPPort, nodeUDPPort, nodeTCPPort, nodeUDPPort)},
+								Command: []string{"/agnhost", "netexec", fmt.Sprintf("--http-port=%v", nodeTCPPort), fmt.Sprintf("--udp-port=%v", nodeUDPPort)},
 								Ports: []v1.ContainerPort{
 									{Name: "tcp", ContainerPort: nodeTCPPort},
 									{Name: "udp", ContainerPort: nodeUDPPort},


### PR DESCRIPTION
The connectivity test for ports 9000-9999 tries to install tcpdump via
apk, and this appears to only be used for debugging purposes. In order
to run these tests disconnected, we can't have dependencies running
in the container that try to reach out to the internet. Currently this
test fails on IPv6 disconnected installs.