### PR TITLE
test: Remove exceptions in fixed bugs in alert/resource tests

### DIFF
--- a/test/extended/operators/resources.go
+++ b/test/extended/operators/resources.go
@@ -37,12 +37,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 		knownBrokenPods := map[string]string{
 			//"<apiVersion>/<kind>/<namespace>/<name>/(initContainer|container)/<container_name>/<violation_type>": "<url to bug>",
 
-			"apps/v1/DaemonSet/openshift-ovn-kubernetes/ovnkube-master/container/sbdb/request[cpu]":    "https://bugzilla.redhat.com/show_bug.cgi?id=1939752",
-			"apps/v1/DaemonSet/openshift-ovn-kubernetes/ovnkube-master/container/sbdb/request[memory]": "https://bugzilla.redhat.com/show_bug.cgi?id=1939752",
-
 			"apps/v1/DaemonSet/openshift-multus/multus-admission-controller/container/multus-admission-controller/request[memory]": "https://bugzilla.redhat.com/show_bug.cgi?id=1938469",
-
-			"apps/v1/Deployment/openshift-kube-scheduler-operator/openshift-kube-scheduler-operator/container/kube-scheduler-operator-container/request[cpu]": "https://bugzilla.redhat.com/show_bug.cgi?id=1938468",
 
 			"apps/v1/Deployment/openshift-machine-api/cluster-autoscaler-default/container/cluster-autoscaler/request[cpu]":    "https://bugzilla.redhat.com/show_bug.cgi?id=1938467",
 			"apps/v1/Deployment/openshift-machine-api/cluster-autoscaler-default/container/cluster-autoscaler/request[memory]": "https://bugzilla.redhat.com/show_bug.cgi?id=1938467",
@@ -52,26 +47,6 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 
 			"batch/v1/Job/openshift-marketplace/<batch_job>/container/extract/request[cpu]":    "https://bugzilla.redhat.com/show_bug.cgi?id=1938492",
 			"batch/v1/Job/openshift-marketplace/<batch_job>/container/extract/request[memory]": "https://bugzilla.redhat.com/show_bug.cgi?id=1938492",
-
-			// Some of these may be allowed to be retained, but proper approval is needed
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/kube-rbac-proxy-machine-mtrc/limit[cpu]":       "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/kube-rbac-proxy-machine-mtrc/limit[memory]":    "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/kube-rbac-proxy-machineset-mtrc/limit[cpu]":    "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/kube-rbac-proxy-machineset-mtrc/limit[memory]": "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/kube-rbac-proxy-mhc-mtrc/limit[cpu]":           "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/kube-rbac-proxy-mhc-mtrc/limit[memory]":        "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/machine-controller/limit[cpu]":                 "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/machine-controller/limit[memory]":              "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/machine-healthcheck-controller/limit[cpu]":     "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/machine-healthcheck-controller/limit[memory]":  "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/machineset-controller/limit[cpu]":              "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/machineset-controller/limit[memory]":           "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/nodelink-controller/limit[cpu]":                "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-controllers/container/nodelink-controller/limit[memory]":             "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-operator/container/kube-rbac-proxy/limit[cpu]":                       "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-operator/container/kube-rbac-proxy/limit[memory]":                    "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-operator/container/machine-api-operator/limit[cpu]":                  "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
-			"apps/v1/Deployment/openshift-machine-api/machine-api-operator/container/machine-api-operator/limit[memory]":               "https://bugzilla.redhat.com/show_bug.cgi?id=1938493",
 
 			"apps/v1/DaemonSet/openshift-machine-api/metal3-image-cache/container/metal3-httpd/request[cpu]":          "https://bugzilla.redhat.com/show_bug.cgi?id=1940518",
 			"apps/v1/DaemonSet/openshift-machine-api/metal3-image-cache/container/metal3-httpd/request[memory]":       "https://bugzilla.redhat.com/show_bug.cgi?id=1940518",

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1895,11 +1895,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]": "should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent] [Disabled:Unimplemented] [Suite:k8s]",
 
-	"[Top Level] [sig-instrumentation][Late] Alerts should have a Watchdog alert in firing state the entire cluster run": "should have a Watchdog alert in firing state the entire cluster run [Suite:openshift/conformance/parallel]",
-
 	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't exceed the 500 series limit of total series sent via telemetry from each cluster": "shouldn't exceed the 500 series limit of total series sent via telemetry from each cluster [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured": "shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any alerts in firing or pending state apart from Watchdog and AlertmanagerReceiversNotConfigured and have no gaps in Watchdog firing": "shouldn't report any alerts in firing or pending state apart from Watchdog and AlertmanagerReceiversNotConfigured and have no gaps in Watchdog firing [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics": "should start and expose a secured proxy and verify build metrics [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
Unify some code between the [Late] alerts test and the upgrade
test and move the exceptions so the code looks the same.