### PR TITLE
Bug 1963909: move verify run test from tools to cli image; narrow scope to /run/secrets

### DIFF
--- a/test/extended/builds/run_fs_verification.go
+++ b/test/extended/builds/run_fs_verification.go
@@ -24,7 +24,7 @@ spec:
   source:
     dockerfile: |-
       FROM %s
-      RUN chmod -R uga+rwx /run
+      RUN chmod -R uga+rwx /run/secrets
       USER 1001
   type: Dockerfile
   strategy:
@@ -34,7 +34,7 @@ spec:
           value: "10"
       imageOptimizationPolicy: SkipLayers
     type: Docker
-`, "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest")  // replace with image.ShellImage()) when github.com/openshift/origin/test/extended/util/image lands in this release
+`, "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest")  // replace with image.LimitedShellImage()) when github.com/openshift/origin/test/extended/util/image lands in this release
 		testVerifyRunFSContentsBuildConfigYaml = fmt.Sprintf(`
 apiVersion: build.openshift.io/v1
 kind: BuildConfig
@@ -45,7 +45,7 @@ spec:
   source:
     dockerfile: |-
       FROM %s
-      RUN ls -R /run
+      RUN ls -R /run/secrets
       USER 1001
   type: Dockerfile
   strategy:
@@ -55,17 +55,8 @@ spec:
           value: "10"
       imageOptimizationPolicy: SkipLayers
     type: Docker
-`, "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest")  // replace with image.ShellImage()) when github.com/openshift/origin/test/extended/util/image lands in this release
+`, "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest")  // replace with image.LimitedShellImage()) when github.com/openshift/origin/test/extended/util/image lands in this release
 		lsRSlashRun = `
-/run:
-lock
-rhsm
-secrets
-
-/run/lock:
-
-/run/rhsm:
-
 /run/secrets:
 rhsm
 
@@ -77,40 +68,13 @@ redhat-entitlement-authority.pem
 redhat-uep.pem
 `
 		lsRSlashRunFIPS = `
-/run:
-lock
-rhsm
-secrets
-
-/run/lock:
-
-/run/rhsm:
-
 /run/secrets:
 system-fips
 `
 		lsRSlashRunOKD = `
-/run:
-lock
-rhsm
-secrets
-
-/run/lock:
-
-/run/rhsm:
-
 /run/secrets:
 `
 		lsRSlashRunRhel7 = `
-/run:
-lock
-rhsm
-secrets
-
-/run/lock:
-
-/run/rhsm:
-
 /run/secrets:
 rhsm
 
@@ -152,7 +116,7 @@ valid_fields.json
 				o.Expect(err).NotTo(o.HaveOccurred())
 				br.AssertSuccess()
 
-				g.By("check build logs for ls -R /run")
+				g.By("check build logs for ls -R /run/secrets")
 				logs, err := br.LogsNoTimestamp()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				hasRightListing := false


### PR DESCRIPTION
manual pick required since bot encountered merge conflict with 4.7 PR