### PR TITLE
Bug 1955669: flake testKubeletToAPIServerGracefulTermination

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -496,8 +496,10 @@ func testKubeAPIServerGracefulTermination(events []*monitor.EventInterval) []*gi
 		},
 	}
 
-	// This should fail a CI run, not flake it.
-	return []*ginkgo.JUnitTestCase{failure}
+	successTest := &ginkgo.JUnitTestCase{Name: testName}
+
+	// This should flake a CI run while waiting for https://bugzilla.redhat.com/show_bug.cgi?id=1928946
+	return []*ginkgo.JUnitTestCase{failure, successTest}
 
 }
 


### PR DESCRIPTION
Backports https://github.com/openshift/origin/pull/25986 to 4.7 to fix release-openshift-origin-installer-old-rhcos-e2e-aws-4.7