### PR TITLE
test: Disable p&f test until rebase PR lands

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -323,7 +323,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial]": "should be stored at the correct location and version for all resources [Serial] [Disabled:Broken]",
 
-	"[Top Level] [sig-api-machinery] API priority and fairness should ensure that requests can be classified by testing flow-schemas/priority-levels": "should ensure that requests can be classified by testing flow-schemas/priority-levels [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-api-machinery] API priority and fairness should ensure that requests can be classified by testing flow-schemas/priority-levels": "should ensure that requests can be classified by testing flow-schemas/priority-levels [Disabled:Broken] [Suite:k8s]",
 
 	"[Top Level] [sig-api-machinery] API priority and fairness should ensure that requests can't be drowned out (fairness)": "should ensure that requests can't be drowned out (fairness) [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -41,6 +41,9 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1945085
 			`API data in etcd should be stored at the correct location and version for all resources`,
 
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1929248, can be enabled after rebase
+			`API priority and fairness should ensure that requests can be classified by testing flow-schemas/priority-levels`,
+
 			// // https://bugzilla.redhat.com/show_bug.cgi?id=1945091
 			`\[Feature:GenericEphemeralVolume\]`,
 		},


### PR DESCRIPTION
GCP p&f is failing much more consistently since rebase, the test
is being updated in the test rebase so this is a temporary disable.