### PR TITLE
Bug 1971590: Enable TestEndpointAdmission test only for OpenShift SDN

### DIFF
--- a/test/extended/networking/endpoint_admission.go
+++ b/test/extended/networking/endpoint_admission.go
@@ -24,16 +24,12 @@ var _ = g.Describe("[sig-network][endpoints] admission", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("endpoint-admission")
 
-	g.It("TestEndpointAdmission", func() {
-		TestEndpointAdmission(g.GinkgoT(), oc)
+	InOpenShiftSDNContext(func() {
+		g.It("blocks manual creation of Endpoints pointing to the cluster or service network", func() {
+			TestEndpointAdmission(g.GinkgoT(), oc)
+		})
 	})
 })
-
-var exampleAddresses = map[string]string{
-	"cluster":  "10.128.0.2",
-	"service":  "172.30.0.2",
-	"external": "1.2.3.4",
-}
 
 func testOne(t g.GinkgoTInterface, oc *exutil.CLI, client kubernetes.Interface, addrType string, success bool) *corev1.Endpoints {
 	networkConfig, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
@@ -113,7 +109,8 @@ func TestEndpointAdmission(t g.GinkgoTInterface, oc *exutil.CLI) {
 	if err != nil {
 		t.Fatalf("unexpected error updating endpoint annotation: %v", err)
 	}
-	ep.Subsets[0].Addresses[0].IP = exampleAddresses["service"]
+
+	ep.Subsets[0].Addresses[0].IP = "172.30.0.2"
 	ep, err = projectAdminClient.CoreV1().Endpoints(oc.Namespace()).Update(context.Background(), ep, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatalf("unexpected success modifying endpoint")

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2261,7 +2261,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:Router] The HAProxy router should support reencrypt to services backed by a serving certificate automatically": "should support reencrypt to services backed by a serving certificate automatically [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][endpoints] admission TestEndpointAdmission": "TestEndpointAdmission [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][endpoints] admission when using openshift-sdn blocks manual creation of Endpoints pointing to the cluster or service network": "blocks manual creation of Endpoints pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined": "can disable an AppArmor profile, using unconfined [Suite:openshift/conformance/parallel] [Suite:k8s]",
 


### PR DESCRIPTION
This PR applies only enabling TestEndpointAdmission test for OpenShift SDN