### PR TITLE
Bug 1980141: Skip new `Netpol` tests for Network Stress Suite

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -317,6 +317,10 @@ var staticSuites = testSuites{
 				if isDisabled(name) {
 					return false
 				}
+				// Skip NetworkPolicy tests for https://bugzilla.redhat.com/show_bug.cgi?id=1980141
+				if strings.Contains(name, "[Feature:NetworkPolicy]") {
+					return false
+				}
 				return (strings.Contains(name, "[Suite:openshift/conformance/") && strings.Contains(name, "[sig-network]")) || isStandardEarlyOrLateTest(name)
 			},
 			Parallelism:         60,


### PR DESCRIPTION
Skip the new network policy tests that were introduced in K8s 1.21 due
to the flakiness they introduced in Openshift's Stress tests.

https://bugzilla.redhat.com/show_bug.cgi?id=1980141

Signed-off-by: astoycos <astoycos@redhat.com>