### PR TITLE
WIP: Recover from panics in ClusterUpgrade test

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -131,6 +131,7 @@ func SetUpgradeAbortAt(policy string) error {
 }
 
 var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
+	defer g.GinkgoRecover()
 	f := framework.NewDefaultFramework("cluster-upgrade")
 	f.SkipNamespaceCreation = true
 	f.SkipPrivilegedPSPBinding = true

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -316,6 +316,7 @@ func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Dur
 	duration := events.Duration(0)
 	describe := events.Strings()
 	if percent := float64(duration) / float64(total); percent > tolerate {
+		defer g.GinkgoRecover()
 		framework.Failf("%s for at least %s of %s (%0.0f%%):\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
 	} else if duration > 0 {
 		FrameworkFlakef(f, "%s for at least %s of %s (%0.0f%%), this is currently sufficient to pass the test/job but not considered completely correct:\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))


### PR DESCRIPTION
Whenever there is a failure in the cluster upgrade test suite, the framework panics with the message:
```
Ginkgo panics to prevent subsequent assertions from running.
Normally Ginkgo rescues this panic so you shouldn't see it.
But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
To circumvent this, you should call
	defer GinkgoRecover()
```

This PR adds `GinkgoRecover()` to the cluster upgrade test to help Ginkgo recover from the panic and output a clean failure log message.