### PR TITLE
Bug 1946479: Skip cluster quota test while bound token projected volume is being re-enabled

### DIFF
--- a/test/extended/quota/clusterquota.go
+++ b/test/extended/quota/clusterquota.go
@@ -29,6 +29,10 @@ var _ = g.Describe("[sig-api-machinery][Feature:ClusterResourceQuota]", func() {
 
 	g.Describe("Cluster resource quota", func() {
 		g.It(fmt.Sprintf("should control resource limits across namespaces"), func() {
+			// This skip can be removed once https://github.com/openshift/kubernetes/pull/714 merges and
+			// the test is updated to reflect the addition of a service ca configmap to every namespace.
+			g.Skip("Skipping to allow bound token projected volume to be re-enabled")
+
 			t := g.GinkgoT(1)
 
 			versionInfo, err := oc.KubeClient().Discovery().ServerVersion()


### PR DESCRIPTION
This skip is intended to allow https://github.com/openshift/kubernetes/pull/714 to merge without breaking CI for everyone. A follow-on PR will re-enable the test once it has been updated to account for the new service ca configmap being created in every namespace.

/cc @sttts @deads2k 