### PR TITLE
Bug 1956989: initialize framework.TestContext.IPFamily correctly

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -61,6 +61,12 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster
 
 	e2e.AfterReadingAllFlags(context)
 	context.DumpLogsOnFailure = true
+
+	// these constants are taken from kube e2e and used by tests
+	context.IPFamily = "ipv4"
+	if config.HasIPv6 && !config.HasIPv4 {
+		context.IPFamily = "ipv6"
+	}
 	return nil
 }
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1767,7 +1767,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] Firewall rule should have correct firewall rules for e2e cluster": "should have correct firewall rules for e2e cluster [Disabled:SpecialConfig] [Suite:k8s]",
 
-	"[Top Level] [sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]": "validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance] [Disabled:Broken] [Suite:k8s]",
+	"[Top Level] [sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]": "validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-network] Ingress API should support creating Ingress API operations [Conformance]": "should support creating Ingress API operations [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
@@ -2047,13 +2047,13 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] Networking Granular Checks: Services should update nodePort: udp [Slow]": "should update nodePort: udp [Slow] [Suite:k8s]",
 
-	"[Top Level] [sig-network] Networking IPerf2 [Feature:Networking-Performance] should run iperf2": "should run iperf2 [Disabled:Broken] [Suite:k8s]",
+	"[Top Level] [sig-network] Networking IPerf2 [Feature:Networking-Performance] should run iperf2": "should run iperf2 [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-network] Networking should check kube-proxy urls": "should check kube-proxy urls [Disabled:Broken] [Suite:k8s]",
 
-	"[Top Level] [sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]": "should provide Internet connection for containers [Feature:Networking-IPv4] [Disabled:Broken] [Skipped:azure] [Suite:k8s]",
+	"[Top Level] [sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]": "should provide Internet connection for containers [Feature:Networking-IPv4] [Skipped:azure] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental][LinuxOnly]": "should provide Internet connection for containers [Feature:Networking-IPv6][Experimental][LinuxOnly] [Disabled:Broken] [Skipped:azure] [Suite:k8s]",
+	"[Top Level] [sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental][LinuxOnly]": "should provide Internet connection for containers [Feature:Networking-IPv6][Experimental][LinuxOnly] [Skipped:Disconnected] [Skipped:azure] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-network] Networking should provide unchanging, static URL paths for kubernetes api services": "should provide unchanging, static URL paths for kubernetes api services [Disabled:Broken] [Suite:k8s]",
 
@@ -2099,7 +2099,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] Services should be able to update service type to NodePort listening on same port number but different protocols": "should be able to update service type to NodePort listening on same port number but different protocols [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-network] Services should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node": "should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node [Disabled:Broken] [Suite:k8s]",
+	"[Top Level] [sig-network] Services should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node": "should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-network] Services should be rejected when no endpoints exist": "should be rejected when no endpoints exist [Skipped:ibmcloud] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -51,12 +51,6 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1953478
 			`\[sig-storage\] Dynamic Provisioning Invalid AWS KMS key should report an error and create no PV`,
 
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1956989
-			`\[sig-network\] Services should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node`,
-			`\[sig-network\] Networking IPerf2 \[Feature:Networking-Performance\] should run iperf2`,
-			`\[sig-network\] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol`,
-			`\[sig-network\] Networking should provide Internet connection for containers`,
-
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1957894
 			`\[sig-node\] Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret`,
 		},
@@ -188,6 +182,7 @@ var (
 			`\[sig-network\]\[Feature:Router\] The HAProxy router should serve the correct routes when scoped to a single namespace and label set`,
 			`\[sig-network\]\[Feature:Router\] The HAProxy router should set Forwarded headers appropriately`,
 			`\[sig-network\]\[Feature:Router\] The HAProxy router should support reencrypt to services backed by a serving certificate automatically`,
+			`\[sig-network\] Networking should provide Internet connection for containers \[Feature:Networking-IPv6\]`,
 			`\[sig-node\] Managed cluster should report ready nodes the entire duration of the test run`,
 			`\[sig-storage\]\[Late\] Metrics should report short attach times`,
 			`\[sig-storage\]\[Late\] Metrics should report short mount times`,


### PR DESCRIPTION
Some tests rely on the TestContext IPFamily field, that is being initialized in the upstream ginkgo suites but not in origin's one.
Here we add the initialization in InitTest so the test find the right value.