### PR TITLE
test/extended/etcd/leader_changes: Explicit 'expected 0'

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		o.Expect(err).ToNot(o.HaveOccurred())
 		leaderChanges := result.(model.Vector)[0].Value
 		if leaderChanges != 0 {
-			o.Expect(fmt.Errorf("Observed %s leader changes in %s: Leader changes are a result of stopping the etcd leader process or from latency (disk or network), review etcd performance metrics", leaderChanges, testDuration)).ToNot(o.HaveOccurred())
+			o.Expect(fmt.Errorf("Observed %s leader changes (expected 0) in %s: Leader changes are a result of stopping the etcd leader process or from latency (disk or network), review etcd performance metrics", leaderChanges, testDuration)).ToNot(o.HaveOccurred())
 		}
 	})
 })


### PR DESCRIPTION
[Because][1]:

> Observed 1.0106666666666666 leader changes in 25m16s: Leader changes are a result of stopping the etcd leader process or from latency (disk or network), review etcd performance metrics

lead me wondering if maybe 1 was acceptable, and there was some rounding error in the PromQL that lead to the test failing.  With the new string, I would have realized that "are not excessive" currently means "never happen when we don't expect them" ;).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1970160#c0