### PR TITLE
Bug 1948606: test: replace dns test with known image

### DIFF
--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	watchtools "k8s.io/client-go/tools/watch"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -41,7 +42,7 @@ func createDNSPod(namespace, probeCmd string) *kapiv1.Pod {
 			Containers: []kapiv1.Container{
 				{
 					Name:    "querier",
-					Image:   "gcr.io/google_containers/dnsutils:e2e",
+					Image:   imageutils.GetE2EImage(imageutils.JessieDnsutils),
 					Command: []string{"sh", "-c", probeCmd},
 				},
 			},


### PR DESCRIPTION
gcr.io/google_containers/dnsutils:e2e isn't a [known image](https://github.com/openshift/origin/blob/839dfa9a49e45ccf103e33cedcfff4834b2b3084/test/extended/util/image/README.md) so dualstack tests are failing the `[sig-arch] Only known images used by tests` test.