### PR TITLE
clusterup.sh lacks creds in CI

### DIFF
--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -61,7 +61,9 @@ function os::test::extended::clusterup::verify_router_and_registry () {
 }
 
 function os::test::extended::clusterup::verify_image_streams () {
-    os::cmd::try_until_text "oc get is -n openshift ruby -o jsonpath='{ .status.tags[*].tag }'" "latest" $(( 10*minute )) 1
+    os::cmd::expect_success "oc login -u system:admin"
+    os::cmd::expect_success "oc import-image -n openshift ruby:2.0"
+    os::cmd::try_until_text "oc get is -n openshift ruby -o jsonpath='{ .status.tags[*].tag }'" "2.0" $(( 10*minute )) 1
 }
 
 function os::test::extended::clusterup::verify_ruby_build () {

--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -39,6 +39,7 @@ function os::test::extended::clusterup::run_test () {
 
     local test_home="${ARTIFACT_DIR}/${test}/home"
     mkdir -p "${test_home}"
+    [ -d "${global_home}/.docker" ] && cp -r ${global_home}/.docker ${test_home}
     export HOME="${test_home}"
     pushd "${HOME}" &> /dev/null
     os::log::info "Using ${HOME} as home directory"


### PR DESCRIPTION
Normally 'oc cluster up' looks in $HOME/.docker/config and wires that up
for imagestream imports.  That isn't happening in the clusterup.sh test
since it does clever things with $HOME.