### PR TITLE
Bug 1961582: Dockerfile.rhel: fix a bash typo

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -8,7 +8,7 @@ RUN make; \
 FROM registry.ci.openshift.org/ocp/4.8:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
 RUN PACKAGES="git gzip util-linux" && \
-    if [ $HOSTTYPE = x86_64] || [ $HOSTTYPE = ppc64le ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
+    if [ $HOSTTYPE = x86_64 ] || [ $HOSTTYPE = ppc64le ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
     yum install --setopt=tsflags=nodocs -y $PACKAGES && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com && \


### PR DESCRIPTION
A regression was introduced in the Dockerfile, with a typo in
the condition:
https://github.com/openshift/origin/pull/26170

This patch fixes it.
