### PR TITLE
Bug 1977454: Use nodejs to test service connection

### DIFF
--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -56,11 +56,10 @@ func init() {
 
 		// allowed upstream kube images - index and value must match upstream or
 		// tests will fail (vendor/k8s.io/kubernetes/test/utils/image/manifest.go)
-		"k8s.gcr.io/e2e-test-images/agnhost:2.32":       1,
-		"k8s.gcr.io/e2e-test-images/busybox:1.29-1":     7,
-		"k8s.gcr.io/e2e-test-images/nginx:1.14-1":       23,
-		"k8s.gcr.io/e2e-test-images/nginx:1.15-1":       24,
-		"k8s.gcr.io/e2e-test-images/redis:5.0.5-alpine": 34,
+		"k8s.gcr.io/e2e-test-images/agnhost:2.32":   1,
+		"k8s.gcr.io/e2e-test-images/busybox:1.29-1": 7,
+		"k8s.gcr.io/e2e-test-images/nginx:1.14-1":   23,
+		"k8s.gcr.io/e2e-test-images/nginx:1.15-1":   24,
 	}
 
 	images = GetMappedImages(allowedImages, os.Getenv("KUBE_TEST_REPO"))


### PR DESCRIPTION
Redis has tighter constraints on client HTTP calls to prevent malicious
attacks. Only official redis clients are guaranteed to receive reliable
HTTP responses. The build test for in-cluster service connections does
not use a redis client, resulting in a test HTTP curl request receiving an
empty repsonse.

This updates the in-cluster service test to use a "hello world" nodejs
application and service. The use of the upstream Redis image is also
removed.