### PR TITLE
Bug 1970969: clarify failure message

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -424,9 +424,9 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			upgradeEnded := time.Now()
 			upgradeDuration := upgradeEnded.Sub(upgradeStarted)
 			if upgradeDuration > durationToSoftFailure {
-				disruption.RecordJUnitResult(f, "[sig-cluster-lifecycle] cluster upgrade should complete in 60m (90m on AWS)", upgradeDuration, fmt.Sprintf("%s to %s took too long: %v", action, versionString(desired), upgradeDuration.Minutes()))
+				disruption.RecordJUnitResult(f, "[sig-cluster-lifecycle] cluster upgrade should complete in 75m (90m on AWS)", upgradeDuration, fmt.Sprintf("%s to %s took too long: %0.2f minutes", action, versionString(desired), upgradeDuration.Minutes()))
 			} else {
-				disruption.RecordJUnitResult(f, "[sig-cluster-lifecycle] cluster upgrade should complete in 60m (90m on AWS)", upgradeDuration, "")
+				disruption.RecordJUnitResult(f, "[sig-cluster-lifecycle] cluster upgrade should complete in 75m (90m on AWS)", upgradeDuration, "")
 			}
 
 			return nil


### PR DESCRIPTION
The failure message for "[sig-cluster-lifecycle] cluster upgrade should be fast" is ambiguous:

upgrade to registry.build01.ci.openshift.org/ci-op-h21l7wld/release@sha256:2148b1c121946ac4f186bb22b166247d3df0ad9cf3966f05dc2a6ea27bc53927 took too long: 86.33481681223333

What does 86.33481681223333 represent? Is it seconds, minutes, hours? What does "too long" mean? Without looking at the test code, one cannot tell. With that info added to the failure string, it's easier to understand:

upgrade to registry.build01.ci.openshift.org/ci-op-h21l7wld/release@sha256:2148b1c121946ac4f186bb22b166247d3df0ad9cf3966f05dc2a6ea27bc53927 took too long: 86.3 minutes, expected 75 minutes or less

I'm happy to change verbiage as needed.