### PR TITLE
Bug 1963160: don't iterate over pod objects

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -406,9 +406,11 @@ func (np *networkPolicyPlugin) selectPods(npns *npNamespace, lsel *metav1.LabelS
 		utilruntime.HandleError(fmt.Errorf("ValidateNetworkPolicy() failure! Invalid PodSelector: %v", err))
 		return ips
 	}
-	for _, pod := range np.pods {
-		if (npns.name == pod.Namespace) && sel.Matches(labels.Set(pod.Labels)) {
-			ips = append(ips, pod.Status.PodIP)
+
+	// Iterate over the key instead of the value for performance reasons
+	for k := range np.pods {
+		if (npns.name == np.pods[k].Namespace) && sel.Matches(labels.Set(np.pods[k].Labels)) {
+			ips = append(ips, np.pods[k].Status.PodIP)
 		}
 	}
 	return ips


### PR DESCRIPTION
Bug 1963160 shows that this function is the more expensive:
Showing top 5 nodes out of 97

flat  flat%   sum%        cum   cum%
18620ms 55.62% 55.62%    18620ms 55.62%  runtime.duffcopy
4700ms 14.04% 69.65%     7420ms 22.16%  runtime.mapiternext
1870ms  5.59% 75.24%     1870ms  5.59%  runtime.aeshashbody
850ms  2.54% 77.78%    28180ms 84.17%  github.com/openshift/origin/pkg/network/node.(*networkPolicyPlugin).selectPods
780ms  2.33% 80.11%      780ms  2.33%  runtime.memeqbody

In order to avoid excessive copies of data better to iterate over the key instead of the value.

Signed-off-by: Antonio Ojea <aojea@redhat.com>