### PR TITLE
Bug 1948233: Add openshift/network/third-party suite, for CNI plugin conformance

### DIFF
--- a/cmd/openshift-tests/cni.go
+++ b/cmd/openshift-tests/cni.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+)
+
+// Determines whether a test should be run for third-party network plugin conformance testing
+func inCNISuite(name string) bool {
+	if strings.Contains(name, "[Suite:k8s]") && strings.Contains(name, "[sig-network]") {
+		// Run all upstream sig-network conformance tests
+		if strings.Contains(name, "[Conformance]") {
+			return true
+		}
+		// Run all upstream NetworkPolicy tests except named port tests. (Neither
+		// openshift-sdn nor ovn-kubernetes supports named ports in NetworkPolicy,
+		// so we don't require third party tests to support them either.)
+		if strings.Contains(name, "NetworkPolicy") && !strings.Contains(name, "named port") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -184,6 +184,15 @@ var staticSuites = []*ginkgo.TestSuite{
 		TestTimeout: 20 * time.Minute,
 	},
 	{
+		Name: "openshift/network/third-party",
+		Description: templates.LongDesc(`
+		The conformance testing suite for certified third-party CNI plugins.
+		`),
+		Matches: func(name string) bool {
+			return !strings.Contains(name, "[Disabled") && inCNISuite(name)
+		},
+	},
+	{
 		Name: "all",
 		Description: templates.LongDesc(`
 		Run all tests.


### PR DESCRIPTION
The certification team pointed out that it would make sense to backport this to 4.6, since we will be supporting it as the EUS release for a long time, and it would be simpler to have it use the same process as 4.7+.

/assign @knobunc 