### PR TITLE
test/extended/prometheus/OWNERS: refresh members

### DIFF
--- a/test/extended/prometheus/OWNERS
+++ b/test/extended/prometheus/OWNERS
@@ -1,15 +1,13 @@
 reviewers:
-- brancz
-- LiliC
 - squat
-- s-urbaniak
 - paulfantom
-- metalmatze
+- simonpasquier
+- dgrisonnet
+- jan--f
 
 approvers:
-- brancz
-- LiliC
 - squat
-- s-urbaniak
 - paulfantom
-- metalmatze
+- simonpasquier
+- dgrisonnet
+- jan--f


### PR DESCRIPTION
This change updates the list of reviewers and approvers to be consistent
with the current team structure.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>