### PR TITLE
Bug 1949042: test/extended/router: skip h2 related tests on OpenStack

### DIFF
--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -7,7 +7,6 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/openshift/origin/test/extended/router/certgen"
@@ -48,8 +47,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 		g.It("should pass the gRPC interoperability tests", func() {
 			infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
-			switch infra.Status.PlatformStatus.Type {
-			case configv1.OvirtPlatformType, configv1.KubevirtPlatformType, configv1.LibvirtPlatformType, configv1.VSpherePlatformType, configv1.BareMetalPlatformType, configv1.NonePlatformType:
+			if !platformHasHTTP2LoadBalancerService(infra.Status.PlatformStatus.Type) {
 				g.Skip("Skip on platforms where the default router is not exposed by a load balancer service.")
 			}
 

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -13,7 +13,6 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	configv1 "github.com/openshift/api/config/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/origin/test/extended/router/h2spec"
 	"github.com/openshift/origin/test/extended/router/shard"
@@ -64,8 +63,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 		g.It("should pass the h2spec conformance tests", func() {
 			infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
-			switch infra.Status.PlatformStatus.Type {
-			case configv1.OvirtPlatformType, configv1.KubevirtPlatformType, configv1.LibvirtPlatformType, configv1.VSpherePlatformType, configv1.BareMetalPlatformType, configv1.NonePlatformType:
+			if !platformHasHTTP2LoadBalancerService(infra.Status.PlatformStatus.Type) {
 				g.Skip("Skip on platforms where the default router is not exposed by a load balancer service.")
 			}
 

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -90,8 +90,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 		g.It("should pass the http2 tests", func() {
 			infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
-			switch infra.Status.PlatformStatus.Type {
-			case configv1.OvirtPlatformType, configv1.KubevirtPlatformType, configv1.LibvirtPlatformType, configv1.VSpherePlatformType, configv1.BareMetalPlatformType, configv1.NonePlatformType:
+			if !platformHasHTTP2LoadBalancerService(infra.Status.PlatformStatus.Type) {
 				g.Skip("Skip on platforms where the default router is not exposed by a load balancer service.")
 			}
 
@@ -377,4 +376,16 @@ func resolveHostAsAddress(oc *exutil.CLI, interval, timeout time.Duration, host,
 	}
 
 	return result, nil
+}
+
+// platformHasHTTP2LoadBalancerService returns true where the default
+// router is exposed by a load balancer service and can support http/2
+// clients.
+func platformHasHTTP2LoadBalancerService(platformType configv1.PlatformType) bool {
+	switch platformType {
+	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Only run http/2, grpc-interop and h2spec tests on platforms where the
default router is exposed by a load balancer service that can also
support http/2.