### PR TITLE
Flake when SCCs are not associated yet

### DIFF
--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -42,6 +42,10 @@ func testPodSandboxCreation(events monitorapi.Intervals) []*ginkgo.JUnitTestCase
 			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to get pods due to LB disruption https://bugzilla.redhat.com/show_bug.cgi?id=1927264 - %v", event.Locator, event.Message))
 			continue
 		}
+		if strings.Contains(event.Message, "Multus") && strings.Contains(event.Message, "Failed to create pod sandbox") && strings.Contains(event.Message, "is forbidden: User \"system:serviceaccount:openshift-multus:multus\"") {
+			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to create pods due to not getting required SCCs https://bugzilla.redhat.com/show_bug.cgi?id=1961204 - %v", event.Locator, event.Message))
+			continue
+		}
 		deletionTime := getPodDeletionTime(eventsForPods[event.Locator], event.Locator)
 		if deletionTime == nil {
 			// this indicates a failure to create the sandbox that should not happen


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1961204 was punted
to 4.9 release, however occasionally we see multus not
getting SCCs in time causing [auth issues](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade/1404364169490206720). This commit
causes the test to flake in such scenarios instead of
failing. This is a temporary measure to get better
signal for 4.8 upgrades. We need to remove this
when the associated bug has been fixed

cc @vrutkovs @dcbw