### PR TITLE
Bug 1938492: test/extended/operators/resources: Marketplace Job sets requests

### DIFF
--- a/test/extended/operators/resources.go
+++ b/test/extended/operators/resources.go
@@ -42,9 +42,6 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 			"apps/v1/Deployment/openshift-operator-lifecycle-manager/packageserver/container/packageserver/request[cpu]":       "https://bugzilla.redhat.com/show_bug.cgi?id=1938466",
 			"apps/v1/Deployment/openshift-operator-lifecycle-manager/packageserver/container/packageserver/request[memory]":    "https://bugzilla.redhat.com/show_bug.cgi?id=1938466",
 
-			"batch/v1/Job/openshift-marketplace/<batch_job>/container/extract/request[cpu]":    "https://bugzilla.redhat.com/show_bug.cgi?id=1938492",
-			"batch/v1/Job/openshift-marketplace/<batch_job>/container/extract/request[memory]": "https://bugzilla.redhat.com/show_bug.cgi?id=1938492",
-
 			"apps/v1/DaemonSet/openshift-machine-api/metal3-image-cache/container/metal3-httpd/request[cpu]":          "https://bugzilla.redhat.com/show_bug.cgi?id=1940518",
 			"apps/v1/DaemonSet/openshift-machine-api/metal3-image-cache/container/metal3-httpd/request[memory]":       "https://bugzilla.redhat.com/show_bug.cgi?id=1940518",
 			"apps/v1/Deployment/openshift-machine-api/metal3/container/ironic-deploy-ramdisk-logs/request[cpu]":       "https://bugzilla.redhat.com/show_bug.cgi?id=1940518",


### PR DESCRIPTION
[1] and [2] have landed.

[1]: https://github.com/openshift/operator-framework-olm/pull/55
[2]: https://github.com/operator-framework/operator-lifecycle-manager/pull/2099