### PR TITLE
Backport s2i MA images

### DIFF
--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -51,4 +51,5 @@ k8s.gcr.io/sig-storage/livenessprobe:v1.1.0 quay.io/openshift/community-e2e-imag
 k8s.gcr.io/sig-storage/mock-driver:v4.0.2 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-mock-driver-v4-0-2-GE9vfPm7mdvjzZh_
 k8s.gcr.io/sig-storage/nfs-provisioner:v2.2.2 quay.io/openshift/community-e2e-images:e2e-22-k8s-gcr-io-sig-storage-nfs-provisioner-v2-2-2-dbgtOCwYmEGggl01
 k8s.gcr.io/sig-storage/snapshot-controller:v2.1.1 quay.io/openshift/community-e2e-images:e2e-k8s-gcr-io-sig-storage-snapshot-controller-v2-1-1-n5BM_jX2npV3RxHM
-registry.svc.ci.openshift.org/ocp/4.7:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-svc-ci-openshift-org-ocp-4-7-test-build-roots2i-ZzDWhWn0wPB9cLFM
+registry.ci.openshift.org/ocp/4.7:test-build-roots2i quay.io/openshift/community-e2e-images:e2e-registry-ci-openshift-org-ocp-4-8-test-build-roots2i-FmW7zebvtGKkls4B
+registry.ci.openshift.org/ocp/4.7:test-build-simples2i quay.io/openshift/community-e2e-images:e2e-registry-ci-openshift-org-ocp-4-8-test-build-simples2i-7A9bkBd9X4G-ELh0


### PR DESCRIPTION
PR to backport MA s2i images in origin #26149 to 4.7 to increase CI test coverage on Z and P.
related discussion - https://coreos.slack.com/archives/C017UFPQA4X/p1624482467132100?thread_ts=1624460396.127600&cid=C017UFPQA4X