### PR TITLE
test: Use last_over_time in pendingAlertQuery

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -170,7 +170,17 @@ count_over_time(ALERTS{alertstate="firing",severity!="info",alertname!~"Watchdog
 	}
 
 	// Invariant: There should be no pending alerts 1m after the upgrade completes
-	pendingAlertQuery := `ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured",alertstate="pending",severity!="info"}`
+	pendingAlertQuery := fmt.Sprintf(`
+sort_desc(
+  time() * ALERTS + 1
+  -
+  last_over_time((
+    time() * ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured",alertstate="pending",severity!="info"}
+    unless
+    ALERTS offset 1s
+  )[%[1]s:1s])
+)
+`, testDuration)
 	result, err = helper.RunQuery(pendingAlertQuery, ns, execPod.Name, t.url, t.bearerToken)
 	o.Expect(err).NotTo(o.HaveOccurred(), "unable to retrieve pending alerts after upgrade")
 	for _, series := range result.Data.Result {


### PR DESCRIPTION
Since `pendingAlertQuery` landed in 59ef04b754 (#25904), it has been measuring pending alerts when the query was run, and the value has always been 1. That would get rendered as:

    alert ... pending for 1 seconds with labels...

regardless of how long the alert had been pending before the query was run.  This commit replaces the query with a new one whose value is actually the number of seconds that a currently-pending alert has been pending.  The new query:

* Uses:

        ALERTS{...} unless ALERTS offset 1s

    to trigger on edges where the alert began pending.

* Uses `last_over_time` to find the most recent edge trigger.
* Uses:

        time() + 1 - last_over_time(time() * ...)

    to figure out how long ago that most-recent trigger was.  The `+1` sets the floor at 1, for cases where one second ago we were not pending, but when the query is run we are pending.

* Multiplies by `ALERTS` again to exclude alerts that are no longer pending by the time the query runs.

* Uses `sort_desc` so we complain first about the alerts that have been pending the longest.