### PR TITLE
Bug 1957295: test/extended/pods/priorityclasses: Improve error actionability

### DIFF
--- a/test/extended/pods/priorityclasses.go
+++ b/test/extended/pods/priorityclasses.go
@@ -71,8 +71,8 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 				knownBugList.Insert(fmt.Sprintf("Component %v has a bug associated already: %v", knownBugKey, bz))
 				continue
 			}
-			if !strings.Contains(pod.Spec.PriorityClassName, "system-") && !strings.EqualFold(pod.Spec.PriorityClassName, "openshift-user-critical") {
-				invalidPodPriority.Insert(pod.Namespace + "/" + pod.Name)
+			if !strings.HasPrefix(pod.Spec.PriorityClassName, "system-") && !strings.EqualFold(pod.Spec.PriorityClassName, "openshift-user-critical") {
+				invalidPodPriority.Insert(fmt.Sprintf("%s/%s (currently %q)", pod.Namespace, pod.Name, pod.Spec.PriorityClassName))
 			}
 		}
 		if len(knownBugList) > 0 {
@@ -81,7 +81,7 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 
 		numInvalidPodPriorities := len(invalidPodPriority)
 		if numInvalidPodPriorities > 0 {
-			e2e.Failf("\n%d pods found with invalid tolerations:\n%s", numInvalidPodPriorities, strings.Join(invalidPodPriority.List(), "\n"))
+			e2e.Failf("\n%d pods found with invalid priority class (should be openshift-user-critical or begin with system-):\n%s", numInvalidPodPriorities, strings.Join(invalidPodPriority.List(), "\n"))
 		}
 	})
 })


### PR DESCRIPTION
Instead of just telling folks which pods are broken, tell folks what the current config is and what the expected config is, so they don't have to dig around to figure out how to fix their component.

Following up on d6c4a516ec (#25931), CC @ravisantoshgudimetla.