### PR TITLE
test: grant exception to installer etcd retry pods

### DIFF
--- a/test/extended/operators/resources.go
+++ b/test/extended/operators/resources.go
@@ -101,6 +101,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 		}
 
 		reNormalizeRunOnceNames := regexp.MustCompile(`^(installer-|revision-pruner-)[\d]+-`)
+		reNormalizeRetryNames := regexp.MustCompile(`-retry-[\d]+-`)
 
 		waitingForFix := sets.NewString()
 		notAllowed := sets.NewString()
@@ -162,6 +163,9 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 					controller = fmt.Sprintf("v1/Pod/%s/%s", pod.Namespace, name)
 				}
 			}
+
+			// Remove -retry-#- for, e.g. openshift-etcd/installer-<revision>-retry-1-<node>
+			controller = reNormalizeRetryNames.ReplaceAllString(controller, "-")
 
 			// These rules apply to both init and regular containers
 			for containerType, containers := range map[string][]v1.Container{


### PR DESCRIPTION
If installer retry pods for etcd are created, the existing exception
doesn't match on these names, resulting on a failure:

```
v1/Pod/openshift-etcd/installer-<revision>-retry-1-<node>/container/installer
defines a limit on cpu of 150m which is not allowed (rule:
"v1/Pod/openshift-etcd/installer-<revision>-retry-1-<node>/container/installer/limit[cpu]")
```

This removes the -retry-N- to normalize the name.