### PR TITLE
Bug 1947800: Router: Switch from networking v1beta1 to v1

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -48868,7 +48868,7 @@ var _testExtendedTestdataRouterIngressYaml = []byte(`kind: List
 apiVersion: v1
 items:
 # an ingress that should be captured as individual routes
-- apiVersion: networking.k8s.io/v1beta1
+- apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: test
@@ -48882,27 +48882,39 @@ items:
       http:
         paths:
         - path: /test
+          pathType: Prefix
           backend:
-            serviceName: ingress-endpoint-1
-            servicePort: 80
+            service:
+              name: ingress-endpoint-1
+              port:
+                number: 80
         - path: /other
+          pathType: Prefix
           backend:
-            serviceName: ingress-endpoint-2
-            servicePort: 80
+            service:
+              name: ingress-endpoint-2
+              port:
+                number: 80
     - host: 2.ingress-test.com
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: ingress-endpoint-1
-            servicePort: 80
+            service:
+              name: ingress-endpoint-1
+              port:
+                number: 80
     - host: 3.ingress-test.com
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: ingress-endpoint-1
-            servicePort: 80
+            service:
+              name: ingress-endpoint-1
+              port:
+                number: 80
 # an empty secret
 - apiVersion: v1
   kind: Secret

--- a/test/extended/testdata/router/ingress.yaml
+++ b/test/extended/testdata/router/ingress.yaml
@@ -2,7 +2,7 @@ kind: List
 apiVersion: v1
 items:
 # an ingress that should be captured as individual routes
-- apiVersion: networking.k8s.io/v1beta1
+- apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     name: test
@@ -16,27 +16,39 @@ items:
       http:
         paths:
         - path: /test
+          pathType: Prefix
           backend:
-            serviceName: ingress-endpoint-1
-            servicePort: 80
+            service:
+              name: ingress-endpoint-1
+              port:
+                number: 80
         - path: /other
+          pathType: Prefix
           backend:
-            serviceName: ingress-endpoint-2
-            servicePort: 80
+            service:
+              name: ingress-endpoint-2
+              port:
+                number: 80
     - host: 2.ingress-test.com
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: ingress-endpoint-1
-            servicePort: 80
+            service:
+              name: ingress-endpoint-1
+              port:
+                number: 80
     - host: 3.ingress-test.com
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: ingress-endpoint-1
-            servicePort: 80
+            service:
+              name: ingress-endpoint-1
+              port:
+                number: 80
 # an empty secret
 - apiVersion: v1
   kind: Secret


### PR DESCRIPTION
test/extended/testdata/router/ingress.yaml:

Change `apiVersion` from `networking.k8s.io/v1beta1` to
`networking.k8s.io/v1`.

To ensure compatibility with the new v1 API, use a `pathType`
of `Prefix` for each of the test Ingress resources (which should be
compatible with existing test logic).

Also, use the correct service backend syntax, which requires a trivial
yaml layout change.

test/extended/testdata/bindata.go:

Regenerate.

This commit is in support of Bug 1947800.

---

Edit 5/11/21:
This PR will affect any backports that touch `test/extended/testdata/router/ingress.yaml` going forward.