### PR TITLE
test: Tolerate no AWS disruption during control plane upgrade

### DIFF
--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -107,7 +107,7 @@ func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	end := time.Now()
 
 	toleratedDisruption := 0.08
-	if framework.ProviderIs("azure") {
+	if framework.ProviderIs("azure") || framework.ProviderIs("aws") {
 		toleratedDisruption = 0
 	}
 	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption (AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804)", t.name))


### PR DESCRIPTION
Now that we increased how long we wait for termination and removal
from AWS load balancing (which is a much longer period than their
documentation) we should lock in the fix by failing if we see
control plane disruption.