### PR TITLE
jenkins: do not pull templates from master

### DIFF
--- a/test/extended/builds/pipeline_origin_bld_rhelimagesonly.go
+++ b/test/extended/builds/pipeline_origin_bld_rhelimagesonly.go
@@ -165,7 +165,7 @@ var _ = g.Describe("[sig-devex][Feature:JenkinsRHELImagesOnly][Slow] openshift p
 
 				g.By("should build and complete successfully", func() {
 					g.By("create pipeline strategy build using nodejs agent and client plugin")
-					err := oc.Run("create").Args("-f", "https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/pipeline/nodejs-sample-pipeline.yaml").Execute()
+					err := oc.Run("create").Args("-f", "https://raw.githubusercontent.com/openshift/origin/release-4.8/examples/jenkins/pipeline/nodejs-sample-pipeline.yaml").Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())
 
 					g.By("starting the pipeline build and waiting for it to complete")

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -47974,7 +47974,7 @@ objects:
                           // Output the url of the currently selected cluster
                           echo "Using project ${openshift.project()} in cluster with url ${openshift.cluster()}"
 
-                          template = openshift.create('https://raw.githubusercontent.com/openshift/origin/master/test/extended/testdata/multi-namespace-template.yaml').object()
+                          template = openshift.create('https://raw.githubusercontent.com/openshift/origin/release-4.8/test/extended/testdata/multi-namespace-template.yaml').object()
 
                           // Explore the Groovy object which models the OpenShift template as a Map
                           echo "Template contains ${template.parameters.size()} parameters"

--- a/test/extended/testdata/multi-namespace-pipeline.yaml
+++ b/test/extended/testdata/multi-namespace-pipeline.yaml
@@ -48,7 +48,7 @@ objects:
                           // Output the url of the currently selected cluster
                           echo "Using project ${openshift.project()} in cluster with url ${openshift.cluster()}"
 
-                          template = openshift.create('https://raw.githubusercontent.com/openshift/origin/master/test/extended/testdata/multi-namespace-template.yaml').object()
+                          template = openshift.create('https://raw.githubusercontent.com/openshift/origin/release-4.8/test/extended/testdata/multi-namespace-template.yaml').object()
 
                           // Explore the Groovy object which models the OpenShift template as a Map
                           echo "Template contains ${template.parameters.size()} parameters"


### PR DESCRIPTION
Changes from development in master should not be pulled automatically
into stable branches.

/cc @gabemontero @akram 