### PR TITLE
Bug 1957222: [test/oc_tag] Add internal option for registry info

### DIFF
--- a/test/extended/images/oc_tag.go
+++ b/test/extended/images/oc_tag.go
@@ -81,7 +81,7 @@ RUN touch /test-image
 
 		g.By("determine the name of the integrated registry")
 
-		registryHost, err := oc.Run("registry").Args("info").Output()
+		registryHost, err := oc.Run("registry").Args("info", "--internal").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("build an image")


### PR DESCRIPTION
If the cluster have publicly exposed registry then following happen
when we do a build and tag to `localimage`.

```
$ oc registry info
default-route-openshift-image-registry.apps-crc.testing

$ cat Dockerfile  | oc -n demo new-build -D - --to localimage:latest
--> Found container image 388056c (3 weeks old) from Docker Hub for "busybox:latest"
[...]
--> Success

$ oc get is localimage -oyaml
apiVersion: image.openshift.io/v1
kind: ImageStream
metadata:
  annotations:
    openshift.io/generated-by: OpenShiftNewBuild
  name: localimage
  namespace: demo
spec:
  lookupPolicy:
    local: false
status:
  dockerImageRepository: image-registry.openshift-image-registry.svc:5000/demo/localimage
  publicDockerImageRepository: default-route-openshift-image-registry.apps-crc.testing/demo/localimage
  tags:
  - items:
    - created: "2021-04-30T03:56:42Z"
      dockerImageReference: image-registry.openshift-image-registry.svc:5000/demo/localimage@sha256:ba7e3310588dfd7198f31feda89c15f5fb8bc5c847bcace6c552df016a5d8603
      generation: 1
      image: sha256:ba7e3310588dfd7198f31feda89c15f5fb8bc5c847bcace6c552df016a5d8603
    tag: latest
```

As per test the `registry info` is what stored as `registryHost` and
then compare it with `Tag[0].DockerImageReference` which only have
internal registy URI.

This patch add `--internal` option for registry info so that
`registryHost` also have internal registry details.