### PR TITLE
pkg/test/ginkgo/cmd_runsuite: Fix e2e-* clobber for upgrade-conformance

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -283,17 +283,18 @@ func (opt *Options) Run(suite *TestSuite) error {
 	// monitor the cluster while the tests are running and report any detected anomalies
 	var syntheticTestResults []*JUnitTestCase
 	var syntheticFailure bool
+	timeSuffix := fmt.Sprintf("_%s", start.UTC().Format("20060102-150405"))
 	events := m.EventIntervals(time.Time{}, time.Time{})
-	if err = monitorserialization.EventsToFile(path.Join(os.Getenv("ARTIFACT_DIR"), "e2e-events.json"), events); err != nil {
+	if err = monitorserialization.EventsToFile(path.Join(os.Getenv("ARTIFACT_DIR"), fmt.Sprintf("e2e-events%s.json", timeSuffix)), events); err != nil {
 		fmt.Fprintf(opt.Out, "Failed to write event file: %v\n", err)
 	}
-	if err = monitorserialization.EventsIntervalsToFile(path.Join(os.Getenv("ARTIFACT_DIR"), "e2e-intervals.json"), events); err != nil {
+	if err = monitorserialization.EventsIntervalsToFile(path.Join(os.Getenv("ARTIFACT_DIR"), fmt.Sprintf("e2e-intervals%s.json", timeSuffix)), events); err != nil {
 		fmt.Fprintf(opt.Out, "Failed to write event file: %v\n", err)
 	}
 	if eventIntervalsJSON, err := monitorserialization.EventsIntervalsToJSON(events); err == nil {
 		e2eChartTemplate := testdata.MustAsset("e2echart/e2e-chart-template.html")
 		e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)
-		e2eChartHTMLPath := path.Join(os.Getenv("ARTIFACT_DIR"), "e2e-intervals.html")
+		e2eChartHTMLPath := path.Join(os.Getenv("ARTIFACT_DIR"), fmt.Sprintf("e2e-intervals%s.html", timeSuffix))
 		if err := ioutil.WriteFile(e2eChartHTMLPath, e2eChartHTML, 0644); err != nil {
 			fmt.Fprintf(opt.Out, "Failed to write event html: %v\n", err)
 		}


### PR DESCRIPTION
When we run an update test followed by a conformance test, the previous, static filenames lead to the update-run output being clobbered by the conformance-run output.  For example, [this job][1] has:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1379237920786878464/artifacts/e2e-gcp-upgrade/openshift-e2e-test/artifacts/e2e.log | grep -A2 'started.*Cluster sh
ould remain functional during upgrade'
started: (0/5/5) "[sig-arch][Feature:ClusterUpgrade] Cluster should remain functional during upgrade [Disruptive] [Serial]"

I0406 01:36:33.559185     246 test_context.go:459] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
```

But all of the intervals and events are from the later conformance run:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1379237920786878464/artifacts/e2e-gcp-upgrade/openshift-e2e-test/artifacts/e2e-intervals.json | jq -r '.items[] | .from + " " + .locator' | sort | head -n2
2021-04-06T02:46:00Z e2e-test/"[sig-arch][Early] Managed cluster should start all core operators [Suite:openshift/conformance/parallel]"
2021-04-06T02:46:00Z e2e-test/"[sig-auth][Feature:SCC][Early] should not have pod creation failures during install [Suite:openshift/conformance/parallel]"
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1379237920786878464/artifacts/e2e-gcp-upgrade/openshift-e2e-test/artifacts/e2e-events.json | jq -r '.items[] | .from + " " + .locator ' | sort | head -n1
2021-04-06T02:46:00Z e2e-test/"[sig-arch][Early] Managed cluster should start all core operators [Suite:openshift/conformance/parallel]"
```

There's no need to do this for `e2e.log`, which later runs will append to:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1379237920786878464/artifacts/e2e-gcp-upgrade/openshift-e2e-test/artifacts/e2e.log | grep -A2 'started.*Managed cluster should start all core operators'
started: (0/2/5) "[sig-arch][Early] Managed cluster should start all core operators [Suite:openshift/conformance/parallel]"

started: (0/3/5) "[sig-instrumentation] Prometheus when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early] [Suite:openshift/conformance/parallel]"
--
started: (0/4/2725) "[sig-arch][Early] Managed cluster should start all core operators [Suite:openshift/conformance/parallel]"

passed: (400ms) 2021-04-06T02:46:01 "[sig-arch][Early] Managed cluster should start all core operators [Suite:openshift/conformance/parallel]"
```

This commit gives the non-append files timestamp suffixes, following [the existing pattern in `writeJUnitReport`][2], to reduce the chance of collision.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1379237920786878464
[2]: https://github.com/openshift/origin/blob/53784e6548d24422f9c227dbd466a85082db2f59/pkg/test/ginkgo/junit.go#L189