### PR TITLE
Bug 1957131: test: Add the Cinder client to the test image

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -7,7 +7,7 @@ RUN make; \
 
 FROM registry.ci.openshift.org/ocp/4.8:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
-RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
+RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux python3-cinderclient && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com && \
     chmod g+w /etc/passwd


### PR DESCRIPTION
Multiple tests in the e2e Conformance suite require the Cinder client to be installed when run
against OpenStack.

In the step-registry CI structure, the "test" ref is shared across
platforms; it is therefore not desirable to run the OpenStack tests
using a separate image.

This change adds the Cinder client to the container image used to run
the tests in the CI.

Implements [OSASINFRA-2308](https://issues.redhat.com/browse/OSASINFRA-2308)

cf. "[sig-storage] In-tree Volumes [Driver: cinder] [Testpattern:
Inline-volume (default fs)] volumes should store data
[Suite:openshift/conformance/parallel] [Suite:k8s]"