### PR TITLE
Bug 1952045: request mirroring for nfs-server image used in jenkins-e2e tests

### DIFF
--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -11,6 +11,9 @@ import (
 
 func init() {
 	allowedImages = map[string]int{
+		// used by jenkins tests
+		"quay.io/redhat-developer/nfs-server:1.0": -1,
+
 		// used by open ldap tests
 		"docker.io/mrogers950/origin-openldap-test:fedora29": -1,
 

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -51,4 +51,5 @@ k8s.gcr.io/sig-storage/livenessprobe:v1.1.0 quay.io/openshift/community-e2e-imag
 k8s.gcr.io/sig-storage/mock-driver:v4.0.2 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-mock-driver-v4-0-2-GE9vfPm7mdvjzZh_
 k8s.gcr.io/sig-storage/nfs-provisioner:v2.2.2 quay.io/openshift/community-e2e-images:e2e-22-k8s-gcr-io-sig-storage-nfs-provisioner-v2-2-2-dbgtOCwYmEGggl01
 k8s.gcr.io/sig-storage/snapshot-controller:v2.1.1 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-snapshot-controller-v2-1-1-n5BM_jX2npV3RxHM
+quay.io/redhat-developer/nfs-server:1.0 quay.io/openshift/community-e2e-images:e2e-quay-io-redhat-developer-nfs-server-1-0-Wz4GFQ2IuhYmh2mB
 registry.ci.openshift.org/ocp/4.7:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-ci-openshift-org-ocp-4-7-test-build-roots2i-tG08qb6aSmDhxBBy

--- a/test/extended/util/nfs.go
+++ b/test/extended/util/nfs.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/kubernetes/test/e2e/framework/volume"
+	"github.com/openshift/origin/test/extended/util/image"
 
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	"k8s.io/kubernetes/test/e2e/framework/volume"
 )
 
 // SetupK8SNFSServerAndVolume sets up an nfs server pod with count number of persistent volumes
@@ -31,7 +32,7 @@ func SetupK8SNFSServerAndVolume(oc *CLI, count int) (*kapiv1.Pod, []*kapiv1.Pers
 		// additional nfs mounts to allow for openshift extended tests with
 		// replicas and shared state (formerly mongo, postgresql, mysql, etc., now only jenkins); defined
 		// in repo https://github.com/redhat-developer/nfs-server
-		ServerImage:   "quay.io/redhat-developer/nfs-server:latest",
+		ServerImage:   image.LocationFor("quay.io/redhat-developer/nfs-server:1.0"),
 		ServerPorts:   []int{2049},
 		ServerVolumes: map[string]string{"": "/exports"},
 	}


### PR DESCRIPTION
The Pr aims to request mirroring for  quay.io/redhat-developer/nfs-server:latest and update jenkins-e2e to use the mirrored image