### PR TITLE
builds: comment out RHEL-only sample-pipeline template test

### DIFF
--- a/test/extended/builds/pipeline_origin_bld_rhelimagesonly.go
+++ b/test/extended/builds/pipeline_origin_bld_rhelimagesonly.go
@@ -161,6 +161,7 @@ var _ = g.Describe("[sig-devex][Feature:JenkinsRHELImagesOnly][Slow] openshift p
 				// In general, while we want at least one verification somewhere in pipeline.go that the agent
 				// images work, we should minimize the actually running of pipelines using them to only one
 				// for each maven/nodejs
+				/* to be moved to jenkins client plugin e2e
 				g.By("Pipeline using nodejs agent and client plugin")
 
 				g.By("should build and complete successfully", func() {
@@ -194,6 +195,7 @@ var _ = g.Describe("[sig-devex][Feature:JenkinsRHELImagesOnly][Slow] openshift p
 					o.Expect(err).NotTo(o.HaveOccurred())
 
 				})
+				*/
 
 				g.By("Pipeline with env vars")
 


### PR DESCRIPTION
This test relies on pulling yaml from github rather than from bindata,
which makes it difficult to pre-commit testing of changes which affect
it.  @akram and @gabemontero will move this to the jenkins client plugin
E2E, but in the meantime, we comment it out.

https://github.com/openshift/origin/pull/26072#issuecomment-862307401

/cc @gabemontero
