### PR TITLE
Bug 1963160: Backport Bug 1896958: NetworkPolicy performance (pod caching) #226

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -43,8 +43,6 @@ type networkPolicyPlugin struct {
 	namespaces map[uint32]*npNamespace
 	// nsMatchCache caches matches for namespaceSelectors; see selectNamespaceInternal
 	nsMatchCache map[string]*npCacheEntry
-
-	pods map[ktypes.UID]kapi.Pod
 }
 
 // npNamespace tracks NetworkPolicy-related data for a Namespace
@@ -88,7 +86,6 @@ func NewNetworkPolicyPlugin() osdnPolicy {
 	return &networkPolicyPlugin{
 		namespaces:       make(map[uint32]*npNamespace),
 		namespacesByName: make(map[string]*npNamespace),
-		pods:             make(map[ktypes.UID]kapi.Pod),
 
 		nsMatchCache: make(map[string]*npCacheEntry),
 	}
@@ -406,10 +403,15 @@ func (np *networkPolicyPlugin) selectPods(npns *npNamespace, lsel *metav1.LabelS
 		utilruntime.HandleError(fmt.Errorf("ValidateNetworkPolicy() failure! Invalid PodSelector: %v", err))
 		return ips
 	}
-	for _, pod := range np.pods {
-		if (npns.name == pod.Namespace) && sel.Matches(labels.Set(pod.Labels)) {
-			ips = append(ips, pod.Status.PodIP)
-		}
+
+	pods, err := np.node.kubeInformers.Core().InternalVersion().Pods().Lister().Pods(npns.name).List(sel)
+	if err != nil {
+		// Shouldn't happen
+		utilruntime.HandleError(fmt.Errorf("Could not find matching pods in namespace %q: %v", npns.name, err))
+		return ips
+	}
+	for _, pod := range pods {
+		ips = append(ips, pod.Status.PodIP)
 	}
 	return ips
 }
@@ -597,7 +599,7 @@ func (np *networkPolicyPlugin) watchPods() {
 	np.node.kubeInformers.Core().InternalVersion().Pods().Informer().AddEventHandler(funcs)
 }
 
-func (np *networkPolicyPlugin) handleAddOrUpdatePod(obj, _ interface{}, eventType watch.EventType) {
+func (np *networkPolicyPlugin) handleAddOrUpdatePod(obj, old interface{}, eventType watch.EventType) {
 	pod := obj.(*kapi.Pod)
 	glog.V(5).Infof("Watch %s event for Pod %q", eventType, getPodFullName(pod))
 
@@ -610,18 +612,16 @@ func (np *networkPolicyPlugin) handleAddOrUpdatePod(obj, _ interface{}, eventTyp
 		return
 	}
 
-	// We don't want to grab np.Lock for every Pod.Status change...
-	// But it's safe to look up oldPod without locking here because no other
-	// threads modify this map.
-	oldPod, podExisted := np.pods[pod.UID]
-	if podExisted && oldPod.Status.PodIP == pod.Status.PodIP && reflect.DeepEqual(oldPod.Labels, pod.Labels) {
-		return
+	if old != nil {
+		oldPod := old.(*kapi.Pod)
+		if oldPod.Status.PodIP == pod.Status.PodIP && reflect.DeepEqual(oldPod.Labels, pod.Labels) {
+			return
+		}
 	}
 
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	np.pods[pod.UID] = *pod
 	np.refreshNetworkPolicies(refreshForPods)
 }
 
@@ -629,15 +629,9 @@ func (np *networkPolicyPlugin) handleDeletePod(obj interface{}) {
 	pod := obj.(*kapi.Pod)
 	glog.V(5).Infof("Watch %s event for Pod %q", watch.Deleted, getPodFullName(pod))
 
-	_, podExisted := np.pods[pod.UID]
-	if !podExisted {
-		return
-	}
-
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	delete(np.pods, pod.UID)
 	np.refreshNetworkPolicies(refreshForPods)
 }
 

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -33,7 +33,6 @@ func newTestNPP() *networkPolicyPlugin {
 
 		namespaces:       make(map[uint32]*npNamespace),
 		namespacesByName: make(map[string]*npNamespace),
-		pods:             make(map[ktypes.UID]kapi.Pod),
 		nsMatchCache:     make(map[string]*npCacheEntry),
 	}
 	np.vnids = newNodeVNIDMap(np, nil)


### PR DESCRIPTION
Backport network policy performance changes from 4.x, adapting the code to 3.11

https://github.com/openshift/origin/pull/26247#discussion_r654645326

> In 4.x we dropped np.pods since the informer already has its own cache (openshift/sdn@4bac7c7 + openshift/sdn@eaf68af) but that also required rewriting the unit tests to use a fake kubeclient (openshift/sdn@2e60296) and I'm not sure how much divergence there's been since 3.11 so that might be too much to backport...
