### PR TITLE
Limit scope of synthetic scc test for disruptive

### DIFF
--- a/test/extended/authorization/scc.go
+++ b/test/extended/authorization/scc.go
@@ -30,7 +30,12 @@ var _ = g.Describe("[sig-auth][Feature:SCC][Early]", func() {
 		suiteStartTime := exutil.SuiteStartTime()
 		var preTestDenialStrings, duringTestDenialStrings []string
 
+		eventsAfterTime := exutil.LimitTestsToStartTime()
 		for _, event := range events.Items {
+			if event.LastTimestamp.Time.Before(eventsAfterTime) {
+				continue
+			}
+
 			if !strings.Contains(event.Message, "unable to validate against any security context constraint") {
 				continue
 			}


### PR DESCRIPTION
Disruptive tests generate events that can trigger synthetic test failures. This change updates the scc synthetic test to ignore events created before the test started for suite types (like disruptive) that set the start time via an env var. Normal execution will be unaffected due to the start time defaulting to 0.