### PR TITLE
Bug 1947809: upgrade: register none suite

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -52,6 +52,23 @@ var upgradeSuites = testSuites{
 		},
 		PreSuite: upgradeTestPreSuite,
 	},
+	{
+		TestSuite: ginkgo.TestSuite{
+			Name: "none",
+			Description: templates.LongDesc(`
+	Don't run disruption tests.
+		`),
+			Matches: func(name string) bool {
+				if isStandardEarlyTest(name) {
+					return true
+				}
+				return strings.Contains(name, "[Feature:ClusterUpgrade]") && !strings.Contains(name, "[Suite:k8s]")
+			},
+			TestTimeout:         240 * time.Minute,
+			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.SystemUpgradeEventInvariants),
+		},
+		PreSuite: upgradeTestPreSuite,
+	},
 }
 
 // upgradeTestPreSuite validates the test options.


### PR DESCRIPTION
Previously skip rules for None suite (no additional tests to run during upgrade) were added in https://github.com/openshift/origin/pull/26061. This commits ensures "none" suite is properly declared.