### PR TITLE
Bug 1938466: test/extended/operators/resources: Packageserver already sets requests

### DIFF
--- a/test/extended/operators/resources.go
+++ b/test/extended/operators/resources.go
@@ -37,9 +37,6 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 		knownBrokenPods := map[string]string{
 			//"<apiVersion>/<kind>/<namespace>/<name>/(initContainer|container)/<container_name>/<violation_type>": "<url to bug>",
 
-			"apps/v1/Deployment/openshift-operator-lifecycle-manager/packageserver/container/packageserver/request[cpu]":    "https://bugzilla.redhat.com/show_bug.cgi?id=1938466",
-			"apps/v1/Deployment/openshift-operator-lifecycle-manager/packageserver/container/packageserver/request[memory]": "https://bugzilla.redhat.com/show_bug.cgi?id=1938466",
-
 			"apps/v1/DaemonSet/openshift-machine-api/metal3-image-cache/container/metal3-httpd/request[cpu]":          "https://bugzilla.redhat.com/show_bug.cgi?id=1940518",
 			"apps/v1/DaemonSet/openshift-machine-api/metal3-image-cache/container/metal3-httpd/request[memory]":       "https://bugzilla.redhat.com/show_bug.cgi?id=1940518",
 			"apps/v1/Deployment/openshift-machine-api/metal3/container/ironic-deploy-ramdisk-logs/request[cpu]":       "https://bugzilla.redhat.com/show_bug.cgi?id=1940518",


### PR DESCRIPTION
The packageserver deployment already sets resource requests for cpu and memory.

See packageserver manifests: https://github.com/openshift/operator-framework-olm/blob/3440fa2c16fc6a744e2e9bbb1352a0b4731cdd6f/manifests/0000_50_olm_15-packageserver.clusterserviceversion.yaml#L129-L132

Also confirmed on a 4.8 nightly cluster:

```console
$ oc get clusterversion
NAME      VERSION                             AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.8.0-0.nightly-2021-04-22-061234   True        False         21m     Cluster version is 4.8.0-0.nightly-2021-04-22-061234


$ oc -n openshift-operator-lifecycle-manager get pods packageserver-94cbcf856-4xc7j -o yaml
apiVersion: v1
kind: Pod
metadata:
  name: packageserver-94cbcf856-4xc7j
  namespace: openshift-operator-lifecycle-manager
  ...
spec:
  containers:
  - command:
    - /bin/package-server
    - -v=4
    - --secure-port
    - "5443"
    - --global-namespace
    - openshift-marketplace
    image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9e27561a75453fcec25e1995e672f657e3802811424365408006c23a4bfb66be
    imagePullPolicy: IfNotPresent
    ...
    resources:
      requests:
        cpu: 10m
        memory: 50Mi
  ...
```