### PR TITLE
test: Associate ClusterOperatorDown for machine-config with bug

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -67,6 +67,10 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
 		},
 		{
+			Selector: map[string]string{"alertname": "ClusterOperatorDown", "name": "machine-config"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955300",
+		},
+		{
 			Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication"},
 			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
 		},


### PR DESCRIPTION
We have opened a high severity bug for this issue and the alert
can be tagged to allow merging.