### PR TITLE
test: Wait for service account token

### DIFF
--- a/test/extended/images/oc_tag.go
+++ b/test/extended/images/oc_tag.go
@@ -153,6 +153,9 @@ RUN touch /test-image
 		err = oc.Run("policy").Args("add-role-to-user", "testrole", "-z", "testsa", "--role-namespace="+oc.Namespace()).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		err = exutil.WaitForServiceAccount(oc.AdminKubeClient().CoreV1().ServiceAccounts(oc.Namespace()), "testsa")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		token, err := oc.Run("serviceaccounts").Args("get-token", "testsa").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
Wait until the token shows up before attempting to read it:

```
Apr 23 12:26:15.876: INFO: Running 'oc ... serviceaccounts get-token testsa'
Apr 23 12:26:16.071: INFO: Error running /usr/bin/oc ... serviceaccounts get-token testsa:
StdOut>
error: could not find a service account token for service account "testsa"
StdErr>
error: could not find a service account token for se
```

Fixes a flake seen in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_kubernetes/666/pull-ci-openshift-kubernetes-master-e2e-gcp/1385547086795116544