### PR TITLE
Bug 1977383: [release-4.7] Skip cluster quota test to enable service ca publisher to merge to o/k

### DIFF
--- a/test/extended/quota/clusterquota.go
+++ b/test/extended/quota/clusterquota.go
@@ -29,6 +29,10 @@ var _ = g.Describe("[sig-api-machinery][Feature:ClusterResourceQuota]", func() {
 
 	g.Describe("Cluster resource quota", func() {
 		g.It(fmt.Sprintf("should control resource limits across namespaces"), func() {
+			// This skip can be removed once https://github.com/openshift/kubernetes/pull/834 and
+			// the test is updated to reflect the addition of a service ca configmap to every namespace.
+			g.Skip("Skipping to allow service ca configmap publication to merge to o/k")
+
 			t := g.GinkgoT(1)
 
 			versionInfo, err := oc.KubeClient().Discovery().ServerVersion()


### PR DESCRIPTION
This skip is intended to allow openshift/kubernetes#834 to merge without breaking CI for everyone. A follow-on PR will re-enable the test once it has been updated to account for the new service ca configmap being created in every namespace.

/cc @s-urbaniak @stlaz @sttts @soltysh 