### PR TITLE
Allow HighlyAvailableWorkloadIncorrectlySpread alert to fire

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -96,6 +96,16 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 				return framework.ProviderIs("gce")
 			},
 		},
+		{
+			// Should be removed one release after the attached bugzilla is fixed.
+			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
+		},
+		{
+			// Should be removed one release after the attached bugzilla is fixed.
+			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
+		},
 	}
 
 	pendingAlertsWithBugs := helper.MetricConditions{

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -85,6 +85,14 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 					return framework.ProviderIs("gce")
 				},
 			},
+			{
+				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
+				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
+			},
+			{
+				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
+				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
+			},
 		}
 		allowedFiringAlerts := helper.MetricConditions{
 			{


### PR DESCRIPTION
Allow the HighlyAvailableWorkloadIncorrectlySpread alert to fire until
we can safely enable hard anti-affinity on hostname to workload with
persistent storage, without breaking customers. The timeline for that
should be 4.9. Note that for upgrade tests, we will need to wait one
more release to remove the alert from the allow list since we will
need both the source version and the target to have hard anti-affinity
enabled to prevent the alert from firing.

I linked the alert scoped to prometheus-k8s to [bug 1929262](https://bugzilla.redhat.com/show_bug.cgi?id=1949262) and the 
one scoped to alertmanager-main to [bug 1955489](https://bugzilla.redhat.com/show_bug.cgi?id=1955489). These bugzillas 
track the effort of adding hard anti-affinity constraints to these
components.