### PR TITLE
test: Don't reuse route.spec.host in tests run in parallel

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -50329,7 +50329,6 @@ items:
       test: router
       select: weighted
   spec:
-    host: weighted.metrics.example.com
     to:
       name: weightedendpoints1
       kind: Service
@@ -50350,7 +50349,6 @@ items:
       test: router
       select: weighted
   spec:
-    host: zeroweight.metrics.example.com
     to:
       name: weightedendpoints1
       kind: Service

--- a/test/extended/testdata/router/router-metrics.yaml
+++ b/test/extended/testdata/router/router-metrics.yaml
@@ -10,7 +10,6 @@ items:
       test: router
       select: weighted
   spec:
-    host: weighted.metrics.example.com
     to:
       name: weightedendpoints1
       kind: Service
@@ -31,7 +30,6 @@ items:
       test: router
       select: weighted
   spec:
-    host: zeroweight.metrics.example.com
     to:
       name: weightedendpoints1
       kind: Service


### PR DESCRIPTION
Tests that hardcode spec.host can fail to be admitted while other instances of the same test are running (in parallel / stress jobs).
We don't need a hardcoded host anyway.

Also, max_sessions tracking is unreliable in the presence of too many restarts, so simply verify after a restart it's zero for our route (as it should be).