### PR TITLE
test/e2e/upgrade/alert: Allow AggregatedAPIDown to unblock 4.7->4.8 CI

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -59,6 +59,10 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
 		},
 		{
+			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-kube-apiserver-operator"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+		},
+		{
 			Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "openshift-apiserver"},
 			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
 		},
@@ -81,6 +85,13 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 		{
 			Selector: map[string]string{"alertname": "KubeAPIErrorBudgetBurn"},
 			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1953798",
+			Matches: func(_ *model.Sample) bool {
+				return framework.ProviderIs("gce")
+			},
+		},
+		{
+			Selector: map[string]string{"alertname": "AggregatedAPIDown", "namespace": "default", "name": "v1beta1.metrics.k8s.io"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1970624",
 			Matches: func(_ *model.Sample) bool {
 				return framework.ProviderIs("gce")
 			},


### PR DESCRIPTION
We're getting:

    alert AggregatedAPIDown fired for 210 seconds with labels: {name="v1beta1.metrics.k8s.io", namespace="default", severity="warning"}

and such pretty consistently in those jobs.  Tracked in [rhbz#1970624][1].  Until that gets fixed, ignore the alert, so we are more likely to notice other breakage.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1970624