### PR TITLE
Bug 1959564: builds: skip /run verification tests

### DIFF
--- a/test/extended/builds/run_fs_verification.go
+++ b/test/extended/builds/run_fs_verification.go
@@ -144,6 +144,7 @@ valid_fields.json
 
 		g.Describe("do not have unexpected content", func() {
 			g.It("using a simple Docker Strategy Build", func() {
+				g.Skip("Bug 1959564: skipping while additional content in /run is investigated")
 				g.By("calling oc create with yaml")
 				err := oc.Run("create").Args("-f", "-").InputString(testVerifyRunFSContentsBuildConfigYaml).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -170,6 +171,7 @@ valid_fields.json
 
 		g.Describe("are writeable", func() {
 			g.It("using a simple Docker Strategy Build", func() {
+				g.Skip("Bug 1959564: skipping while additional content in /run is investigated")
 				g.By("calling oc create with yaml")
 				err := oc.Run("create").Args("-f", "-").InputString(testVerityRunFSWriteableBuildConfigYaml).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
Skipping verification tests for the /run directory in builds. A change was
recently made at the node/cri-o layer which added additional content to
the /run directory.

This change should be reverted once the contents added to /run have been
vetted.