### PR TITLE
Bug 1978717: Add BareMetalPlatformType into e2e upgrade service unsupported list

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -49,7 +49,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	// ovirt does not support service type loadbalancer because it doesn't program a cloud.
-	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.LibvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType {
+	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.LibvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType || infra.Status.PlatformStatus.Type == configv1.BareMetalPlatformType {
 		t.unsupportedPlatform = true
 	}
 	if t.unsupportedPlatform {


### PR DESCRIPTION
4.5 -> 4.6 upgrade jobs are perma failing: https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.6-upgrade-from-stable-4.5-e2e-metal-ipi-upgrade

Among the failures the test: `: [sig-arch][Feature:ClusterUpgrade] Cluster should remain functional during upgrade [Disruptive] [Serial]` and `[sig-network-edge] Application behind service load balancer with PDB is not disrupted` are perma failing. 

These test are failing because they need to create load balancer type services on bare metal - it should not even try, since that can't work, ex: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.6-upgrade-from-stable-4.5-e2e-metal-ipi-upgrade/1410709653960003584/build-log.txt

/assign @dhellmann 