### PR TITLE
test/extended/single_node: update for monitoring components

### DIFF
--- a/test/extended/single_node/topology.go
+++ b/test/extended/single_node/topology.go
@@ -105,10 +105,6 @@ func isAllowedToFail(deployment appsv1.Deployment) bool {
 		"openshift-image-registry": {
 			"image-registry",
 		},
-		"openshift-monitoring": {
-			"prometheus-adapter",
-			"thanos-querier",
-		},
 		"openshift-operator-lifecycle-manager": {
 			"packageserver",
 		},


### PR DESCRIPTION
The cluster monitoring operator should honor the topology configuration
since [1] has been merged.

[1] https://github.com/openshift/cluster-monitoring-operator/pull/1077

cc @romfreiman 