### PR TITLE
test: skip checking nodejs 10 and perl 5.26

### DIFF
--- a/test/extended/image_ecosystem/s2i_images.go
+++ b/test/extended/image_ecosystem/s2i_images.go
@@ -60,13 +60,6 @@ var s2iImages = map[string][]tc{
 	},
 	"nodejs": {
 		{
-			Version:  "10",
-			Cmd:      "node --version",
-			Expected: "v10",
-			Tag:      "10",
-			NonAMD:   true,
-		},
-		{
 			Version:  "12",
 			Cmd:      "node --version",
 			Expected: "v12",
@@ -76,10 +69,10 @@ var s2iImages = map[string][]tc{
 	},
 	"perl": {
 		{
-			Version:  "526",
+			Version:  "530",
 			Cmd:      "perl --version",
-			Expected: "v5.26",
-			Tag:      "5.26",
+			Expected: "v5.30",
+			Tag:      "5.30",
 			NonAMD:   true,
 		},
 	},

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1649,11 +1649,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations": "run sample related validations [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:10\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:10\" should print the usage",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:12\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:12\" should print the usage",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/perl:5.26\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/perl:5.26\" should print the usage",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/perl:5.30\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/perl:5.30\" should print the usage",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/php:7.2-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/php:7.2-ubi8\" should print the usage",
 
@@ -1667,11 +1665,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7\" should print the usage",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:10\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:10\" should be SCL enabled",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:12\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:12\" should be SCL enabled",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/perl:5.26\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/perl:5.26\" should be SCL enabled",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/perl:5.30\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/perl:5.30\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/php:7.2-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/php:7.2-ubi8\" should be SCL enabled",
 


### PR DESCRIPTION
SCL org has deprecated Perl 5.26 and NodeJS 10, so we should be checking Perl 5.30 and NodeJS 12 instead.

See https://github.com/openshift/cluster-samples-operator/pull/360