### PR TITLE
upgrade: extend upgrade duration to 105mins on AWS

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -277,7 +277,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 	framework.ExpectNoError(err)
 	if infra.Status.PlatformStatus.Type == configv1.AWSPlatformType {
 		// due to https://bugzilla.redhat.com/show_bug.cgi?id=1943804 upgrades take ~12 extra minutes on AWS
-		durationToSoftFailure = 90 * time.Minute
+		durationToSoftFailure = 105 * time.Minute
 	}
 
 	framework.Logf("Starting upgrade to version=%s image=%s attempt=%s", version.Version.String(), version.NodeImage, uid)
@@ -424,9 +424,9 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			upgradeEnded := time.Now()
 			upgradeDuration := upgradeEnded.Sub(upgradeStarted)
 			if upgradeDuration > durationToSoftFailure {
-				disruption.RecordJUnitResult(f, "[sig-cluster-lifecycle] cluster upgrade should complete in 75m (90m on AWS)", upgradeDuration, fmt.Sprintf("%s to %s took too long: %0.2f minutes", action, versionString(desired), upgradeDuration.Minutes()))
+				disruption.RecordJUnitResult(f, "[sig-cluster-lifecycle] cluster upgrade should complete in 75m (105m on AWS)", upgradeDuration, fmt.Sprintf("%s to %s took too long: %0.2f minutes", action, versionString(desired), upgradeDuration.Minutes()))
 			} else {
-				disruption.RecordJUnitResult(f, "[sig-cluster-lifecycle] cluster upgrade should complete in 75m (90m on AWS)", upgradeDuration, "")
+				disruption.RecordJUnitResult(f, "[sig-cluster-lifecycle] cluster upgrade should complete in 75m (105m on AWS)", upgradeDuration, "")
 			}
 
 			return nil


### PR DESCRIPTION
Some upgrades finish slightly above 90m limit - https://search.ci.openshift.org/?search=sig-cluster-lifecycle.*cluster+upgrade+should+complete+in+&maxAge=96h0m0s&context=3&type=junit&name=aws&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Longest so far seems to be [aws-ovn-upgrade](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/19195/rehearse-19195-periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-aws-ovn-upgrade/1403820023339814912) - 104.34.

[test upgrade 4.8.0-rc.0 https://github.com/openshift/origin/pull/26230 aws](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1405784553200553984)

This would bump AWS timeout to 105m until this is thoroughly investigated