### PR TITLE
Bug 1948629: upgrades: add "none" / "minimal" test suites to skip disruption tests

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -77,6 +77,8 @@ func upgradeTestPreTest() error {
 	parseUpgradeOptions(opt.TestOptions)
 	upgrade.SetToImage(opt.ToImage)
 	switch opt.Suite {
+	case "none":
+		return filterUpgrade(upgrade.NoTests(), func(string) bool { return true })
 	case "platform":
 		return filterUpgrade(upgrade.AllTests(), func(name string) bool {
 			return name == controlplane.NewKubeAvailableWithNewConnectionsTest().Name() || name == controlplane.NewKubeAvailableWithNewConnectionsTest().Name()

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -38,6 +38,12 @@ import (
 	"github.com/openshift/origin/test/extended/util/operator"
 )
 
+// NoTests is an empty list of tests
+func NoTests() []upgrades.Test {
+	return []upgrades.Test{}
+}
+
+// AllTests includes all tests (minimal + disruption)
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
 		controlplane.NewKubeAvailableWithNewConnectionsTest(),


### PR DESCRIPTION
For SNO upgrades most disruption tests would fail as there is no HA. This option would allow SNO upgrade test suite to skip those