### PR TITLE
Bug 1957476: Ignore [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig conformance tests for IBMCloud

### DIFF
--- a/test/extended/apiserver/kubeconfigs.go
+++ b/test/extended/apiserver/kubeconfigs.go
@@ -13,8 +13,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/ibmcloud"
 )
 
 var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig", func() {
@@ -28,6 +31,9 @@ var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] local ku
 		"localhost-recovery.kubeconfig",
 	} {
 		g.It(fmt.Sprintf("%q should be present on all masters and work", kubeconfig), func() {
+			if e2e.TestContext.Provider == ibmcloud.ProviderName {
+				e2eskipper.Skipf("IBM ROKS cluster do not allow the customer to view or access master nodes.")
+			}
 			masterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
 				LabelSelector: `node-role.kubernetes.io/master`,
 			})


### PR DESCRIPTION
related: https://bugzilla.redhat.com/show_bug.cgi?id=1957476