### PR TITLE
Bug 1965588: Testimage install cinder 4.6

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -7,7 +7,9 @@ RUN make; \
 
 FROM registry.ci.openshift.org/ocp/4.6:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
-RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
+RUN PACKAGES="git gzip util-linux" && \
+    if [ $HOSTTYPE = x86_64 ] || [ $HOSTTYPE = ppc64le ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
+    yum install --setopt=tsflags=nodocs -y $PACKAGES && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com && \
     chmod g+w /etc/passwd


### PR DESCRIPTION
Multiple tests require the Cinder client to be installed when run
against OpenStack.

In the step-registry CI structure, the "test" ref is shared across
platforms; it is therefore not desirable to run the OpenStack tests
using a separate image.

This change adds the Cinder client to the container image used to run
the tests in the CI.

Implements OSASINFRA-2308

cf. "[sig-storage] In-tree Volumes [Driver: cinder] [Testpattern:
Inline-volume (default fs)] volumes should store data
[Suite:openshift/conformance/parallel] [Suite:k8s]"

This is a cherry-pick of 559db12abbe938db5d726aa196901e7d5ef47c12
(https://github.com/openshift/origin/pull/26131) modified with the fix
for the architectures where the openstack repository is not available
5c861b50e95153cf2c56a34f1cf29790c25eb10c
(https://github.com/openshift/origin/pull/26170)

This also includes the fix in 8eaf838a8c5cd5bdd9d8691f8c2668a5dda8dbf2
(https://github.com/openshift/origin/pull/26192)

Supersedes https://github.com/openshift/origin/pull/26190