### PR TITLE
Extends monitoring of Kube API servers by hitting NodeIPs directly

### DIFF
--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -426,7 +426,13 @@ func (rt *kubeAPIEndpointsAwareRT) RoundTrip(r *http.Request) (*http.Response, e
 	r.Host = nextEndpoint
 	r.URL.Host = nextEndpoint
 
-	return rt.delegate.RoundTrip(r)
+	resp, err := rt.delegate.RoundTrip(r)
+	if err == nil {
+		fmt.Println(fmt.Sprintf("status %v", resp.StatusCode))
+	} else {
+		fmt.Println(err)
+	}
+	return resp, err
 }
 
 func (rt *kubeAPIEndpointsAwareRT) nextEndpointLocked() (string, error) {

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -47,9 +47,11 @@ func NoTests() []upgrades.Test {
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
 		controlplane.NewKubeAvailableWithNewConnectionsTest(),
+		controlplane.NewKubeAvailableWithNewConnectionsNodeIPsTest(),
 		controlplane.NewOpenShiftAvailableNewConnectionsTest(),
 		controlplane.NewOAuthAvailableNewConnectionsTest(),
 		controlplane.NewKubeAvailableWithConnectionReuseTest(),
+		controlplane.NewKubeAvailableWithConnectionReuseNodeIPsTest(),
 		controlplane.NewOpenShiftAvailableWithConnectionReuseTest(),
 		controlplane.NewOAuthAvailableWithConnectionReuseTest(),
 		&alert.UpgradeTest{},

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -23,6 +23,15 @@ func NewKubeAvailableWithNewConnectionsTest() upgrades.Test {
 	}
 }
 
+// NewKubeAvailableWithNewConnectionsNodeIPsTest tests that the Kubernetes control plane remains available during and after a cluster upgrade.
+func NewKubeAvailableWithNewConnectionsNodeIPsTest() upgrades.Test {
+	return &availableTest{
+		testName:        "[sig-api-machinery] Kubernetes APIs remain available for new connections over NodeIPs",
+		name:            "kube-apiserver-new-connection-node-ips",
+		startMonitoring: monitor.StartKubeAPIMonitoringWithNewConnectionsForNodeIPs,
+	}
+}
+
 // NewOpenShiftAvailableNewConnectionsTest tests that the OpenShift APIs remains available during and after a cluster upgrade.
 func NewOpenShiftAvailableNewConnectionsTest() upgrades.Test {
 	return &availableTest{
@@ -47,6 +56,15 @@ func NewKubeAvailableWithConnectionReuseTest() upgrades.Test {
 		testName:        "[sig-api-machinery] Kubernetes APIs remain available with reused connections",
 		name:            "kubernetes-api-available-reused-connections",
 		startMonitoring: monitor.StartKubeAPIMonitoringWithConnectionReuse,
+	}
+}
+
+// NewKubeAvailableWithConnectionReuseNodeIPsTest tests that the Kubernetes control plane remains available during and after a cluster upgrade.
+func NewKubeAvailableWithConnectionReuseNodeIPsTest() upgrades.Test {
+	return &availableTest{
+		testName:        "[sig-api-machinery] Kubernetes APIs remain available with reused connections over NodeIPs",
+		name:            "kube-apiserver-reused-connection-node-ips",
+		startMonitoring: monitor.StartKubeAPIMonitoringWithConnectionReuseForNodeIPs,
 	}
 }
 


### PR DESCRIPTION
Already existing tests monitor the availability of the Kube API servers via the external load balancer.
The issue we see is when the tests fail we cannot tell if it was a misconfigured load balancer or a broken API server.

This PR adds new tests that simply reuse already existing monitors but use the IP addresses assigned to Servers/Nodes instead.

An alternative approach would be to run a separate monitor for each endpoint and using a lister to see if it is still on the list and silence if not.