### PR TITLE
monitor: Move "crashlooping pods" test to an invariant

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -15,6 +15,8 @@ import (
 // etcd, or apis).
 func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
 	tests = SystemEventInvariants(events, duration)
+	tests = append(tests, testContainerFailures(events)...)
+	tests = append(tests, testDeleteGracePeriodZero(events)...)
 	tests = append(tests, testKubeAPIServerGracefulTermination(events)...)
 	tests = append(tests, testKubeletToAPIServerGracefulTermination(events)...)
 	tests = append(tests, testPodTransitions(events)...)
@@ -34,6 +36,8 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 // that is being upgraded without induced disruption
 func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Duration) (tests []*ginkgo.JUnitTestCase) {
 	tests = SystemEventInvariants(events, duration)
+	tests = append(tests, testContainerFailures(events)...)
+	tests = append(tests, testDeleteGracePeriodZero(events)...)
 	tests = append(tests, testKubeAPIServerGracefulTermination(events)...)
 	tests = append(tests, testKubeletToAPIServerGracefulTermination(events)...)
 	tests = append(tests, testPodTransitions(events)...)

--- a/test/extended/operators/cluster.go
+++ b/test/extended/operators/cluster.go
@@ -40,13 +40,13 @@ func recyclerPod(pod *corev1.Pod) bool {
 	return strings.HasPrefix(pod.Name, "recycler-for-nfs-")
 }
 
-var _ = g.Describe("[sig-arch] Managed cluster should", func() {
+/*var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	g.It("have no crashlooping pods in core namespaces over four minutes", func() {
 		crashloopingContainerCheck(inCoreNamespaces, not(recyclerPod))
 	})
-})
+})*/
 
 func crashloopingContainerCheck(podFilters ...podFilter) {
 	c, err := e2e.LoadClientset()

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -843,8 +843,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] Managed cluster should ensure pods use downstream images from our release image with proper ImagePullPolicy": "should ensure pods use downstream images from our release image with proper ImagePullPolicy [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should have no crashlooping pods in core namespaces over four minutes": "have no crashlooping pods in core namespaces over four minutes [Suite:openshift/conformance/parallel]",
-
 	"[Top Level] [sig-arch] Managed cluster should have operators on the cluster version": "have operators on the cluster version [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch] Managed cluster should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent": "should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Crashlooping, long pulls, and other container waiting / failing
states should really be in the event log. Update the pod monitor
to catch more transitions and conditions and to be more explicit
about what is happening in containers. Disable the current
crashloop test and replace with a synthetic.

Adds reporting on:

* Duration of all container starts and restarts
* Container exit code 0
* Pods deleted without a grace period
* Pods deleted before they are scheduled to a node
* Reasons containers are waiting and the time at which the event shows up


Still have to test this and add the invariant check