### PR TITLE
test: Mark known alert failure for auth operator to bug

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -66,6 +66,14 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 
 		firingAlertsWithBugs := helper.MetricConditions{
 			{
+				Selector: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication"},
+				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+			},
+			{
+				Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication"},
+				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+			},
+			{
 				Selector: map[string]string{"alertname": "AggregatedAPIDown", "name": "v1alpha1.wardle.example.com"},
 				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1933144",
 			},


### PR DESCRIPTION
The bug is open and covers this for normal e2e and upgrades, so make
sure we exclude it until the team can fix the issue (degraded is
not currently causing other failures).

Ties https://bugzilla.redhat.com/show_bug.cgi?id=1939580 to the tests (I thought https://bugzilla.redhat.com/show_bug.cgi?id=1929922 was the issue but the former is more appropriate).