### PR TITLE
Bug 1929396: Revert part of PR #25406 - use ExternalTrafficPolicyCluster

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -67,7 +67,8 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("creating a TCP service " + serviceName + " with type=LoadBalancer in namespace " + ns.Name)
 	tcpService, err := jig.CreateTCPService(func(s *v1.Service) {
 		s.Spec.Type = v1.ServiceTypeLoadBalancer
-		s.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+		// ServiceExternalTrafficPolicyTypeCluster performs during disruption, Local does not
+		s.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster
 		if s.Annotations == nil {
 			s.Annotations = make(map[string]string)
 		}


### PR DESCRIPTION
PR #25406 changed ExternalTrafficPolicy from Cluster to Local to try to optimize network performance.  Unfortunately, Local will drop traffic instead of rerouting it.  For this test we need to use Cluster.