### PR TITLE
Bug 1972684: Add failing tests in OVN-K into skipped list

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2135,9 +2135,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] Granular Checks: Services Secondary IP Family should be able to handle large requests: udp": "should be able to handle large requests: udp [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] Granular Checks: Services Secondary IP Family should function for client IP based session affinity: http [LinuxOnly]": "should function for client IP based session affinity: http [LinuxOnly] [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] Granular Checks: Services Secondary IP Family should function for client IP based session affinity: http [LinuxOnly]": "should function for client IP based session affinity: http [LinuxOnly] [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] Granular Checks: Services Secondary IP Family should function for client IP based session affinity: udp [LinuxOnly]": "should function for client IP based session affinity: udp [LinuxOnly] [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] Granular Checks: Services Secondary IP Family should function for client IP based session affinity: udp [LinuxOnly]": "should function for client IP based session affinity: udp [LinuxOnly] [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] Granular Checks: Services Secondary IP Family should function for endpoint-Service: http": "should function for endpoint-Service: http [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -2175,7 +2175,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] should have ipv4 and ipv6 internal node ip": "should have ipv4 and ipv6 internal node ip [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] should have ipv4 and ipv6 node podCIDRs": "should have ipv4 and ipv6 node podCIDRs [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-network] [Feature:IPv6DualStack] [LinuxOnly] should have ipv4 and ipv6 node podCIDRs": "should have ipv4 and ipv6 node podCIDRs [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-network] [Feature:PerformanceDNS][Serial] Should answer DNS query for maximum number of services per cluster": "Should answer DNS query for maximum number of services per cluster [Slow] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -206,6 +206,12 @@ var (
 			`\[sig-network\] Services should have session affinity timeout work for NodePort service`,
 			`\[sig-network\] Services should have session affinity timeout work for service with type clusterIP`,
 
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1972684 - [Feature:IPv6DualStack] tests are failing in dualstack
+			// https://jira.coreos.com/browse/SDN-510: OVN-K doesn't support session affinity
+			`\[sig-network\] \[Feature:IPv6DualStack\] \[LinuxOnly\] Granular Checks: Services Secondary IP Family should function for client IP based session affinity: http`,
+			`\[sig-network\] \[Feature:IPv6DualStack\] \[LinuxOnly\] Granular Checks: Services Secondary IP Family should function for client IP based session affinity: udp`,
+			`\[sig-network\] \[Feature:IPv6DualStack\] \[LinuxOnly\] should have ipv4 and ipv6 node podCIDRs`,
+
 			// ovn-kubernetes does not support named ports
 			`NetworkPolicy.*named port`,
 		},


### PR DESCRIPTION
e2e-metal-ipi-ovn-dualstack jobs are permanently failing.

This PR adds 3 tests that are failing in dualstack into the `[Skipped:Network/OVNKubernetes]` list. As stated in https://bugzilla.redhat.com/show_bug.cgi?id=1972684#c5, these tests are not supported by OVN-Kubernetes.