### PR TITLE
require operator availability and non-degraded for upgrades

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -25,7 +25,7 @@ func StableSystemEventInvariants(events monitorapi.EventIntervals, duration time
 	tests = append(tests, testServerAvailability(monitor.LocatorKubeAPIServerReusedConnection, events, duration)...)
 	tests = append(tests, testServerAvailability(monitor.LocatorOpenshiftAPIServerReusedConnection, events, duration)...)
 	tests = append(tests, testServerAvailability(monitor.LocatorOAuthAPIServerReusedConnection, events, duration)...)
-	tests = append(tests, testOperatorStateTransitions(events)...)
+	tests = append(tests, testStableSystemOperatorStateTransitions(events)...)
 
 	return tests
 }
@@ -39,6 +39,7 @@ func SystemUpgradeEventInvariants(events monitorapi.EventIntervals, duration tim
 	tests = append(tests, testPodTransitions(events)...)
 	tests = append(tests, testPodSandboxCreation(events)...)
 	tests = append(tests, testNodeUpgradeTransitions(events)...)
+	tests = append(tests, testUpgradeOperatorStateTransitions(events)...)
 	return tests
 }
 

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -13,13 +13,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testOperatorStateTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testStableSystemOperatorStateTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded, configv1.OperatorProgressing})
+}
+
+func testUpgradeOperatorStateTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded})
+}
+func testOperatorStateTransitions(events []*monitorapi.EventInterval, conditionTypes []configv1.ClusterStatusConditionType) []*ginkgo.JUnitTestCase {
 	ret := []*ginkgo.JUnitTestCase{}
 
 	knownOperators := allOperators(events)
 	eventsByOperator := getEventsByOperator(events)
 	e2eEvents := monitor.E2ETestEvents(events)
-	for _, condition := range []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded, configv1.OperatorProgressing} {
+	for _, condition := range conditionTypes {
 		for _, operatorName := range knownOperators.List() {
 			bzComponent := GetBugzillaComponentForOperator(operatorName)
 			if bzComponent == "Unknown" {


### PR DESCRIPTION
re-uses the operator monitor to avoid degraded and unavailable operators during an upgrade.