### PR TITLE
Bug 1978338: Skip Prometheus upgrade test if persistance storage is not enabled

### DIFF
--- a/test/extended/prometheus/upgrade.go
+++ b/test/extended/prometheus/upgrade.go
@@ -7,7 +7,10 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 	helper "github.com/openshift/origin/test/extended/util/prometheus"
 	"github.com/prometheus/common/model"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
@@ -15,7 +18,8 @@ import (
 // MetricsAvailableAfterUpgradeTest tests that metrics from before an upgrade
 // are also available after the upgrade.
 type MetricsAvailableAfterUpgradeTest struct {
-	executionTimestamp model.Time
+	executionTimestamp      model.Time
+	persistentVolumeEnabled bool
 }
 
 func (t *MetricsAvailableAfterUpgradeTest) Name() string {
@@ -68,10 +72,41 @@ func (t *MetricsAvailableAfterUpgradeTest) Test(f *e2e.Framework, done <-chan st
 	g.By("verifying that the timeseries is queryable at the same timestamp after the upgrade")
 	postUpgradeQuery := `prometheus_build_info{pod="prometheus-k8s-0"}`
 	postUpgradeResponse, err := helper.RunQueryAtTime(postUpgradeQuery, ns, execPod.Name, queryUrl, bearerToken, t.executionTimestamp)
+
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(postUpgradeResponse.Data.Result).NotTo(o.BeEmpty())
 }
 
 func (t MetricsAvailableAfterUpgradeTest) Teardown(f *e2e.Framework) {
 	return
+}
+
+func (t *MetricsAvailableAfterUpgradeTest) Skip(_ upgrades.UpgradeContext) bool {
+	cfg, err := exutil.GetClientConfig(exutil.KubeConfigPath())
+	if err != nil {
+		return false
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return false
+	}
+
+	return !isPersistentStorageEnabled(client)
+}
+
+func isPersistentStorageEnabled(kubeClient kubernetes.Interface) bool {
+	cmClient := kubeClient.CoreV1().ConfigMaps("openshift-monitoring")
+	config, err := cmClient.Get(context.TODO(), "cluster-monitoring-config", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return false
+	}
+
+	var configData map[string]map[string]interface{}
+	err = yaml.Unmarshal([]byte(config.Data["config.yaml"]), &configData)
+	if err != nil {
+		return false
+	}
+
+	_, found := configData["prometheusK8s"]["volumeClaimTemplate"]
+	return found
 }

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -511,7 +511,7 @@ func (c *CLI) AdminDynamicClient() dynamic.Interface {
 }
 
 func (c *CLI) UserConfig() *rest.Config {
-	clientConfig, err := getClientConfig(c.configPath)
+	clientConfig, err := GetClientConfig(c.configPath)
 	if err != nil {
 		FatalErr(err)
 	}
@@ -519,7 +519,7 @@ func (c *CLI) UserConfig() *rest.Config {
 }
 
 func (c *CLI) AdminConfig() *rest.Config {
-	clientConfig, err := getClientConfig(c.adminConfigPath)
+	clientConfig, err := GetClientConfig(c.adminConfigPath)
 	if err != nil {
 		FatalErr(err)
 	}
@@ -813,7 +813,7 @@ func waitForAccess(c kubernetes.Interface, allowed bool, review *kubeauthorizati
 	})
 }
 
-func getClientConfig(kubeConfigFile string) (*rest.Config, error) {
+func GetClientConfig(kubeConfigFile string) (*rest.Config, error) {
 	kubeConfigBytes, err := ioutil.ReadFile(kubeConfigFile)
 	if err != nil {
 		return nil, err

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -216,7 +216,7 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 
 	// Add anyuid and privileged permissions for upstream tests
 	if strings.HasPrefix(baseName, "e2e-k8s-") || (isKubernetesE2ETest() && !skipTestNamespaceCustomization()) {
-		clientConfig, err := getClientConfig(KubeConfigPath())
+		clientConfig, err := GetClientConfig(KubeConfigPath())
 		if err != nil {
 			return ns, err
 		}


### PR DESCRIPTION
Some platforms, like the metal-ipi, have no persistent storage enabled
in the CI. In this case, we should skip the Prometheus upgrade test
since there is no way to preserve metrics across upgrades.
