### PR TITLE
Bug 1949978: test/extended/router: skip http2, grpc-interop and h2spec on AWS

### DIFF
--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -389,8 +389,11 @@ func resolveHostAsAddress(oc *exutil.CLI, interval, timeout time.Duration, host,
 // clients.
 func platformHasHTTP2LoadBalancerService(platformType configv1.PlatformType) bool {
 	switch platformType {
-	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType:
+	case configv1.AzurePlatformType, configv1.GCPPlatformType:
 		return true
+	case configv1.AWSPlatformType:
+		e2e.Logf("AWS support waiting on https://bugzilla.redhat.com/show_bug.cgi?id=1912413")
+		fallthrough
 	default:
 		return false
 	}


### PR DESCRIPTION
AWS/UPI jobs are failing on http2, grpc-interop and h2spec tests
because deleting the ingresscontroller which was explicitly created
for the test takes more than 10 minutes[1] and that (plus the overall
test time) exceeds the amount of time the test is allowed to run for
before being marked as failing.

This commit skips tests on AWS until we fix BZ #1912413.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1912413.
