### PR TITLE
test: Allow KubeAPIErrorBudgetBurn on GCP platforms only

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -8,6 +8,7 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+	"github.com/prometheus/common/model"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/disruption"
@@ -72,6 +73,13 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 		{
 			Selector: map[string]string{"alertname": "KubeDaemonSetRolloutStuck"},
 			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1943667",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeAPIErrorBudgetBurn"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1953798",
+			Matches: func(_ *model.Sample) bool {
+				return framework.ProviderIs("gce")
+			},
 		},
 	}
 

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -15,6 +15,7 @@ import (
 	o "github.com/onsi/gomega"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -76,6 +77,13 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 			{
 				Selector: map[string]string{"alertname": "AggregatedAPIDown", "name": "v1alpha1.wardle.example.com"},
 				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1933144",
+			},
+			{
+				Selector: map[string]string{"alertname": "KubeAPIErrorBudgetBurn"},
+				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1953798",
+				Matches: func(_ *model.Sample) bool {
+					return framework.ProviderIs("gce")
+				},
 			},
 		}
 		allowedFiringAlerts := helper.MetricConditions{

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -107,7 +107,7 @@ func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	end := time.Now()
 
 	toleratedDisruption := 0.08
-	if framework.ProviderIs("azure", "gcp") {
+	if framework.ProviderIs("azure") {
 		toleratedDisruption = 0
 	}
 	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption (AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804)", t.name))

--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -97,6 +97,7 @@ func LocatePrometheus(oc *exutil.CLI) (queryURL, prometheusURL, bearerToken stri
 type MetricCondition struct {
 	Selector map[string]string
 	Text     string
+	Matches  func(sample *model.Sample) bool
 }
 
 type MetricConditions []MetricCondition
@@ -109,9 +110,9 @@ func (c MetricConditions) Matches(sample *model.Sample) *MetricCondition {
 				matches = false
 				break
 			}
-			if matches {
-				return &c[i]
-			}
+		}
+		if matches && (condition.Matches == nil || condition.Matches(sample)) {
+			return &c[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
The alert seems to fire on GCP in both upgrade and normal cases in 
https://bugzilla.redhat.com/show_bug.cgi?id=1953798, although the symptoms
described there should *also* happen on other clouds, so maybe we have a
general latency issue on GCP.  Disable only on GCP.

Also fix two issues:

test: Alert check should check all conditions

The alert was exiting early after only one matching condition, which means
it was overly aggressively matching the first label. We may have more bugs
after this.

Also add a new custom function to allow conditions to apply only in 
specific cases.

test: Disable upgrade disruption check on GCP

The constant is 'gce', not 'gcp', and the test is failing because of an as
yet undiagnosed issue.