### PR TITLE
BUILD-250 pull in multi-arch friendly version of roots2i and simples2i, add simples2i to mirroring test infra

### DIFF
--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -3,7 +3,6 @@ package builds
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/origin/test/extended/util/image"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -14,6 +13,7 @@ import (
 
 	buildv1 "github.com/openshift/api/build/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
 )
 
 func Before(oc *exutil.CLI) {
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 		Before(oc)
 		defer After(oc)
 
-		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.ci.openshift.org/ocp/4.7:test-build-roots2i"))
+		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.ci.openshift.org/ocp/4.8:test-build-roots2i"))
 		err := oc.Run("new-app").Args(firstArgString, "--name", "nodejsfail").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 		roleBinding, err = oc.AdminKubeClient().RbacV1().RoleBindings(oc.Namespace()).Create(context.Background(), roleBinding, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.ci.openshift.org/ocp/4.7:test-build-roots2i"))
+		firstArgString := fmt.Sprintf("%s~https://github.com/sclorg/nodejs-ex", image.LocationFor("registry.ci.openshift.org/ocp/4.8:test-build-roots2i"))
 		err = oc.Run("new-build").Args(firstArgString, "--name", "nodejspass").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17206,7 +17206,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
     resources: {}
     postCommit: {}
     nodeSelector: null
@@ -18290,7 +18290,7 @@ var _testExtendedTestdataBuildsBuildTimingTestS2iBuildJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+          "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
         },
         "env": [
           {
@@ -18836,7 +18836,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
 `)
 
 func testExtendedTestdataBuildsStatusfailFailedassembleYamlBytes() ([]byte, error) {
@@ -19071,7 +19071,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
     type: Source
 `)
 
@@ -19107,7 +19107,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
     type: Source
 `)
 
@@ -19336,7 +19336,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
       type: Source
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -19354,7 +19354,7 @@ items:
           value: "5"
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
       type: Source
 `)
 
@@ -19483,7 +19483,7 @@ items:
           value: 127.0.0.1:3128
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -19505,7 +19505,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -19595,7 +19595,7 @@ var _testExtendedTestdataBuildsTestBuildRevisionJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+              "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
             }
           }
         },
@@ -21072,7 +21072,7 @@ var _testExtendedTestdataBuildsTestNosrcBuildJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+              "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
             }
           }
         }
@@ -21110,7 +21110,7 @@ var _testExtendedTestdataBuildsTestS2iBuildQuotaJson = []byte(`{
   "spec": {
     "resources": {
       "limits": {
-        "cpu": "60m",
+        "cpu": "400m",
         "memory": "400Mi"
       }
     },
@@ -21123,8 +21123,8 @@ var _testExtendedTestdataBuildsTestS2iBuildQuotaJson = []byte(`{
       "type": "Source",
       "sourceStrategy": {
         "from": {
-          "kind":"DockerImage",
-          "name":"quay.io/redhat-developer/test-build-simples2i:latest"
+          "kind": "DockerImage",
+          "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
         },
         "env": [
           {
@@ -21181,7 +21181,7 @@ var _testExtendedTestdataBuildsTestS2iBuildJson = []byte(`{
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+          "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
         }
       }
     },
@@ -21252,7 +21252,7 @@ var _testExtendedTestdataBuildsTestS2iNoOutputnameJson = []byte(`{
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+          "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
         }
       }
     }
@@ -21398,7 +21398,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
       env:
         - name: BUILD_LOGLEVEL
           value: "5"
@@ -21534,7 +21534,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
       env:
         - name: BUILD_LOGLEVEL
           value: "5"
@@ -52368,7 +52368,7 @@ objects:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/builds/build-postcommit/sti.yaml
+++ b/test/extended/testdata/builds/build-postcommit/sti.yaml
@@ -20,7 +20,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
     resources: {}
     postCommit: {}
     nodeSelector: null

--- a/test/extended/testdata/builds/build-timing/test-s2i-build.json
+++ b/test/extended/testdata/builds/build-timing/test-s2i-build.json
@@ -18,7 +18,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+          "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/statusfail-failedassemble.yaml
+++ b/test/extended/testdata/builds/statusfail-failedassemble.yaml
@@ -10,4 +10,4 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i

--- a/test/extended/testdata/builds/statusfail-postcommithook.yaml
+++ b/test/extended/testdata/builds/statusfail-postcommithook.yaml
@@ -13,5 +13,5 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
     type: Source

--- a/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
+++ b/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
@@ -15,5 +15,5 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
     type: Source

--- a/test/extended/testdata/builds/test-build-cluster-config.yaml
+++ b/test/extended/testdata/builds/test-build-cluster-config.yaml
@@ -15,7 +15,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
       type: Source
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -33,5 +33,5 @@ items:
           value: "5"
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
       type: Source

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -35,7 +35,7 @@ items:
           value: 127.0.0.1:3128
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -57,7 +57,7 @@ items:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com

--- a/test/extended/testdata/builds/test-build-revision.json
+++ b/test/extended/testdata/builds/test-build-revision.json
@@ -22,7 +22,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+              "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
             }
           }
         },

--- a/test/extended/testdata/builds/test-nosrc-build.json
+++ b/test/extended/testdata/builds/test-nosrc-build.json
@@ -32,7 +32,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+              "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
             }
           }
         }

--- a/test/extended/testdata/builds/test-s2i-build-quota.json
+++ b/test/extended/testdata/builds/test-s2i-build-quota.json
@@ -11,7 +11,7 @@
   "spec": {
     "resources": {
       "limits": {
-        "cpu": "60m",
+        "cpu": "400m",
         "memory": "400Mi"
       }
     },
@@ -24,8 +24,8 @@
       "type": "Source",
       "sourceStrategy": {
         "from": {
-          "kind":"DockerImage",
-          "name":"quay.io/redhat-developer/test-build-simples2i:latest"
+          "kind": "DockerImage",
+          "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/test-s2i-build.json
+++ b/test/extended/testdata/builds/test-s2i-build.json
@@ -26,7 +26,7 @@
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+          "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
         }
       }
     },

--- a/test/extended/testdata/builds/test-s2i-no-outputname.json
+++ b/test/extended/testdata/builds/test-s2i-no-outputname.json
@@ -26,7 +26,7 @@
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/redhat-developer/test-build-simples2i:latest"
+          "name": "registry.ci.openshift.org/ocp/4.8:test-build-simples2i"
         }
       }
     }

--- a/test/extended/testdata/builds/valuefrom/failed-sti-build-value-from-config.yaml
+++ b/test/extended/testdata/builds/valuefrom/failed-sti-build-value-from-config.yaml
@@ -16,7 +16,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
       env:
         - name: BUILD_LOGLEVEL
           value: "5"

--- a/test/extended/testdata/builds/valuefrom/successful-sti-build-value-from-config.yaml
+++ b/test/extended/testdata/builds/valuefrom/successful-sti-build-value-from-config.yaml
@@ -16,7 +16,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: quay.io/redhat-developer/test-build-simples2i:latest
+        name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
       env:
         - name: BUILD_LOGLEVEL
           value: "5"

--- a/test/extended/testdata/templates/templateinstance_readiness.yaml
+++ b/test/extended/testdata/templates/templateinstance_readiness.yaml
@@ -49,7 +49,7 @@ objects:
       sourceStrategy:
         from:
           kind: DockerImage
-          name: quay.io/redhat-developer/test-build-simples2i:latest
+          name: registry.ci.openshift.org/ocp/4.8:test-build-simples2i
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -27,7 +27,7 @@ func init() {
 
 		// used by build s2i e2e's to verify that builder with USER root are not allowed
 		// the github.com/openshift/build-test-images repo is built out of github.com/openshift/release
-		"registry.ci.openshift.org/ocp/4.7:test-build-roots2i": -1,
+		"registry.ci.openshift.org/ocp/4.8:test-build-roots2i": -1,
 
 		// moved to GCR
 		"k8s.gcr.io/sig-storage/csi-attacher:v2.2.0":              -1,

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -29,6 +29,9 @@ func init() {
 		// the github.com/openshift/build-test-images repo is built out of github.com/openshift/release
 		"registry.ci.openshift.org/ocp/4.8:test-build-roots2i": -1,
 
+		// used by all the rest build s2s e2e tests
+		"registry.ci.openshift.org/ocp/4.8:test-build-simples2i": -1,
+
 		// moved to GCR
 		"k8s.gcr.io/sig-storage/csi-attacher:v2.2.0":              -1,
 		"k8s.gcr.io/sig-storage/csi-attacher:v3.0.0":              -1,

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -61,3 +61,4 @@ k8s.gcr.io/sig-storage/snapshot-controller:v2.1.1 quay.io/openshift/community-e2
 k8s.gcr.io/sig-storage/snapshot-controller:v3.0.2 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-snapshot-controller-v3-0-2-IVmgAhsROusslTdY
 quay.io/redhat-developer/nfs-server:1.0 quay.io/openshift/community-e2e-images:e2e-quay-io-redhat-developer-nfs-server-1-0-Wz4GFQ2IuhYmh2mB
 registry.ci.openshift.org/ocp/4.8:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-ci-openshift-org-ocp-4-8-test-build-roots2i-FmW7zebvtGKkls4B
+registry.ci.openshift.org/ocp/4.8:test-build-simples2i quay.io/openshift/community-e2e-images:e2e-registry-ci-openshift-org-ocp-4-8-test-build-simples2i-7A9bkBd9X4G-ELh0

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -60,4 +60,4 @@ k8s.gcr.io/sig-storage/nfs-provisioner:v2.2.2 quay.io/openshift/community-e2e-im
 k8s.gcr.io/sig-storage/snapshot-controller:v2.1.1 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-snapshot-controller-v2-1-1-n5BM_jX2npV3RxHM
 k8s.gcr.io/sig-storage/snapshot-controller:v3.0.2 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-snapshot-controller-v3-0-2-IVmgAhsROusslTdY
 quay.io/redhat-developer/nfs-server:1.0 quay.io/openshift/community-e2e-images:e2e-quay-io-redhat-developer-nfs-server-1-0-Wz4GFQ2IuhYmh2mB
-registry.ci.openshift.org/ocp/4.7:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-ci-openshift-org-ocp-4-7-test-build-roots2i-tG08qb6aSmDhxBBy
+registry.ci.openshift.org/ocp/4.8:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-ci-openshift-org-ocp-4-8-test-build-roots2i-FmW7zebvtGKkls4B


### PR DESCRIPTION
Replaced `registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i` in Origin build tests with `quay.io/multi-arch/test-build-roots2i:ubi8`.
Latest image is multiarch - has multiple references of different architectures in its manifest.

Since `quay.io/multi-arch/test-build-roots2i:ubi8` is a new image, it is not present in the `quay.io/openshift/community-e2e-images` - needs to be mirrored there as described in the `util/image` [README.md](https://github.com/openshift/origin/blob/master/test/extended/util/image/README.md).