### PR TITLE
Bug 1957512: openshift-tests: fix a --provider --dry-run edge case

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -120,7 +120,8 @@ func decodeProvider(provider string, dryRun, discover bool, clusterState *exutil
 			if clusterState != nil {
 				config, _ = exutilcluster.LoadConfig(clusterState)
 			}
-		} else {
+		}
+		if config == nil {
 			config = &exutilcluster.ClusterConfiguration{}
 		}
 


### PR DESCRIPTION
regression from #25818: Trying to override --provider while not actually connected to a cluster (eg, to look at the output of --dry-run) would fail, rather than just falling back to not trying to autodetect anything.