### PR TITLE
e2echart: Handle intervals that extend past the test range

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -128,12 +128,27 @@
 
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc) {
         const data = {}
+        var now = new Date();
+        var earliest = rawEventIntervals.items.reduce(
+            (accumulator, currentValue) => !currentValue.from || accumulator < new Date(currentValue.from) ? accumulator : new Date(currentValue.from),
+            new Date(now.getTime() + 1),
+        );
+        var latest = rawEventIntervals.items.reduce(
+            (accumulator, currentValue) => !currentValue.to || accumulator > new Date(currentValue.to) ? accumulator : new Date(currentValue.to),
+            new Date(now.getTime() - 1),
+        );
         rawEventIntervals.items.forEach((item) => {
             if (!preconditionFunc(item)) {
                 return
             }
             var startDate = new Date(item.from)
+            if (!item.from) {
+                startDate = earliest;
+            }
             var endDate = new Date(item.to)
+            if (!item.to) {
+                endDate = latest
+            }
             let label = item.locator
             let sub = ""
             let val = timelineVal

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53374,12 +53374,27 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc) {
         const data = {}
+        var now = new Date();
+        var earliest = rawEventIntervals.items.reduce(
+            (accumulator, currentValue) => !currentValue.from || accumulator < new Date(currentValue.from) ? accumulator : new Date(currentValue.from),
+            new Date(now.getTime() + 1),
+        );
+        var latest = rawEventIntervals.items.reduce(
+            (accumulator, currentValue) => !currentValue.to || accumulator > new Date(currentValue.to) ? accumulator : new Date(currentValue.to),
+            new Date(now.getTime() - 1),
+        );
         rawEventIntervals.items.forEach((item) => {
             if (!preconditionFunc(item)) {
                 return
             }
             var startDate = new Date(item.from)
+            if (!item.from) {
+                startDate = earliest;
+            }
             var endDate = new Date(item.to)
+            if (!item.to) {
+                endDate = latest
+            }
             let label = item.locator
             let sub = ""
             let val = timelineVal


### PR DESCRIPTION
For example, when [kube-apiserver opens with `Progressing=True`][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1379189196182261760/artifacts/e2e-gcp-upgrade/openshift-e2e-test/artifacts/e2e-intervals.json | jq '.items[:2]'
[
  {
    "level": "Warning",
    "locator": "clusteroperator/kube-apiserver",
    "message": "condition/Progressing status/True reason/Unknown",
    "from": null,
    "to": "2021-04-05T22:22:24Z"
  },
  {
    "level": "Info",
    "locator": "e2e-test/\"[sig-arch][Early] Managed cluster should start all core operators [Suite:openshift/conformance/parallel]\"",
    "message": "e2e test finished As \"Passed\"",
    "from": "2021-04-05T22:20:18Z",
    "to": "2021-04-05T22:20:19Z"
  }
]
```

With the older code, that Progressing=True entry stretched back to the Unix epoc.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1379189196182261760