### PR TITLE
Bug 1961582: Do not install python3-cinderclient on s390x

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -7,7 +7,9 @@ RUN make; \
 
 FROM registry.ci.openshift.org/ocp/4.8:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
-RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux python3-cinderclient && yum clean all && rm -rf /var/cache/yum/* && \
+RUN PACKAGES="git gzip util-linux" && \
+    if [ $HOSTTYPE = x86_64] || [ $HOSTTYPE = ppc64le ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
+    yum install --setopt=tsflags=nodocs -y $PACKAGES && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com && \
     chmod g+w /etc/passwd


### PR DESCRIPTION
The openstack repository does not yet exist for s390x, where
python3-cinderclient should be coming from. Safelisting the
existing arches.