### PR TITLE
monitor: Clamp intervals to the test duration

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -199,7 +199,7 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 
 	// any image not in the allowed prefixes is considered a failure, as the user
 	// may have added a new test image without calling the appropriate helpers
-	return func(events monitorapi.EventIntervals, _ time.Duration) []*ginkgo.JUnitTestCase {
+	return func(events monitorapi.Intervals, _ time.Duration) []*ginkgo.JUnitTestCase {
 		imageStreamPrefixes, err := imagePrefixesFromNamespaceImageStreams("openshift")
 		if err != nil {
 			klog.Errorf("Unable to identify image prefixes from the openshift namespace: %v", err)

--- a/pkg/monitor/cmd.go
+++ b/pkg/monitor/cmd.go
@@ -54,7 +54,7 @@ func (opt *Options) Run() error {
 			case <-ctx.Done():
 				done = true
 			}
-			events := m.EventIntervals(last, time.Time{})
+			events := m.Intervals(last, time.Time{})
 			if len(events) > 0 {
 				for _, event := range events {
 					if !event.From.Equal(event.To) {

--- a/pkg/monitor/e2etest.go
+++ b/pkg/monitor/e2etest.go
@@ -6,9 +6,9 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
-// E2ETestEventIntervals returns only EventIntervals for e2e tests
-func E2ETestEventIntervals(events monitorapi.EventIntervals) monitorapi.EventIntervals {
-	e2eEventIntervals := monitorapi.EventIntervals{}
+// E2ETestEventIntervals returns only Intervals for e2e tests
+func E2ETestEventIntervals(events monitorapi.Intervals) monitorapi.Intervals {
+	e2eEventIntervals := monitorapi.Intervals{}
 	for i := range events {
 		event := events[i]
 		if event.From == event.To {
@@ -23,8 +23,8 @@ func E2ETestEventIntervals(events monitorapi.EventIntervals) monitorapi.EventInt
 }
 
 // FindOverlap finds intervals that overlap with the time between start and end.
-func FindOverlap(intervals monitorapi.EventIntervals, start, end time.Time) monitorapi.EventIntervals {
-	overlappingIntervals := monitorapi.EventIntervals{}
+func FindOverlap(intervals monitorapi.Intervals, start, end time.Time) monitorapi.Intervals {
+	overlappingIntervals := monitorapi.Intervals{}
 	for i := range intervals {
 		interval := intervals[i]
 		switch {

--- a/pkg/monitor/intervalcreation/e2etest.go
+++ b/pkg/monitor/intervalcreation/e2etest.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
-func IntervalsFromEvents_E2ETests(events []*monitorapi.Event, beginning, end time.Time) monitorapi.EventIntervals {
-	ret := monitorapi.EventIntervals{}
+func IntervalsFromEvents_E2ETests(events monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals {
+	ret := monitorapi.Intervals{}
 	testNameToLastStart := map[string]time.Time{}
 
 	for _, event := range events {
@@ -18,7 +18,7 @@ func IntervalsFromEvents_E2ETests(events []*monitorapi.Event, beginning, end tim
 			continue
 		}
 		if event.Message == "started" {
-			testNameToLastStart[testName] = event.At
+			testNameToLastStart[testName] = event.From
 			continue
 		}
 		if !strings.Contains(event.Message, "finishedStatus/") {
@@ -57,7 +57,7 @@ func IntervalsFromEvents_E2ETests(events []*monitorapi.Event, beginning, end tim
 				Message: fmt.Sprintf("e2e test finished As %q", endState),
 			},
 			From: from,
-			To:   event.At,
+			To:   event.From,
 		})
 	}
 

--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
-func IntervalsFromEvents_NodeChanges(events []*monitorapi.Event, beginning, end time.Time) monitorapi.EventIntervals {
-	var intervals monitorapi.EventIntervals
+func IntervalsFromEvents_NodeChanges(events monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals {
+	var intervals monitorapi.Intervals
 	nodeChangeToLastStart := map[string]map[string]time.Time{}
 
 	openInterval := func(state map[string]time.Time, name string, from time.Time) bool {
@@ -62,22 +62,22 @@ func IntervalsFromEvents_NodeChanges(events []*monitorapi.Event, beginning, end 
 		// a new interval).
 		switch reason {
 		case "MachineConfigChange":
-			openInterval(state, "Update", event.At)
+			openInterval(state, "Update", event.From)
 		case "MachineConfigReached":
-			closeInterval(state, "Update", monitorapi.Info, event.Locator, strings.ReplaceAll(event.Message, "reason/MachineConfigReached ", "reason/NodeUpdate phase/Update "), event.At)
+			closeInterval(state, "Update", monitorapi.Info, event.Locator, strings.ReplaceAll(event.Message, "reason/MachineConfigReached ", "reason/NodeUpdate phase/Update "), event.From)
 		case "Cordon", "Drain":
-			openInterval(state, "Drain", event.At)
+			openInterval(state, "Drain", event.From)
 		case "OSUpdateStarted":
-			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.At)
-			openInterval(state, "OperatingSystemUpdate", event.At)
+			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.From)
+			openInterval(state, "OperatingSystemUpdate", event.From)
 		case "Reboot":
-			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.At)
-			closeInterval(state, "OperatingSystemUpdate", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/OperatingSystemUpdate updated operating system", event.At)
-			openInterval(state, "Reboot", event.At)
+			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.From)
+			closeInterval(state, "OperatingSystemUpdate", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/OperatingSystemUpdate updated operating system", event.From)
+			openInterval(state, "Reboot", event.From)
 		case "Starting":
-			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.At)
-			closeInterval(state, "OperatingSystemUpdate", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/OperatingSystemUpdate updated operating system", event.At)
-			closeInterval(state, "Reboot", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Reboot rebooted and kubelet started", event.At)
+			closeInterval(state, "Drain", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Drain drained node", event.From)
+			closeInterval(state, "OperatingSystemUpdate", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/OperatingSystemUpdate updated operating system", event.From)
+			closeInterval(state, "Reboot", monitorapi.Info, event.Locator, "reason/NodeUpdate phase/Reboot rebooted and kubelet started", event.From)
 		}
 	}
 

--- a/pkg/monitor/intervalcreation/node_test.go
+++ b/pkg/monitor/intervalcreation/node_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 )
 
@@ -13,14 +12,7 @@ func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	events := make([]*monitorapi.Event, 0, len(intervals))
-	for _, i := range intervals {
-		events = append(events, &monitorapi.Event{
-			Condition: i.Condition,
-			At:        i.From,
-		})
-	}
-	changes := IntervalsFromEvents_NodeChanges(events, time.Time{}, time.Now())
+	changes := IntervalsFromEvents_NodeChanges(intervals, time.Time{}, time.Now())
 	out, _ := monitorserialization.EventsIntervalsToJSON(changes)
 	if len(changes) != 3 {
 		t.Fatalf("unexpected changes: %s", string(out))

--- a/pkg/monitor/intervalcreation/operator.go
+++ b/pkg/monitor/intervalcreation/operator.go
@@ -8,23 +8,23 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
-func IntervalsFromEvents_OperatorAvailable(events []*monitorapi.Event, beginning, end time.Time) monitorapi.EventIntervals {
-	return intervalsFromEvents_OperatorStatus(events, beginning, end, configv1.OperatorAvailable, configv1.ConditionTrue, monitorapi.Error)
+func IntervalsFromEvents_OperatorAvailable(intervals monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals {
+	return intervalsFromEvents_OperatorStatus(intervals, beginning, end, configv1.OperatorAvailable, configv1.ConditionTrue, monitorapi.Error)
 }
 
-func IntervalsFromEvents_OperatorProgressing(events []*monitorapi.Event, beginning, end time.Time) monitorapi.EventIntervals {
-	return intervalsFromEvents_OperatorStatus(events, beginning, end, configv1.OperatorProgressing, configv1.ConditionFalse, monitorapi.Warning)
+func IntervalsFromEvents_OperatorProgressing(intervals monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals {
+	return intervalsFromEvents_OperatorStatus(intervals, beginning, end, configv1.OperatorProgressing, configv1.ConditionFalse, monitorapi.Warning)
 }
 
-func IntervalsFromEvents_OperatorDegraded(events []*monitorapi.Event, beginning, end time.Time) monitorapi.EventIntervals {
-	return intervalsFromEvents_OperatorStatus(events, beginning, end, configv1.OperatorDegraded, configv1.ConditionFalse, monitorapi.Error)
+func IntervalsFromEvents_OperatorDegraded(intervals monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals {
+	return intervalsFromEvents_OperatorStatus(intervals, beginning, end, configv1.OperatorDegraded, configv1.ConditionFalse, monitorapi.Error)
 }
 
-func intervalsFromEvents_OperatorStatus(events []*monitorapi.Event, beginning, end time.Time, conditionType configv1.ClusterStatusConditionType, conditionGoodState configv1.ConditionStatus, level monitorapi.EventLevel) monitorapi.EventIntervals {
-	ret := monitorapi.EventIntervals{}
+func intervalsFromEvents_OperatorStatus(intervals monitorapi.Intervals, beginning, end time.Time, conditionType configv1.ClusterStatusConditionType, conditionGoodState configv1.ConditionStatus, level monitorapi.EventLevel) monitorapi.Intervals {
+	ret := monitorapi.Intervals{}
 	operatorToInterestingBadCondition := map[string]*configv1.ClusterOperatorStatusCondition{}
 
-	for _, event := range events {
+	for _, event := range intervals {
 		operatorName, ok := monitorapi.OperatorFromLocator(event.Locator)
 		if !ok {
 			continue
@@ -47,7 +47,7 @@ func intervalsFromEvents_OperatorStatus(events []*monitorapi.Event, beginning, e
 			// don't overwrite a previous condition in a bad state
 			if lastCondition == nil {
 				// force teh last transition time, sinc we think we just transitioned at this instant
-				currentCondition.LastTransitionTime.Time = event.At
+				currentCondition.LastTransitionTime.Time = event.From
 				operatorToInterestingBadCondition[operatorName] = currentCondition
 			}
 			continue
@@ -78,7 +78,7 @@ func intervalsFromEvents_OperatorStatus(events []*monitorapi.Event, beginning, e
 				Message: fmt.Sprintf("condition/%s status/%s reason/%s", conditionType, lastStatus, lastMessage),
 			},
 			From: from,
-			To:   event.At,
+			To:   event.From,
 		})
 	}
 

--- a/pkg/monitor/intervalcreation/operator_test.go
+++ b/pkg/monitor/intervalcreation/operator_test.go
@@ -18,27 +18,27 @@ func timeFor(asString string) time.Time {
 }
 
 func TestIntervalsFromEvents_OperatorProgressing(t *testing.T) {
-	events := []*monitorapi.Event{}
-	events = append(events,
-		&monitorapi.Event{
+	intervals := monitorapi.Intervals{}
+	intervals = append(intervals,
+		monitorapi.EventInterval{
 			Condition: monitorapi.Condition{
 				Level:   monitorapi.Info,
 				Locator: "clusteroperator/network",
 				Message: "condition/Progressing status/True reason/Deploying changed: Deployment \\\"openshift-network-diagnostics/network-check-source\\\" is not available (awaiting 1 nodes)",
 			},
-			At: timeFor("2021-03-29T15:56:00Z"),
+			From: timeFor("2021-03-29T15:56:00Z"),
 		},
-		&monitorapi.Event{
+		monitorapi.EventInterval{
 			Condition: monitorapi.Condition{
 				Level:   monitorapi.Info,
 				Locator: "clusteroperator/network",
 				Message: "condition/Progressing status/False changed: ",
 			},
-			At: timeFor("2021-03-29T15:56:11Z"),
+			From: timeFor("2021-03-29T15:56:11Z"),
 		},
 	)
 
-	actual := IntervalsFromEvents_OperatorProgressing(events, time.Time{}, time.Time{})
+	actual := IntervalsFromEvents_OperatorProgressing(intervals, time.Time{}, time.Time{})
 	expectedSummary := `Mar 29 15:56:00.000 - 11s   W clusteroperator/network condition/Progressing status/True reason/Deployment \"openshift-network-diagnostics/network-check-source\" is not available (awaiting 1 nodes)`
 	if actual[0].String() != expectedSummary {
 		t.Fatal(spew.Sdump(actual))

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMonitor_Newlines(t *testing.T) {
-	evt := &monitorapi.Event{Condition: monitorapi.Condition{Message: "a\nb\n"}}
+	evt := &monitorapi.EventInterval{Condition: monitorapi.Condition{Message: "a\nb\n"}}
 	expected := "Jan 01 00:00:00.000 I  a\\nb\\n"
 	if evt.String() != expected {
 		t.Fatalf("unexpected:\n%s\n%s", expected, evt.String())
@@ -21,50 +21,50 @@ func TestMonitor_Newlines(t *testing.T) {
 func TestMonitor_Events(t *testing.T) {
 	tests := []struct {
 		name    string
-		events  []*monitorapi.Event
+		events  monitorapi.Intervals
 		samples []*sample
 		from    time.Time
 		to      time.Time
-		want    monitorapi.EventIntervals
+		want    monitorapi.Intervals
 	}{
 		{
-			events: []*monitorapi.Event{
-				{Condition: monitorapi.Condition{Message: "1"}, At: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
+			events: monitorapi.Intervals{
+				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
-			want: monitorapi.EventIntervals{
+			want: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
-			events: []*monitorapi.Event{
-				{Condition: monitorapi.Condition{Message: "1"}, At: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
+			events: monitorapi.Intervals{
+				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 			from: time.Unix(1, 0),
-			want: monitorapi.EventIntervals{
+			want: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
-			events: []*monitorapi.Event{
-				{Condition: monitorapi.Condition{Message: "1"}, At: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
+			events: monitorapi.Intervals{
+				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 			from: time.Unix(1, 0),
 			to:   time.Unix(2, 0),
-			want: monitorapi.EventIntervals{
+			want: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
-			events: []*monitorapi.Event{
-				{Condition: monitorapi.Condition{Message: "1"}, At: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, At: time.Unix(2, 0)},
+			events: monitorapi.Intervals{
+				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 			from: time.Unix(2, 0),
-			want: nil,
+			want: monitorapi.Intervals{},
 		},
 		{
 			samples: []*sample{
@@ -73,7 +73,7 @@ func TestMonitor_Events(t *testing.T) {
 				{at: time.Unix(3, 0), conditions: []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
 			},
 			from: time.Unix(1, 0),
-			want: monitorapi.EventIntervals{
+			want: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
 				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
 			},
@@ -84,7 +84,7 @@ func TestMonitor_Events(t *testing.T) {
 				{at: time.Unix(2, 0), conditions: []*monitorapi.Condition{{Message: "2"}}},
 				{at: time.Unix(3, 0), conditions: []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
 			},
-			want: monitorapi.EventIntervals{
+			want: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
 				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
@@ -98,7 +98,7 @@ func TestMonitor_Events(t *testing.T) {
 				events:  tt.events,
 				samples: tt.samples,
 			}
-			if got := m.EventIntervals(tt.from, tt.to); !reflect.DeepEqual(got, tt.want) {
+			if got := m.Intervals(tt.from, tt.to); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%s", diff.ObjectReflectDiff(tt.want, got))
 			}
 		})

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -43,16 +43,6 @@ func EventLevelFromString(s string) (EventLevel, error) {
 
 }
 
-type Event struct {
-	Condition
-
-	At time.Time
-}
-
-func (e *Event) String() string {
-	return fmt.Sprintf("%s.%03d %s %s %s", e.At.Format("Jan 02 15:04:05"), e.At.Nanosecond()/1000000, e.Level.String()[:1], e.Locator, strings.Replace(e.Message, "\n", "\\n", -1))
-}
-
 type Condition struct {
 	Level EventLevel
 
@@ -78,11 +68,11 @@ func (i EventInterval) String() string {
 	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Second))+"s", i.Level.String()[:1], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 }
 
-type EventIntervals []EventInterval
+type Intervals []EventInterval
 
-var _ sort.Interface = EventIntervals{}
+var _ sort.Interface = Intervals{}
 
-func (intervals EventIntervals) Less(i, j int) bool {
+func (intervals Intervals) Less(i, j int) bool {
 	switch d := intervals[i].From.Sub(intervals[j].From); {
 	case d < 0:
 		return true
@@ -97,26 +87,72 @@ func (intervals EventIntervals) Less(i, j int) bool {
 	}
 	return intervals[i].Message < intervals[j].Message
 }
-func (intervals EventIntervals) Len() int { return len(intervals) }
-func (intervals EventIntervals) Swap(i, j int) {
+func (intervals Intervals) Len() int { return len(intervals) }
+func (intervals Intervals) Swap(i, j int) {
 	intervals[i], intervals[j] = intervals[j], intervals[i]
 }
 
-type Events []*Event
+// CopyAndSort assumes intervals is unsorted and returns a sorted copy of intervals
+// for all intervals between from and to.
+func (intervals Intervals) CopyAndSort(from, to time.Time) Intervals {
+	copied := make(Intervals, 0, len(intervals))
 
-var _ sort.Interface = Events{}
-
-func (events Events) Less(i, j int) bool {
-	switch d := events[i].At.Sub(events[j].At); {
-	case d < 0:
-		return true
-	case d > 0:
-		return false
-	default:
-		return true
+	if from.IsZero() && to.IsZero() {
+		for _, e := range intervals {
+			copied = append(copied, e)
+		}
+		sort.Sort(copied)
+		return copied
 	}
+
+	for _, e := range intervals {
+		if !e.From.After(from) {
+			continue
+		}
+		if !to.IsZero() && !e.From.Before(to) {
+			continue
+		}
+		copied = append(copied, e)
+	}
+	sort.Sort(copied)
+	return copied
+
 }
-func (events Events) Len() int { return len(events) }
-func (events Events) Swap(i, j int) {
-	events[i], events[j] = events[j], events[i]
+
+// Slice works on a sorted Intervals list and returns the set of intervals
+// that start after from and start before to (if to is set). The zero value will
+// return all elements. If intervals is unsorted the result is undefined. This
+// runs in O(n).
+func (intervals Intervals) Slice(from, to time.Time) Intervals {
+	if from.IsZero() && to.IsZero() {
+		return intervals
+	}
+
+	first := sort.Search(len(intervals), func(i int) bool {
+		return intervals[i].From.After(from)
+	})
+	if first == -1 {
+		return nil
+	}
+	if to.IsZero() {
+		return intervals[first:]
+	}
+	for i := first; i < len(intervals); i++ {
+		if intervals[i].From.After(to) {
+			return intervals[first:i]
+		}
+	}
+	return intervals[first:]
+}
+
+// Clamp sets all zero value From or To fields to from or to.
+func (intervals Intervals) Clamp(from, to time.Time) {
+	for i := range intervals {
+		if intervals[i].From.IsZero() {
+			intervals[i].From = from
+		}
+		if intervals[i].To.IsZero() {
+			intervals[i].To = to
+		}
+	}
 }

--- a/pkg/monitor/sampler_test.go
+++ b/pkg/monitor/sampler_test.go
@@ -54,7 +54,7 @@ func TestStartSampling(t *testing.T) {
 
 	var describe []string
 	var log []string
-	events := m.EventIntervals(time.Time{}, time.Time{})
+	events := m.Intervals(time.Time{}, time.Time{})
 	for _, interval := range events {
 		i := interval.To.Sub(interval.From)
 		describe = append(describe, fmt.Sprintf("%v %s", interval.Condition, i))

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -27,7 +27,7 @@ type EventIntervalList struct {
 	Items []EventInterval `json:"items"`
 }
 
-func EventsToFile(filename string, events monitorapi.EventIntervals) error {
+func EventsToFile(filename string, events monitorapi.Intervals) error {
 	json, err := EventsToJSON(events)
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func EventsToFile(filename string, events monitorapi.EventIntervals) error {
 	return ioutil.WriteFile(filename, json, 0644)
 }
 
-func EventsFromFile(filename string) (monitorapi.EventIntervals, error) {
+func EventsFromFile(filename string) (monitorapi.Intervals, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func EventsFromFile(filename string) (monitorapi.EventIntervals, error) {
 	if err := json.Unmarshal(data, &list); err != nil {
 		return nil, err
 	}
-	events := make(monitorapi.EventIntervals, len(list.Items))
+	events := make(monitorapi.Intervals, len(list.Items))
 	for _, interval := range list.Items {
 		level, err := monitorapi.EventLevelFromString(interval.Level)
 		if err != nil {
@@ -64,7 +64,7 @@ func EventsFromFile(filename string) (monitorapi.EventIntervals, error) {
 	return events, nil
 }
 
-func EventsToJSON(events monitorapi.EventIntervals) ([]byte, error) {
+func EventsToJSON(events monitorapi.Intervals) ([]byte, error) {
 	outputEvents := []EventInterval{}
 	for _, curr := range events {
 		outputEvents = append(outputEvents, monitorEventIntervalToEventInterval(curr))
@@ -75,7 +75,7 @@ func EventsToJSON(events monitorapi.EventIntervals) ([]byte, error) {
 	return json.MarshalIndent(list, "", "    ")
 }
 
-func EventsIntervalsToFile(filename string, events monitorapi.EventIntervals) error {
+func EventsIntervalsToFile(filename string, events monitorapi.Intervals) error {
 	json, err := EventsIntervalsToJSON(events)
 	if err != nil {
 		return err
@@ -83,7 +83,7 @@ func EventsIntervalsToFile(filename string, events monitorapi.EventIntervals) er
 	return ioutil.WriteFile(filename, json, 0644)
 }
 
-func EventsIntervalsToJSON(events monitorapi.EventIntervals) ([]byte, error) {
+func EventsIntervalsToJSON(events monitorapi.Intervals) ([]byte, error) {
 	outputEvents := []EventInterval{}
 	for _, curr := range events {
 		if curr.From == curr.To {

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -6,13 +6,13 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
-type IntervalCreationFunc func(events []*monitorapi.Event, beginning, end time.Time) monitorapi.EventIntervals
+type IntervalCreationFunc func(intervals monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals
 
 type SamplerFunc func(time.Time) []*monitorapi.Condition
 
 type Interface interface {
-	EventIntervals(from, to time.Time) monitorapi.EventIntervals
-	Conditions(from, to time.Time) monitorapi.EventIntervals
+	Intervals(from, to time.Time) monitorapi.Intervals
+	Conditions(from, to time.Time) monitorapi.Intervals
 }
 
 type Recorder interface {

--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -16,7 +16,7 @@ const (
 	tolerateDisruptionPercent = 0.01
 )
 
-func testServerAvailability(locator string, events monitorapi.EventIntervals, duration time.Duration) []*ginkgo.JUnitTestCase {
+func testServerAvailability(locator string, events monitorapi.Intervals, duration time.Duration) []*ginkgo.JUnitTestCase {
 	errDuration, errMessages := disruption.GetDisruption(events, locator)
 
 	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -13,7 +13,7 @@ import (
 // steady state (not being changed externally). Use these with suites that assume the
 // cluster is under no adversarial change (config changes, induced disruption to nodes,
 // etcd, or apis).
-func StableSystemEventInvariants(events monitorapi.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
+func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
 	tests = SystemEventInvariants(events, duration)
 	tests = append(tests, testKubeAPIServerGracefulTermination(events)...)
 	tests = append(tests, testKubeletToAPIServerGracefulTermination(events)...)
@@ -32,7 +32,7 @@ func StableSystemEventInvariants(events monitorapi.EventIntervals, duration time
 
 // systemUpgradeEventInvariants are invariants tested against events that should hold true in a cluster
 // that is being upgraded without induced disruption
-func SystemUpgradeEventInvariants(events monitorapi.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
+func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
 	tests = SystemEventInvariants(events, duration)
 	tests = append(tests, testKubeAPIServerGracefulTermination(events)...)
 	tests = append(tests, testKubeletToAPIServerGracefulTermination(events)...)
@@ -46,7 +46,7 @@ func SystemUpgradeEventInvariants(events monitorapi.EventIntervals, duration tim
 // systemEventInvariants are invariants tested against events that should hold true in any cluster,
 // even one undergoing disruption. These are usually focused on things that must be true on a single
 // machine, even if the machine crashes.
-func SystemEventInvariants(events monitorapi.EventIntervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
+func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
 	tests = append(tests, testSystemDTimeout(events)...)
 	return tests
 }

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testKubeletToAPIServerGracefulTermination(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
+func testKubeletToAPIServerGracefulTermination(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] kubelet terminates kube-apiserver gracefully"
 
 	var failures []string
@@ -44,7 +44,7 @@ func testKubeletToAPIServerGracefulTermination(events monitorapi.EventIntervals)
 	return tests
 }
 
-func testKubeAPIServerGracefulTermination(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
+func testKubeAPIServerGracefulTermination(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-api-machinery] kube-apiserver terminates within graceful termination period"
 
 	var failures []string
@@ -72,7 +72,7 @@ func testKubeAPIServerGracefulTermination(events monitorapi.EventIntervals) []*g
 	return tests
 }
 
-func testPodTransitions(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
+func testPodTransitions(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] pods should never transition back to pending"
 	success := &ginkgo.JUnitTestCase{Name: testName}
 
@@ -105,7 +105,7 @@ func formatTimes(times []time.Time) []string {
 	return s
 }
 
-func testNodeUpgradeTransitions(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
+func testNodeUpgradeTransitions(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] nodes should not go unready after being upgraded and go unready only once"
 
 	var buf bytes.Buffer
@@ -206,7 +206,7 @@ func testNodeUpgradeTransitions(events monitorapi.EventIntervals) []*ginkgo.JUni
 	return testCases
 }
 
-func testSystemDTimeout(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
+func testSystemDTimeout(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-node] pods should not fail on systemd timeouts"
 	success := &ginkgo.JUnitTestCase{Name: testName}
 

--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -15,7 +15,7 @@ type testCategorizer struct {
 	substring string
 }
 
-func testPodSandboxCreation(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
+func testPodSandboxCreation(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
 	const testName = "[sig-network] pods should successfully create sandboxes"
 	// we can further refine this signal by subdividing different failure modes if it is pertinent.  Right now I'm seeing
 	// 1. error reading container (probably exited) json message: EOF
@@ -129,8 +129,8 @@ func categorizeBySubset(categorizers []testCategorizer, failures, flakes []strin
 }
 
 // getEventsByPod returns map keyed by pod locator with all events associated with it.
-func getEventsByPod(events monitorapi.EventIntervals) map[string]monitorapi.EventIntervals {
-	eventsByPods := map[string]monitorapi.EventIntervals{}
+func getEventsByPod(events monitorapi.Intervals) map[string]monitorapi.Intervals {
+	eventsByPods := map[string]monitorapi.Intervals{}
 	for _, event := range events {
 		if !strings.Contains(event.Locator, "pod/") {
 			continue
@@ -140,7 +140,7 @@ func getEventsByPod(events monitorapi.EventIntervals) map[string]monitorapi.Even
 	return eventsByPods
 }
 
-func getPodDeletionTime(events monitorapi.EventIntervals, podLocator string) *time.Time {
+func getPodDeletionTime(events monitorapi.Intervals, podLocator string) *time.Time {
 	for _, event := range events {
 		if event.Locator == podLocator && event.Message == "reason/Deleted" {
 			return &event.From

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -12,14 +12,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testStableSystemOperatorStateTransitions(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
+func testStableSystemOperatorStateTransitions(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
 	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded, configv1.OperatorProgressing})
 }
 
-func testUpgradeOperatorStateTransitions(events monitorapi.EventIntervals) []*ginkgo.JUnitTestCase {
+func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
 	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded})
 }
-func testOperatorStateTransitions(events monitorapi.EventIntervals, conditionTypes []configv1.ClusterStatusConditionType) []*ginkgo.JUnitTestCase {
+func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []configv1.ClusterStatusConditionType) []*ginkgo.JUnitTestCase {
 	ret := []*ginkgo.JUnitTestCase{}
 
 	knownOperators := allOperators(events)
@@ -56,7 +56,7 @@ func testOperatorStateTransitions(events monitorapi.EventIntervals, conditionTyp
 	return ret
 }
 
-func allOperators(events monitorapi.EventIntervals) sets.String {
+func allOperators(events monitorapi.Intervals) sets.String {
 	// start with a list of known values
 	knownOperators := sets.NewString(KnownOperators.List()...)
 
@@ -72,8 +72,8 @@ func allOperators(events monitorapi.EventIntervals) sets.String {
 }
 
 // getEventsByOperator returns map keyed by operator locator with all events associated with it.
-func getEventsByOperator(events monitorapi.EventIntervals) map[string]monitorapi.EventIntervals {
-	eventsByClusterOperator := map[string]monitorapi.EventIntervals{}
+func getEventsByOperator(events monitorapi.Intervals) map[string]monitorapi.Intervals {
+	eventsByClusterOperator := map[string]monitorapi.Intervals{}
 	for _, event := range events {
 		operatorName, ok := monitorapi.OperatorFromLocator(event.Locator)
 		if !ok {
@@ -84,7 +84,7 @@ func getEventsByOperator(events monitorapi.EventIntervals) map[string]monitorapi
 	return eventsByClusterOperator
 }
 
-func testOperatorState(interestingCondition configv1.ClusterStatusConditionType, eventIntervals monitorapi.EventIntervals, e2eEventIntervals monitorapi.EventIntervals) []string {
+func testOperatorState(interestingCondition configv1.ClusterStatusConditionType, eventIntervals monitorapi.Intervals, e2eEventIntervals monitorapi.Intervals) []string {
 	failures := []string{}
 
 	for _, eventInterval := range eventIntervals {

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -273,7 +273,8 @@ func (opt *Options) Run(suite *TestSuite) error {
 	// calculate the effective test set we ran, excluding any incompletes
 	tests, _ = splitTests(tests, func(t *testCase) bool { return t.success || t.failed || t.skipped })
 
-	duration := time.Now().Sub(start).Round(time.Second / 10)
+	end := time.Now()
+	duration := end.Sub(start).Round(time.Second / 10)
 	if duration > time.Minute {
 		duration = duration.Round(time.Second)
 	}
@@ -284,7 +285,8 @@ func (opt *Options) Run(suite *TestSuite) error {
 	var syntheticTestResults []*JUnitTestCase
 	var syntheticFailure bool
 	timeSuffix := fmt.Sprintf("_%s", start.UTC().Format("20060102-150405"))
-	events := m.EventIntervals(time.Time{}, time.Time{})
+	events := m.Intervals(time.Time{}, time.Time{})
+	events.Clamp(start, end)
 	if err = monitorserialization.EventsToFile(path.Join(os.Getenv("ARTIFACT_DIR"), fmt.Sprintf("e2e-events%s.json", timeSuffix)), events); err != nil {
 		fmt.Fprintf(opt.Out, "Failed to write event file: %v\n", err)
 	}

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -14,13 +14,13 @@ type JUnitsForEvents interface {
 	// JUnitsForEvents returns a set of additional test passes or failures implied by the
 	// events sent during the test suite run. If passed is false, the entire suite is failed.
 	// To set a test as flaky, return a passing and failing JUnitTestCase with the same name.
-	JUnitsForEvents(events monitorapi.EventIntervals, duration time.Duration) []*JUnitTestCase
+	JUnitsForEvents(events monitorapi.Intervals, duration time.Duration) []*JUnitTestCase
 }
 
 // JUnitForEventsFunc converts a function into the JUnitForEvents interface.
-type JUnitForEventsFunc func(events monitorapi.EventIntervals, duration time.Duration) []*JUnitTestCase
+type JUnitForEventsFunc func(events monitorapi.Intervals, duration time.Duration) []*JUnitTestCase
 
-func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.EventIntervals, duration time.Duration) []*JUnitTestCase {
+func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration) []*JUnitTestCase {
 	return fn(events, duration)
 }
 
@@ -28,7 +28,7 @@ func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.EventIntervals, d
 // the result of all invocations. It ignores nil interfaces.
 type JUnitsForAllEvents []JUnitsForEvents
 
-func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.EventIntervals, duration time.Duration) []*JUnitTestCase {
+func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration) []*JUnitTestCase {
 	var all []*JUnitTestCase
 	for _, obj := range a {
 		if obj == nil {
@@ -40,7 +40,7 @@ func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.EventIntervals, du
 	return all
 }
 
-func createSyntheticTestsFromMonitor(events monitorapi.EventIntervals, monitorDuration time.Duration) ([]*JUnitTestCase, *bytes.Buffer, *bytes.Buffer) {
+func createSyntheticTestsFromMonitor(events monitorapi.Intervals, monitorDuration time.Duration) ([]*JUnitTestCase, *bytes.Buffer, *bytes.Buffer) {
 	var syntheticTestResults []*JUnitTestCase
 
 	buf, errBuf := &bytes.Buffer{}, &bytes.Buffer{}

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -157,7 +157,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.02, end.Sub(start), m.EventIntervals(time.Time{}, time.Time{}), "Service was unreachable during disruption")
+	disruption.ExpectNoDisruption(f, 0.02, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Service was unreachable during disruption")
 
 	// verify finalizer behavior
 	defer func() {

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -110,7 +110,7 @@ func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	if framework.ProviderIs("azure", "gcp") {
 		toleratedDisruption = 0
 	}
-	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.EventIntervals(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption (AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804)", t.name))
+	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption (AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804)", t.name))
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -279,7 +279,7 @@ func createTestFrameworks(tests []upgrades.Test) map[string]*framework.Framework
 // ExpectNoDisruption fails if the sum of the duration of all events exceeds tolerate as a fraction ([0-1]) of total, reports a
 // disruption flake if any disruption occurs, and uses reason to prefix the message. I.e. tolerate 0.1 of 10m total will fail
 // if the sum of the intervals is greater than 1m, or report a flake if any interval is found.
-func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Duration, events monitorapi.EventIntervals, reason string) {
+func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Duration, events monitorapi.Intervals, reason string) {
 	duration, describe := GetDisruption(events, "")
 	if percent := float64(duration) / float64(total); percent > tolerate {
 		framework.Failf("%s for at least %s of %s (%0.0f%%):\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
@@ -290,7 +290,7 @@ func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Dur
 
 // GetDisruption returns total duration of all error events and array of event description for printing.
 // When requiredLocator is specified (non-empty), only events matching this locator are considered.
-func GetDisruption(events monitorapi.EventIntervals, requiredLocator string) (time.Duration, []string) {
+func GetDisruption(events monitorapi.Intervals, requiredLocator string) (time.Duration, []string) {
 	var duration time.Duration
 	var describe []string
 	for _, interval := range events {

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -105,7 +105,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.EventIntervals(time.Time{}, time.Time{}), "Frontends were unreachable during disruption")
+	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Frontends were unreachable during disruption")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/extended/util/disruption/imageregistry/imageregistry.go
+++ b/test/extended/util/disruption/imageregistry/imageregistry.go
@@ -121,7 +121,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.EventIntervals(time.Time{}, time.Time{}), "Image registry was unreachable during disruption")
+	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Image registry was unreachable during disruption")
 }
 
 // Teardown cleans up any remaining resources.


### PR DESCRIPTION
Ensure all events going to the output are in fully specified and
clamped intervals.

* Remove the Event object and simply use EventInterval everywhere
* Rename EventInterval to Interval
* Move some helper methods to the monitorapi