### PR TITLE
Bug 1948634: upgrade: allow upgrades without version change

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -227,7 +227,7 @@ func getUpgradeContext(c configv1client.Interface, upgradeImage string) (*upgrad
 
 	upgradeImages := strings.Split(upgradeImage, ",")
 	if (len(upgradeImages[0]) > 0 && upgradeImages[0] == current.Image) || (len(upgradeImages[0]) > 0 && upgradeImages[0] == current.Version) {
-		return nil, fmt.Errorf("cluster is already at version %s", versionString(*current))
+		framework.Logf("cluster is already at version %s", versionString(*current))
 	}
 	for _, upgradeImage := range upgradeImages {
 		var next upgrades.VersionContext


### PR DESCRIPTION
Paused workers test requires watching upgrade to complete on final stage when worker pools is resumed and upgrade proceeds. This commit would record this warning in the log instead of throwing the error

See test results in https://github.com/openshift/release/pull/15939