### PR TITLE
Skip watch consistency test pending vendoring a fix from o/k

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -257,7 +257,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-api-machinery] Watchers should observe an object deletion if it stops meeting the requirements of the selector [Conformance]": "should observe an object deletion if it stops meeting the requirements of the selector [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-api-machinery] Watchers should receive events on concurrent watches in same order [Conformance]": "should receive events on concurrent watches in same order [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[Top Level] [sig-api-machinery] Watchers should receive events on concurrent watches in same order [Conformance]": "should receive events on concurrent watches in same order [Conformance] [Disabled:Broken] [Suite:k8s]",
 
 	"[Top Level] [sig-api-machinery] client-go should negotiate watch and report errors with accept \"application/json,application/vnd.kubernetes.protobuf\"": "watch and report errors with accept \"application/json,application/vnd.kubernetes.protobuf\" [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -66,6 +66,11 @@ var (
 			// Broken for metal-ipi-ovn-ipv6
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1962950
 			`\[Feature:NetworkPolicy\]`,
+
+			// Flakey against master, broken by the addition of a service ca configmap in every
+			// namespace introduced by https://github.com/openshift/kubernetes/pull/714. Will be
+			// re-enabled by https://github.com/openshift/origin/pull/26186 once 714 merges.
+			`\[sig-api-machinery\] Watchers should receive events on concurrent watches in same order`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {},


### PR DESCRIPTION
This unblocks the merge of https://github.com/openshift/kubernetes/pull/714 since the fips jobs is running the watch consistency test built from origin rather than o/kubernetes.

https://github.com/openshift/origin/pull/26186 will ensure that testing is restored once 714 merges.

/cc @deads2k @mfojtik @sttts @soltysh 