### PR TITLE
test: App availability test during upgrade must set minReady

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -89,8 +89,11 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 
 	ginkgo.By("creating RC to be part of service " + serviceName)
 	rc, err := jig.Run(func(rc *v1.ReplicationController) {
+		// ensure the pod waits long enough during update for the LB to see the newly ready pod, which
+		// must be longer than the worst load balancer above (GCP at 32s)
+		rc.Spec.MinReadySeconds = 33
 		// ensure the pod waits long enough for most LBs to take it out of rotation, which has to be
-		// longer than the LB failed health check interval
+		// longer than the LB failed health check duration + 1 cycle
 		rc.Spec.Template.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
 			PreStop: &v1.Handler{
 				Exec: &v1.ExecAction{Command: []string{"sleep", "45"}},


### PR DESCRIPTION
Apps behind service load balancers must also set a minReadySeconds
threshold longer than the time it takes for the load balancer to
see the new pod, otherwise they can fail to be reachable which can
cause the SLB to route to all pods including the unready ones
(implementation dependent behavior).