### PR TITLE
test/e2e/upgrade: Do not force updates

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -317,7 +317,6 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			desired = configv1.Update{
 				Version: version.Version.String(),
 				Image:   version.NodeImage,
-				Force:   true,
 			}
 			monitor.oldVersion = original.Status.Desired.Version
 
@@ -378,7 +377,6 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 					framework.Logf("Instructing the cluster to return to %s / %s", original.Status.Desired.Version, original.Status.Desired.Image)
 					desired = configv1.Update{
 						Image: original.Status.Desired.Image,
-						Force: true,
 					}
 					if err := retry.RetryOnConflict(wait.Backoff{Steps: 10, Duration: time.Second}, func() error {
 						cv, err := c.ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})


### PR DESCRIPTION
We've been forcing since 429521d733 (#22645).  Back then we were maybe not signing CI releases then?  We're currently [trusting (and hopefully signing) CI releases with a CI key, and signing nightlies with the beta 2 or release keys][1].  Blocking nightly -> CI updates would be good, and we don't need to run those jobs.  CI -> nightly updates would be allowed if we landed something like openshift/cluster-update-keys#16, but we can also get by without any update jobs connecting CI and nightly trust.

[1]: https://github.com/openshift/cluster-update-keys/blob/41d14d4c27e274b236426ef80d2144cf46ded532/Makefile#L4-L25