### PR TITLE
test: Expose node changes as intervals

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -52,60 +52,6 @@
 </script>
 
 <script>
-    var loc = window.location.href;
-
-    const el = document.querySelector('#chart');
-
-    var timelineGroups = []
-    timelineGroups.push({group: "operator-unavailable", data: []})
-    createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorAvailable)
-
-    timelineGroups.push({group: "operator-degraded", data: []})
-    createTimelineData("OperatorDegraded", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorDegraded)
-
-    timelineGroups.push({group: "operator-progressing", data: []})
-    createTimelineData("OperatorProgressing", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorProgressing)
-
-    timelineGroups.push({group: "apiserver-availability", data: []})
-    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerConnectivity)
-
-    timelineGroups.push({group: "e2e-test-failed", data: []})
-    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed)
-
-    timelineGroups.push({group: "e2e-test-flaked", data: []})
-    createTimelineData("Flaked", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFlaked)
-
-    timelineGroups.push({group: "e2e-test-passed", data: []})
-    createTimelineData("Passed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EPassed)
-
-    var segmentFunc = function (segment) {
-        // for (var i in data) {
-        //     if (data[i].group == segment.group) {
-        //         var groupdata = data[i].data
-        //         for (var j in groupdata) {
-        //             if (groupdata[j].label == segment.label) {
-        //                 labeldata = groupdata[j].data
-        //                 for (var k in labeldata) {
-        //                     var startDate = new Date(labeldata[k].timeRange[0])
-        //                     var endDate = new Date(labeldata[k].timeRange[1])
-        //                     if (startDate.getTime() == segment.timeRange[0].getTime() &&
-        //                         endDate.getTime() == segment.timeRange[1].getTime()) {
-        //                         $('#myModalContent').text(labeldata[k].extended)
-        //                         $('#myModal').modal()
-        //                     }
-        //                 }
-        //             }
-        //         }
-        //     }
-        // }
-    }
-    const myChart = TimelinesChart();
-    var ordinalScale = d3.scaleOrdinal()
-        .domain(['OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', 'Passed', 'Skipped', 'Flaked', 'Failed', 'Degraded', 'Upgradeable', 'False', 'Unknown'])
-        .range(['#d0312d', '#ffa500', '#fada5e', '#3cb043', '#ceba76', '#ffa500', '#d0312d', '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
-    myChart.data(timelineGroups).zQualitative(true).enableAnimations(false).leftMargin(320).rightMargin(550).maxLineHeight(20).maxHeight(10000).zColorScale(ordinalScale).onSegmentClick(segmentFunc)
-    (el);
-
     function isOperatorAvailable(eventInterval) {
         if (eventInterval.locator.startsWith("clusteroperator/") && eventInterval.message.includes("condition/Available") && eventInterval.message.includes("status/False")) {
             return true
@@ -161,6 +107,25 @@
         return false
     }
 
+    function isNodeState(eventInterval) {
+        if (eventInterval.locator.startsWith("node/")) {
+            return (eventInterval.message.startsWith("reason/NodeUpdate ") || eventInterval.message == "node is not ready")
+        }
+        return false
+    }
+
+    const rePhase = new RegExp("(^| )phase/([^ ]+)")
+    function nodeStateValue(item) {
+        if (item.message == "node is not ready") {
+            return [item.locator, " (not ready)", "NodeNotReady"]
+        }
+        let m = item.message.match(rePhase);
+        if (m && m[2] != "Update") {
+            return [item.locator, " (update phases)", m[2]];
+        }
+        return [item.locator, " (updates)", "Update"];
+    }
+
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc) {
         const data = {}
         rawEventIntervals.items.forEach((item) => {
@@ -169,19 +134,91 @@
             }
             var startDate = new Date(item.from)
             var endDate = new Date(item.to)
-            if (!data[item.locator]) {
-                data[item.locator] = []
+            let label = item.locator
+            let sub = ""
+            let val = timelineVal
+            if (typeof val === "function") {
+                [label, sub, val] = timelineVal(item)
             }
-            data[item.locator].push({
+            let section = data[label]
+            if (!section) {
+                section = {};
+                data[label] = section
+            }
+            let ranges = section[sub]
+            if (!ranges) {
+                ranges = [];
+                section[sub] = ranges
+            }
+            ranges.push({
                 timeRange: [startDate, endDate],
-                val: timelineVal
+                val: val,
             });
         });
         for (const label in data) {
-            timelineData.push({label, data: data[label]})
+            const section = data[label]
+            for (const sub in section) {
+                timelineData.push({label: label+sub, data: section[sub]})
+            }
         }
     }
 
+    var loc = window.location.href;
+
+    var timelineGroups = []
+    timelineGroups.push({group: "operator-unavailable", data: []})
+    createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorAvailable)
+
+    timelineGroups.push({group: "operator-degraded", data: []})
+    createTimelineData("OperatorDegraded", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorDegraded)
+
+    timelineGroups.push({group: "operator-progressing", data: []})
+    createTimelineData("OperatorProgressing", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorProgressing)
+
+    timelineGroups.push({group: "node-state", data: []})
+    createTimelineData(nodeStateValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isNodeState)
+
+    timelineGroups.push({group: "apiserver-availability", data: []})
+    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerConnectivity)
+
+    timelineGroups.push({group: "e2e-test-failed", data: []})
+    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed)
+
+    timelineGroups.push({group: "e2e-test-flaked", data: []})
+    createTimelineData("Flaked", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFlaked)
+
+    timelineGroups.push({group: "e2e-test-passed", data: []})
+    createTimelineData("Passed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EPassed)
+
+    var segmentFunc = function (segment) {
+        // for (var i in data) {
+        //     if (data[i].group == segment.group) {
+        //         var groupdata = data[i].data
+        //         for (var j in groupdata) {
+        //             if (groupdata[j].label == segment.label) {
+        //                 labeldata = groupdata[j].data
+        //                 for (var k in labeldata) {
+        //                     var startDate = new Date(labeldata[k].timeRange[0])
+        //                     var endDate = new Date(labeldata[k].timeRange[1])
+        //                     if (startDate.getTime() == segment.timeRange[0].getTime() &&
+        //                         endDate.getTime() == segment.timeRange[1].getTime()) {
+        //                         $('#myModalContent').text(labeldata[k].extended)
+        //                         $('#myModal').modal()
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
+    }
+
+    const el = document.querySelector('#chart');
+    const myChart = TimelinesChart();
+    var ordinalScale = d3.scaleOrdinal()
+        .domain(['OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', 'Passed', 'Skipped', 'Flaked', 'Failed', 'Degraded', 'Upgradeable', 'False', 'Unknown'])
+        .range(['#d0312d', '#ffa500', '#fada5e', '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', '#3cb043', '#ceba76', '#ffa500', '#d0312d', '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
+    myChart.data(timelineGroups).zQualitative(true).enableAnimations(false).leftMargin(320).rightMargin(550).maxLineHeight(20).maxHeight(10000).zColorScale(ordinalScale).onSegmentClick(segmentFunc)
+    (el);
 </script>
 </body>
 </html>

--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -80,9 +80,9 @@ func Start(ctx context.Context) (*Monitor, error) {
 		intervalcreation.IntervalsFromEvents_OperatorAvailable,
 		intervalcreation.IntervalsFromEvents_OperatorProgressing,
 		intervalcreation.IntervalsFromEvents_OperatorDegraded,
+		intervalcreation.IntervalsFromEvents_E2ETests,
+		intervalcreation.IntervalsFromEvents_NodeChanges,
 	)
-
-	m.intervalCreationFns = append(m.intervalCreationFns, intervalcreation.IntervalsFromEvents_E2ETests)
 
 	m.StartSampling(ctx)
 	return m, nil

--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -7,8 +7,8 @@ import (
 )
 
 // E2ETestEventIntervals returns only EventIntervals for e2e tests
-func E2ETestEventIntervals(events []*monitorapi.EventInterval) []*monitorapi.EventInterval {
-	e2eEventIntervals := []*monitorapi.EventInterval{}
+func E2ETestEventIntervals(events monitorapi.EventIntervals) monitorapi.EventIntervals {
+	e2eEventIntervals := monitorapi.EventIntervals{}
 	for i := range events {
 		event := events[i]
 		if event.From == event.To {
@@ -23,8 +23,8 @@ func E2ETestEventIntervals(events []*monitorapi.EventInterval) []*monitorapi.Eve
 }
 
 // FindOverlap finds intervals that overlap with the time between start and end.
-func FindOverlap(intervals []*monitorapi.EventInterval, start, end time.Time) []*monitorapi.EventInterval {
-	overlappingIntervals := []*monitorapi.EventInterval{}
+func FindOverlap(intervals monitorapi.EventIntervals, start, end time.Time) monitorapi.EventIntervals {
+	overlappingIntervals := monitorapi.EventIntervals{}
 	for i := range intervals {
 		interval := intervals[i]
 		switch {

--- a/pkg/monitor/intervalcreation/e2etest.go
+++ b/pkg/monitor/intervalcreation/e2etest.go
@@ -50,8 +50,8 @@ func IntervalsFromEvents_E2ETests(events []*monitorapi.Event, beginning, end tim
 		}
 
 		delete(testNameToLastStart, testName)
-		ret = append(ret, &monitorapi.EventInterval{
-			Condition: &monitorapi.Condition{
+		ret = append(ret, monitorapi.EventInterval{
+			Condition: monitorapi.Condition{
 				Level:   level,
 				Locator: event.Locator,
 				Message: fmt.Sprintf("e2e test finished As %q", endState),
@@ -62,8 +62,8 @@ func IntervalsFromEvents_E2ETests(events []*monitorapi.Event, beginning, end tim
 	}
 
 	for testName, testStart := range testNameToLastStart {
-		ret = append(ret, &monitorapi.EventInterval{
-			Condition: &monitorapi.Condition{
+		ret = append(ret, monitorapi.EventInterval{
+			Condition: monitorapi.Condition{
 				Level:   monitorapi.Warning,
 				Locator: monitorapi.OperatorLocator(testName),
 				Message: fmt.Sprintf("e2e test did not finish %q", "DidNotFinish"),

--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -24,8 +24,8 @@ func IntervalsFromEvents_NodeChanges(events []*monitorapi.Event, beginning, end 
 		if !ok {
 			return
 		}
-		intervals = append(intervals, &monitorapi.EventInterval{
-			Condition: &monitorapi.Condition{
+		intervals = append(intervals, monitorapi.EventInterval{
+			Condition: monitorapi.Condition{
 				Level:   level,
 				Locator: locator,
 				Message: message,

--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -1,0 +1,91 @@
+package intervalcreation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+func IntervalsFromEvents_NodeChanges(events []*monitorapi.Event, beginning, end time.Time) monitorapi.EventIntervals {
+	var intervals monitorapi.EventIntervals
+	nodeChangeToLastStart := map[string]map[string]time.Time{}
+
+	openInterval := func(state map[string]time.Time, name string, from time.Time) bool {
+		if _, ok := state[name]; !ok {
+			state[name] = from
+			return false
+		}
+		return true
+	}
+	closeInterval := func(state map[string]time.Time, name string, level monitorapi.EventLevel, locator, message string, to time.Time) {
+		from, ok := state[name]
+		if !ok {
+			return
+		}
+		intervals = append(intervals, &monitorapi.EventInterval{
+			Condition: &monitorapi.Condition{
+				Level:   level,
+				Locator: locator,
+				Message: message,
+			},
+			From: from,
+			To:   to,
+		})
+		delete(state, name)
+	}
+
+	for _, event := range events {
+		node, ok := monitorapi.NodeFromLocator(event.Locator)
+		if !ok {
+			continue
+		}
+		if !strings.HasPrefix(event.Message, "reason/") {
+			continue
+		}
+		reason := strings.SplitN(strings.TrimPrefix(event.Message, "reason/"), " ", 2)[0]
+
+		state, ok := nodeChangeToLastStart[node]
+		if !ok {
+			state = make(map[string]time.Time)
+			nodeChangeToLastStart[node] = state
+		}
+
+		// Use the four key reasons set by the MCD in events - since events are best effort these
+		// could easily be incorrect or hide problems like double invocations. For now use these as
+		// timeline indicators only, and use the stronger observed state events from the node object.
+		// A separate test should look for anomalies in these intervals if the need is identified.
+		//
+		// The current structure will hold events open until they are closed, so you would see
+		// excessively long intervals if the events are missing (because openInterval does not create
+		// a new interval).
+		switch reason {
+		case "MachineConfigChange":
+			openInterval(state, "Update", event.At)
+		case "MachineConfigReached":
+			closeInterval(state, "Update", monitorapi.Info, event.Locator, strings.ReplaceAll(event.Message, "reason/MachineConfigReached ", "reason/NodeUpdate phase/Update "), event.At)
+		case "Cordon", "Drain":
+			openInterval(state, "Drain", event.At)
+		case "OSUpdateStarted":
+			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.At)
+			openInterval(state, "OperatingSystemUpdate", event.At)
+		case "Reboot":
+			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.At)
+			closeInterval(state, "OperatingSystemUpdate", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/OperatingSystemUpdate updated operating system", event.At)
+			openInterval(state, "Reboot", event.At)
+		case "Starting":
+			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.At)
+			closeInterval(state, "OperatingSystemUpdate", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/OperatingSystemUpdate updated operating system", event.At)
+			closeInterval(state, "Reboot", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Reboot rebooted and kubelet started", event.At)
+		}
+	}
+
+	for nodeName, state := range nodeChangeToLastStart {
+		for name := range state {
+			closeInterval(state, name, monitorapi.Warning, monitorapi.NodeLocator(nodeName), fmt.Sprintf("reason/NodeUpdate phase/%s phase never completed", name), end)
+		}
+	}
+
+	return intervals
+}

--- a/pkg/monitor/intervalcreation/node_test.go
+++ b/pkg/monitor/intervalcreation/node_test.go
@@ -1,0 +1,37 @@
+package intervalcreation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+)
+
+func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
+	intervals, err := monitorserialization.EventsFromFile("testdata/node.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make([]*monitorapi.Event, 0, len(intervals))
+	for _, i := range intervals {
+		events = append(events, &monitorapi.Event{
+			Condition: i.Condition,
+			At:        i.From,
+		})
+	}
+	changes := IntervalsFromEvents_NodeChanges(events, time.Time{}, time.Now())
+	out, _ := monitorserialization.EventsIntervalsToJSON(changes)
+	if len(changes) != 3 {
+		t.Fatalf("unexpected changes: %s", string(out))
+	}
+	if changes[0].Message != "reason/NodeUpdate phase/Drain drained node" {
+		t.Errorf("unexpected event: %s", string(out))
+	}
+	if changes[1].Message != "reason/NodeUpdate phase/OperatingSystemUpdate updated operating system" {
+		t.Errorf("unexpected event: %s", string(out))
+	}
+	if changes[2].Message != "reason/NodeUpdate phase/Reboot rebooted and kubelet started" {
+		t.Errorf("unexpected event: %s", string(out))
+	}
+}

--- a/pkg/monitor/intervalcreation/operator.go
+++ b/pkg/monitor/intervalcreation/operator.go
@@ -71,8 +71,8 @@ func intervalsFromEvents_OperatorStatus(events []*monitorapi.Event, beginning, e
 				lastStatus = "True"
 			}
 		}
-		ret = append(ret, &monitorapi.EventInterval{
-			Condition: &monitorapi.Condition{
+		ret = append(ret, monitorapi.EventInterval{
+			Condition: monitorapi.Condition{
 				Level:   level,
 				Locator: event.Locator,
 				Message: fmt.Sprintf("condition/%s status/%s reason/%s", conditionType, lastStatus, lastMessage),
@@ -83,8 +83,8 @@ func intervalsFromEvents_OperatorStatus(events []*monitorapi.Event, beginning, e
 	}
 
 	for operatorName, lastCondition := range operatorToInterestingBadCondition {
-		ret = append(ret, &monitorapi.EventInterval{
-			Condition: &monitorapi.Condition{
+		ret = append(ret, monitorapi.EventInterval{
+			Condition: monitorapi.Condition{
 				Level:   level,
 				Locator: monitorapi.OperatorLocator(operatorName),
 				Message: fmt.Sprintf("condition/%s status/%s reason/%s", conditionType, lastCondition.Status, lastCondition.Message),

--- a/pkg/monitor/intervalcreation/testdata/node.json
+++ b/pkg/monitor/intervalcreation/testdata/node.json
@@ -1,0 +1,130 @@
+{
+  "items": [
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/RegisteredNode Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 event: Registered Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 in Controller",
+      "from": "2021-04-12T21:58:08Z",
+      "to": "2021-04-12T21:58:08Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/RegisteredNode Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 event: Registered Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 in Controller",
+      "from": "2021-04-12T21:58:55Z",
+      "to": "2021-04-12T21:58:55Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/Starting openshift-sdn done initializing node networking.",
+      "from": "2021-04-12T22:17:10Z",
+      "to": "2021-04-12T22:17:10Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/Cordon Cordoned node to apply update",
+      "from": "2021-04-12T22:25:29Z",
+      "to": "2021-04-12T22:25:29Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/Drain Draining node to update config.",
+      "from": "2021-04-12T22:25:29Z",
+      "to": "2021-04-12T22:25:29Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/NodeNotSchedulable Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 status is now: NodeNotSchedulable",
+      "from": "2021-04-12T22:25:34Z",
+      "to": "2021-04-12T22:25:34Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/OSUpdateStarted Upgrading OS",
+      "from": "2021-04-12T22:27:00Z",
+      "to": "2021-04-12T22:27:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/InClusterUpgrade Updating from oscontainer registry.build02.ci.openshift.org/ci-op-8sllkmg5/stable@sha256:59298bf4359e51de44b6ca28c211df62ab823566823e8e1b5aaafa090ff481bb",
+      "from": "2021-04-12T22:27:00Z",
+      "to": "2021-04-12T22:27:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/OSUpdateStaged Changes to OS staged",
+      "from": "2021-04-12T22:27:21Z",
+      "to": "2021-04-12T22:27:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/PendingConfig Written pending config rendered-worker-2f04672635ea44b389119d4a0e747bc7",
+      "from": "2021-04-12T22:27:22Z",
+      "to": "2021-04-12T22:27:22Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/Reboot Node will reboot into config rendered-worker-2f04672635ea44b389119d4a0e747bc7",
+      "from": "2021-04-12T22:27:22Z",
+      "to": "2021-04-12T22:27:22Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "condition/DiskPressure status/Unknown reason/NodeStatusUnknown changed",
+      "from": "2021-04-12T22:28:07Z",
+      "to": "2021-04-12T22:28:07Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "condition/MemoryPressure status/Unknown reason/NodeStatusUnknown changed",
+      "from": "2021-04-12T22:28:07Z",
+      "to": "2021-04-12T22:28:07Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "condition/PIDPressure status/Unknown reason/NodeStatusUnknown changed",
+      "from": "2021-04-12T22:28:07Z",
+      "to": "2021-04-12T22:28:07Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "condition/Ready status/Unknown reason/NodeStatusUnknown changed",
+      "from": "2021-04-12T22:28:07Z",
+      "to": "2021-04-12T22:28:07Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/NodeNotReady Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 status is now: NodeNotReady",
+      "from": "2021-04-12T22:28:07Z",
+      "to": "2021-04-12T22:28:07Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "node is not ready",
+      "from": "2021-04-12T22:28:08Z",
+      "to": "2021-04-12T22:29:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "message": "reason/Starting Starting kubelet.",
+      "from": "2021-04-12T22:28:50Z",
+      "to": "2021-04-12T22:28:50Z"
+    }
+  ]
+}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -17,9 +17,10 @@ type Monitor struct {
 	samplers            []SamplerFunc
 	intervalCreationFns []IntervalCreationFunc
 
-	lock    sync.Mutex
-	events  []*monitorapi.Event
-	samples []*sample
+	lock           sync.Mutex
+	events         []*monitorapi.Event
+	samples        []*sample
+	unsortedEvents []*monitorapi.Event
 }
 
 // NewMonitor creates a monitor with the default sampling interval.
@@ -85,6 +86,22 @@ func (m *Monitor) Record(conditions ...monitorapi.Condition) {
 	}
 }
 
+// RecordAt captures one or more conditions at the provided time. All conditions are recorded
+// as Event objects.
+func (m *Monitor) RecordAt(t time.Time, conditions ...monitorapi.Condition) {
+	if len(conditions) == 0 {
+		return
+	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	for _, condition := range conditions {
+		m.unsortedEvents = append(m.unsortedEvents, &monitorapi.Event{
+			At:        t,
+			Condition: condition,
+		})
+	}
+}
+
 func (m *Monitor) sample(hasPrevious bool) bool {
 	m.lock.Lock()
 	samplers := m.samplers
@@ -111,10 +128,10 @@ func (m *Monitor) sample(hasPrevious bool) bool {
 	return len(conditions) > 0
 }
 
-func (m *Monitor) snapshot() ([]*sample, []*monitorapi.Event) {
+func (m *Monitor) snapshot() ([]*sample, []*monitorapi.Event, monitorapi.Events) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.samples, m.events
+	return m.samples, m.events, m.unsortedEvents
 }
 
 // Conditions returns all conditions that were sampled in the interval
@@ -124,7 +141,7 @@ func (m *Monitor) snapshot() ([]*sample, []*monitorapi.Event) {
 // returned with from == to. No duplicate conditions are returned
 // unless a sampling interval did not report that value.
 func (m *Monitor) Conditions(from, to time.Time) monitorapi.EventIntervals {
-	samples, _ := m.snapshot()
+	samples, _, _ := m.snapshot()
 	return filterSamples(samples, from, to)
 }
 
@@ -132,9 +149,9 @@ func (m *Monitor) Conditions(from, to time.Time) monitorapi.EventIntervals {
 // any sampled conditions that were encountered during that period.
 // EventIntervals are returned in order of their occurrence.
 func (m *Monitor) EventIntervals(from, to time.Time) monitorapi.EventIntervals {
-	samples, events := m.snapshot()
+	samples, events, unsortedEvents := m.snapshot()
 	intervals := filterSamples(samples, from, to)
-	events = filterEvents(events, from, to)
+	events = mergeEvents(filterEvents(events, from, to), filterAndSortEvents(unsortedEvents, from, to))
 
 	// create additional intervals from events
 	for _, createIntervals := range m.intervalCreationFns {
@@ -239,4 +256,45 @@ func filterEvents(events []*monitorapi.Event, from, to time.Time) []*monitorapi.
 		}
 	}
 	return events[first:]
+}
+
+// mergeEvents returns a sorted list of all events provided as sources. This could be
+// more efficient by requiring all sources to be sorted (would be O(n)).
+func mergeEvents(events ...[]*monitorapi.Event) []*monitorapi.Event {
+	total := 0
+	for _, event := range events {
+		total += len(event)
+	}
+	merged := make([]*monitorapi.Event, 0, total)
+	for _, event := range events {
+		merged = append(merged, event...)
+	}
+	sort.Sort(monitorapi.Events(merged))
+	return merged
+}
+
+// filterAndSortEvents returns events before to and after from in sorted order, assuming
+// the input events are unsorted.
+func filterAndSortEvents(events monitorapi.Events, from, to time.Time) monitorapi.Events {
+	copied := make(monitorapi.Events, 0, len(events))
+
+	if from.IsZero() && to.IsZero() {
+		for _, e := range events {
+			copied = append(copied, e)
+		}
+		sort.Sort(monitorapi.Events(copied))
+		return copied
+	}
+
+	for _, e := range events {
+		if !e.At.After(from) {
+			continue
+		}
+		if !to.IsZero() && !e.At.Before(to) {
+			continue
+		}
+		copied = append(copied, e)
+	}
+	sort.Sort(monitorapi.Events(copied))
+	return copied
 }

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -154,8 +154,8 @@ func (m *Monitor) EventIntervals(from, to time.Time) monitorapi.EventIntervals {
 			from = to
 		}
 
-		condition := &events[i].Condition
-		intervals = append(intervals, &monitorapi.EventInterval{
+		condition := events[i].Condition
+		intervals = append(intervals, monitorapi.EventInterval{
 			From:      from,
 			To:        to,
 			Condition: condition,
@@ -204,13 +204,12 @@ func filterSamples(samples []*sample, from, to time.Time) monitorapi.EventInterv
 				next[*condition] = interval
 				continue
 			}
-			interval = &monitorapi.EventInterval{
-				Condition: condition,
+			intervals = append(intervals, monitorapi.EventInterval{
+				Condition: *condition,
 				From:      sample.at,
 				To:        sample.at,
-			}
-			next[*condition] = interval
-			intervals = append(intervals, interval)
+			})
+			next[*condition] = &intervals[len(intervals)-1]
 		}
 		for k := range last {
 			delete(last, k)

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -33,8 +33,8 @@ func TestMonitor_Events(t *testing.T) {
 				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
 			},
 			want: monitorapi.EventIntervals{
-				{Condition: &monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
@@ -44,7 +44,7 @@ func TestMonitor_Events(t *testing.T) {
 			},
 			from: time.Unix(1, 0),
 			want: monitorapi.EventIntervals{
-				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
@@ -55,7 +55,7 @@ func TestMonitor_Events(t *testing.T) {
 			from: time.Unix(1, 0),
 			to:   time.Unix(2, 0),
 			want: monitorapi.EventIntervals{
-				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
@@ -74,8 +74,8 @@ func TestMonitor_Events(t *testing.T) {
 			},
 			from: time.Unix(1, 0),
 			want: monitorapi.EventIntervals{
-				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
-				{Condition: &monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
+				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
 			},
 		},
 		{
@@ -85,10 +85,10 @@ func TestMonitor_Events(t *testing.T) {
 				{at: time.Unix(3, 0), conditions: []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
 			},
 			want: monitorapi.EventIntervals{
-				{Condition: &monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: &monitorapi.Condition{Message: "A"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: &monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
-				{Condition: &monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
+				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
+				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
 			},
 		},
 	}

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -41,8 +41,8 @@ func NodeFromLocator(locator string) (string, bool) {
 	if !strings.HasPrefix(locator, "node/") {
 		return "", false
 	}
-	parts := strings.SplitN(locator, "/", 2)
-	return parts[1], true
+	parts := strings.SplitN(strings.TrimPrefix(locator, "node/"), " ", 2)
+	return parts[0], true
 }
 
 func OperatorLocator(testName string) string {
@@ -58,6 +58,6 @@ func OperatorFromLocator(locator string) (string, bool) {
 	if !strings.HasPrefix(locator, "clusteroperator/") {
 		return "", false
 	}
-	parts := strings.SplitN(locator, "/", 2)
-	return parts[1], true
+	parts := strings.SplitN(strings.TrimPrefix(locator, "clusteroperator/"), " ", 2)
+	return parts[0], true
 }

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -29,6 +29,20 @@ func (e EventLevel) String() string {
 	}
 }
 
+func EventLevelFromString(s string) (EventLevel, error) {
+	switch s {
+	case "Info":
+		return Info, nil
+	case "Warning":
+		return Warning, nil
+	case "Error":
+		return Error, nil
+	default:
+		return Error, fmt.Errorf("did not define event level string for %q", s)
+	}
+
+}
+
 type Event struct {
 	Condition
 
@@ -47,13 +61,13 @@ type Condition struct {
 }
 
 type EventInterval struct {
-	*Condition
+	Condition
 
 	From time.Time
 	To   time.Time
 }
 
-func (i *EventInterval) String() string {
+func (i EventInterval) String() string {
 	if i.From.Equal(i.To) {
 		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), i.Level.String()[:1], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 	}
@@ -64,7 +78,7 @@ func (i *EventInterval) String() string {
 	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Second))+"s", i.Level.String()[:1], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 }
 
-type EventIntervals []*EventInterval
+type EventIntervals []EventInterval
 
 var _ sort.Interface = EventIntervals{}
 

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -101,3 +101,22 @@ func (intervals EventIntervals) Len() int { return len(intervals) }
 func (intervals EventIntervals) Swap(i, j int) {
 	intervals[i], intervals[j] = intervals[j], intervals[i]
 }
+
+type Events []*Event
+
+var _ sort.Interface = Events{}
+
+func (events Events) Less(i, j int) bool {
+	switch d := events[i].At.Sub(events[j].At); {
+	case d < 0:
+		return true
+	case d > 0:
+		return false
+	default:
+		return true
+	}
+}
+func (events Events) Len() int { return len(events) }
+func (events Events) Swap(i, j int) {
+	events[i], events[j] = events[j], events[i]
+}

--- a/pkg/monitor/noop.go
+++ b/pkg/monitor/noop.go
@@ -1,6 +1,10 @@
 package monitor
 
-import "github.com/openshift/origin/pkg/monitor/monitorapi"
+import (
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
 
 type noOpMonitor struct {
 }
@@ -9,5 +13,6 @@ func NewNoOpMonitor() Recorder {
 	return &noOpMonitor{}
 }
 
-func (*noOpMonitor) Record(conditions ...monitorapi.Condition) {}
-func (*noOpMonitor) AddSampler(fn SamplerFunc)                 {}
+func (*noOpMonitor) Record(conditions ...monitorapi.Condition)                {}
+func (*noOpMonitor) RecordAt(t time.Time, conditions ...monitorapi.Condition) {}
+func (*noOpMonitor) AddSampler(fn SamplerFunc)                                {}

--- a/pkg/monitor/sampler_test.go
+++ b/pkg/monitor/sampler_test.go
@@ -57,18 +57,17 @@ func TestStartSampling(t *testing.T) {
 	events := m.EventIntervals(time.Time{}, time.Time{})
 	for _, interval := range events {
 		i := interval.To.Sub(interval.From)
-		describe = append(describe, fmt.Sprintf("%v %s", *interval.Condition, i))
-		log = append(log, fmt.Sprintf("%v", *interval.Condition))
+		describe = append(describe, fmt.Sprintf("%v %s", interval.Condition, i))
+		log = append(log, fmt.Sprintf("%v", interval.Condition))
 	}
 
-	zero := time.Time{}.String()
 	expected := []string{
-		fmt.Sprintf("{2 tester dying %s}", zero),
-		fmt.Sprintf("{2 tester down %s}", zero),
-		fmt.Sprintf("{0 tester recovering %s}", zero),
-		fmt.Sprintf("{2 tester dying 2 %s}", zero),
-		fmt.Sprintf("{2 tester down %s}", zero),
-		fmt.Sprintf("{0 tester recovering 2 %s}", zero),
+		fmt.Sprintf("{Error tester dying}"),
+		fmt.Sprintf("{Error tester down}"),
+		fmt.Sprintf("{Info tester recovering}"),
+		fmt.Sprintf("{Error tester dying 2}"),
+		fmt.Sprintf("{Error tester down}"),
+		fmt.Sprintf("{Info tester recovering 2}"),
 	}
 	if !reflect.DeepEqual(log, expected) {
 		t.Fatalf("%s", diff.ObjectReflectDiff(log, expected))

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -17,6 +17,7 @@ type Interface interface {
 
 type Recorder interface {
 	Record(conditions ...monitorapi.Condition)
+	RecordAt(t time.Time, conditions ...monitorapi.Condition)
 	AddSampler(fn SamplerFunc)
 }
 

--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -16,7 +16,7 @@ const (
 	tolerateDisruptionPercent = 0.01
 )
 
-func testServerAvailability(locator string, events []*monitorapi.EventInterval, duration time.Duration) []*ginkgo.JUnitTestCase {
+func testServerAvailability(locator string, events monitorapi.EventIntervals, duration time.Duration) []*ginkgo.JUnitTestCase {
 	errDuration, errMessages := disruption.GetDisruption(events, locator)
 
 	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testKubeletToAPIServerGracefulTermination(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testKubeletToAPIServerGracefulTermination(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] kubelet terminates kube-apiserver gracefully"
 
 	var failures []string
@@ -44,7 +44,7 @@ func testKubeletToAPIServerGracefulTermination(events []*monitorapi.EventInterva
 	return tests
 }
 
-func testKubeAPIServerGracefulTermination(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testKubeAPIServerGracefulTermination(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-api-machinery] kube-apiserver terminates within graceful termination period"
 
 	var failures []string
@@ -72,7 +72,7 @@ func testKubeAPIServerGracefulTermination(events []*monitorapi.EventInterval) []
 	return tests
 }
 
-func testPodTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testPodTransitions(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] pods should never transition back to pending"
 	success := &ginkgo.JUnitTestCase{Name: testName}
 
@@ -105,7 +105,7 @@ func formatTimes(times []time.Time) []string {
 	return s
 }
 
-func testNodeUpgradeTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testNodeUpgradeTransitions(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] nodes should not go unready after being upgraded and go unready only once"
 
 	var buf bytes.Buffer
@@ -206,7 +206,7 @@ func testNodeUpgradeTransitions(events []*monitorapi.EventInterval) []*ginkgo.JU
 	return testCases
 }
 
-func testSystemDTimeout(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testSystemDTimeout(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] pods should not fail on systemd timeouts"
 	success := &ginkgo.JUnitTestCase{Name: testName}
 

--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -15,7 +15,7 @@ type testCategorizer struct {
 	substring string
 }
 
-func testPodSandboxCreation(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testPodSandboxCreation(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-network] pods should successfully create sandboxes"
 	// we can further refine this signal by subdividing different failure modes if it is pertinent.  Right now I'm seeing
 	// 1. error reading container (probably exited) json message: EOF
@@ -129,8 +129,8 @@ func categorizeBySubset(categorizers []testCategorizer, failures, flakes []strin
 }
 
 // getEventsByPod returns map keyed by pod locator with all events associated with it.
-func getEventsByPod(events []*monitorapi.EventInterval) map[string][]*monitorapi.EventInterval {
-	eventsByPods := map[string][]*monitorapi.EventInterval{}
+func getEventsByPod(events monitorapi.EventIntervals) map[string]monitorapi.EventIntervals {
+	eventsByPods := map[string]monitorapi.EventIntervals{}
 	for _, event := range events {
 		if !strings.Contains(event.Locator, "pod/") {
 			continue
@@ -140,7 +140,7 @@ func getEventsByPod(events []*monitorapi.EventInterval) map[string][]*monitorapi
 	return eventsByPods
 }
 
-func getPodDeletionTime(events []*monitorapi.EventInterval, podLocator string) *time.Time {
+func getPodDeletionTime(events monitorapi.EventIntervals, podLocator string) *time.Time {
 	for _, event := range events {
 		if event.Locator == podLocator && event.Message == "reason/Deleted" {
 			return &event.From

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -12,14 +12,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testStableSystemOperatorStateTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testStableSystemOperatorStateTransitions(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
 	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded, configv1.OperatorProgressing})
 }
 
-func testUpgradeOperatorStateTransitions(events []*monitorapi.EventInterval) []*ginkgo.JUnitTestCase {
+func testUpgradeOperatorStateTransitions(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
 	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded})
 }
-func testOperatorStateTransitions(events []*monitorapi.EventInterval, conditionTypes []configv1.ClusterStatusConditionType) []*ginkgo.JUnitTestCase {
+func testOperatorStateTransitions(events monitorapi.EventIntervals, conditionTypes []configv1.ClusterStatusConditionType) []*ginkgo.JUnitTestCase {
 	ret := []*ginkgo.JUnitTestCase{}
 
 	knownOperators := allOperators(events)
@@ -56,7 +56,7 @@ func testOperatorStateTransitions(events []*monitorapi.EventInterval, conditionT
 	return ret
 }
 
-func allOperators(events []*monitorapi.EventInterval) sets.String {
+func allOperators(events monitorapi.EventIntervals) sets.String {
 	// start with a list of known values
 	knownOperators := sets.NewString(KnownOperators.List()...)
 
@@ -72,8 +72,8 @@ func allOperators(events []*monitorapi.EventInterval) sets.String {
 }
 
 // getEventsByOperator returns map keyed by operator locator with all events associated with it.
-func getEventsByOperator(events []*monitorapi.EventInterval) map[string][]*monitorapi.EventInterval {
-	eventsByClusterOperator := map[string][]*monitorapi.EventInterval{}
+func getEventsByOperator(events monitorapi.EventIntervals) map[string]monitorapi.EventIntervals {
+	eventsByClusterOperator := map[string]monitorapi.EventIntervals{}
 	for _, event := range events {
 		operatorName, ok := monitorapi.OperatorFromLocator(event.Locator)
 		if !ok {
@@ -84,7 +84,7 @@ func getEventsByOperator(events []*monitorapi.EventInterval) map[string][]*monit
 	return eventsByClusterOperator
 }
 
-func testOperatorState(interestingCondition configv1.ClusterStatusConditionType, eventIntervals []*monitorapi.EventInterval, e2eEventIntervals []*monitorapi.EventInterval) []string {
+func testOperatorState(interestingCondition configv1.ClusterStatusConditionType, eventIntervals monitorapi.EventIntervals, e2eEventIntervals monitorapi.EventIntervals) []string {
 	failures := []string{}
 
 	for _, eventInterval := range eventIntervals {

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -303,10 +303,8 @@ func (opt *Options) Run(suite *TestSuite) error {
 	}
 
 	if len(events) > 0 {
-		eventsForTests := createEventsForTests(tests)
-
 		var buf *bytes.Buffer
-		syntheticTestResults, buf, _ = createSyntheticTestsFromMonitor(m, eventsForTests, duration)
+		syntheticTestResults, buf, _ = createSyntheticTestsFromMonitor(events, duration)
 		testCases := syntheticEventTests.JUnitsForEvents(events, duration)
 		syntheticTestResults = append(syntheticTestResults, testCases...)
 

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -3,12 +3,9 @@ package ginkgo
 import (
 	"bytes"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
-
-	"github.com/openshift/origin/pkg/monitor"
 )
 
 // JUnitsForEvents returns a set of JUnit results for the provided events encountered
@@ -43,42 +40,8 @@ func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.EventIntervals, du
 	return all
 }
 
-func createEventsForTests(tests []*testCase) []*monitorapi.EventInterval {
-	eventsForTests := []*monitorapi.EventInterval{}
-	for _, test := range tests {
-		if !test.failed {
-			continue
-		}
-		eventsForTests = append(eventsForTests,
-			&monitorapi.EventInterval{
-				From: test.start,
-				To:   test.end,
-				Condition: &monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: fmt.Sprintf("test=%q", test.name),
-					Message: "running",
-				},
-			},
-			&monitorapi.EventInterval{
-				From: test.end,
-				To:   test.end,
-				Condition: &monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: fmt.Sprintf("test=%q", test.name),
-					Message: "failed",
-				},
-			},
-		)
-	}
-	return eventsForTests
-}
-
-func createSyntheticTestsFromMonitor(m *monitor.Monitor, eventsForTests []*monitorapi.EventInterval, monitorDuration time.Duration) ([]*JUnitTestCase, *bytes.Buffer, *bytes.Buffer) {
+func createSyntheticTestsFromMonitor(events monitorapi.EventIntervals, monitorDuration time.Duration) ([]*JUnitTestCase, *bytes.Buffer, *bytes.Buffer) {
 	var syntheticTestResults []*JUnitTestCase
-
-	events := m.EventIntervals(time.Time{}, time.Time{})
-	events = append(events, eventsForTests...)
-	sort.Sort(events)
 
 	buf, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
 	fmt.Fprintf(buf, "\nTimeline:\n\n")

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53328,60 +53328,6 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 </script>
 
 <script>
-    var loc = window.location.href;
-
-    const el = document.querySelector('#chart');
-
-    var timelineGroups = []
-    timelineGroups.push({group: "operator-unavailable", data: []})
-    createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorAvailable)
-
-    timelineGroups.push({group: "operator-degraded", data: []})
-    createTimelineData("OperatorDegraded", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorDegraded)
-
-    timelineGroups.push({group: "operator-progressing", data: []})
-    createTimelineData("OperatorProgressing", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorProgressing)
-
-    timelineGroups.push({group: "apiserver-availability", data: []})
-    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerConnectivity)
-
-    timelineGroups.push({group: "e2e-test-failed", data: []})
-    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed)
-
-    timelineGroups.push({group: "e2e-test-flaked", data: []})
-    createTimelineData("Flaked", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFlaked)
-
-    timelineGroups.push({group: "e2e-test-passed", data: []})
-    createTimelineData("Passed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EPassed)
-
-    var segmentFunc = function (segment) {
-        // for (var i in data) {
-        //     if (data[i].group == segment.group) {
-        //         var groupdata = data[i].data
-        //         for (var j in groupdata) {
-        //             if (groupdata[j].label == segment.label) {
-        //                 labeldata = groupdata[j].data
-        //                 for (var k in labeldata) {
-        //                     var startDate = new Date(labeldata[k].timeRange[0])
-        //                     var endDate = new Date(labeldata[k].timeRange[1])
-        //                     if (startDate.getTime() == segment.timeRange[0].getTime() &&
-        //                         endDate.getTime() == segment.timeRange[1].getTime()) {
-        //                         $('#myModalContent').text(labeldata[k].extended)
-        //                         $('#myModal').modal()
-        //                     }
-        //                 }
-        //             }
-        //         }
-        //     }
-        // }
-    }
-    const myChart = TimelinesChart();
-    var ordinalScale = d3.scaleOrdinal()
-        .domain(['OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', 'Passed', 'Skipped', 'Flaked', 'Failed', 'Degraded', 'Upgradeable', 'False', 'Unknown'])
-        .range(['#d0312d', '#ffa500', '#fada5e', '#3cb043', '#ceba76', '#ffa500', '#d0312d', '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
-    myChart.data(timelineGroups).zQualitative(true).enableAnimations(false).leftMargin(320).rightMargin(550).maxLineHeight(20).maxHeight(10000).zColorScale(ordinalScale).onSegmentClick(segmentFunc)
-    (el);
-
     function isOperatorAvailable(eventInterval) {
         if (eventInterval.locator.startsWith("clusteroperator/") && eventInterval.message.includes("condition/Available") && eventInterval.message.includes("status/False")) {
             return true
@@ -53437,6 +53383,25 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return false
     }
 
+    function isNodeState(eventInterval) {
+        if (eventInterval.locator.startsWith("node/")) {
+            return (eventInterval.message.startsWith("reason/NodeUpdate ") || eventInterval.message == "node is not ready")
+        }
+        return false
+    }
+
+    const rePhase = new RegExp("(^| )phase/([^ ]+)")
+    function nodeStateValue(item) {
+        if (item.message == "node is not ready") {
+            return [item.locator, " (not ready)", "NodeNotReady"]
+        }
+        let m = item.message.match(rePhase);
+        if (m && m[2] != "Update") {
+            return [item.locator, " (update phases)", m[2]];
+        }
+        return [item.locator, " (updates)", "Update"];
+    }
+
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc) {
         const data = {}
         rawEventIntervals.items.forEach((item) => {
@@ -53445,19 +53410,91 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             }
             var startDate = new Date(item.from)
             var endDate = new Date(item.to)
-            if (!data[item.locator]) {
-                data[item.locator] = []
+            let label = item.locator
+            let sub = ""
+            let val = timelineVal
+            if (typeof val === "function") {
+                [label, sub, val] = timelineVal(item)
             }
-            data[item.locator].push({
+            let section = data[label]
+            if (!section) {
+                section = {};
+                data[label] = section
+            }
+            let ranges = section[sub]
+            if (!ranges) {
+                ranges = [];
+                section[sub] = ranges
+            }
+            ranges.push({
                 timeRange: [startDate, endDate],
-                val: timelineVal
+                val: val,
             });
         });
         for (const label in data) {
-            timelineData.push({label, data: data[label]})
+            const section = data[label]
+            for (const sub in section) {
+                timelineData.push({label: label+sub, data: section[sub]})
+            }
         }
     }
 
+    var loc = window.location.href;
+
+    var timelineGroups = []
+    timelineGroups.push({group: "operator-unavailable", data: []})
+    createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorAvailable)
+
+    timelineGroups.push({group: "operator-degraded", data: []})
+    createTimelineData("OperatorDegraded", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorDegraded)
+
+    timelineGroups.push({group: "operator-progressing", data: []})
+    createTimelineData("OperatorProgressing", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorProgressing)
+
+    timelineGroups.push({group: "node-state", data: []})
+    createTimelineData(nodeStateValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isNodeState)
+
+    timelineGroups.push({group: "apiserver-availability", data: []})
+    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerConnectivity)
+
+    timelineGroups.push({group: "e2e-test-failed", data: []})
+    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed)
+
+    timelineGroups.push({group: "e2e-test-flaked", data: []})
+    createTimelineData("Flaked", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFlaked)
+
+    timelineGroups.push({group: "e2e-test-passed", data: []})
+    createTimelineData("Passed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EPassed)
+
+    var segmentFunc = function (segment) {
+        // for (var i in data) {
+        //     if (data[i].group == segment.group) {
+        //         var groupdata = data[i].data
+        //         for (var j in groupdata) {
+        //             if (groupdata[j].label == segment.label) {
+        //                 labeldata = groupdata[j].data
+        //                 for (var k in labeldata) {
+        //                     var startDate = new Date(labeldata[k].timeRange[0])
+        //                     var endDate = new Date(labeldata[k].timeRange[1])
+        //                     if (startDate.getTime() == segment.timeRange[0].getTime() &&
+        //                         endDate.getTime() == segment.timeRange[1].getTime()) {
+        //                         $('#myModalContent').text(labeldata[k].extended)
+        //                         $('#myModal').modal()
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
+    }
+
+    const el = document.querySelector('#chart');
+    const myChart = TimelinesChart();
+    var ordinalScale = d3.scaleOrdinal()
+        .domain(['OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', 'Passed', 'Skipped', 'Flaked', 'Failed', 'Degraded', 'Upgradeable', 'False', 'Unknown'])
+        .range(['#d0312d', '#ffa500', '#fada5e', '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', '#3cb043', '#ceba76', '#ffa500', '#d0312d', '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
+    myChart.data(timelineGroups).zQualitative(true).enableAnimations(false).leftMargin(320).rightMargin(550).maxLineHeight(20).maxHeight(10000).zColorScale(ordinalScale).onSegmentClick(segmentFunc)
+    (el);
 </script>
 </body>
 </html>


### PR DESCRIPTION
Expose both existing node not ready intervals as well as add two new sources of intervals:

* The events generated by MCD creating quasi-accurate intervals (events are lossy and MCD logic omits some events some times)
* The transition between two different sets of config at the node level

![image](https://user-images.githubusercontent.com/1163175/114652650-50e28180-9cb4-11eb-820a-39ea078dd40d.png)
