### PR TITLE
test/extended: Ensure all containers in the OLM deployment resources contain the IfNotPresent image pull policy

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -88,7 +88,13 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 				e2e.Failf("Unable to get %s, error:%v", msg, err)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(msg).To(o.Equal("IfNotPresent"))
+
+			// ensure that all containers in the current deployment contain the IfNotPresent
+			// image pull policy
+			policies := strings.Split(msg, " ")
+			for _, policy := range policies {
+				o.Expect(policy).To(o.Equal("IfNotPresent"))
+			}
 		}
 	})
 


### PR DESCRIPTION
Update the test/extended/operators/olm.go and ensure that all containers
in the OLM deployment resources contain the IfNotPresent image pull
policy.

Previously, this test would make the assumption that all the OLM-related
deployments contain a single container, which won't always be the case
in the future. This updates that test to split the output from the oc
command into array elements, checking each element to ensure it matches
the correct image pull policy.