### PR TITLE
test/extended/prometheus: Drop ClusterOperatorDegraded and KubeAPIErrorBudgetBurn exceptions

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -15,7 +15,6 @@ import (
 	o "github.com/onsi/gomega"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -71,19 +70,8 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
 			},
 			{
-				Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
-			},
-			{
 				Selector: map[string]string{"alertname": "AggregatedAPIDown", "name": "v1alpha1.wardle.example.com"},
 				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1933144",
-			},
-			{
-				Selector: map[string]string{"alertname": "KubeAPIErrorBudgetBurn"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1953798",
-				Matches: func(_ *model.Sample) bool {
-					return framework.ProviderIs("gce")
-				},
 			},
 		}
 		allowedFiringAlerts := helper.MetricConditions{


### PR DESCRIPTION
[Bug 1939580 had a narrow fix][1], and while the `ClusterOperatorDown` failure is still frequent:

```console
$ w3m -dump -cols 200 'https://search.ci.openshift.org/?maxAge=24h&type=junit&search=alert+ClusterOperatorDown.*fired+for.*name="authentication"' | grep 'failures match' | grep -v 'pull-ci-\|rehearse' | sort
periodic-ci-openshift-release-master-ci-4.8-e2e-aws-serial (all) - 18 runs, 39% failed, 29% of failures match = 11% impact
periodic-ci-openshift-release-master-ci-4.8-e2e-azure (all) - 1 runs, 100% failed, 100% of failures match = 100% impact
periodic-ci-openshift-release-master-nightly-4.8-e2e-aws (all) - 11 runs, 27% failed, 33% of failures match = 9% impact
periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-serial (all) - 11 runs, 27% failed, 67% of failures match = 18% impact
periodic-ci-openshift-release-master-nightly-4.8-e2e-azure (all) - 9 runs, 11% failed, 100% of failures match = 11% impact
periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial (all) - 11 runs, 18% failed, 50% of failures match = 9% impact
promote-release-openshift-machine-os-content-e2e-aws-4.8 (all) - 60 runs, 3% failed, 50% of failures match = 2% impact
release-openshift-ocp-installer-e2e-aws-ovn-4.8 (all) - 8 runs, 25% failed, 150% of failures match = 38% impact
release-openshift-ocp-installer-e2e-azure-ovn-4.8 (all) - 9 runs, 33% failed, 33% of failures match = 11% impact
release-openshift-ocp-installer-e2e-gcp-ovn-4.8 (all) - 9 runs, 67% failed, 17% of failures match = 11% impact
release-openshift-ocp-installer-e2e-gcp-serial-4.8 (all) - 9 runs, 33% failed, 67% of failures match = 22% impact
release-openshift-ocp-installer-e2e-metal-serial-4.8 (all) - 9 runs, 22% failed, 100% of failures match = 22% impact
release-openshift-ocp-installer-e2e-remote-libvirt-jenkins-e2e-ppc64le-4.8 (all) - 2 runs, 50% failed, 100% of failures match = 50% impact
release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.8 (all) - 3 runs, 100% failed, 33% of failures match = 33% impact
```

The ClusterOperatorDegraded failure is not:

```console
$ w3m -dump -cols 200 'https://search.ci.openshift.org/?maxAge=24h&type=junit&search=alert+ClusterOperatorDegraded.*fired+for.*name="authentication"' | grep 'failures match' | grep -v 'pull-ci-\|rehearse' | sort
...no hits...
```

This may be due to the `for` bump from [rhbz#1957991][2].  Checking on the other exceptions:

```console
$ w3m -dump -cols 200 'https://search.ci.openshift.org/?maxAge=24h&type=junit&search=alert+AggregatedAPIDown.*fired+for.*name="v1alpha1.wardle.example.com"' | grep 'failures match' | grep -v 'pull-ci-\|rehearse' | sort
periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade (all) - 18 runs, 44% failed, 13% of failures match = 6% impact
periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips (all) - 8 runs, 25% failed, 50% of failures match = 13% impact
periodic-ci-openshift-release-master-nightly-4.8-e2e-azure (all) - 9 runs, 11% failed, 100% of failures match = 11% impact
promote-release-openshift-machine-os-content-e2e-aws-4.8 (all) - 60 runs, 3% failed, 50% of failures match = 2% impact
release-openshift-ocp-installer-e2e-aws-ovn-4.8 (all) - 8 runs, 25% failed, 100% of failures match = 25% impact
release-openshift-ocp-installer-e2e-aws-upi-4.8 (all) - 9 runs, 44% failed, 25% of failures match = 11% impact
release-openshift-ocp-installer-e2e-azure-ovn-4.8 (all) - 9 runs, 33% failed, 67% of failures match = 22% impact
```

so we need to keep that one.  And:

```console
$ w3m -dump -cols 200 'https://search.ci.openshift.org/?maxAge=24h&type=junit&search=alert+KubeAPIErrorBudgetBurn.*fired+for' | grep 'failures match' | grep -v 'pull-ci-\|rehearse' | sort
...no hits...
```

so we can drop the exception for the `ON_QA` [rbhz#1953798][3].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1939580#c12
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1957991
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1953798