### PR TITLE
Bug 1953729: test/extended/router: Fix-up Unidling test

### DIFF
--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -101,6 +103,10 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to fetch the service")
 			mustVerifyIdleAnnotationValues(annotations)
 
+			// wait for target deployment to actually scale down
+			err = waitForRunningPods(oc, 0, exutil.ParseLabelsOrDie("app=idle-test"), timeout)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
 			g.By("Unidling the service by making a GET request on the route")
 			err = waitHTTPGetStatus(hostname, http.StatusOK, timeout)
 			o.Expect(err).NotTo(o.HaveOccurred(), "expected status 200 from the GET request")
@@ -196,18 +202,20 @@ func waitForRunningPods(oc *exutil.CLI, podCount int, podLabels labels.Selector,
 // and will return an error if the conditions are not met after the
 // specified timeout.
 func waitHTTPGetStatus(hostname string, statusCode int, timeout time.Duration) error {
-	client := makeHTTPClient(false, timeout)
-
+	client := makeHTTPClient(false, 30*time.Second)
 	var attempt int
+
+	url := "http://" + hostname
 
 	return wait.Poll(time.Second, timeout, func() (bool, error) {
 		attempt += 1
-		url := "http://" + hostname
 		resp, err := client.Get(url)
 		if err != nil {
 			e2e.Logf("GET#%v %q error=%v", attempt, url, err)
 			return false, nil // could be 503 if service not ready
 		}
+		defer resp.Body.Close()
+		io.Copy(ioutil.Discard, resp.Body)
 		e2e.Logf("GET#%v %q status=%v", attempt, url, resp.StatusCode)
 		return resp.StatusCode == statusCode, nil
 	})


### PR DESCRIPTION
test/extended/router/idle.go:

Wait for the test workload to scale down to
zero replicas once idled before attempting to unidle
the test workload. This is to prevent a race condition
where the test route is GET'd before the test workload
has been idled successfully.

Use a 30 second (instead of 15 minute) HTTP timeout
when trying to unidle the test workload over it's HTTP
route. This way, the HTTP retry logic won't get hung up
on lengthy timeouts. Also, close the HTTP connection if we
receive a valid response.

---

/assign @frobware 