### PR TITLE
Bug 1972829: Verify upgrades don't disrupt frontends

### DIFF
--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -13,6 +13,7 @@ import (
 	"github.com/blang/semver"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -110,7 +111,7 @@ func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	end := time.Now()
 
 	// starting from 4.8, enforce the requirement that control plane remains available
-	hasAllFixes, err := allClusterVersionsAreGTE(semver.Version{Major: 4, Minor: 8}, config)
+	hasAllFixes, err := util.AllClusterVersionsAreGTE(semver.Version{Major: 4, Minor: 8}, config)
 	if err != nil {
 		framework.Logf("Cannot require full control plane availability, some versions could not be checked: %v", err)
 	}

--- a/test/extended/util/disruption/imageregistry/imageregistry.go
+++ b/test/extended/util/disruption/imageregistry/imageregistry.go
@@ -122,7 +122,21 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Image registry was unreachable during disruption")
+	toleratedDisruption := 0.20
+	// BUG: https://bugzilla.redhat.com/show_bug.cgi?id=1972827
+	// starting from 4.x, enforce the requirement that ingress remains available
+	// hasAllFixes, err := util.AllClusterVersionsAreGTE(semver.Version{Major: 4, Minor: 8}, config)
+	// if err != nil {
+	// 	framework.Logf("Cannot require full control plane availability, some versions could not be checked: %v", err)
+	// }
+	// switch {
+	// case framework.ProviderIs("azure"), framework.ProviderIs("aws"), framework.ProviderIs("gce"):
+	// 	if hasAllFixes {
+	// 		framework.Logf("Cluster contains no versions older than 4.8, tolerating no disruption")
+	// 		toleratedDisruption = 0
+	// 	}
+	// }
+	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Image registry was unreachable during disruption (https://bugzilla.redhat.com/show_bug.cgi?id=1972827)")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
@@ -37,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/framework/statefulset"
@@ -48,6 +50,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	buildv1clienttyped "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	imagev1typedclient "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	projectv1typedclient "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	"github.com/openshift/library-go/pkg/build/naming"
@@ -1931,4 +1934,36 @@ func IsClusterOperated(oc *CLI) bool {
 		return false
 	}
 	return true
+}
+
+// AllClusterVersionsAreGTE returns true if all historical versions on the cluster version are
+// at or newer than the provided semver, ignoring prerelease status. If no versions are found
+// an error is returned.
+func AllClusterVersionsAreGTE(version semver.Version, config *rest.Config) (bool, error) {
+	c, err := configv1client.NewForConfig(config)
+	if err != nil {
+		return false, err
+	}
+	cv, err := c.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	if len(cv.Status.History) == 0 {
+		return false, fmt.Errorf("no versions in cluster version history")
+	}
+	for _, v := range cv.Status.History {
+		ver, err := semver.Parse(v.Version)
+		if err != nil {
+			return false, err
+		}
+
+		// ignore prerelease version matching here
+		ver.Pre = nil
+		ver.Build = nil
+
+		if ver.LT(version) {
+			return false, nil
+		}
+	}
+	return true, nil
 }


### PR DESCRIPTION
Enforce that frontends must remain available now that 4.8 is fixed.
Share code across the three test types and leave a comment about the
known image registry disruption.