### PR TITLE
Create a new serial test suite with tests assuming high-availability removed

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -91,6 +91,24 @@ var staticSuites = testSuites{
 	},
 	{
 		TestSuite: ginkgo.TestSuite{
+			Name: "openshift/conformance/serial-non-highly-available",
+			Description: templates.LongDesc(`
+		Same as openshift/conformance/serial, but with tests that assume high-availability removed, for Single Node Openshift.
+		`),
+			Matches: func(name string) bool {
+				if isDisabled(name) {
+					return false
+				}
+                isSerial := strings.Contains(name, "[Suite:openshift/conformance/serial")
+                isAssumingHa := strings.Contains(name, "[Skipped:NonHighlyAvailable]")
+                return (isSerial && !isAssumingHa) || isStandardEarlyOrLateTest(name)
+			},
+			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.StableSystemEventInvariants),
+		},
+		PreSuite: suiteWithProviderPreSuite,
+	},
+	{
+		TestSuite: ginkgo.TestSuite{
 			Name: "openshift/disruptive",
 			Description: templates.LongDesc(`
 		The disruptive test suite.

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2363,17 +2363,17 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] Mount propagation should propagate mounts to the host": "should propagate mounts to the host [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds [Disruptive] [Conformance]": "evicts pods with minTolerationSeconds [Disruptive] [Conformance] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds [Disruptive] [Conformance]": "evicts pods with minTolerationSeconds [Disruptive] [Conformance] [Skipped:NonHighlyAvailable] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] only evicts pods without tolerations from tainted nodes": "only evicts pods without tolerations from tainted nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] only evicts pods without tolerations from tainted nodes": "only evicts pods without tolerations from tainted nodes [Skipped:NonHighlyAvailable] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] doesn't evict pod with tolerations from tainted nodes": "doesn't evict pod with tolerations from tainted nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] doesn't evict pod with tolerations from tainted nodes": "doesn't evict pod with tolerations from tainted nodes [Skipped:NonHighlyAvailable] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] eventually evict pod with finite tolerations from tainted nodes": "eventually evict pod with finite tolerations from tainted nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] eventually evict pod with finite tolerations from tainted nodes": "eventually evict pod with finite tolerations from tainted nodes [Skipped:NonHighlyAvailable] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] evicts pods from tainted nodes": "evicts pods from tainted nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] evicts pods from tainted nodes": "evicts pods from tainted nodes [Skipped:NonHighlyAvailable] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] removing taint cancels eviction [Disruptive] [Conformance]": "removing taint cancels eviction [Disruptive] [Conformance] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] removing taint cancels eviction [Disruptive] [Conformance]": "removing taint cancels eviction [Disruptive] [Conformance] [Skipped:NonHighlyAvailable] [Suite:k8s]",
 
 	"[Top Level] [sig-node] NodeLease when the NodeLease feature is enabled should have OwnerReferences set": "should have OwnerReferences set [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -240,6 +240,10 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1825027
 			`\[Feature:Platform\] Managed cluster should ensure control plane operators do not make themselves unevictable`,
 		},
+		"[Skipped:NonHighlyAvailable]": {
+			`\[sig-node\] NoExecuteTaintManager Single Pod`,
+			`\[sig-node\] NoExecuteTaintManager Multiple Pods`,
+		},
 	}
 
 	// labelExcludes temporarily block tests out of a specific suite


### PR DESCRIPTION
While running the serial test suite on single-node openshift clusters, some tests
add taints to the node, causing disruptions to tests that come after them. This commit
adds a new suite, duplicating the existing serial suite, but excluding the tests mentioned
above because they're not applicable in non-highly-available clusters
