### PR TITLE
Bug 1948012: Revert "test/extended/operators: Drop service-ca Upgradeable exception"

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -219,7 +219,9 @@ func surprisingConditions(co objx.Map) ([]configv1.ClusterOperatorStatusConditio
 				expected = configv1.ConditionTrue
 			}
 			if cond.Get("status").String() != string(expected) {
-				if conditionType == configv1.OperatorUpgradeable && name == "kube-storage-version-migrator" { // https://bugzilla.redhat.com/show_bug.cgi?id=1928141
+				if conditionType == configv1.OperatorUpgradeable && (name == "kube-storage-version-migrator" || // https://bugzilla.redhat.com/show_bug.cgi?id=1928141
+					name == "openshift-controller-manager" || // https://bugzilla.redhat.com/show_bug.cgi?id=1948011
+					name == "service-ca") { // https://bugzilla.redhat.com/show_bug.cgi?id=1948012
 					continue
 				}
 				badConditions = append(badConditions, configv1.ClusterOperatorStatusCondition{


### PR DESCRIPTION
This reverts commit b4a00cbeacf6317ae6dc91fa14a012963667f08e, #26183.

Until the operator fixes make it back to 4.7, dropping the exceptions in 4.8's origin breaks 4.7->4.8 testing.  We'll try dropping the exceptions again after the operator changes make it back to 4.7, or master opens for 4.9.