### PR TITLE
Bug 1957041: Update e2echart to include node roles info

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -109,21 +109,31 @@
 
     function isNodeState(eventInterval) {
         if (eventInterval.locator.startsWith("node/")) {
-            return (eventInterval.message.startsWith("reason/NodeUpdate ") || eventInterval.message == "node is not ready")
+            return (eventInterval.message.startsWith("reason/NodeUpdate ") || eventInterval.message.includes("node is not ready"))
         }
         return false
     }
 
     const rePhase = new RegExp("(^| )phase/([^ ]+)")
     function nodeStateValue(item) {
-        if (item.message == "node is not ready") {
-            return [item.locator, " (not ready)", "NodeNotReady"]
+        let roles = ""
+        let i = item.message.indexOf("roles/")
+        if (i != -1) {
+          roles = item.message.substring(i+"roles/".length)
+          let j = roles.indexOf(" ")
+          if (j != -1) {
+            roles = roles.substring(0, j)
+          }
+        }
+
+        if (item.message.includes("node is not ready")) {
+            return [item.locator, ` (${roles},not ready)`, "NodeNotReady"]
         }
         let m = item.message.match(rePhase);
         if (m && m[2] != "Update") {
-            return [item.locator, " (update phases)", m[2]];
+            return [item.locator, ` (${roles},update phases)`, m[2]];
         }
-        return [item.locator, " (updates)", "Update"];
+        return [item.locator, ` (${roles},updates)`, "Update"];
     }
 
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc) {
@@ -177,6 +187,12 @@
 
     timelineGroups.push({group: "node-state", data: []})
     createTimelineData(nodeStateValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isNodeState)
+    timelineGroups[timelineGroups.length - 1].data.sort(function (e1 ,e2){
+      if (e1.label.includes("master") && e2.label.includes("worker")) {
+        return -1
+      }
+      return 0
+    })
 
     timelineGroups.push({group: "apiserver-availability", data: []})
     createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerConnectivity)

--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -76,6 +76,13 @@ func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Int
 							if obj.Count > 1 {
 								message += fmt.Sprintf(" (%d times)", obj.Count)
 							}
+
+							if obj.InvolvedObject.Kind == "Node" {
+								if node, err := client.CoreV1().Nodes().Get(ctx, obj.InvolvedObject.Name, metav1.GetOptions{}); err == nil {
+									message = fmt.Sprintf("roles/%s %s", nodeRoles(node), message)
+								}
+							}
+
 							// special case some very common events
 							switch obj.Reason {
 							case "":

--- a/pkg/monitor/intervalcreation/node_test.go
+++ b/pkg/monitor/intervalcreation/node_test.go
@@ -17,13 +17,13 @@ func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 	if len(changes) != 3 {
 		t.Fatalf("unexpected changes: %s", string(out))
 	}
-	if changes[0].Message != "reason/NodeUpdate phase/Drain drained node" {
+	if changes[0].Message != "reason/NodeUpdate phase/Drain roles/worker drained node" {
 		t.Errorf("unexpected event: %s", string(out))
 	}
-	if changes[1].Message != "reason/NodeUpdate phase/OperatingSystemUpdate updated operating system" {
+	if changes[1].Message != "reason/NodeUpdate phase/OperatingSystemUpdate roles/worker updated operating system" {
 		t.Errorf("unexpected event: %s", string(out))
 	}
-	if changes[2].Message != "reason/NodeUpdate phase/Reboot rebooted and kubelet started" {
+	if changes[2].Message != "reason/NodeUpdate phase/Reboot roles/worker rebooted and kubelet started" {
 		t.Errorf("unexpected event: %s", string(out))
 	}
 }

--- a/pkg/monitor/intervalcreation/testdata/node.json
+++ b/pkg/monitor/intervalcreation/testdata/node.json
@@ -3,126 +3,127 @@
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/RegisteredNode Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 event: Registered Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 in Controller",
+      "message": "reason/RegisteredNode roles/worker Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 event: Registered Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 in Controller",
       "from": "2021-04-12T21:58:08Z",
       "to": "2021-04-12T21:58:08Z"
     },
     {
+
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/RegisteredNode Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 event: Registered Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 in Controller",
+      "message": "reason/RegisteredNode roles/worker Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 event: Registered Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 in Controller",
       "from": "2021-04-12T21:58:55Z",
       "to": "2021-04-12T21:58:55Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/Starting openshift-sdn done initializing node networking.",
+      "message": "reason/Starting roles/worker openshift-sdn done initializing node networking.",
       "from": "2021-04-12T22:17:10Z",
       "to": "2021-04-12T22:17:10Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/Cordon Cordoned node to apply update",
+      "message": "reason/Cordon roles/worker Cordoned node to apply update",
       "from": "2021-04-12T22:25:29Z",
       "to": "2021-04-12T22:25:29Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/Drain Draining node to update config.",
+      "message": "reason/Drain roles/worker Draining node to update config.",
       "from": "2021-04-12T22:25:29Z",
       "to": "2021-04-12T22:25:29Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/NodeNotSchedulable Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 status is now: NodeNotSchedulable",
+      "message": "reason/NodeNotSchedulable roles/worker Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 status is now: NodeNotSchedulable",
       "from": "2021-04-12T22:25:34Z",
       "to": "2021-04-12T22:25:34Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/OSUpdateStarted Upgrading OS",
+      "message": "reason/OSUpdateStarted roles/worker Upgrading OS",
       "from": "2021-04-12T22:27:00Z",
       "to": "2021-04-12T22:27:00Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/InClusterUpgrade Updating from oscontainer registry.build02.ci.openshift.org/ci-op-8sllkmg5/stable@sha256:59298bf4359e51de44b6ca28c211df62ab823566823e8e1b5aaafa090ff481bb",
+      "message": "reason/InClusterUpgrade roles/worker Updating from oscontainer registry.build02.ci.openshift.org/ci-op-8sllkmg5/stable@sha256:59298bf4359e51de44b6ca28c211df62ab823566823e8e1b5aaafa090ff481bb",
       "from": "2021-04-12T22:27:00Z",
       "to": "2021-04-12T22:27:00Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/OSUpdateStaged Changes to OS staged",
+      "message": "reason/OSUpdateStaged roles/worker Changes to OS staged",
       "from": "2021-04-12T22:27:21Z",
       "to": "2021-04-12T22:27:21Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/PendingConfig Written pending config rendered-worker-2f04672635ea44b389119d4a0e747bc7",
+      "message": "reason/PendingConfig roles/worker Written pending config rendered-worker-2f04672635ea44b389119d4a0e747bc7",
       "from": "2021-04-12T22:27:22Z",
       "to": "2021-04-12T22:27:22Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/Reboot Node will reboot into config rendered-worker-2f04672635ea44b389119d4a0e747bc7",
+      "message": "reason/Reboot roles/worker Node will reboot into config rendered-worker-2f04672635ea44b389119d4a0e747bc7",
       "from": "2021-04-12T22:27:22Z",
       "to": "2021-04-12T22:27:22Z"
     },
     {
       "level": "Warning",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "condition/DiskPressure status/Unknown reason/NodeStatusUnknown changed",
+      "message": "condition/DiskPressure status/Unknown reason/NodeStatusUnknown roles/worker changed",
       "from": "2021-04-12T22:28:07Z",
       "to": "2021-04-12T22:28:07Z"
     },
     {
       "level": "Warning",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "condition/MemoryPressure status/Unknown reason/NodeStatusUnknown changed",
+      "message": "condition/MemoryPressure status/Unknown reason/NodeStatusUnknown roles/worker changed",
       "from": "2021-04-12T22:28:07Z",
       "to": "2021-04-12T22:28:07Z"
     },
     {
       "level": "Warning",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "condition/PIDPressure status/Unknown reason/NodeStatusUnknown changed",
+      "message": "condition/PIDPressure status/Unknown reason/NodeStatusUnknown roles/worker changed",
       "from": "2021-04-12T22:28:07Z",
       "to": "2021-04-12T22:28:07Z"
     },
     {
       "level": "Warning",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "condition/Ready status/Unknown reason/NodeStatusUnknown changed",
+      "message": "condition/Ready status/Unknown reason/NodeStatusUnknown roles/worker changed",
       "from": "2021-04-12T22:28:07Z",
       "to": "2021-04-12T22:28:07Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/NodeNotReady Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 status is now: NodeNotReady",
+      "message": "reason/NodeNotReady roles/worker Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 status is now: NodeNotReady",
       "from": "2021-04-12T22:28:07Z",
       "to": "2021-04-12T22:28:07Z"
     },
     {
       "level": "Warning",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "node is not ready",
+      "message": "roles/worker node is not ready",
       "from": "2021-04-12T22:28:08Z",
       "to": "2021-04-12T22:29:00Z"
     },
     {
       "level": "Info",
       "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/Starting Starting kubelet.",
+      "message": "reason/Starting roles/worker Starting kubelet.",
       "from": "2021-04-12T22:28:50Z",
       "to": "2021-04-12T22:28:50Z"
     }

--- a/pkg/monitor/monitorapi/identification_node.go
+++ b/pkg/monitor/monitorapi/identification_node.go
@@ -1,0 +1,16 @@
+package monitorapi
+
+import "strings"
+
+// GetNodeRoles extract the node roles from the event message.
+func GetNodeRoles(event EventInterval) string {
+	var roles string
+	if i := strings.Index(event.Message, "roles/"); i != -1 {
+		roles = event.Message[i+len("roles/"):]
+		if j := strings.Index(roles, " "); j != -1 {
+			roles = roles[:j]
+		}
+	}
+
+	return roles
+}

--- a/pkg/monitor/monitorapi/identification_node_test.go
+++ b/pkg/monitor/monitorapi/identification_node_test.go
@@ -1,0 +1,49 @@
+package monitorapi
+
+import "testing"
+
+func TestGetNodeRoles(t *testing.T) {
+	var testCases = []struct {
+		event    EventInterval
+		expected string
+	}{
+		{
+			event: EventInterval{
+				Condition: Condition{
+					Message: "",
+				},
+			},
+			expected: "",
+		},
+		{
+			event: EventInterval{
+				Condition: Condition{
+					Message: "roles/master",
+				},
+			},
+			expected: "master",
+		},
+		{
+			event: EventInterval{
+				Condition: Condition{
+					Message: "roles/worker",
+				},
+			},
+			expected: "worker",
+		},
+		{
+			event: EventInterval{
+				Condition: Condition{
+					Message: "roles/master,worker",
+				},
+			},
+			expected: "master,worker",
+		},
+	}
+
+	for i, tc := range testCases {
+		if actual := GetNodeRoles(tc.event); tc.expected != actual {
+			t.Errorf("mismatch node roles. test case:#%d expected: %s, actual: %s", i, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/monitor/node_test.go
+++ b/pkg/monitor/node_test.go
@@ -1,0 +1,57 @@
+package monitor
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNodeRoles(t *testing.T) {
+	var testCases = []struct {
+		node     *corev1.Node
+		expected string
+	}{
+		{
+			node:     &corev1.Node{},
+			expected: "",
+		},
+		{
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"node-role.kubernetes.io/master": "",
+					},
+				},
+			},
+			expected: "master",
+		},
+		{
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"node-role.kubernetes.io/worker": "",
+					},
+				},
+			},
+			expected: "worker",
+		},
+		{
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"node-role.kubernetes.io/master": "",
+						"node-role.kubernetes.io/worker": "",
+					},
+				},
+			},
+			expected: "master,worker",
+		},
+	}
+
+	for _, tc := range testCases {
+		if actual := nodeRoles(tc.node); tc.expected != actual {
+			t.Errorf("mismatch roles. expected: %s, actual: %s", tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This PR updates the `node-state` section in the e2echart with node roles, by
embedding the information (in the form of `roles/$roles`) in the `Message` field. 
This change preserves the dependency some tests have on the event
messages, where certain prefix and suffix are expected, as seen in
[pkg/synthetictests/kubelet.go](https://github.com/openshift/origin/blob/36b43d1c8df3a74e1e1fca5e8a9c1c6824d67fe6/pkg/synthetictests/kubelet.go#L132-L134) and [pkg/monitor/intervalcreation/node.go](https://github.com/openshift/origin/blob/36b43d1c8df3a74e1e1fca5e8a9c1c6824d67fe6/pkg/monitor/intervalcreation/node.go#L44-L46)  

This is what the updated section looks like:
![image](https://user-images.githubusercontent.com/1330522/115421699-04fe7380-a1b1-11eb-9c1a-075ebd74e980.png)  The `eventIntervals` JS object used for testing can be found in this [gist](https://gist.github.com/ihcsim/8e5b70883b5335de46a88046625e19ad). 

Signed-off-by: Ivan Sim <isim@redhat.com>