### PR TITLE
test: SetupNamespace in cli helper should wait for default service account

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -225,6 +225,11 @@ func (c *CLI) SetupNamespace() string {
 	c.kubeFramework.AddNamespacesToDelete(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: newNamespace}})
 
 	WaitForNamespaceSCCAnnotations(c.AdminKubeClient().CoreV1(), newNamespace)
+	for _, sa := range []string{"default"} {
+		framework.Logf("Waiting for ServiceAccount %q to be provisioned...", sa)
+		err = WaitForServiceAccount(c.KubeClient().CoreV1().ServiceAccounts(newNamespace), sa)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
 	return newNamespace
 }
 


### PR DESCRIPTION
Otherwise pods running in that namespace won't be able to access all
images on the cluster.

At least one cause of failure to pull openshift/tools from registry - registry requires auth, if the pod is created before SA provisioning then you can't pull that image (because the pull secret isn't added).

Likely introduced when we switched to docker.