### PR TITLE
on SNO, skip disruptive or multinodes tests

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -349,7 +349,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]": "should retry creating failed daemon pods [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]": "should rollback without unnecessary restarts [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]",
+	"[Top Level] [sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]": "should rollback without unnecessary restarts [Conformance] [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]": "should run and stop complex daemon [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]",
 
@@ -1217,7 +1217,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] Kubectl client Kubectl server-side dry-run should check if kubectl can dry-run update Pods [Conformance]": "should check if kubectl can dry-run update Pods [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-cli] Kubectl client Kubectl taint [Serial] should remove all the taints with the same key off a node": "should remove all the taints with the same key off a node [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-cli] Kubectl client Kubectl taint [Serial] should remove all the taints with the same key off a node": "should remove all the taints with the same key off a node [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
 	"[Top Level] [sig-cli] Kubectl client Kubectl taint [Serial] should update the taint on a node": "should update the taint on a node [Suite:openshift/conformance/serial] [Suite:k8s]",
 
@@ -2363,17 +2363,17 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] Mount propagation should propagate mounts to the host": "should propagate mounts to the host [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds [Disruptive] [Conformance]": "evicts pods with minTolerationSeconds [Disruptive] [Conformance] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds [Disruptive] [Conformance]": "evicts pods with minTolerationSeconds [Disruptive] [Conformance] [Skipped:SingleReplicaTopology] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] only evicts pods without tolerations from tainted nodes": "only evicts pods without tolerations from tainted nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] only evicts pods without tolerations from tainted nodes": "only evicts pods without tolerations from tainted nodes [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] doesn't evict pod with tolerations from tainted nodes": "doesn't evict pod with tolerations from tainted nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] doesn't evict pod with tolerations from tainted nodes": "doesn't evict pod with tolerations from tainted nodes [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] eventually evict pod with finite tolerations from tainted nodes": "eventually evict pod with finite tolerations from tainted nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] eventually evict pod with finite tolerations from tainted nodes": "eventually evict pod with finite tolerations from tainted nodes [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] evicts pods from tainted nodes": "evicts pods from tainted nodes [Suite:openshift/conformance/serial] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] evicts pods from tainted nodes": "evicts pods from tainted nodes [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] removing taint cancels eviction [Disruptive] [Conformance]": "removing taint cancels eviction [Disruptive] [Conformance] [Suite:k8s]",
+	"[Top Level] [sig-node] NoExecuteTaintManager Single Pod [Serial] removing taint cancels eviction [Disruptive] [Conformance]": "removing taint cancels eviction [Disruptive] [Conformance] [Skipped:SingleReplicaTopology] [Suite:k8s]",
 
 	"[Top Level] [sig-node] NodeLease when the NodeLease feature is enabled should have OwnerReferences set": "should have OwnerReferences set [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -74,6 +74,17 @@ var (
 		"[Skipped:ovirt]": {},
 		"[Skipped:gce]":   {},
 
+		"[Skipped:SingleReplicaTopology]": {
+			`\[sig-apps\] Daemon set \[Serial\] should rollback without unnecessary restarts \[Conformance\]`,
+			`\[sig-node\] NoExecuteTaintManager Single Pod \[Serial\] doesn't evict pod with tolerations from tainted nodes`,
+			`\[sig-node\] NoExecuteTaintManager Single Pod \[Serial\] eventually evict pod with finite tolerations from tainted nodes`,
+			`\[sig-node\] NoExecuteTaintManager Single Pod \[Serial\] evicts pods from tainted nodes`,
+			`\[sig-node\] NoExecuteTaintManager Single Pod \[Serial\] removing taint cancels eviction \[Disruptive\] \[Conformance\]`,
+			`\[sig-node\] NoExecuteTaintManager Multiple Pods \[Serial\] evicts pods with minTolerationSeconds \[Disruptive\] \[Conformance\]`,
+			`\[sig-node\] NoExecuteTaintManager Multiple Pods \[Serial\] only evicts pods without tolerations from tainted nodes`,
+			`\[sig-cli\] Kubectl client Kubectl taint \[Serial\] should remove all the taints with the same key off a node`,
+		},
+
 		// Tests that don't pass on disconnected, either due to requiring
 		// internet access for GitHub (e.g. many of the s2i builds), or
 		// because of pullthrough not supporting ICSP (https://bugzilla.redhat.com/show_bug.cgi?id=1918376)


### PR DESCRIPTION
Skipping disruptive tests on single-node clusters which are not considered as highly available.
This will mark those kind of tests with the ``[Skip:NonHighlyAvailable]`` tag, and make any run with a single-node cluster to skip tests with this tag.