### PR TITLE
Change BindNetwork of outhserver to tcp to support IPv6

### DIFF
--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -343,7 +343,7 @@ func oauthServerConfig(oc *exutil.CLI, routeURL string, idps []osinv1.IdentityPr
 			ServingInfo: configv1.HTTPServingInfo{
 				ServingInfo: configv1.ServingInfo{
 					BindAddress: "0.0.0.0:6443",
-					BindNetwork: "tcp4",
+					BindNetwork: "tcp",
 					// we have valid serving certs provided by service-ca
 					// this is our main server cert which is used if SNI does not match
 					CertInfo: configv1.CertInfo{


### PR DESCRIPTION
This PR changes oauthserver's ServingInfo resource's BindNetwork to tcp to support IPv6.