### PR TITLE
Bug 1980338: test/cmd/newapp: update app name to match existing tag

### DIFF
--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -15,6 +15,13 @@ function os::build::environment::create() {
   workingdir=$( os::build::environment::release::workingdir )
   additional_context+=" -w ${workingdir}"
 
+  if [[ -d "${HOME}/.docker" ]]; then
+    os::log::debug "Mounting docker credentials"
+    additional_context+=" -v ${HOME}/.docker:/root/.docker"
+  else
+    os::log::debug "No docker credentials found"
+  fi
+
   if [[ "${OS_BUILD_ENV_USE_DOCKER:-y}" == "y" ]]; then
     additional_context+=" --privileged -v /var/run/docker.sock:/var/run/docker.sock"
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -34,6 +34,30 @@ function find_tests() {
 }
 tests=( $(find_tests ${1:-.*}) )
 
+# install_image_pull_secret will look for ~/docker/config.json and create an image pull secret.  If no suitable credentials are found a warning will be displayed.  It assumes a running server.
+#
+# Globals:
+#  - ADMIN_KUBECONFIG
+#  - REAL_HOME
+# Arguments:
+#  -  namespace (optional)
+# Returns:
+#  None
+function install_image_pull_secret() {
+	local ns="${1:-}"
+	local dockerconfig="${REAL_HOME}/.docker/config.json"
+
+	if [[ -f $dockerconfig ]]; then
+		os::log::debug "Installing imagestreamsecret..."
+		oc create secret generic imagestreamsecret --dry-run -o yaml --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=${dockerconfig} -n ${ns} --config=$ADMIN_KUBECONFIG >& /tmp/secret.yaml
+		oc apply -f /tmp/secret.yaml -n ${ns} --config=$ADMIN_KUBECONFIG
+	else
+		os::log::debug "No docker credentials found.  Image pull secret will not be installed."
+	fi
+}
+readonly -f install_image_pull_secret
+
+
 # deconflict ports so we can run in parallel with other test suites
 export API_PORT=${API_PORT:-28443}
 export ETCD_PORT=${ETCD_PORT:-24001}
@@ -66,6 +90,7 @@ os::start::master
 
 os::start::registry
 
+export REAL_HOME=$HOME
 export HOME="${FAKE_HOME_DIR}"
 mkdir -p "${HOME}/.kube"
 cp "${MASTER_CONFIG_DIR}/admin.kubeconfig" "${HOME}/.kube/non-default-config"
@@ -87,6 +112,7 @@ for test in "${tests[@]}"; do
   os::cmd::expect_success "oc login --server='${KUBERNETES_MASTER}' --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything"
   os::cmd::expect_success "oc project ${CLUSTER_ADMIN_CONTEXT}"
   os::cmd::expect_success "oc new-project '${namespace}'"
+  install_image_pull_secret "${namespace}"
   # wait for the project cache to catch up and correctly list us in the new project
   os::cmd::try_until_text "oc get projects -o name" "project.project.openshift.io/${namespace}"
   os::test::junit::declare_suite_end

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -32,9 +32,9 @@ os::cmd::try_until_success 'oc get istag php-73:latest -n test-imagestreams'
 os::cmd::expect_success 'oc create istag php-73:latest --from=openshift/php:7.3 -n openshift'
 
 # create a new tag for an existing imagestream in the current namespace
-os::cmd::expect_success 'oc create istag perl:5.20 --from=openshift/perl:5.20'
-os::cmd::expect_success 'oc new-app --docker-image=library/perl https://github.com/sclorg/dancer-ex --strategy=source'
-os::cmd::try_until_success 'oc get istag perl:latest -n test-imagestreams'
+os::cmd::expect_success 'oc create istag perl:5.26 --from=openshift/perl:5.26'
+os::cmd::expect_success 'oc new-app --docker-image=registry.access.redhat.com/ubi8/perl-530  https://github.com/sclorg/dancer-ex --strategy=source'
+os::cmd::try_until_success 'oc get istag perl:5.26 -n test-imagestreams'
 
 # remove redundant imagestream tag before creating objects
 os::cmd::expect_success_and_text 'oc new-app registry.access.redhat.com/ubi8/ruby-27 https://github.com/openshift/ruby-hello-world  --strategy=docker --loglevel=5' 'Removing duplicate tag from object list'

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -27,9 +27,9 @@ os::cmd::try_until_failure 'oc get istag php:latest -n openshift'
 os::cmd::expect_failure 'oc new-app --image-stream=openshift/php https://github.com/sclorg/cakephp-ex'
 
 # should succeed and create the php:latest tag in the current namespace
-os::cmd::expect_success 'oc new-app --docker-image=library/php https://github.com/sclorg/cakephp-ex --strategy=source'
-os::cmd::try_until_success 'oc get istag php:latest -n test-imagestreams'
-os::cmd::expect_success 'oc create istag php:latest --from=openshift/php:7.1 -n openshift'
+os::cmd::expect_success 'oc new-app --docker-image=registry.access.redhat.com/ubi7/php-73 https://github.com/sclorg/cakephp-ex --strategy=source --name=php'
+os::cmd::try_until_success 'oc get istag php-73:latest -n test-imagestreams'
+os::cmd::expect_success 'oc create istag php-73:latest --from=openshift/php:7.3 -n openshift'
 
 # create a new tag for an existing imagestream in the current namespace
 os::cmd::expect_success 'oc create istag perl:5.20 --from=openshift/perl:5.20'

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -37,7 +37,7 @@ os::cmd::expect_success 'oc new-app --docker-image=library/perl https://github.c
 os::cmd::try_until_success 'oc get istag perl:latest -n test-imagestreams'
 
 # remove redundant imagestream tag before creating objects
-os::cmd::expect_success_and_text 'oc new-app centos/ruby-27-centos7 https://github.com/openshift/ruby-hello-world  --strategy=docker --loglevel=5' 'Removing duplicate tag from object list'
+os::cmd::expect_success_and_text 'oc new-app registry.access.redhat.com/ubi8/ruby-27 https://github.com/openshift/ruby-hello-world  --strategy=docker --loglevel=5' 'Removing duplicate tag from object list'
 
 # create imagestream in the correct namespace
 os::cmd::expect_success 'oc new-app --name=mytest --image-stream=mysql --env=MYSQL_USER=test --env=MYSQL_PASSWORD=redhat --env=MYSQL_DATABASE=testdb -l app=mytest'
@@ -507,7 +507,7 @@ os::cmd::expect_success_and_text 'oc new-build mysql https://github.com/openshif
 os::cmd::expect_failure_and_text 'oc new-build mysql https://github.com/openshift/ruby-hello-world --binary' 'specifying binary builds and source repositories at the same time is not allowed'
 # binary builds cannot be created unless a builder image is specified.
 os::cmd::expect_failure_and_text 'oc new-build --name mybuild --binary --strategy=source -o yaml' 'you must provide a builder image when using the source strategy with a binary build'
-os::cmd::expect_success_and_text 'oc new-build --name mybuild centos/ruby-27-centos7 --binary --strategy=source -o yaml' 'name: ruby-27-centos7:latest'
+os::cmd::expect_success_and_text 'oc new-build --name mybuild registry.access.redhat.com/ubi8/ruby-27 --binary --strategy=source -o yaml' 'name: ruby-27:latest'
 # binary builds can be created with no builder image if no strategy or docker strategy is specified
 os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary -o yaml' 'type: Binary'
 os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary --strategy=docker -o yaml' 'type: Binary'
@@ -591,7 +591,7 @@ os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest --code https://git
 os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest --code ./test/testdata/testapp --dry-run'
 
 os::cmd::expect_success 'oc new-app --code ./test/testdata/testapp --name test'
-os::cmd::expect_success_and_text 'oc get bc test --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27-centos7:latest'
+os::cmd::expect_success_and_text 'oc get bc test --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27:latest'
 
 os::cmd::expect_success 'oc new-app -i php-55-centos7:latest --code ./test/testdata/testapp --name test2'
 os::cmd::expect_success_and_text 'oc get bc test2 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
@@ -609,7 +609,7 @@ os::cmd::expect_success 'oc new-app php-55-centos7:latest --code https://github.
 os::cmd::expect_success_and_text 'oc get bc test6 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
 
 os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-world.git --name test7'
-os::cmd::expect_success_and_text 'oc get bc test7 --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27-centos7:latest'
+os::cmd::expect_success_and_text 'oc get bc test7 --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27:latest'
 
 os::cmd::expect_success 'oc new-app php-55-centos7:latest https://github.com/openshift/ruby-hello-world.git --name test8'
 os::cmd::expect_success_and_text 'oc get bc test8 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'

--- a/test/cmd/printer.sh
+++ b/test/cmd/printer.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 # Test that resource printer includes resource kind on multiple resources
 os::test::junit::declare_suite_start "cmd/basicresources/printer"
 os::cmd::expect_success 'oc create imagestream test1'
-os::cmd::expect_success 'oc new-app node'
+os::cmd::expect_success 'oc new-app php'
 os::cmd::expect_success_and_text 'oc get all' 'imagestream.image.openshift.io/test1'
 os::cmd::expect_success_and_not_text 'oc get is' 'imagestream.image.openshift.io/test1'
 
@@ -15,10 +15,10 @@ os::cmd::expect_success_and_text 'oc new-app ruby-helloworld-sample' 'deployment
 os::cmd::expect_success_and_text 'oc get all --all-namespaces' 'cmd-printer[\ ]+buildconfig.build.openshift.io\/ruby\-sample\-build'
 
 # Test that infos printer supports all outputFormat options
-os::cmd::expect_success_and_text 'oc new-app node -o yaml | oc set env -f - MYVAR=value' 'deploymentconfig.apps.openshift.io/node updated'
+os::cmd::expect_success_and_text 'oc new-app php -o yaml | oc set env -f - MYVAR=value' 'deploymentconfig.apps.openshift.io/php updated'
 # FIXME: what to do with this?
-# os::cmd::expect_success 'oc new-app node -o yaml | oc set env -f - MYVAR=value -o custom-colums="NAME:.metadata.name"'
-os::cmd::expect_success_and_text 'oc new-app node -o yaml | oc set env -f - MYVAR=value -o yaml' 'apiVersion: apps.openshift.io/v1'
-os::cmd::expect_success_and_text 'oc new-app node -o yaml | oc set env -f - MYVAR=value -o json' '"apiVersion": "apps.openshift.io/v1"'
+# os::cmd::expect_success 'oc new-app php -o yaml | oc set env -f - MYVAR=value -o custom-colums="NAME:.metadata.name"'
+os::cmd::expect_success_and_text 'oc new-app php -o yaml | oc set env -f - MYVAR=value -o yaml' 'apiVersion: apps.openshift.io/v1'
+os::cmd::expect_success_and_text 'oc new-app php -o yaml | oc set env -f - MYVAR=value -o json' '"apiVersion": "apps.openshift.io/v1"'
 echo "resource printer: ok"
 os::test::junit::declare_suite_end

--- a/test/cmd/set-image.sh
+++ b/test/cmd/set-image.sh
@@ -14,7 +14,7 @@ os::test::junit::declare_suite_start "cmd/oc/set/image"
 os::cmd::expect_success 'oc create -f test/integration/testdata/test-deployment-config.yaml'
 os::cmd::expect_success 'oc create -f examples/hello-openshift/hello-pod.json'
 os::cmd::expect_success 'oc create -f examples/image-streams/image-streams-centos7.json'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.5'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
 
 # test --local flag

--- a/test/cmd/timeout.sh
+++ b/test/cmd/timeout.sh
@@ -12,7 +12,7 @@ trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/request-timeout"
 # This test validates the global request-timeout option
-os::cmd::expect_success_and_text 'oc new-app node' 'Success'
+os::cmd::expect_success_and_text 'oc new-app --name node --docker-image=registry.access.redhat.com/ubi8/nodejs-12' 'Success'
 os::cmd::expect_success_and_text 'oc get dc node -w --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 os::cmd::expect_success_and_text 'oc get dc node --request-timeout=1s' 'node'
 os::cmd::expect_success_and_text 'oc get dc node --request-timeout=1' 'node'

--- a/test/cmd/triggers.sh
+++ b/test/cmd/triggers.sh
@@ -16,7 +16,7 @@ project="$(oc project -q)"
 os::test::junit::declare_suite_start "cmd/triggers"
 # This test validates triggers
 
-os::cmd::expect_success 'oc new-app centos/ruby-27-centos7~https://github.com/openshift/ruby-hello-world.git'
+os::cmd::expect_success 'oc new-app registry.access.redhat.com/ubi7/ruby-27~https://github.com/openshift/ruby-hello-world.git'
 os::cmd::expect_success 'oc get bc/ruby-hello-world'
 os::cmd::expect_success 'oc get dc/ruby-hello-world'
 
@@ -30,7 +30,7 @@ os::cmd::expect_failure_and_text 'oc set triggers bc/ruby-hello-world --remove -
 os::cmd::expect_failure_and_text 'oc set triggers bc/ruby-hello-world --auto --manual' 'at most one of --auto or --manual'
 # print
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'config.*true'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:latest.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27:latest.*true'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'webhook'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'github'
 # note, oc new-app currently does not set up gitlab or bitbucket webhooks by default
@@ -47,7 +47,7 @@ os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --remove-a
 
 os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'webhook|github'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'config.*false'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:latest.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27:latest.*false'
 # set github hook
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-github' 'updated'
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'github'
@@ -74,18 +74,18 @@ os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'bitbucke
 os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --remove --from-bitbucket' 'updated'
 os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'bitbucket'
 # set from-image
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27:other' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27:other.*true'
 # manual and remove both clear build configs
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other --manual' 'updated'
-os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other.*false'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27-centos7:other --remove' 'updated'
-os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27-centos7:other'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27:other --manual' 'updated'
+os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27:other.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27:other' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers bc/ruby-hello-world --from-image=ruby-27:other --remove' 'updated'
+os::cmd::expect_success_and_not_text 'oc set triggers bc/ruby-hello-world' 'image.*ruby-27:other'
 # test --all
-os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-27-centos7:latest.*false'
+os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-27:latest.*false'
 os::cmd::expect_success_and_text 'oc set triggers bc --all --auto' 'updated'
-os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-27-centos7:latest.*true'
+os::cmd::expect_success_and_text 'oc set triggers bc --all' 'buildconfigs/ruby-hello-world.*image.*ruby-27:latest.*true'
 # set a trigger on a build that doesn't have an imagestream strategy.from-image
 os::cmd::expect_success_and_text 'oc set triggers bc/scratch --from-image=test:latest' 'updated'
 


### PR DESCRIPTION
Fixes several `test/cmd` entries to match the current state of imagestreams.
Includes #26292 to have Dockerhub pullsecret placed, so that import would not hit rate limits