### PR TITLE
Wait longer in tests where namespace cleanup is slow

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -22,6 +22,7 @@ var (
 	cliInterval        = 5 * time.Second
 	cliTimeout         = 1 * time.Minute
 	extendedCliTimeout = 2 * time.Minute
+	deleteCliTimeout   = 3 * time.Minute
 )
 
 var _ = g.Describe("[sig-cli] oc adm", func() {
@@ -418,7 +419,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		// Test deleting and recreating a project
 		o.Expect(oc.Run("adm", "new-project").Args("recreated-project", "--admin=createuser1").Execute()).To(o.Succeed())
 		o.Expect(oc.Run("delete").Args("project", "recreated-project").Execute()).To(o.Succeed())
-		err := wait.Poll(cliInterval, cliTimeout, func() (bool, error) {
+		err := wait.Poll(cliInterval, deleteCliTimeout, func() (bool, error) {
 			out, err := ocns.Run("get").Args("project/recreated-project").Output()
 			return err != nil && strings.Contains(out, "not found"), nil
 		})

--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -326,7 +326,7 @@ func waitForOnlyDelete(projectName string, w watch.Interface) {
 				}
 				g.Fail(fmt.Sprintf("got unexpected project %v", project.Name))
 
-			case <-time.After(time.Minute):
+			case <-time.After(3 * time.Minute): // namespace deletions can take a while during busy e2e runs
 				g.Fail(fmt.Sprintf("timeout: %v", projectName))
 			}
 		}

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -225,6 +225,11 @@ func (c *CLI) SetupNamespace() string {
 	c.kubeFramework.AddNamespacesToDelete(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: newNamespace}})
 
 	WaitForNamespaceSCCAnnotations(c.AdminKubeClient().CoreV1(), newNamespace)
+	for _, sa := range []string{"default"} {
+		framework.Logf("Waiting for ServiceAccount %q to be provisioned...", sa)
+		err = WaitForServiceAccount(c.AdminKubeClient().CoreV1().ServiceAccounts(newNamespace), sa)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
 	return newNamespace
 }
 


### PR DESCRIPTION
Also fix a case where we waited for dockercfg but not the token (which we need).

This fixes the failure to pull openshift/tools in a number of tests (we raced with the secret controller)