### PR TITLE
bug 1951705: allow HighOverallControlPlaneCPU during e2e runs

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -72,7 +72,12 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		}
 
 		pendingAlertsWithBugs := helper.MetricConditions{}
-		allowedPendingAlerts := helper.MetricConditions{}
+		allowedPendingAlerts := helper.MetricConditions{
+			{
+				Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
+				Text:     "high CPU utilization during e2e runs is normal",
+			},
+		}
 
 		knownViolations := sets.NewString()
 		unexpectedViolations := sets.NewString()


### PR DESCRIPTION
adding the alert in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1073, high CPU during e2e runs isn't anything to be concerned over.  But in general it is a significant issue and masters should be provisioned larger