### PR TITLE
Bug 1957927: test/e2e/upgrade/upgrade.go: Bump upgrade ACK timeout to 4 minutes

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -305,7 +305,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			updated = cv
 
 			// wait until the cluster acknowledges the update
-			if err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+			if err := wait.PollImmediate(5*time.Second, 4*time.Minute, func() (bool, error) {
 				cv, _, err := monitor.Check(updated.Generation, desired)
 				if err != nil || cv == nil {
 					return false, err


### PR DESCRIPTION
Sometimes during CI upgrade tests connection errors occur delaying initial CVO pod's shutdown and subsequent CVO pod's startup. This then delays CVO's version sync at times resulting in a failure to ACK the upgrade within the 2 minute constraint of the test.