### PR TITLE
Bug 1947806: test/extended/router: Re-enable h2spec tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -454,6 +454,7 @@
 // test/extended/testdata/router/router-config-manager.yaml
 // test/extended/testdata/router/router-grpc-interop-routes.yaml
 // test/extended/testdata/router/router-grpc-interop.yaml
+// test/extended/testdata/router/router-h2spec-routes.yaml
 // test/extended/testdata/router/router-h2spec.yaml
 // test/extended/testdata/router/router-http-echo-server.yaml
 // test/extended/testdata/router/router-http2-routes.yaml
@@ -49801,11 +49802,53 @@ func testExtendedTestdataRouterRouterGrpcInteropYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataRouterRouterH2specRoutesYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: DOMAIN
+- name: TYPE
+objects:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: h2spec-haproxy
+      type: ${TYPE}
+    name: h2spec-passthrough
+  spec:
+    host: h2spec-passthrough.${DOMAIN}
+    port:
+      targetPort: 8443
+    tls:
+      termination: passthrough
+      insecureEdgeTerminationPolicy: Redirect
+    to:
+      kind: Service
+      name: h2spec-haproxy
+      weight: 100
+    wildcardPolicy: None
+`)
+
+func testExtendedTestdataRouterRouterH2specRoutesYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterRouterH2specRoutesYaml, nil
+}
+
+func testExtendedTestdataRouterRouterH2specRoutesYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterRouterH2specRoutesYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/router-h2spec-routes.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataRouterRouterH2specYaml = []byte(`apiVersion: v1
 kind: Template
 parameters:
 - name: HAPROXY_IMAGE
-  value: haproxy:2.0
+- name: H2SPEC_IMAGE
 objects:
 - apiVersion: v1
   kind: ConfigMap
@@ -49828,148 +49871,132 @@ objects:
         timeout server-fin 1s
         timeout http-request 10s
         timeout http-keep-alive 300s
-        option httplog
-        option http-use-htx
         option logasap
         option http-buffer-request
         log-format "frontend:%f/%H/%fi:%fp GMT:%T\ body:%[capture.req.hdr(0)]\  request:%r"
-      frontend fe_proxy
-        declare capture request len 40000
-        http-request capture req.body id 0
-        log global
-        bind *:8080 alpn h2
-        default_backend haproxy-availability-ok
       frontend fe_proxy_tls
+        option http-buffer-request
         declare capture request len 40000
         http-request capture req.body id 0
         log global
         bind *:8443 ssl crt /tmp/bundle.pem alpn h2
         default_backend haproxy-availability-ok
       backend haproxy-availability-ok
-        errorfile 200 /etc/haproxy/errorfile
+        errorfile 503 /etc/haproxy/errorfile
         http-request deny deny_status 200
     errorfile: |
-      HTTP/1.0 200 OK
-      Cache-Control: no-cache
-      Connection: close
-      Content-Type: text/html
+      HTTP/1.1 200 OK
+      Content-Length: 8192
+      Cache-Control: max-age=28800
+      Content-Type: text/plain
 
-      <html>
-      <body>
-      The way this errorfile works is summarized in this post:
-          https://www.gilesorr.com/blog/haproxy-static-content.html
-      And based on this discussion we need to return some data on GET requests:
-          https://www.mail-archive.com/haproxy@formilux.org/msg36762.html
-      Generated content comes from: $ base64 /dev/urandom | head -c 4k
-      dP0po9iAj6Skj24AUfnCKRWsp0M4YewCwVXemnQ77nmP3boAa/kImSTGiuFXiw0p0JGVOKqwXS7D
-      C95zCp76AWuQnyW3JSCUCJK3oD1V0A1SwqnjQMVGEiulm0t4A/U443+4/D658SJQnVUJNVA1kmc7
-      6vadxrlkVjV//DZaG0MxM+BdXBzcQce+vLQ48VvcWKTayF9Xq4QBWoiikSrdQSQ6ZxNvB3V5LGVV
-      u9WKxSnGnB1NPzb6fXQzZb1DPJm4VJWC8RK8+rU+RidXRBUmv+u+zqDXWAxeUUovN8ZdAMLM+0Fe
-      3iWLwph7jTlT1acR9tH8EidObt2PSOzUxshk0mHigcOKbF1Pow19MoS9CH8KVGltJd3VFoVTLoLH
-      L63mJVGfaK9JIU45dhdAqe3/l+jen1HybE2UE+cIg1kQSshZdXMU6L+0A8smrCKXeiguFTsZ6fIC
-      OcqxoX3I8w5aq85v77wgoqe9J7OBqoRs9/2nUYQC3F/NZ+rnMDLMX69p7BGqHy+8kt2Iq2IysPYO
-      253/rHR8xDlPl2GfHeTRINJJHrHk+d1L9rwYCY/DrUtHqNjexfKK83a2PwIbS3B3W6ti3X/UYE+t
-      1YVVXq+gAKAaXnqdqDLcd0Kep4hVrAXbOmXM2shY8kGT4k6osQLhlu4BQT8DxUv4nIqGaQHxH34d
-      XcSHp9ANBB+97RnagzrB6l3s/Kq0MpYOm+mSyNyq6BjhEx+zbl3bhlzq1PbbdHA2A4VAtE8TbAdJ
-      BGzw9ND7DDUV+Bhd3HbUxwTlgCl5Mzhou0BgnlVl87GupGi2+rx/VncTJ8eRfilTcOEVcOztmquK
-      JCND1CgRQ1R26IwbUjKQlQuh/H3DZ6I9NUItVjKbqJkybNc8mh+cIgcLgfDXhj7CJR/S83F06Yq9
-      0PQYOO63ZY85mDkEbtdvVLTVEaxr7S5TXuoCFYmYr63XBs6iCK6cVZafiiyUySpReiUmNbvMeoUl
-      h65iDWYe6GK0OGtdZISKTPj/EP9+hSudv9TnW1LgYJCgfwHIbUx0/jZ0AP8y5xdcsY2RU57jnIKm
-      fbSDjKpfFh8Hai5Jy0O6CnNoGqE0N+nuvF0PzZtfHA2vx8cx+IR8hEc2dRXks4SWt69q33kKdD58
-      ZJ2G2YGaibigG6Po/Lp/RPSpmgmKXmLXLGnE4qJLcxs2T00O6xqi0OrrHXlKFX0COwkU9iSbDTY4
-      KLkRqeGLnUvdEQwKVamVIRkJIog1Jo2CTcdHvHilQFV/LHd8P3KQZAl3TfC0RDIK2qrXFRUreqF6
-      1TxqiiLAtOsfsoqXj0LOQsZq3CqLD6ZpE3rOWe+9lCX6FQnauWB6XxFViG9KGknrejXu/UtbhzfS
-      uDffHlJsw58hneWXEKyZLJvenGEbRqKN81ood871k+cS/RIHZZa1kFpY0DUQ8j0P0nemKMtlK5NN
-      6ZVUqBezx+W2lZTEVbxEFZWHRDLlsg9GOBWsnDzgEXXBVoRqwa1inhB8dzmpzmUByXdgT+ulerqn
-      T+nrSSFdtEGW2O0dEv3dKchETGyIMbziLaVPrtonB8/mkgHCvwb5tWgGtoB+CPHAqgsuniTOYVZu
-      2Vqi3mrtgrFZbnd8+TGDlZeybeNDUuI3CGj61nzIDMq7LUZ/yOcIy+iEIiFAoAJ8WWZEOwBxVE+l
-      9COv5ZAuH5eAXBrFUijK2FuhCIMgbP2tEU046XgeHCX9nrr6BtM5JJRHWxrVKoi6zLTRNb752mGR
-      xRWOo90rk6Wq3HYD4LM9Y3PO8GAHRidiJu6gBRuA5OXbn2B1BN6Iph0SbjOwHRXUFNqd1tfF74h9
-      15zSjW4Ntzp4lcr276PazyrDxG7SK8ee7qU71r/C04OhuCR9A9qAHRMWAK8fTrScuQVB7HvDBDtg
-      CBKUecuPrwyzD6g3K1xSdcC+lcAd0bN3nzmNzibd5Qqg7dubHWDJIRFw+6aFBs9tmfTXNMR0wMCM
-      ihErUqMaVUt2590zg3qtzRCucJ2Yb4YlQb58NjLhGcay7G+wPf21xp0RvgCLncv9OhHS/S/eYAGV
-      B1nS17ehGq/IYB2lYnSLL4/K3pCIhZ4MC2AYbI2s/bUcluMbT42heI1ZZ4+J4EEldLnXW7DviSYt
-      O2AhYNnDEcUb4mcxKY7S1mhVvM+Efu8r9ELV8gwiZvk+nbLlzbTRCFQx9nBnrg6PjGi/x0uTkYvG
-      ugtQPiHWrJSyfmtWAQnlUHM0pCO5pd6jwJChqnGa2N8LzfIfCkmjNtGJ6BdhRpBTF2DyIGlDGUpZ
-      NJEq5iFQFIi2Zvm3w8wmyqdAIso56UHNQJn2BGJ5mhZsPEO73XFN4RJYWtsRFByoymRVOLiPA+Be
-      Lf/A0CPPqAL+fDAUjNfPTtNTTxCqXA9pOyDArDg+iNLLkynX0jdh1+o1v1BunA/WYmQyOkyRZE6w
-      WDq/khGNHguPwTI/gbSxLTlHjpDaQAC2RxQr/fA8PQyGbcN/1KZQNMOHxririBVHqLcjTE0X9lz9
-      POdPuAixpEfQ6ph8BIfkNvV1CwtSm4cMDaVweYaCJDaLx6N0FiXtm2RiLJ9L10EoFY/zXdQVXzmU
-      LztQJOOxnffHUhY9ecPH97QbnJE4TJPNisX2ri7ZdlJu8BsaR03y5huvw7fk5USJVr4oJfnAJ5Ll
-      qvJV9Jzn74BVUzUTcxMQvHo6ij67YGm0SWdxzdxzCwvr25aeey/Gf+SKNcru/wwNgVR+sUXavNtY
-      w2M5DZgghGOLC6N9uFsAt09d+rg9gfjx6ZSpsjx5cqtr/e85c+HVz0jl6lwGkEDBwDmJO+mTX/Tn
-      eiAx7/yG9D1rHzX/V7R2Eywsk5CIQQglvfGOY8+p3Uh1RWsLHQJ/gx41Q8od058lyx2hh2O9ylIN
-      z6fRRff5E2SPNUXTMzvXMA92nPgTtvBS4v+E7/JWauCogkYUokbeZvdAELf03rvH35E1DULW/pa0
-      13O9+hAXKoESYA90EsO1UUj/2spSD7CEQqnN/Nfk0OPekbQwErPIuEWC6Lze/mQIYG9PQ5d4bcO/
-      Yu9P4HlLbhCd8Uii1RPfkGs20ywx1gWX1cXGmNgHZ4ES0g/SHISylSPio1ESU8TpiPi7aQiJDizs
-      splkBaPkOV+PJGWjeOabJPQsdKSFHiOoA51p/4KRJSxmgr8sZrfu42XD7sA5pJ/jw8tprr4tLdbQ
-      x5DTWqPuCy0fgEPoU45cXJcN737Kn5RflTxEaROEoo9tO6NexdcoKPX/HermIGPA8rV6hnfLeWIo
-      K2WZ94PUqyxEo64tKutHndp63VO+c6evd0Jm1BWwa3YfY6mmDm8IyCi/J7/C7G7eg5qd4A4uTaUK
-      gJzVtfjz6UyUe3Coz+soggsb/T4HH3wroBeQxD7IaUFWR9e5XQ2fGXt5ash5NNyYPwjt04SjiIEu
-      a2pw+Sk06W8JCgo5661qydRCvM93LEmMuw4FNyq33AsRK7Q+BfKlqlkPR2qL5GRAwQt4uAVVcVPy
-      Fzf2zmY9pek6A5elq8c4aRrk8AGF5Aq9Xp2CJlX6jwzSeAuFvuxXBqToFvxZGsR9PpM2pgx42iVE
-      Xqsr3qTS4/TgLl/Hw8cr3zpxP7PvUb7sk9/lXa34vzXWcatOnUSYvVfXMoiePejsuc2AbrHmizcz
-      Kk8wBi5noMAqJCaM4xmwZO+wShnS1Kk/Qq5UKVe+OBGA7UR07QeXgZ80gk2ZJZgWqe9P28iy7P+B
-      S31MtxIrH9MMAPjBUOvx56nvBLOcc5g2n1e47PvAQ7nw3FzuoZTrY32lPh7vCX4h5W9xz5+aiXs3
-      N9gWr66Rv9g7RJ3a/F5gMjSp8bA6FokOVzUU6exT8WLhLVee6vN0WuistEtvqwPDzdat1/UpMCey
-      tv9o6I6GEm69drLT910zd0rHJKkvAwSKGoeHt346Tfvt0uoZW1URNJu6mfDb7KrpRNFBLIA3yFQG
-      jvzxoloQH7hHsQojFIzVvs0Vh8umdoyi8cEBHz9Wnokxn/5BkH8Z6uJmWywYlHsLZLYzcSaLBm4X
-      MR2VkJFYcQyxdQUWF7Fh52TLG3JAX2DOiLxmFqOKuRJEj+NC9NUyo2y/vFSym3Lic+kn39lby5fA
-      GPYootffwwHEI3Gt4ep9899WFPRjjlW1u+cWkX9zXkWYKKEEKljIr1fYqU89TImoH8UST0P5CRLJ
-      /g8EMBmR61h3eyjbtwKKmmUvcqZOZ2sy8jLn6SBa+3HYf9DYimVETie9vZNTi2Z7lttpqep6Stj0
-      wsj+F9O4ghvYF8vqFjpr86TZdCN8GROEspq5aZMIG7EQXBkFqIV7X966PSpIdflMDftnJFb5Eusl
-      3tbpS5xMms5/gLT60/uF2Q58vtJ1+8z91bLp4JqfmvI3B0tvHXKYyZAkcADrK4Dbqbugb0htQMx0
-      RzbZKay1p/nINQdTZlEbrNhlepJCaTayowULpdGlJRJQwaTX8ty6SAk60Gr8P2ACVX455rjciMOg
-      CNdlJIYIsQv1E8jzMu1CrqOhrH7HubWxGRGIXYKWgyp5UCa+zUHKKzVSCB9hxPG8L5jNEFpS3v1x
-      7uCqrBeKkYEeh5Wa/J5ai3XMTiDhbRzrDOeR9j2zY2YdwyeSD2RGsyyLPgucFchgjG7rgxbmxj37
-      m87Xm7ebN5gFeCwW72wU1locMx5/Q46GAvBE4Kz7Np/MlyPlBmnH6j+RWJmwrTlxIeeYssA6Yf2D
-      7/rdlPPbx3c13wOsgtqtpco/+aQ+Jl1OX7nBihRC9NiPeA1zNpxff6XbgxGE4JaKUnCciRMoholv
-      T5MpLM8pYbbj2fywmYwAHnftDpo3NuKF3NCIW6DIGNsEqURdeTjfLRPKI70MPQnq22zSEQF1t6Ti
-      Y+OSLEPukJq1QKsaYjlyvXPxiPEXeImVas5fDDhqC32N7dQXAwzO1oCGDmC8E2dzfdqkPojgzKMz
-      A9QJ/P1IjFQwhZQkREtPw6FOuWuTQ7L+jU9JodMNQ76+KKTgAwY41WzijS9yshMF5RBJ+XPPMUnu
-      ZuiUPJmBWqlxyULMcuVmWrsAtU+iYEz9N7fLGeDMnUU9pxvZfpMI8lgmtVAsSs/763PCGW/YhsFy
-      boPVE62mrruUWfKRq1/hh6q6JZ3t4nXYGHkQsCGGz+jFy0Yi3vn/p/wmpFh4IDDrsXRq5cd8EyzO
-      +QSDf982TiR+5DNI0bwv58uxMQ7g9piDE2PtyY+0D0AQavEhT0Mx6999f/hEURuUUTycPRBuGGh1
-      H8TGXi/VZFXZdIPJ5Onz+7+SMSvJ5Ks8sKK4EtaHhvREAb03aO8hsD4sZCqBz+HAklr26giJynUI
-      A6fFyaYhfwJRMVvwhGF2ulWlpPZiagwzvm1bpRbP2tnfRgbWwljxqzMuwVpcS6Zv9QokaUNIrxFb
-      531GrkAljqd/oHbNPvlYSwy6eyk7nEP59jtIN38bp8pHpogqVWUp+ZjFkazcOuQLGduCNUUSp9eL
-      jS/7tAfYUmdjPDZg9LY3LZ3mWs0T6wZcMrFvK0FP7R9EL2VzkvqvRuLOPGpjDDqOgqARyY05Jmik
-      qD+jAjntqtyXHDlyxL5lpX2DOaqz3qRL/woPLyKIa/WN91dKJ94YpAPNNLaLZh4jW4GtPEsqoX31
-      enT/r4nw5OfpiINXQd92GumgBzcf40RaQ4V3C4PvPPK6cxn9baOFSn1amfA7veMHJf+5WjmMr6vC
-      smE6OAXFvqxrRfCF+5a4+zEXQnqBKvxTRp2kzu+n1Sgz3HSRNJy1yg9iVEixr2GmavovH3fsumQW
-      /pMuk6upGzkunISGm7oEJU4uY2iHA8w2v+IUYWdbYwdGpkJKNP1BO+eFKSr/3quqq2JPcJEsU8v0
-      f1KSwfPheaGmsUDuyVVnDVqAQh6Wll8CAP8bPy78MEpg0n7wGsq/QEF4tPg+RqhkKORaEKGNzm+N
-      lgArkSzEDM8bh752XgmlJTnW5h6bBn5t33FYdUxRr/i/+Pk5GYuLyHa6YXAHuSPLhnWubQaycABq
-      QLyohd4uL6Mp/AQ12iZ2ml+LqiQDONP9PK/QZsuz6MSR+NbMYtO7Ky5B/OTFzMEqe5K6Rvk+XUz0
-      yCSEh34SNAYtYfDHH0URdjIrxm5out/aJZyrgog0Hrqk1XMHMovhyEb/u4kuYGn8oZifl6pRYOyF
-      WZuwrgqZiFBHtY4b9oSTfMxMYArjictBUHfK0Kv/EqP3y7REYdVNon5Y7UBi2rbpGVqPuF1NeH9D
-      49SH3Px9rGpyn56d4eR3ssuJHozcpR07MMxXFTZVRSCzq9rL6vSxTfkpHEJX7UCfJWXa7OFHsM3l
-      aa+/qrRD3dU71W2eALR8PkjflJIVpYjU+/lTnWB0joh1zCmUxDMlCFpkgtJfjm8L1GDgH41cA02E
-      79YKc+ZN14cOtlw6kXI+eBz4zZFz3JCgO6yc9QHwYaSMgwwFy3Ea5gy7yokXWjLGOeiqQY18fCqW
-      Jw/gpHsD+HNdxYy5Jp8RC7wW8lw9db2YZnQ0wygsUBsug6LTVxGBoSLX46dFrdhSx4AsgbSIcIpA
-      djZG8hQalRpHwxTtFAntvoC1sMvl6yJGLgqYzrORaqYhJPkOgwheXzu3AN3Rjykg6ImlORyypk+w
-      mrg8psVss4shXZit+kdSYsUgerPpnXRFxq/b61ORhcv6yBSPi4OPesQnCkfxV9Otpceq7RJC9T+Z
-      pxJifdPS4rsbmtw/vl387KO6vPYlZV/7XajPr42NAe1r9SZRqWhq6LUjaa2ukp+GexfbAPIew1hA
-      J9aZmOV8Whxj+pn7dJuFLocIAAttgOIpg1+ZLWqjaYtnL0S2bNB4618dyn/TDKAdvSCkjXPHpJbh
-      bmjlWw0Tin1M2Cjy4skp6slJlV5lKjd7M7qizld6MaSXeT4w6jvnMxRjoAdCg/oqxBH++QxBHgyT
-      BT/cLArmYNXXtkpIsMK8MLhDuq5kB7jzjFKGiJswuQ7zeEiP4KHQO2t1ffHHJgzHM0t0IySOLL3i
-      Z2wV4KQc9Y6K++0jXGD3J85/BQSiM4DJfWOWJi/xUnzHetr7q3+j/bGRzZWS3Sxh62WpJrD8NdKc
-      KAOvQTkIQGDd2Bp8e89T9X0NSsFujljaxnYJCttfEe7aAk1cAz1Zt4KJoAwB9iPYiUT5erEQFvCb
-      XV5UVyzMIw+X0RzVn3kZRmaUe60sK/awXD8dnLRBtipxYGe3/ugafwsvs+O3kGkY357r9wiQsOJ2
-      tjpJ+p2Jfn2Dakp7pdOIwcgEuG9tJNn+TXafuS0bqI6E6LYtyjMTToqYo2W9g4xL1EwH9nAiRiNb
-      m8Ju7Xsz3BxPMATen+dD2BaQRGKKVIHdj1GV5Is8xZcdNfotCSNbwgsxkHNiWd123Nn5tmgSy4ZA
-      lebwajYiKGhaW2d86IV4PvFBUJzE2GbSxY7IqoHglMyH16Kmq4VjxUvsn2JunWbboB6Yn0lHiJom
-      13bMZxkzdibtiIUO5o+kV2diZdM6vWasOFdyyUVLXZWhx6eBVGEjNxRRM6+QMQg2R/5IPOvb0Ybq
-      Nqe3O0KLr6hE9K7/zZRscrxV2/43eXey6lRWbkp+jiBrjWssnbsC9so3w0oz8a9yyEE2GRMzMn7P
-      z6amWn3gFbt5XftxCfBh56bkgIjYVIw4qQjE5sOz/sIz2Ep9e/jtVK8vPIYhYpy1r6YYV/wg2rM8
-      8HVvFHrENCaQUHGaMWdI0UsaTEaSBTM8VgI+MGFeVDdl1YsZFBgcWeytoCfZhmSFjLK7E2ujN8aB
-      TY7WWu0gnNI7eq9v+Ck9BtlAAQOvBWK7hPWgooO++PTXgN4SGDAXA2q3capHpGbWoym8WutcZBrP
-      XcW6E7J1Rh6nga3Umt7B4HQ1M1kv+T/oniPGu+Ms/PM/EHVocQMCVsYyo5JuqsNoq3hY4fMZch+T
-      8J2TGkYvrjF9StjiMf7OdFjrOo8QiVWTx68VFGfa7QpOr/hVi9IcDlesbiwypoC2lhP1DEZL8Z4m
-      w4SbZxB2PMilJZDLYJ8UxQZ5R+w1fM4m4/5c6pEaZFWqX2XVmwCDWtAHlAxvTVzbmFeU3QmnhFGC
-      ykvHjLw+2KatoB7v7qVoN/GLsHsMij
-      </body>
-      </html>
+      2wWvUP5ISuTTzmzf27uZ/hGEVQMowYJYgDBZPGj3VY9XEHtdiCILqnw6oMvB95lUtNDPfVh+sEpM
+      4NbGyxC/hALxe98LaexsWfMgdtrOs0Cre2MwGeL2Vgr68Ju9mTzL3YpYetU09WSesko6RfnqjPyA
+      b0dsc7XecYeh8XfetC5WgUfsGGhJTKEd80ClFAWv0usTU+qccoG7zkxxTGzw5qzp7L+B4t8Bwgjf
+      dvFOZZ3cwPowiGg+4iF7rwbBCtOfXgFe/eBVGpP5KtW6hcdf7Wqw/w6Tkf8ZXlKSzT6xLXrq0C73
+      OrUwvRn+NJl6wbpSOFEvB3Cp19Q0oMTa9+alvPwWZxwXEIi85hT5YVDZsb0pP1hcTOQAsT5LOWzm
+      mtNcIstM50XZj1hHEhJeixp5gAsrwY1m+Uwm2X6a70NBEtqnP0B04oOIPfTtebORGu1DiJGgntWM
+      wdk1ReLyDLTS2tISn6ItAwknF0Qk3D5kMqNN2sB1GBcWf7zqTlgB3W2p6I31P2Vt/I+z859JwbIw
+      3w3AI5UAGSPmguLzzdPrqKa1igzrBcoDvEJnk2O0+39qlJ+Sa2Ko02KjGkl7ZNZJwUAIKMsC5vAl
+      hV2KFRtRnWa7YzDMuNzoOZezPnIz8zvLVQFVGCSnpu7crAKrrhJD9F/nDBEnLtA5lzJRf32LUYNI
+      tCs2CHt8guaddJ1U1+lEGLKX3QM0N62MhDQy2lZwAvag8WlW1le+kj0vO1NYCwauzEWZtdHEedGv
+      E98m9Y4OWDLl4k8uTV0f8vsgwHTCgFcJ8EmWYizi/ykL1kfdR324JiW+3YpH3F8GEp9L7ESkqIns
+      eXajNzKhagc1e+YM8Xe6SjWDXbdVV9ZSEsgdhK2gy0MQchK2vU1hzUKq4cxDTMJ8k3CAkuG3IFpd
+      Nyv9eW4aJUSsNv2OzH0iRUaXs3qAefORFQgn8/Qe2c6wSDAI5wHEi7zi/Lick3UVv+7V13zfvcWl
+      32A2p1Erotjl/tgj4lX60Ci3uRgRBQ/9wR/N9JuH0A4ynn0uBaS1M/Qpbmz78/oeXQgCEnUCEA4k
+      DXYvXl6o+dEfJkuUYMIAH4wadtmdf+DSH9oOPvBFSM93X8BF21SSDeb8K+YfIi6+Ivzll+5jcNoi
+      uUryTyp1don75Zk6CT7b2m1o514MS68ulcNI4g36GpaS44rnuvQGyacdau6NabzgR0Q/3n9kOlFE
+      IOse9+eUEmR6KXZ/DuoeT7M2+Qul4uNwJz8i2RrF7mAToB3k0qdA8fO2munXXWoGr77vSkEDdJeq
+      ihFBQ60KNZeZh4x18uAxYigNrYfWjmIFAdzQd9XpsGL7iHYmjyHUQQabzFirJdeS4w4hZoSznA5m
+      1CtCvRtAT8RPoiUPSqKU3QtH46iNGusjRoRfCj7ynrmeqeDqkw4H34CrnkolqT1hDqvaqZIyJo50
+      D3MGeURwMM6DYjWKOaVJaQDbXC8Ahb67+1nKUEyEaLKkfTh8GPGOnmBiWub/Y/N3AL9TEuihw9KP
+      NtjZQ82jL32NqdSdwKDXmE2SMmElUOY6fVFEGDVdgx9eJbeMaiSwXLTtUFxAxsO1wY5jDf8Cr97w
+      P8tLv1CPcec381Y2jAD0CgkGaa1u0VTj0jLFIwZK2faeKa3VJrB7ldYD74+PwiIgfl9nbvxlC8KN
+      5RTd7ThSGRQ+N7zpjRdaoftafUcFj6G/O/QrbhPxLZHcHG+zBGt/Fkr1lswfjiDsHHSM1ZyLiuny
+      ZqFBSSjL8X+NOa76tUq414UrZZ85w6nDTkzitXb36x8TEgfaoipUZJVNQ8smjE3bO9wB1zyzYXh7
+      vDQe9p3GfRN223tJKGhXZ1SewOqoZsEWTogk6FFxngAyYb6jfqFFChe9gSrjS54+WUm0HyvSGuks
+      q/NwwvgI69cXqPZL6eXpgAAwFbt366HbGDHcKaG02fmuBNdhguw1BuF3EaBiPF2beQvYx9GPyzua
+      VDTflywUGXI3JixRbwT0TgXDIX+2FceA5NcyGQLjwF5CpDH650PaholA3dUif8Blls+FpJ74UdK1
+      Ws+mG/UaBZ31hLHKqHI986G3PSxEWYyrF6vL6+CuNfet/SYh7AMRWK93Rkb3/N8GPosuFPaBNZLR
+      EBSHW9HUTP0viNWDupGx8mmncAUb9HLjqcFJoWGqZjVKaYe8J3NwvaL1P8+/v7ckpLUzOgiZVake
+      azDZDBoEfqFp/EGwnwm/KsnCQZ/I0aqrVW8T3AjUyFRIBw+rYLLGC2oIiUDH5ccvYhDY1epYS3C/
+      qW+mWa1XNz0Aat+7LFoMt4BG3319S/fqApIRMq3rcoegfPhGSI9CBoNnLCxz/GHnlSxstCIQdnMJ
+      xwWBgvHuVb84bHfsRknUQX7g5s7xf9UK06TXRmYG+lb70Trkb0EZKzT17IMIOnZk4BCJkX08YK88
+      C1rP68EjSdLSRiln3EPJ6kuNVFct077SfDG3SiLldx/VsZGSFzqWv69Qdb82wI+v5FcV3TZkrZAP
+      mhHJEWFaWvtEMyc7TtNI+0XhME96RIscBSLtoaRRV8CbMSJ8uanfox5LFId0gD4kfWiGtirj9/1/
+      GnAUoMhFeipQ8mYKu2zwOFsDVmWzC10uNyorY4qg/WBJ6A3asEcHIUVkmOnakPkRipKTKxFYlXjF
+      1Jau+KsvHTvWxOP/LTDipJjxwQWBzDEmUHOQJJrHQG/grmOPFB891bcFRLWzYSuSYCSLetA8HlCK
+      m9Bxit43AUhLeeUoVHroflvyHhI1LT2k6crEz4g/bdLMi7ncbtCmB88k6UYXUaXKL2YlzxRp+cWA
+      nxeR63cR2RXeqUVdO3GqgAFKHFw96lgbF74qBc9AE5r5juzvT6qoHq7sHNJ31VhA6cASdIio+H+D
+      O2sb8xvGyuCfydIHgJoRc2ilhVsMPwEoMsCrp1MRWE5tLgkn0uH5RjV1K1yDYY0PivgJYbBtjOhx
+      mcaaa+P8jHc7J/Q6rI6BCjehbOwFY7dbCjcBJ8y39yNvDFwtj53UxMiWoRSwNO8ICJNFwm1dXjUa
+      gJ/+g6q0U4qf0nL5f/whHCsY8qdD9Jj9qcRjvSNaiP/l44ETGA2bc+/33cdZZImYAw54nfoN1UPx
+      hcvP3dsol6SaHgGOvZV0R6sapasMbIuFOkAXEVjn75E1dnWoom2k/cWH1gCxStYKUE4ilsMi+Smb
+      ejw1wXXJ4IG/861DPEAfrhwXO5nBppSClyf8ASMI+EjJmEO9o9b+hvKST0lN/+qnXfgzyirrhjSH
+      B8mMyArxcZo3+avdi1hC8VgNsRpR9aC7Sim9v8gjMfVg0qvIcDPjfvozyXhiEhrc7T+GDqk6Ledv
+      lOwTMw+i5UlrEEeJXDp8Ae8dQ1i/aLN/J7bR6LI9off7egiSIgnoOaUJl5LfvHqzFJsbjpSrm9U9
+      hrhs9ChG6Qa1VsB/cvoaLwbzXi3XcbPue8DuNrgTP4CcP7KtiiS+NM+n0nRKEk9y7eeSfjXI5pE7
+      6JFIdYs2qXFLtc+SuBq4M2dtKySiOr27gi59sbgr/OlWl+JQDNKPZ3XFM9nsoNpD3QU5Ye0DKzrI
+      rJh5Q/Gt3fQg91sFiB76kkpsQ88GQ/kgui9jadTYZcRmz/vQkoiQShX0xhdbkmwQgocnNO9IkZy+
+      vua906n5skPPQIpaZOPuIxBoHE/1y+Ap2ofezIBj9p/HNv5Aolc1TL0eY5dPabXWwab/4vutMKos
+      MKAbI1Gow+RyptiZsau72g/IicWTIpBbveRnbiDWTmw2uwLus4asSanzWjZnlNyy0MIVK0uZRNVn
+      NBKCXH2VbYMyPIvN9CQbCl7/VnL4qPC8sxkJL28ZtwW881Kn79k49Go7FXZn/go1hdig8av4h+JZ
+      cHw+bjsNKe3Mr6JvyLIpkvsBFL3TGRQkEy/me6V2HI8dl3RoryJy3SiE8G5uXlKXJywYOaCoIUIp
+      2uyalKb2YNaZFc6xHjputeIegC4zJh6KmKK8H4n92/qn33DK813xaFpcQWh6HfTL33V1xn6x93jX
+      x40RmHxbslHN0DYbYcK8fDEdvHfAY/zzKpvXg1TsKYuW8tyeXWL5NjfGND7XliJCo/GIj0dAyWro
+      IkLvv7XqnAUvLyH+Kd1LBzMa+1Q6luGSQaYaw1Uwioi0+W8VP/vd2MZifv/M+Fg9jXQ0YAPxvnqw
+      dMNjVq+kCJY9wjwBpgEOdXte5cZebR4b9Zyn0DRFzb4levpCF0bjmJcbzgE/doh8c+qfCIxK57/l
+      j37u34+y4OjnTeqm991+jnzqjHP9Dr96IjRRVh268Hgqymx670MolqAFlb7Fazwi/+3n4wH6oIjj
+      cbgFVrsOH0KFnLKf3QFOA2Rr/x+ycY8e0A3Br90AjEzHBsbV2LCpmcB5JaFxQG3K8IGXP2O3h7jP
+      yXHLPG/Euu0CTN4TlDNl45Ppk2GY48jGb6bdhJjV/qeL49y9wSghFmnGlXkbOxZ/JqI2QeIXleAe
+      xeVcdnCF9d3mEE0POtHvh4/nF3SS6IwqQd9qtiNLvDrCuhLJCTfowCfTm0WzpNJmaXxrKG4jyUJG
+      IpVcQSKulIDwkgt66V/PtbgE/2V+4+EvYgP5uM8tf7AAskxlnqB5L81Ph/0zsumrqLUsX1gTONCW
+      Hqf0cPJlALcHY/FaKq3sZl3J/BoIygIR2IwMeOQCEprt46RsJeY8AAWEk0p9eDoiX7eniV8YFes9
+      mNUXxHyg1GYzRtbXv0Ua/TomdZwFVhOYGb2SeVCDmzmjPcWLnLZ8949jbHIKIvKgkYgFF5qrtukA
+      PcPkKGAbzAUpiWr7zn8pp1emm3YRhzvYVJ2gNMtxHZkRg6uNAbt/mF1BqIS8ODtTUUo4+gC/RGYF
+      bgJryFrYBuFihZLOSXV0T6KNcp/04xRTXI63nfGuJaY0iSoPI3mbeulgxMIFAoALb3nQ9z0bVSzT
+      Lf6jPmaeM379NQ0bg0IoF+lrRYNTOAE5LssUrDTO8EV402wulLU0MR3bKKkt4jvp04/GpIjn9xmJ
+      3ZuWjxjvyZGjlaGT/BgsAgi/MuNN1Syty0Pzw8cJUWAogcak/2Xt7cY0+xTWtk7JHy9npv0hNzaw
+      mpt6NM0Yk4wqMDE9VL8G5P302eAYv11/ZlRM9yDUmTr15wwEc2J0koLqulN96VwMekGsPMi1makl
+      JpcHjgSuuM4CrD8sd6L8K6IyZWyGBmWV4JQ2Sd4lGvuzxf9+5pS3Q2Iq6QqPzW6rBa9GUAufvtI0
+      cR+JxqDOwCEd9IwaDq1mvLFUqlfvlGgyj1GrOYMJMMjBa/ErFtnsFL2rzO9g1QkHtErTND50VM8C
+      IdAybJLV4DOUwzOK3NSElr4Wej8K0Lfbwe4R3KzE4vRc+mO1ZesiPyfM7VsR7dN2NRDTTqWF7dXn
+      jrCpI2Pwz/BSwbtNvKnVrELydJYqQZ4YN0Kgkb5ZQ+Ei23t+X6IjRNTY576q5BtmNw9MEV70/b4w
+      Ac0ArzOfp+PbLaC6WdjxzI/AdpZJ5RSBo3w5PY+3P8IG4tz1UyKMhvCtA/xBGTu77C83a0R696aL
+      kMA5RhYjlCdm73+BMTLp17jXM+j5ek8pt0l5beEWOQSQQuzowiyPwfyp3c77A+3OsuK1dIdTpxh4
+      EeGLY1UuMQla1ugZODWHac42h6uBftP7Q77qKbCQHHB6G7HlH8xIJp6YfoBbqeQuMhrZrbeWGMpE
+      XGHizQFlsiHAniPfcY+XaCE4sgW+2gAlR6ESkO3DnGFnyejMspfa+BDdZBfuUO1JNWQwOtlooicQ
+      JXbSKAVrfDTsFrerk1LJkuhCvIGINt7D+9i9/t+twgA834ObDzb89dpWJAiFV1JtfJW4DGTKga6I
+      850NJW8/GP4l/hqH0EH9jSDXgjdhS0716/nEjXnwZ0rsHLfGq1AaMUHv972wv+3TA188kzlk7fRr
+      wuJbuLpwVqp/H1LNueJu+/lzFQoh9eeboguENZNIoZQ7cD0pINwHdeyhXZDomaxHnIrxiZmy72P/
+      aNkruB+Kf7evbRHzPNZAWkie/PwDrAsPLpeiTuK3nhpd/XIfmnNXZtt1X53MJHRwDMl00ze7lXwn
+      37Pm2dYsZo2f20cIuVrzyOPv9f9y2y92UAJ6VvPxHjci2lQupmdn/D7kdeF44nZWUMRkvnHW+Lxj
+      NYHuwwX6sOoKavnmVALOhYk9mukP4pNliuvcJmuhJxaI9oQah8encM2WA8Z7s61Xf1Gk2luMH709
+      0EX6VvPrNLFUY7xJJsXT191vyrg6Wu5Yd2ZIFXrCgKBLfHumvO3NE+YE+LKK6xrH7Urk9trmKJKt
+      sfsgmIz8xj4D59tlIsgKZfwGsIbIlachpjhXM9jNdOSe5k2tHNdnh1OvBJvOIqKSp4uVlHZnLUMZ
+      07rzxr9wdzU4ihaUgvreVpar6vnNYuj/TTDRP0FcBay0IuPunVhX9Wel5ga+NWIV9srCmzsJN7/d
+      puvaV9sb5dc0M0klEq41bMKDFd86YKifRhwagol5OAHTPjvIqZ9WOr/7XVuxAtOG0l1ohgrKTtfV
+      jw4KZCd+zIazzwuA0ItCENMmAm2Xppqy1T0Uu7gql3b8XAtsk+IhQw+L8H/oJtt/vaRSnbfTS02N
+      umm7CcneYyHT1FiuMfm5rkHee7rPR+YiDXlnkrTjd6HaBk3a/mEf0amzsMH9s4FzQRLbYPcXZrfi
+      ah18pV5ZlcfsC1kmM+wBbxCjxoUcV2DyeGiMdQo2Pif9LpPXOo6SE9a4lDovQF5brB6z9MGUZlKf
+      n+bQ1SVZxu4ArWLnbmXrgHzz+APsWh6VBfCw0MT8oP7uzB6tzIP1RCm7uKgb1Hi2f8f4DympfW4r
+      K3/H/5c3foZqlZDSDCGv3amzwkSZ3VsWHPrGFa0jLkTweBf+8UyzRIdoceDI7Ovg9cOiVf4bVqA/
+      B4DavbV6xOAbHloEJTIEI54epi2CEFnAvpJUgr+uWkgQbSTJVmXUWw0s6gv+2sbeNYYz169c1ScP
+      U1afX80IXtL0iq7sQjbEPfOg9hWbHQWoAaSgLT0mvGkMHn8eKUBFdvF2paNOfU47OirGz1ifdRZe
+      9BgBR6glFDlp5g99K6PXxADoy+nHAKnzxlWuxjfMoXgcIWpmIXad+vi3m7J48Z8xAaN8/657UjNW
+      JmYHVjst8m+Q14lyMJfFj1Q+9FjyKTGwSjryd5dUJacyGrg3mli2v99KnTsOjY1Wm6//G5dcuRIT
+      IceUARlCKNONQVe3tM4LoIglqTipwfzLwjDfb223BAfNt41otmZ3VGM8yesZQmAnokKhcErDTrw3
+      g9aoCI6OlrtLrTx3V1k7qW9INLZXspvhU4CalQdWvugpH4prAQO6FeFLCu66/KIL9FZoe5n66UBz
+      TFR2ih8dKo1JV/aLuqjpsZ+l4lNal4vnqgaLUehC7j1zQAiLD585VMuEliJSmES8wHL3nt5JUKoe
+      2Y6+aRDQqYUZsEhnPQ1H+0AT5LHOh6P1576m52Bp2tczVjN2K6Hgw+koDUmZj7YUj1stzjKso5rM
+      0zRAppa9g4XJSDnjaBFdYcRmWZ+PE/sjXzcu1eNtttlJqmYqO4dMGHiffoBIvz9nvqn8eZIRMPdt
+      D1/ykxN6Cbl42Ox9WTSIZncj6LbhB/5dT12DdCtedx7ljDcGVQm30HbB5GSYWYuWphJSJ0YWX8O+
+      lW8A3Qy0Vnu2EZUsNKBzgSbws63t2xrizMq0eRkMkHL8L4OUFKenwro6m0PJcuPhTBhVN0ek73vl
+      YVdXRPoPejw6wPeETZ6ObnCFqySDsycqyIwYXmxFNw3aYiTjFls2i+BZ6lGManDeJ/U/VKdrJt74
+      Ua3HXuQXe9z/uOBdmiWPBuIA79uzt3C/g5hTFt3L4Q25aRMRXIQkrtRRfP6AEyKJmAUY1hwyIJQV
+      +HVW+djWL9nO1/REKbJcGPmQwscoH9YYrP4XpLaXbWV/XbuCsyPzW+QKqUinMIX3LlAIYgJp+pyb
+      m2/3So5gYJkPZxx4UxVrqxAkKhSkQVHvv6Rvj6LkdomEfA76eWKxxvksde+zZkD2ZcWMg0obX1Ox
+      BFNBRELPe53ZdLKWpf2Sr96vRPRNw
 - apiVersion: v1
   kind: Pod
   metadata:
@@ -49979,144 +50006,55 @@ objects:
   spec:
     containers:
     - image: ${HAPROXY_IMAGE}
-      name: serve
+      name: haproxy
       command: ["/bin/bash", "-c" ]
       args:
         - set -e;
-          cat /etc/service-certs/tls.key /etc/service-certs/tls.crt > /tmp/bundle.pem;
+          cat /etc/serving-cert/tls.key /etc/serving-cert/tls.crt > /tmp/bundle.pem;
           haproxy -f /etc/haproxy/haproxy.config -db
       ports:
       - containerPort: 8443
         protocol: TCP
-      - containerPort: 8080
-        protocol: TCP
       readinessProbe:
+        failureThreshold: 3
         tcpSocket:
-          port: 8080
+          port: 8443
         initialDelaySeconds: 10
-        periodSeconds: 3
+        periodSeconds: 30
+        successThreshold: 1
+      livenessProbe:
+        failureThreshold: 3
+        tcpSocket:
+          port: 8443
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        successThreshold: 1
       volumeMounts:
-      - name: service-certs
-        mountPath: /etc/service-certs
-      - name: config
-        mountPath: /etc/haproxy
-      - name: tmp
-        mountPath: /var/cache/haproxy
-      - name: tmp
-        mountPath: /var/run
+      - mountPath: /etc/serving-cert
+        name: cert
+      - mountPath: /etc/haproxy
+        name: config
     volumes:
     - name: config
       configMap:
         name: h2spec-haproxy-config
-    - name: service-certs
+    - name: cert
       secret:
-        secretName: service-certs
-    - name: tmp
-      emptyDir: {}
-    - name: tmp2
-      emptyDir: {}
+        secretName: serving-cert-h2spec
 - apiVersion: v1
   kind: Service
   metadata:
     name: h2spec-haproxy
     annotations:
-      service.beta.openshift.io/serving-cert-secret-name: service-certs
+      service.beta.openshift.io/serving-cert-secret-name: serving-cert-h2spec
   spec:
     selector:
       app: h2spec-haproxy
     ports:
-      - port: 443
+      - port: 8443
         name: https
         targetPort: 8443
         protocol: TCP
-      - port: 80
-        name: http
-        targetPort: 8080
-        protocol: TCP
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    labels:
-      app: h2spec-haproxy
-    name: h2spec-haproxy-edge
-  spec:
-    port:
-      targetPort: 8080
-    tls:
-      termination: edge
-      key: |-
-        -----BEGIN EC PRIVATE KEY-----
-        MHcCAQEEIFTS3l3jU0kF0cQ27MTn+a27Oz1CMr5gSnDQQwZ3BI0moAoGCCqGSM49
-        AwEHoUQDQgAE0XRkp541S/i1bBYEtl/xWsKHDtmuFu7X1rIQiRAU4SB43B52iDxJ
-        V5P5usDcYPghidR7m0hVj6s5iMskxwLr6g==
-        -----END EC PRIVATE KEY-----
-      certificate: |-
-        -----BEGIN CERTIFICATE-----
-        MIIBizCCATGgAwIBAgIQJN1GzcsQZOXK7xqks+2aijAKBggqhkjOPQQDAjAoMRQw
-        EgYDVQQKEwtDZXJ0IEdlbiBDbzEQMA4GA1UEAxMHUm9vdCBDQTAgFw0yMDA1MTgw
-        OTU3MjNaGA8yMTIwMDQyNDA5NTcyM1owLjEZMBcGA1UEChMQQ2VydCBHZW4gQ29t
-        cGFueTERMA8GA1UEAxMIdGVzdGNlcnQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
-        AATRdGSnnjVL+LVsFgS2X/FawocO2a4W7tfWshCJEBThIHjcHnaIPElXk/m6wNxg
-        +CGJ1HubSFWPqzmIyyTHAuvqozUwMzAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAww
-        CgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAKBggqhkjOPQQDAgNIADBFAiBgjygk
-        ycGFHUK+b3hdvylD3ftaRT/muv+FKuuMqNCHsAIhAPW1owpVKlLHC/NaApFW/d0f
-        Gf2Mda0JAqYv0ehJUh7w
-        -----END CERTIFICATE-----
-    to:
-      kind: Service
-      name: h2spec-haproxy
-      weight: 100
-    wildcardPolicy: None
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    labels:
-      app: h2spec-haproxy
-    name: h2spec-haproxy-reencrypt
-  spec:
-    port:
-      targetPort: 8443
-    tls:
-      termination: reencrypt
-      key: |-
-        -----BEGIN EC PRIVATE KEY-----
-        MHcCAQEEIDKH71OdAhMZUgZ2Pf6p4/EBVR+KwyULozkTqQr8KDiQoAoGCCqGSM49
-        AwEHoUQDQgAEo8hY5B0vhT69FhEXVzzIsJzd8Uz8gXlsrvN0kBN9LyEZQIF/jEaz
-        JkczsyB718xQ69sePwAz9mz4IziYevSsBw==
-        -----END EC PRIVATE KEY-----
-      certificate: |-
-        -----BEGIN CERTIFICATE-----
-        MIIBjTCCATKgAwIBAgIRAJ08uWkebJb9qoYo8hJS7C8wCgYIKoZIzj0EAwIwKDEU
-        MBIGA1UEChMLQ2VydCBHZW4gQ28xEDAOBgNVBAMTB1Jvb3QgQ0EwIBcNMjAwNTE4
-        MDk1NzU5WhgPMjEyMDA0MjQwOTU3NTlaMC4xGTAXBgNVBAoTEENlcnQgR2VuIENv
-        bXBhbnkxETAPBgNVBAMTCHRlc3RjZXJ0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcD
-        QgAEo8hY5B0vhT69FhEXVzzIsJzd8Uz8gXlsrvN0kBN9LyEZQIF/jEazJkczsyB7
-        18xQ69sePwAz9mz4IziYevSsB6M1MDMwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQM
-        MAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhAKhn
-        j6sLRgUGcHdi/PTcM0vCD5d0sgakmQQB8M8Fdq5NAiEAxwuNfS8p2mJpnygCeMr2
-        YWcPcuBP6slsMyV/nyuk4DM=
-        -----END CERTIFICATE-----
-    to:
-      kind: Service
-      name: h2spec-haproxy
-      weight: 100
-    wildcardPolicy: None
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    labels:
-      app: h2spec-haproxy
-    name: h2spec-haproxy-passthrough
-  spec:
-    port:
-      targetPort: 8443
-    tls:
-      termination: passthrough
-    to:
-      kind: Service
-      name: h2spec-haproxy
-      weight: 100
-    wildcardPolicy: None
 - apiVersion: v1
   kind: Pod
   metadata:
@@ -50126,9 +50064,9 @@ objects:
   spec:
     containers:
     - name: h2spec
-      image: docker.io/summerwind/h2spec:2.4.0
-      command: ["/bin/bash"]
-      args: ["-c", "while true; do echo -n 'heartbeat: '; date; sleep 60; done"]
+      image: ${H2SPEC_IMAGE}
+      command: ["sleep"]
+      args: ["infinity"]
 `)
 
 func testExtendedTestdataRouterRouterH2specYamlBytes() ([]byte, error) {
@@ -54046,6 +53984,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/router/router-config-manager.yaml":                                               testExtendedTestdataRouterRouterConfigManagerYaml,
 	"test/extended/testdata/router/router-grpc-interop-routes.yaml":                                          testExtendedTestdataRouterRouterGrpcInteropRoutesYaml,
 	"test/extended/testdata/router/router-grpc-interop.yaml":                                                 testExtendedTestdataRouterRouterGrpcInteropYaml,
+	"test/extended/testdata/router/router-h2spec-routes.yaml":                                                testExtendedTestdataRouterRouterH2specRoutesYaml,
 	"test/extended/testdata/router/router-h2spec.yaml":                                                       testExtendedTestdataRouterRouterH2specYaml,
 	"test/extended/testdata/router/router-http-echo-server.yaml":                                             testExtendedTestdataRouterRouterHttpEchoServerYaml,
 	"test/extended/testdata/router/router-http2-routes.yaml":                                                 testExtendedTestdataRouterRouterHttp2RoutesYaml,
@@ -54801,6 +54740,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"router-config-manager.yaml":      {testExtendedTestdataRouterRouterConfigManagerYaml, map[string]*bintree{}},
 					"router-grpc-interop-routes.yaml": {testExtendedTestdataRouterRouterGrpcInteropRoutesYaml, map[string]*bintree{}},
 					"router-grpc-interop.yaml":        {testExtendedTestdataRouterRouterGrpcInteropYaml, map[string]*bintree{}},
+					"router-h2spec-routes.yaml":       {testExtendedTestdataRouterRouterH2specRoutesYaml, map[string]*bintree{}},
 					"router-h2spec.yaml":              {testExtendedTestdataRouterRouterH2specYaml, map[string]*bintree{}},
 					"router-http-echo-server.yaml":    {testExtendedTestdataRouterRouterHttpEchoServerYaml, map[string]*bintree{}},
 					"router-http2-routes.yaml":        {testExtendedTestdataRouterRouterHttp2RoutesYaml, map[string]*bintree{}},

--- a/test/extended/testdata/router/router-h2spec-routes.yaml
+++ b/test/extended/testdata/router/router-h2spec-routes.yaml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: DOMAIN
+- name: TYPE
+objects:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: h2spec-haproxy
+      type: ${TYPE}
+    name: h2spec-passthrough
+  spec:
+    host: h2spec-passthrough.${DOMAIN}
+    port:
+      targetPort: 8443
+    tls:
+      termination: passthrough
+      insecureEdgeTerminationPolicy: Redirect
+    to:
+      kind: Service
+      name: h2spec-haproxy
+      weight: 100
+    wildcardPolicy: None

--- a/test/extended/testdata/router/router-h2spec.yaml
+++ b/test/extended/testdata/router/router-h2spec.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Template
 parameters:
 - name: HAPROXY_IMAGE
-  value: haproxy:2.0
+- name: H2SPEC_IMAGE
 objects:
 - apiVersion: v1
   kind: ConfigMap
@@ -25,148 +25,132 @@ objects:
         timeout server-fin 1s
         timeout http-request 10s
         timeout http-keep-alive 300s
-        option httplog
-        option http-use-htx
         option logasap
         option http-buffer-request
         log-format "frontend:%f/%H/%fi:%fp GMT:%T\ body:%[capture.req.hdr(0)]\  request:%r"
-      frontend fe_proxy
-        declare capture request len 40000
-        http-request capture req.body id 0
-        log global
-        bind *:8080 alpn h2
-        default_backend haproxy-availability-ok
       frontend fe_proxy_tls
+        option http-buffer-request
         declare capture request len 40000
         http-request capture req.body id 0
         log global
         bind *:8443 ssl crt /tmp/bundle.pem alpn h2
         default_backend haproxy-availability-ok
       backend haproxy-availability-ok
-        errorfile 200 /etc/haproxy/errorfile
+        errorfile 503 /etc/haproxy/errorfile
         http-request deny deny_status 200
     errorfile: |
-      HTTP/1.0 200 OK
-      Cache-Control: no-cache
-      Connection: close
-      Content-Type: text/html
+      HTTP/1.1 200 OK
+      Content-Length: 8192
+      Cache-Control: max-age=28800
+      Content-Type: text/plain
 
-      <html>
-      <body>
-      The way this errorfile works is summarized in this post:
-          https://www.gilesorr.com/blog/haproxy-static-content.html
-      And based on this discussion we need to return some data on GET requests:
-          https://www.mail-archive.com/haproxy@formilux.org/msg36762.html
-      Generated content comes from: $ base64 /dev/urandom | head -c 4k
-      dP0po9iAj6Skj24AUfnCKRWsp0M4YewCwVXemnQ77nmP3boAa/kImSTGiuFXiw0p0JGVOKqwXS7D
-      C95zCp76AWuQnyW3JSCUCJK3oD1V0A1SwqnjQMVGEiulm0t4A/U443+4/D658SJQnVUJNVA1kmc7
-      6vadxrlkVjV//DZaG0MxM+BdXBzcQce+vLQ48VvcWKTayF9Xq4QBWoiikSrdQSQ6ZxNvB3V5LGVV
-      u9WKxSnGnB1NPzb6fXQzZb1DPJm4VJWC8RK8+rU+RidXRBUmv+u+zqDXWAxeUUovN8ZdAMLM+0Fe
-      3iWLwph7jTlT1acR9tH8EidObt2PSOzUxshk0mHigcOKbF1Pow19MoS9CH8KVGltJd3VFoVTLoLH
-      L63mJVGfaK9JIU45dhdAqe3/l+jen1HybE2UE+cIg1kQSshZdXMU6L+0A8smrCKXeiguFTsZ6fIC
-      OcqxoX3I8w5aq85v77wgoqe9J7OBqoRs9/2nUYQC3F/NZ+rnMDLMX69p7BGqHy+8kt2Iq2IysPYO
-      253/rHR8xDlPl2GfHeTRINJJHrHk+d1L9rwYCY/DrUtHqNjexfKK83a2PwIbS3B3W6ti3X/UYE+t
-      1YVVXq+gAKAaXnqdqDLcd0Kep4hVrAXbOmXM2shY8kGT4k6osQLhlu4BQT8DxUv4nIqGaQHxH34d
-      XcSHp9ANBB+97RnagzrB6l3s/Kq0MpYOm+mSyNyq6BjhEx+zbl3bhlzq1PbbdHA2A4VAtE8TbAdJ
-      BGzw9ND7DDUV+Bhd3HbUxwTlgCl5Mzhou0BgnlVl87GupGi2+rx/VncTJ8eRfilTcOEVcOztmquK
-      JCND1CgRQ1R26IwbUjKQlQuh/H3DZ6I9NUItVjKbqJkybNc8mh+cIgcLgfDXhj7CJR/S83F06Yq9
-      0PQYOO63ZY85mDkEbtdvVLTVEaxr7S5TXuoCFYmYr63XBs6iCK6cVZafiiyUySpReiUmNbvMeoUl
-      h65iDWYe6GK0OGtdZISKTPj/EP9+hSudv9TnW1LgYJCgfwHIbUx0/jZ0AP8y5xdcsY2RU57jnIKm
-      fbSDjKpfFh8Hai5Jy0O6CnNoGqE0N+nuvF0PzZtfHA2vx8cx+IR8hEc2dRXks4SWt69q33kKdD58
-      ZJ2G2YGaibigG6Po/Lp/RPSpmgmKXmLXLGnE4qJLcxs2T00O6xqi0OrrHXlKFX0COwkU9iSbDTY4
-      KLkRqeGLnUvdEQwKVamVIRkJIog1Jo2CTcdHvHilQFV/LHd8P3KQZAl3TfC0RDIK2qrXFRUreqF6
-      1TxqiiLAtOsfsoqXj0LOQsZq3CqLD6ZpE3rOWe+9lCX6FQnauWB6XxFViG9KGknrejXu/UtbhzfS
-      uDffHlJsw58hneWXEKyZLJvenGEbRqKN81ood871k+cS/RIHZZa1kFpY0DUQ8j0P0nemKMtlK5NN
-      6ZVUqBezx+W2lZTEVbxEFZWHRDLlsg9GOBWsnDzgEXXBVoRqwa1inhB8dzmpzmUByXdgT+ulerqn
-      T+nrSSFdtEGW2O0dEv3dKchETGyIMbziLaVPrtonB8/mkgHCvwb5tWgGtoB+CPHAqgsuniTOYVZu
-      2Vqi3mrtgrFZbnd8+TGDlZeybeNDUuI3CGj61nzIDMq7LUZ/yOcIy+iEIiFAoAJ8WWZEOwBxVE+l
-      9COv5ZAuH5eAXBrFUijK2FuhCIMgbP2tEU046XgeHCX9nrr6BtM5JJRHWxrVKoi6zLTRNb752mGR
-      xRWOo90rk6Wq3HYD4LM9Y3PO8GAHRidiJu6gBRuA5OXbn2B1BN6Iph0SbjOwHRXUFNqd1tfF74h9
-      15zSjW4Ntzp4lcr276PazyrDxG7SK8ee7qU71r/C04OhuCR9A9qAHRMWAK8fTrScuQVB7HvDBDtg
-      CBKUecuPrwyzD6g3K1xSdcC+lcAd0bN3nzmNzibd5Qqg7dubHWDJIRFw+6aFBs9tmfTXNMR0wMCM
-      ihErUqMaVUt2590zg3qtzRCucJ2Yb4YlQb58NjLhGcay7G+wPf21xp0RvgCLncv9OhHS/S/eYAGV
-      B1nS17ehGq/IYB2lYnSLL4/K3pCIhZ4MC2AYbI2s/bUcluMbT42heI1ZZ4+J4EEldLnXW7DviSYt
-      O2AhYNnDEcUb4mcxKY7S1mhVvM+Efu8r9ELV8gwiZvk+nbLlzbTRCFQx9nBnrg6PjGi/x0uTkYvG
-      ugtQPiHWrJSyfmtWAQnlUHM0pCO5pd6jwJChqnGa2N8LzfIfCkmjNtGJ6BdhRpBTF2DyIGlDGUpZ
-      NJEq5iFQFIi2Zvm3w8wmyqdAIso56UHNQJn2BGJ5mhZsPEO73XFN4RJYWtsRFByoymRVOLiPA+Be
-      Lf/A0CPPqAL+fDAUjNfPTtNTTxCqXA9pOyDArDg+iNLLkynX0jdh1+o1v1BunA/WYmQyOkyRZE6w
-      WDq/khGNHguPwTI/gbSxLTlHjpDaQAC2RxQr/fA8PQyGbcN/1KZQNMOHxririBVHqLcjTE0X9lz9
-      POdPuAixpEfQ6ph8BIfkNvV1CwtSm4cMDaVweYaCJDaLx6N0FiXtm2RiLJ9L10EoFY/zXdQVXzmU
-      LztQJOOxnffHUhY9ecPH97QbnJE4TJPNisX2ri7ZdlJu8BsaR03y5huvw7fk5USJVr4oJfnAJ5Ll
-      qvJV9Jzn74BVUzUTcxMQvHo6ij67YGm0SWdxzdxzCwvr25aeey/Gf+SKNcru/wwNgVR+sUXavNtY
-      w2M5DZgghGOLC6N9uFsAt09d+rg9gfjx6ZSpsjx5cqtr/e85c+HVz0jl6lwGkEDBwDmJO+mTX/Tn
-      eiAx7/yG9D1rHzX/V7R2Eywsk5CIQQglvfGOY8+p3Uh1RWsLHQJ/gx41Q8od058lyx2hh2O9ylIN
-      z6fRRff5E2SPNUXTMzvXMA92nPgTtvBS4v+E7/JWauCogkYUokbeZvdAELf03rvH35E1DULW/pa0
-      13O9+hAXKoESYA90EsO1UUj/2spSD7CEQqnN/Nfk0OPekbQwErPIuEWC6Lze/mQIYG9PQ5d4bcO/
-      Yu9P4HlLbhCd8Uii1RPfkGs20ywx1gWX1cXGmNgHZ4ES0g/SHISylSPio1ESU8TpiPi7aQiJDizs
-      splkBaPkOV+PJGWjeOabJPQsdKSFHiOoA51p/4KRJSxmgr8sZrfu42XD7sA5pJ/jw8tprr4tLdbQ
-      x5DTWqPuCy0fgEPoU45cXJcN737Kn5RflTxEaROEoo9tO6NexdcoKPX/HermIGPA8rV6hnfLeWIo
-      K2WZ94PUqyxEo64tKutHndp63VO+c6evd0Jm1BWwa3YfY6mmDm8IyCi/J7/C7G7eg5qd4A4uTaUK
-      gJzVtfjz6UyUe3Coz+soggsb/T4HH3wroBeQxD7IaUFWR9e5XQ2fGXt5ash5NNyYPwjt04SjiIEu
-      a2pw+Sk06W8JCgo5661qydRCvM93LEmMuw4FNyq33AsRK7Q+BfKlqlkPR2qL5GRAwQt4uAVVcVPy
-      Fzf2zmY9pek6A5elq8c4aRrk8AGF5Aq9Xp2CJlX6jwzSeAuFvuxXBqToFvxZGsR9PpM2pgx42iVE
-      Xqsr3qTS4/TgLl/Hw8cr3zpxP7PvUb7sk9/lXa34vzXWcatOnUSYvVfXMoiePejsuc2AbrHmizcz
-      Kk8wBi5noMAqJCaM4xmwZO+wShnS1Kk/Qq5UKVe+OBGA7UR07QeXgZ80gk2ZJZgWqe9P28iy7P+B
-      S31MtxIrH9MMAPjBUOvx56nvBLOcc5g2n1e47PvAQ7nw3FzuoZTrY32lPh7vCX4h5W9xz5+aiXs3
-      N9gWr66Rv9g7RJ3a/F5gMjSp8bA6FokOVzUU6exT8WLhLVee6vN0WuistEtvqwPDzdat1/UpMCey
-      tv9o6I6GEm69drLT910zd0rHJKkvAwSKGoeHt346Tfvt0uoZW1URNJu6mfDb7KrpRNFBLIA3yFQG
-      jvzxoloQH7hHsQojFIzVvs0Vh8umdoyi8cEBHz9Wnokxn/5BkH8Z6uJmWywYlHsLZLYzcSaLBm4X
-      MR2VkJFYcQyxdQUWF7Fh52TLG3JAX2DOiLxmFqOKuRJEj+NC9NUyo2y/vFSym3Lic+kn39lby5fA
-      GPYootffwwHEI3Gt4ep9899WFPRjjlW1u+cWkX9zXkWYKKEEKljIr1fYqU89TImoH8UST0P5CRLJ
-      /g8EMBmR61h3eyjbtwKKmmUvcqZOZ2sy8jLn6SBa+3HYf9DYimVETie9vZNTi2Z7lttpqep6Stj0
-      wsj+F9O4ghvYF8vqFjpr86TZdCN8GROEspq5aZMIG7EQXBkFqIV7X966PSpIdflMDftnJFb5Eusl
-      3tbpS5xMms5/gLT60/uF2Q58vtJ1+8z91bLp4JqfmvI3B0tvHXKYyZAkcADrK4Dbqbugb0htQMx0
-      RzbZKay1p/nINQdTZlEbrNhlepJCaTayowULpdGlJRJQwaTX8ty6SAk60Gr8P2ACVX455rjciMOg
-      CNdlJIYIsQv1E8jzMu1CrqOhrH7HubWxGRGIXYKWgyp5UCa+zUHKKzVSCB9hxPG8L5jNEFpS3v1x
-      7uCqrBeKkYEeh5Wa/J5ai3XMTiDhbRzrDOeR9j2zY2YdwyeSD2RGsyyLPgucFchgjG7rgxbmxj37
-      m87Xm7ebN5gFeCwW72wU1locMx5/Q46GAvBE4Kz7Np/MlyPlBmnH6j+RWJmwrTlxIeeYssA6Yf2D
-      7/rdlPPbx3c13wOsgtqtpco/+aQ+Jl1OX7nBihRC9NiPeA1zNpxff6XbgxGE4JaKUnCciRMoholv
-      T5MpLM8pYbbj2fywmYwAHnftDpo3NuKF3NCIW6DIGNsEqURdeTjfLRPKI70MPQnq22zSEQF1t6Ti
-      Y+OSLEPukJq1QKsaYjlyvXPxiPEXeImVas5fDDhqC32N7dQXAwzO1oCGDmC8E2dzfdqkPojgzKMz
-      A9QJ/P1IjFQwhZQkREtPw6FOuWuTQ7L+jU9JodMNQ76+KKTgAwY41WzijS9yshMF5RBJ+XPPMUnu
-      ZuiUPJmBWqlxyULMcuVmWrsAtU+iYEz9N7fLGeDMnUU9pxvZfpMI8lgmtVAsSs/763PCGW/YhsFy
-      boPVE62mrruUWfKRq1/hh6q6JZ3t4nXYGHkQsCGGz+jFy0Yi3vn/p/wmpFh4IDDrsXRq5cd8EyzO
-      +QSDf982TiR+5DNI0bwv58uxMQ7g9piDE2PtyY+0D0AQavEhT0Mx6999f/hEURuUUTycPRBuGGh1
-      H8TGXi/VZFXZdIPJ5Onz+7+SMSvJ5Ks8sKK4EtaHhvREAb03aO8hsD4sZCqBz+HAklr26giJynUI
-      A6fFyaYhfwJRMVvwhGF2ulWlpPZiagwzvm1bpRbP2tnfRgbWwljxqzMuwVpcS6Zv9QokaUNIrxFb
-      531GrkAljqd/oHbNPvlYSwy6eyk7nEP59jtIN38bp8pHpogqVWUp+ZjFkazcOuQLGduCNUUSp9eL
-      jS/7tAfYUmdjPDZg9LY3LZ3mWs0T6wZcMrFvK0FP7R9EL2VzkvqvRuLOPGpjDDqOgqARyY05Jmik
-      qD+jAjntqtyXHDlyxL5lpX2DOaqz3qRL/woPLyKIa/WN91dKJ94YpAPNNLaLZh4jW4GtPEsqoX31
-      enT/r4nw5OfpiINXQd92GumgBzcf40RaQ4V3C4PvPPK6cxn9baOFSn1amfA7veMHJf+5WjmMr6vC
-      smE6OAXFvqxrRfCF+5a4+zEXQnqBKvxTRp2kzu+n1Sgz3HSRNJy1yg9iVEixr2GmavovH3fsumQW
-      /pMuk6upGzkunISGm7oEJU4uY2iHA8w2v+IUYWdbYwdGpkJKNP1BO+eFKSr/3quqq2JPcJEsU8v0
-      f1KSwfPheaGmsUDuyVVnDVqAQh6Wll8CAP8bPy78MEpg0n7wGsq/QEF4tPg+RqhkKORaEKGNzm+N
-      lgArkSzEDM8bh752XgmlJTnW5h6bBn5t33FYdUxRr/i/+Pk5GYuLyHa6YXAHuSPLhnWubQaycABq
-      QLyohd4uL6Mp/AQ12iZ2ml+LqiQDONP9PK/QZsuz6MSR+NbMYtO7Ky5B/OTFzMEqe5K6Rvk+XUz0
-      yCSEh34SNAYtYfDHH0URdjIrxm5out/aJZyrgog0Hrqk1XMHMovhyEb/u4kuYGn8oZifl6pRYOyF
-      WZuwrgqZiFBHtY4b9oSTfMxMYArjictBUHfK0Kv/EqP3y7REYdVNon5Y7UBi2rbpGVqPuF1NeH9D
-      49SH3Px9rGpyn56d4eR3ssuJHozcpR07MMxXFTZVRSCzq9rL6vSxTfkpHEJX7UCfJWXa7OFHsM3l
-      aa+/qrRD3dU71W2eALR8PkjflJIVpYjU+/lTnWB0joh1zCmUxDMlCFpkgtJfjm8L1GDgH41cA02E
-      79YKc+ZN14cOtlw6kXI+eBz4zZFz3JCgO6yc9QHwYaSMgwwFy3Ea5gy7yokXWjLGOeiqQY18fCqW
-      Jw/gpHsD+HNdxYy5Jp8RC7wW8lw9db2YZnQ0wygsUBsug6LTVxGBoSLX46dFrdhSx4AsgbSIcIpA
-      djZG8hQalRpHwxTtFAntvoC1sMvl6yJGLgqYzrORaqYhJPkOgwheXzu3AN3Rjykg6ImlORyypk+w
-      mrg8psVss4shXZit+kdSYsUgerPpnXRFxq/b61ORhcv6yBSPi4OPesQnCkfxV9Otpceq7RJC9T+Z
-      pxJifdPS4rsbmtw/vl387KO6vPYlZV/7XajPr42NAe1r9SZRqWhq6LUjaa2ukp+GexfbAPIew1hA
-      J9aZmOV8Whxj+pn7dJuFLocIAAttgOIpg1+ZLWqjaYtnL0S2bNB4618dyn/TDKAdvSCkjXPHpJbh
-      bmjlWw0Tin1M2Cjy4skp6slJlV5lKjd7M7qizld6MaSXeT4w6jvnMxRjoAdCg/oqxBH++QxBHgyT
-      BT/cLArmYNXXtkpIsMK8MLhDuq5kB7jzjFKGiJswuQ7zeEiP4KHQO2t1ffHHJgzHM0t0IySOLL3i
-      Z2wV4KQc9Y6K++0jXGD3J85/BQSiM4DJfWOWJi/xUnzHetr7q3+j/bGRzZWS3Sxh62WpJrD8NdKc
-      KAOvQTkIQGDd2Bp8e89T9X0NSsFujljaxnYJCttfEe7aAk1cAz1Zt4KJoAwB9iPYiUT5erEQFvCb
-      XV5UVyzMIw+X0RzVn3kZRmaUe60sK/awXD8dnLRBtipxYGe3/ugafwsvs+O3kGkY357r9wiQsOJ2
-      tjpJ+p2Jfn2Dakp7pdOIwcgEuG9tJNn+TXafuS0bqI6E6LYtyjMTToqYo2W9g4xL1EwH9nAiRiNb
-      m8Ju7Xsz3BxPMATen+dD2BaQRGKKVIHdj1GV5Is8xZcdNfotCSNbwgsxkHNiWd123Nn5tmgSy4ZA
-      lebwajYiKGhaW2d86IV4PvFBUJzE2GbSxY7IqoHglMyH16Kmq4VjxUvsn2JunWbboB6Yn0lHiJom
-      13bMZxkzdibtiIUO5o+kV2diZdM6vWasOFdyyUVLXZWhx6eBVGEjNxRRM6+QMQg2R/5IPOvb0Ybq
-      Nqe3O0KLr6hE9K7/zZRscrxV2/43eXey6lRWbkp+jiBrjWssnbsC9so3w0oz8a9yyEE2GRMzMn7P
-      z6amWn3gFbt5XftxCfBh56bkgIjYVIw4qQjE5sOz/sIz2Ep9e/jtVK8vPIYhYpy1r6YYV/wg2rM8
-      8HVvFHrENCaQUHGaMWdI0UsaTEaSBTM8VgI+MGFeVDdl1YsZFBgcWeytoCfZhmSFjLK7E2ujN8aB
-      TY7WWu0gnNI7eq9v+Ck9BtlAAQOvBWK7hPWgooO++PTXgN4SGDAXA2q3capHpGbWoym8WutcZBrP
-      XcW6E7J1Rh6nga3Umt7B4HQ1M1kv+T/oniPGu+Ms/PM/EHVocQMCVsYyo5JuqsNoq3hY4fMZch+T
-      8J2TGkYvrjF9StjiMf7OdFjrOo8QiVWTx68VFGfa7QpOr/hVi9IcDlesbiwypoC2lhP1DEZL8Z4m
-      w4SbZxB2PMilJZDLYJ8UxQZ5R+w1fM4m4/5c6pEaZFWqX2XVmwCDWtAHlAxvTVzbmFeU3QmnhFGC
-      ykvHjLw+2KatoB7v7qVoN/GLsHsMij
-      </body>
-      </html>
+      2wWvUP5ISuTTzmzf27uZ/hGEVQMowYJYgDBZPGj3VY9XEHtdiCILqnw6oMvB95lUtNDPfVh+sEpM
+      4NbGyxC/hALxe98LaexsWfMgdtrOs0Cre2MwGeL2Vgr68Ju9mTzL3YpYetU09WSesko6RfnqjPyA
+      b0dsc7XecYeh8XfetC5WgUfsGGhJTKEd80ClFAWv0usTU+qccoG7zkxxTGzw5qzp7L+B4t8Bwgjf
+      dvFOZZ3cwPowiGg+4iF7rwbBCtOfXgFe/eBVGpP5KtW6hcdf7Wqw/w6Tkf8ZXlKSzT6xLXrq0C73
+      OrUwvRn+NJl6wbpSOFEvB3Cp19Q0oMTa9+alvPwWZxwXEIi85hT5YVDZsb0pP1hcTOQAsT5LOWzm
+      mtNcIstM50XZj1hHEhJeixp5gAsrwY1m+Uwm2X6a70NBEtqnP0B04oOIPfTtebORGu1DiJGgntWM
+      wdk1ReLyDLTS2tISn6ItAwknF0Qk3D5kMqNN2sB1GBcWf7zqTlgB3W2p6I31P2Vt/I+z859JwbIw
+      3w3AI5UAGSPmguLzzdPrqKa1igzrBcoDvEJnk2O0+39qlJ+Sa2Ko02KjGkl7ZNZJwUAIKMsC5vAl
+      hV2KFRtRnWa7YzDMuNzoOZezPnIz8zvLVQFVGCSnpu7crAKrrhJD9F/nDBEnLtA5lzJRf32LUYNI
+      tCs2CHt8guaddJ1U1+lEGLKX3QM0N62MhDQy2lZwAvag8WlW1le+kj0vO1NYCwauzEWZtdHEedGv
+      E98m9Y4OWDLl4k8uTV0f8vsgwHTCgFcJ8EmWYizi/ykL1kfdR324JiW+3YpH3F8GEp9L7ESkqIns
+      eXajNzKhagc1e+YM8Xe6SjWDXbdVV9ZSEsgdhK2gy0MQchK2vU1hzUKq4cxDTMJ8k3CAkuG3IFpd
+      Nyv9eW4aJUSsNv2OzH0iRUaXs3qAefORFQgn8/Qe2c6wSDAI5wHEi7zi/Lick3UVv+7V13zfvcWl
+      32A2p1Erotjl/tgj4lX60Ci3uRgRBQ/9wR/N9JuH0A4ynn0uBaS1M/Qpbmz78/oeXQgCEnUCEA4k
+      DXYvXl6o+dEfJkuUYMIAH4wadtmdf+DSH9oOPvBFSM93X8BF21SSDeb8K+YfIi6+Ivzll+5jcNoi
+      uUryTyp1don75Zk6CT7b2m1o514MS68ulcNI4g36GpaS44rnuvQGyacdau6NabzgR0Q/3n9kOlFE
+      IOse9+eUEmR6KXZ/DuoeT7M2+Qul4uNwJz8i2RrF7mAToB3k0qdA8fO2munXXWoGr77vSkEDdJeq
+      ihFBQ60KNZeZh4x18uAxYigNrYfWjmIFAdzQd9XpsGL7iHYmjyHUQQabzFirJdeS4w4hZoSznA5m
+      1CtCvRtAT8RPoiUPSqKU3QtH46iNGusjRoRfCj7ynrmeqeDqkw4H34CrnkolqT1hDqvaqZIyJo50
+      D3MGeURwMM6DYjWKOaVJaQDbXC8Ahb67+1nKUEyEaLKkfTh8GPGOnmBiWub/Y/N3AL9TEuihw9KP
+      NtjZQ82jL32NqdSdwKDXmE2SMmElUOY6fVFEGDVdgx9eJbeMaiSwXLTtUFxAxsO1wY5jDf8Cr97w
+      P8tLv1CPcec381Y2jAD0CgkGaa1u0VTj0jLFIwZK2faeKa3VJrB7ldYD74+PwiIgfl9nbvxlC8KN
+      5RTd7ThSGRQ+N7zpjRdaoftafUcFj6G/O/QrbhPxLZHcHG+zBGt/Fkr1lswfjiDsHHSM1ZyLiuny
+      ZqFBSSjL8X+NOa76tUq414UrZZ85w6nDTkzitXb36x8TEgfaoipUZJVNQ8smjE3bO9wB1zyzYXh7
+      vDQe9p3GfRN223tJKGhXZ1SewOqoZsEWTogk6FFxngAyYb6jfqFFChe9gSrjS54+WUm0HyvSGuks
+      q/NwwvgI69cXqPZL6eXpgAAwFbt366HbGDHcKaG02fmuBNdhguw1BuF3EaBiPF2beQvYx9GPyzua
+      VDTflywUGXI3JixRbwT0TgXDIX+2FceA5NcyGQLjwF5CpDH650PaholA3dUif8Blls+FpJ74UdK1
+      Ws+mG/UaBZ31hLHKqHI986G3PSxEWYyrF6vL6+CuNfet/SYh7AMRWK93Rkb3/N8GPosuFPaBNZLR
+      EBSHW9HUTP0viNWDupGx8mmncAUb9HLjqcFJoWGqZjVKaYe8J3NwvaL1P8+/v7ckpLUzOgiZVake
+      azDZDBoEfqFp/EGwnwm/KsnCQZ/I0aqrVW8T3AjUyFRIBw+rYLLGC2oIiUDH5ccvYhDY1epYS3C/
+      qW+mWa1XNz0Aat+7LFoMt4BG3319S/fqApIRMq3rcoegfPhGSI9CBoNnLCxz/GHnlSxstCIQdnMJ
+      xwWBgvHuVb84bHfsRknUQX7g5s7xf9UK06TXRmYG+lb70Trkb0EZKzT17IMIOnZk4BCJkX08YK88
+      C1rP68EjSdLSRiln3EPJ6kuNVFct077SfDG3SiLldx/VsZGSFzqWv69Qdb82wI+v5FcV3TZkrZAP
+      mhHJEWFaWvtEMyc7TtNI+0XhME96RIscBSLtoaRRV8CbMSJ8uanfox5LFId0gD4kfWiGtirj9/1/
+      GnAUoMhFeipQ8mYKu2zwOFsDVmWzC10uNyorY4qg/WBJ6A3asEcHIUVkmOnakPkRipKTKxFYlXjF
+      1Jau+KsvHTvWxOP/LTDipJjxwQWBzDEmUHOQJJrHQG/grmOPFB891bcFRLWzYSuSYCSLetA8HlCK
+      m9Bxit43AUhLeeUoVHroflvyHhI1LT2k6crEz4g/bdLMi7ncbtCmB88k6UYXUaXKL2YlzxRp+cWA
+      nxeR63cR2RXeqUVdO3GqgAFKHFw96lgbF74qBc9AE5r5juzvT6qoHq7sHNJ31VhA6cASdIio+H+D
+      O2sb8xvGyuCfydIHgJoRc2ilhVsMPwEoMsCrp1MRWE5tLgkn0uH5RjV1K1yDYY0PivgJYbBtjOhx
+      mcaaa+P8jHc7J/Q6rI6BCjehbOwFY7dbCjcBJ8y39yNvDFwtj53UxMiWoRSwNO8ICJNFwm1dXjUa
+      gJ/+g6q0U4qf0nL5f/whHCsY8qdD9Jj9qcRjvSNaiP/l44ETGA2bc+/33cdZZImYAw54nfoN1UPx
+      hcvP3dsol6SaHgGOvZV0R6sapasMbIuFOkAXEVjn75E1dnWoom2k/cWH1gCxStYKUE4ilsMi+Smb
+      ejw1wXXJ4IG/861DPEAfrhwXO5nBppSClyf8ASMI+EjJmEO9o9b+hvKST0lN/+qnXfgzyirrhjSH
+      B8mMyArxcZo3+avdi1hC8VgNsRpR9aC7Sim9v8gjMfVg0qvIcDPjfvozyXhiEhrc7T+GDqk6Ledv
+      lOwTMw+i5UlrEEeJXDp8Ae8dQ1i/aLN/J7bR6LI9off7egiSIgnoOaUJl5LfvHqzFJsbjpSrm9U9
+      hrhs9ChG6Qa1VsB/cvoaLwbzXi3XcbPue8DuNrgTP4CcP7KtiiS+NM+n0nRKEk9y7eeSfjXI5pE7
+      6JFIdYs2qXFLtc+SuBq4M2dtKySiOr27gi59sbgr/OlWl+JQDNKPZ3XFM9nsoNpD3QU5Ye0DKzrI
+      rJh5Q/Gt3fQg91sFiB76kkpsQ88GQ/kgui9jadTYZcRmz/vQkoiQShX0xhdbkmwQgocnNO9IkZy+
+      vua906n5skPPQIpaZOPuIxBoHE/1y+Ap2ofezIBj9p/HNv5Aolc1TL0eY5dPabXWwab/4vutMKos
+      MKAbI1Gow+RyptiZsau72g/IicWTIpBbveRnbiDWTmw2uwLus4asSanzWjZnlNyy0MIVK0uZRNVn
+      NBKCXH2VbYMyPIvN9CQbCl7/VnL4qPC8sxkJL28ZtwW881Kn79k49Go7FXZn/go1hdig8av4h+JZ
+      cHw+bjsNKe3Mr6JvyLIpkvsBFL3TGRQkEy/me6V2HI8dl3RoryJy3SiE8G5uXlKXJywYOaCoIUIp
+      2uyalKb2YNaZFc6xHjputeIegC4zJh6KmKK8H4n92/qn33DK813xaFpcQWh6HfTL33V1xn6x93jX
+      x40RmHxbslHN0DYbYcK8fDEdvHfAY/zzKpvXg1TsKYuW8tyeXWL5NjfGND7XliJCo/GIj0dAyWro
+      IkLvv7XqnAUvLyH+Kd1LBzMa+1Q6luGSQaYaw1Uwioi0+W8VP/vd2MZifv/M+Fg9jXQ0YAPxvnqw
+      dMNjVq+kCJY9wjwBpgEOdXte5cZebR4b9Zyn0DRFzb4levpCF0bjmJcbzgE/doh8c+qfCIxK57/l
+      j37u34+y4OjnTeqm991+jnzqjHP9Dr96IjRRVh268Hgqymx670MolqAFlb7Fazwi/+3n4wH6oIjj
+      cbgFVrsOH0KFnLKf3QFOA2Rr/x+ycY8e0A3Br90AjEzHBsbV2LCpmcB5JaFxQG3K8IGXP2O3h7jP
+      yXHLPG/Euu0CTN4TlDNl45Ppk2GY48jGb6bdhJjV/qeL49y9wSghFmnGlXkbOxZ/JqI2QeIXleAe
+      xeVcdnCF9d3mEE0POtHvh4/nF3SS6IwqQd9qtiNLvDrCuhLJCTfowCfTm0WzpNJmaXxrKG4jyUJG
+      IpVcQSKulIDwkgt66V/PtbgE/2V+4+EvYgP5uM8tf7AAskxlnqB5L81Ph/0zsumrqLUsX1gTONCW
+      Hqf0cPJlALcHY/FaKq3sZl3J/BoIygIR2IwMeOQCEprt46RsJeY8AAWEk0p9eDoiX7eniV8YFes9
+      mNUXxHyg1GYzRtbXv0Ua/TomdZwFVhOYGb2SeVCDmzmjPcWLnLZ8949jbHIKIvKgkYgFF5qrtukA
+      PcPkKGAbzAUpiWr7zn8pp1emm3YRhzvYVJ2gNMtxHZkRg6uNAbt/mF1BqIS8ODtTUUo4+gC/RGYF
+      bgJryFrYBuFihZLOSXV0T6KNcp/04xRTXI63nfGuJaY0iSoPI3mbeulgxMIFAoALb3nQ9z0bVSzT
+      Lf6jPmaeM379NQ0bg0IoF+lrRYNTOAE5LssUrDTO8EV402wulLU0MR3bKKkt4jvp04/GpIjn9xmJ
+      3ZuWjxjvyZGjlaGT/BgsAgi/MuNN1Syty0Pzw8cJUWAogcak/2Xt7cY0+xTWtk7JHy9npv0hNzaw
+      mpt6NM0Yk4wqMDE9VL8G5P302eAYv11/ZlRM9yDUmTr15wwEc2J0koLqulN96VwMekGsPMi1makl
+      JpcHjgSuuM4CrD8sd6L8K6IyZWyGBmWV4JQ2Sd4lGvuzxf9+5pS3Q2Iq6QqPzW6rBa9GUAufvtI0
+      cR+JxqDOwCEd9IwaDq1mvLFUqlfvlGgyj1GrOYMJMMjBa/ErFtnsFL2rzO9g1QkHtErTND50VM8C
+      IdAybJLV4DOUwzOK3NSElr4Wej8K0Lfbwe4R3KzE4vRc+mO1ZesiPyfM7VsR7dN2NRDTTqWF7dXn
+      jrCpI2Pwz/BSwbtNvKnVrELydJYqQZ4YN0Kgkb5ZQ+Ei23t+X6IjRNTY576q5BtmNw9MEV70/b4w
+      Ac0ArzOfp+PbLaC6WdjxzI/AdpZJ5RSBo3w5PY+3P8IG4tz1UyKMhvCtA/xBGTu77C83a0R696aL
+      kMA5RhYjlCdm73+BMTLp17jXM+j5ek8pt0l5beEWOQSQQuzowiyPwfyp3c77A+3OsuK1dIdTpxh4
+      EeGLY1UuMQla1ugZODWHac42h6uBftP7Q77qKbCQHHB6G7HlH8xIJp6YfoBbqeQuMhrZrbeWGMpE
+      XGHizQFlsiHAniPfcY+XaCE4sgW+2gAlR6ESkO3DnGFnyejMspfa+BDdZBfuUO1JNWQwOtlooicQ
+      JXbSKAVrfDTsFrerk1LJkuhCvIGINt7D+9i9/t+twgA834ObDzb89dpWJAiFV1JtfJW4DGTKga6I
+      850NJW8/GP4l/hqH0EH9jSDXgjdhS0716/nEjXnwZ0rsHLfGq1AaMUHv972wv+3TA188kzlk7fRr
+      wuJbuLpwVqp/H1LNueJu+/lzFQoh9eeboguENZNIoZQ7cD0pINwHdeyhXZDomaxHnIrxiZmy72P/
+      aNkruB+Kf7evbRHzPNZAWkie/PwDrAsPLpeiTuK3nhpd/XIfmnNXZtt1X53MJHRwDMl00ze7lXwn
+      37Pm2dYsZo2f20cIuVrzyOPv9f9y2y92UAJ6VvPxHjci2lQupmdn/D7kdeF44nZWUMRkvnHW+Lxj
+      NYHuwwX6sOoKavnmVALOhYk9mukP4pNliuvcJmuhJxaI9oQah8encM2WA8Z7s61Xf1Gk2luMH709
+      0EX6VvPrNLFUY7xJJsXT191vyrg6Wu5Yd2ZIFXrCgKBLfHumvO3NE+YE+LKK6xrH7Urk9trmKJKt
+      sfsgmIz8xj4D59tlIsgKZfwGsIbIlachpjhXM9jNdOSe5k2tHNdnh1OvBJvOIqKSp4uVlHZnLUMZ
+      07rzxr9wdzU4ihaUgvreVpar6vnNYuj/TTDRP0FcBay0IuPunVhX9Wel5ga+NWIV9srCmzsJN7/d
+      puvaV9sb5dc0M0klEq41bMKDFd86YKifRhwagol5OAHTPjvIqZ9WOr/7XVuxAtOG0l1ohgrKTtfV
+      jw4KZCd+zIazzwuA0ItCENMmAm2Xppqy1T0Uu7gql3b8XAtsk+IhQw+L8H/oJtt/vaRSnbfTS02N
+      umm7CcneYyHT1FiuMfm5rkHee7rPR+YiDXlnkrTjd6HaBk3a/mEf0amzsMH9s4FzQRLbYPcXZrfi
+      ah18pV5ZlcfsC1kmM+wBbxCjxoUcV2DyeGiMdQo2Pif9LpPXOo6SE9a4lDovQF5brB6z9MGUZlKf
+      n+bQ1SVZxu4ArWLnbmXrgHzz+APsWh6VBfCw0MT8oP7uzB6tzIP1RCm7uKgb1Hi2f8f4DympfW4r
+      K3/H/5c3foZqlZDSDCGv3amzwkSZ3VsWHPrGFa0jLkTweBf+8UyzRIdoceDI7Ovg9cOiVf4bVqA/
+      B4DavbV6xOAbHloEJTIEI54epi2CEFnAvpJUgr+uWkgQbSTJVmXUWw0s6gv+2sbeNYYz169c1ScP
+      U1afX80IXtL0iq7sQjbEPfOg9hWbHQWoAaSgLT0mvGkMHn8eKUBFdvF2paNOfU47OirGz1ifdRZe
+      9BgBR6glFDlp5g99K6PXxADoy+nHAKnzxlWuxjfMoXgcIWpmIXad+vi3m7J48Z8xAaN8/657UjNW
+      JmYHVjst8m+Q14lyMJfFj1Q+9FjyKTGwSjryd5dUJacyGrg3mli2v99KnTsOjY1Wm6//G5dcuRIT
+      IceUARlCKNONQVe3tM4LoIglqTipwfzLwjDfb223BAfNt41otmZ3VGM8yesZQmAnokKhcErDTrw3
+      g9aoCI6OlrtLrTx3V1k7qW9INLZXspvhU4CalQdWvugpH4prAQO6FeFLCu66/KIL9FZoe5n66UBz
+      TFR2ih8dKo1JV/aLuqjpsZ+l4lNal4vnqgaLUehC7j1zQAiLD585VMuEliJSmES8wHL3nt5JUKoe
+      2Y6+aRDQqYUZsEhnPQ1H+0AT5LHOh6P1576m52Bp2tczVjN2K6Hgw+koDUmZj7YUj1stzjKso5rM
+      0zRAppa9g4XJSDnjaBFdYcRmWZ+PE/sjXzcu1eNtttlJqmYqO4dMGHiffoBIvz9nvqn8eZIRMPdt
+      D1/ykxN6Cbl42Ox9WTSIZncj6LbhB/5dT12DdCtedx7ljDcGVQm30HbB5GSYWYuWphJSJ0YWX8O+
+      lW8A3Qy0Vnu2EZUsNKBzgSbws63t2xrizMq0eRkMkHL8L4OUFKenwro6m0PJcuPhTBhVN0ek73vl
+      YVdXRPoPejw6wPeETZ6ObnCFqySDsycqyIwYXmxFNw3aYiTjFls2i+BZ6lGManDeJ/U/VKdrJt74
+      Ua3HXuQXe9z/uOBdmiWPBuIA79uzt3C/g5hTFt3L4Q25aRMRXIQkrtRRfP6AEyKJmAUY1hwyIJQV
+      +HVW+djWL9nO1/REKbJcGPmQwscoH9YYrP4XpLaXbWV/XbuCsyPzW+QKqUinMIX3LlAIYgJp+pyb
+      m2/3So5gYJkPZxx4UxVrqxAkKhSkQVHvv6Rvj6LkdomEfA76eWKxxvksde+zZkD2ZcWMg0obX1Ox
+      BFNBRELPe53ZdLKWpf2Sr96vRPRNw
 - apiVersion: v1
   kind: Pod
   metadata:
@@ -176,144 +160,55 @@ objects:
   spec:
     containers:
     - image: ${HAPROXY_IMAGE}
-      name: serve
+      name: haproxy
       command: ["/bin/bash", "-c" ]
       args:
         - set -e;
-          cat /etc/service-certs/tls.key /etc/service-certs/tls.crt > /tmp/bundle.pem;
+          cat /etc/serving-cert/tls.key /etc/serving-cert/tls.crt > /tmp/bundle.pem;
           haproxy -f /etc/haproxy/haproxy.config -db
       ports:
       - containerPort: 8443
         protocol: TCP
-      - containerPort: 8080
-        protocol: TCP
       readinessProbe:
+        failureThreshold: 3
         tcpSocket:
-          port: 8080
+          port: 8443
         initialDelaySeconds: 10
-        periodSeconds: 3
+        periodSeconds: 30
+        successThreshold: 1
+      livenessProbe:
+        failureThreshold: 3
+        tcpSocket:
+          port: 8443
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        successThreshold: 1
       volumeMounts:
-      - name: service-certs
-        mountPath: /etc/service-certs
-      - name: config
-        mountPath: /etc/haproxy
-      - name: tmp
-        mountPath: /var/cache/haproxy
-      - name: tmp
-        mountPath: /var/run
+      - mountPath: /etc/serving-cert
+        name: cert
+      - mountPath: /etc/haproxy
+        name: config
     volumes:
     - name: config
       configMap:
         name: h2spec-haproxy-config
-    - name: service-certs
+    - name: cert
       secret:
-        secretName: service-certs
-    - name: tmp
-      emptyDir: {}
-    - name: tmp2
-      emptyDir: {}
+        secretName: serving-cert-h2spec
 - apiVersion: v1
   kind: Service
   metadata:
     name: h2spec-haproxy
     annotations:
-      service.beta.openshift.io/serving-cert-secret-name: service-certs
+      service.beta.openshift.io/serving-cert-secret-name: serving-cert-h2spec
   spec:
     selector:
       app: h2spec-haproxy
     ports:
-      - port: 443
+      - port: 8443
         name: https
         targetPort: 8443
         protocol: TCP
-      - port: 80
-        name: http
-        targetPort: 8080
-        protocol: TCP
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    labels:
-      app: h2spec-haproxy
-    name: h2spec-haproxy-edge
-  spec:
-    port:
-      targetPort: 8080
-    tls:
-      termination: edge
-      key: |-
-        -----BEGIN EC PRIVATE KEY-----
-        MHcCAQEEIFTS3l3jU0kF0cQ27MTn+a27Oz1CMr5gSnDQQwZ3BI0moAoGCCqGSM49
-        AwEHoUQDQgAE0XRkp541S/i1bBYEtl/xWsKHDtmuFu7X1rIQiRAU4SB43B52iDxJ
-        V5P5usDcYPghidR7m0hVj6s5iMskxwLr6g==
-        -----END EC PRIVATE KEY-----
-      certificate: |-
-        -----BEGIN CERTIFICATE-----
-        MIIBizCCATGgAwIBAgIQJN1GzcsQZOXK7xqks+2aijAKBggqhkjOPQQDAjAoMRQw
-        EgYDVQQKEwtDZXJ0IEdlbiBDbzEQMA4GA1UEAxMHUm9vdCBDQTAgFw0yMDA1MTgw
-        OTU3MjNaGA8yMTIwMDQyNDA5NTcyM1owLjEZMBcGA1UEChMQQ2VydCBHZW4gQ29t
-        cGFueTERMA8GA1UEAxMIdGVzdGNlcnQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
-        AATRdGSnnjVL+LVsFgS2X/FawocO2a4W7tfWshCJEBThIHjcHnaIPElXk/m6wNxg
-        +CGJ1HubSFWPqzmIyyTHAuvqozUwMzAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAww
-        CgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAKBggqhkjOPQQDAgNIADBFAiBgjygk
-        ycGFHUK+b3hdvylD3ftaRT/muv+FKuuMqNCHsAIhAPW1owpVKlLHC/NaApFW/d0f
-        Gf2Mda0JAqYv0ehJUh7w
-        -----END CERTIFICATE-----
-    to:
-      kind: Service
-      name: h2spec-haproxy
-      weight: 100
-    wildcardPolicy: None
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    labels:
-      app: h2spec-haproxy
-    name: h2spec-haproxy-reencrypt
-  spec:
-    port:
-      targetPort: 8443
-    tls:
-      termination: reencrypt
-      key: |-
-        -----BEGIN EC PRIVATE KEY-----
-        MHcCAQEEIDKH71OdAhMZUgZ2Pf6p4/EBVR+KwyULozkTqQr8KDiQoAoGCCqGSM49
-        AwEHoUQDQgAEo8hY5B0vhT69FhEXVzzIsJzd8Uz8gXlsrvN0kBN9LyEZQIF/jEaz
-        JkczsyB718xQ69sePwAz9mz4IziYevSsBw==
-        -----END EC PRIVATE KEY-----
-      certificate: |-
-        -----BEGIN CERTIFICATE-----
-        MIIBjTCCATKgAwIBAgIRAJ08uWkebJb9qoYo8hJS7C8wCgYIKoZIzj0EAwIwKDEU
-        MBIGA1UEChMLQ2VydCBHZW4gQ28xEDAOBgNVBAMTB1Jvb3QgQ0EwIBcNMjAwNTE4
-        MDk1NzU5WhgPMjEyMDA0MjQwOTU3NTlaMC4xGTAXBgNVBAoTEENlcnQgR2VuIENv
-        bXBhbnkxETAPBgNVBAMTCHRlc3RjZXJ0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcD
-        QgAEo8hY5B0vhT69FhEXVzzIsJzd8Uz8gXlsrvN0kBN9LyEZQIF/jEazJkczsyB7
-        18xQ69sePwAz9mz4IziYevSsB6M1MDMwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQM
-        MAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwCgYIKoZIzj0EAwIDSQAwRgIhAKhn
-        j6sLRgUGcHdi/PTcM0vCD5d0sgakmQQB8M8Fdq5NAiEAxwuNfS8p2mJpnygCeMr2
-        YWcPcuBP6slsMyV/nyuk4DM=
-        -----END CERTIFICATE-----
-    to:
-      kind: Service
-      name: h2spec-haproxy
-      weight: 100
-    wildcardPolicy: None
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    labels:
-      app: h2spec-haproxy
-    name: h2spec-haproxy-passthrough
-  spec:
-    port:
-      targetPort: 8443
-    tls:
-      termination: passthrough
-    to:
-      kind: Service
-      name: h2spec-haproxy
-      weight: 100
-    wildcardPolicy: None
 - apiVersion: v1
   kind: Pod
   metadata:
@@ -323,6 +218,6 @@ objects:
   spec:
     containers:
     - name: h2spec
-      image: docker.io/summerwind/h2spec:2.4.0
-      command: ["/bin/bash"]
-      args: ["-c", "while true; do echo -n 'heartbeat: '; date; sleep 60; done"]
+      image: ${H2SPEC_IMAGE}
+      command: ["sleep"]
+      args: ["infinity"]


### PR DESCRIPTION
- Requires https://github.com/openshift/cluster-ingress-operator/pull/590
- Builds on https://github.com/openshift/origin/pull/25897 and that should merge first

This PR re-enables the h2spec tests They were previously
disabled as the default ingresscontroller is not configured with http/2
support by default.

There are a number of changes here:

- The text fixture has been split up so that we can first apply the
pod/service, then apply the configured routes, then roll out a
dedicated ingresscontroller.

- There is a new fixture to rollout a new router shard with http/2
enabled.

- There is a new test fixture for the routes which are now parameterised
with an explicit domain and namespace selector to match on the router
shard type.

- The test now spins up a dedicated ingresscontroller.

- Rework and simplify the h2spec tests to only test via a passthrough route.

I ran the tests with `export ROUTER_H2SPEC_SAMPLE=100` and we have 2
failures, both related to GOAWAY; previous discussion https://github.com/haproxy/haproxy/issues/471#issuecomment-591420924

