### PR TITLE
Bug 1989158: rewrite idling tests to not be [Local]

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -42871,12 +42871,9 @@ items:
           replicationcontroller: idling-echo
       spec:
         containers:
-        - image: openshift/origin-base
-          name: idling-echo
-          command:
-            - /usr/bin/socat
-            - TCP4-LISTEN:8675,reuseaddr,fork
-            - EXEC:'/bin/cat'
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+          name: idling-echo-server
+          args: [ "netexec", "--http-port", "8675" ]
           ports:
           - containerPort: 8675
             protocol: TCP
@@ -42940,22 +42937,12 @@ items:
           deploymentconfig: idling-echo
       spec:
         containers:
-        - image: openshift/origin-base
-          name: idling-tcp-echo
-          command:
-            - /usr/bin/socat
-            - TCP4-LISTEN:8675,reuseaddr,fork
-            - EXEC:'/bin/cat'
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+          name: idling-echo-server
+          args: [ "netexec", "--http-port", "8675", "--udp-port", "3090" ]
           ports:
           - containerPort: 8675
             protocol: TCP
-        - image: openshift/origin-base
-          name: idling-udp-echo
-          command:
-            - /usr/bin/socat
-            - UDP4-LISTEN:3090,reuseaddr,fork
-            - EXEC:'/bin/cat'
-          ports:
           - containerPort: 3090
             protocol: UDP
         dnsPolicy: ClusterFirst

--- a/test/extended/testdata/idling-echo-server-rc.yaml
+++ b/test/extended/testdata/idling-echo-server-rc.yaml
@@ -17,12 +17,9 @@ items:
           replicationcontroller: idling-echo
       spec:
         containers:
-        - image: openshift/origin-base
-          name: idling-echo
-          command:
-            - /usr/bin/socat
-            - TCP4-LISTEN:8675,reuseaddr,fork
-            - EXEC:'/bin/cat'
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+          name: idling-echo-server
+          args: [ "netexec", "--http-port", "8675" ]
           ports:
           - containerPort: 8675
             protocol: TCP

--- a/test/extended/testdata/idling-echo-server.yaml
+++ b/test/extended/testdata/idling-echo-server.yaml
@@ -20,22 +20,12 @@ items:
           deploymentconfig: idling-echo
       spec:
         containers:
-        - image: openshift/origin-base
-          name: idling-tcp-echo
-          command:
-            - /usr/bin/socat
-            - TCP4-LISTEN:8675,reuseaddr,fork
-            - EXEC:'/bin/cat'
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.32
+          name: idling-echo-server
+          args: [ "netexec", "--http-port", "8675", "--udp-port", "3090" ]
           ports:
           - containerPort: 8675
             protocol: TCP
-        - image: openshift/origin-base
-          name: idling-udp-echo
-          command:
-            - /usr/bin/socat
-            - UDP4-LISTEN:3090,reuseaddr,fork
-            - EXEC:'/bin/cat'
-          ports:
           - containerPort: 3090
             protocol: UDP
         dnsPolicy: ClusterFirst

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1725,9 +1725,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should handle many UDP senders (by continuing to drop all packets on the floor) [Serial]": "should handle many UDP senders (by continuing to drop all packets on the floor) [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (when fully idled)": "should work with TCP (when fully idled) [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (when fully idled)": "should work with TCP (when fully idled) [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (while idling)": "should work with TCP (while idling) [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (while idling)": "should work with TCP (while idling) [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with UDP": "should work with UDP [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1717,19 +1717,19 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the http2 tests": "should pass the http2 tests [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling idling [Local] with a single service and DeploymentConfig should idle the service and DeploymentConfig properly": "should idle the service and DeploymentConfig properly [Disabled:Broken]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Idling with a single service and DeploymentConfig should idle the service and DeploymentConfig properly": "should idle the service and DeploymentConfig properly [Disabled:Broken]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling idling [Local] with a single service and ReplicationController should idle the service and ReplicationController properly": "should idle the service and ReplicationController properly",
+	"[Top Level] [sig-network-edge][Feature:Idling] Idling with a single service and ReplicationController should idle the service and ReplicationController properly": "should idle the service and ReplicationController properly [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling unidling should handle many TCP connections by dropping those under a certain bound [Local]": "should handle many TCP connections by dropping those under a certain bound [Local]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should handle many TCP connections by possibly dropping those over a certain bound [Serial]": "should handle many TCP connections by possibly dropping those over a certain bound [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling unidling should handle many UDP senders (by continuing to drop all packets on the floor) [Local]": "should handle many UDP senders (by continuing to drop all packets on the floor) [Local]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should handle many UDP senders (by continuing to drop all packets on the floor) [Serial]": "should handle many UDP senders (by continuing to drop all packets on the floor) [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling unidling should work with TCP (when fully idled) [Local]": "should work with TCP (when fully idled) [Local]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (when fully idled)": "should work with TCP (when fully idled) [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling unidling should work with TCP (while idling) [Local]": "should work with TCP (while idling) [Local]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (while idling)": "should work with TCP (while idling) [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling and unidling unidling should work with UDP [Local]": "should work with UDP [Local]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with UDP": "should work with UDP [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network] ClusterDns [Feature:Example] should create pod that uses dns": "should create pod that uses dns [Disabled:Broken] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -246,6 +246,9 @@ var (
 
 			// ovn-kubernetes does not support internal traffic policy
 			`\[Feature:ServiceInternalTrafficPolicy\]`,
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1989169: unidling tests are flaky under ovn-kubernetes
+			`Unidling should work with TCP`,
 		},
 		"[Skipped:ibmcloud]": {
 			// skip Gluster tests (not supported on ROKS worker nodes)


### PR DESCRIPTION
While investigating bz 1953705, I discovered that most of the unidling e2e tests have been disabled for years because they were written under the assumption that the test runner was running inside the cluster. (There is one unidling test in `test/extended/router/` that is not disabled, so we weren't _completely_ without test coverage...)
