### PR TITLE
comment out broken local git, env var,  jenkins pipeline test (moving to remote repo and openshift/jenkins)

### DIFF
--- a/test/extended/builds/pipeline_jenkins_e2e.go
+++ b/test/extended/builds/pipeline_jenkins_e2e.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
 
@@ -403,7 +401,13 @@ var _ = g.Describe("[sig-devex][Feature:Jenkins][Slow] Jenkins repos e2e openshi
 					o.Expect(err).NotTo(o.HaveOccurred())
 				})
 
-				g.By("Pipeline with env vars and git repo source")
+				/* this test does not work reliably because the git repo created locally is not in the same container/pod
+				that Jenkins is running in.  It becomes a timing window of what the sync plugin updates when for BCs during
+				error scenarios.
+
+				We want to a) move the git repo / Jenkinsfile refereneced to a repo on https://github.com/openshift
+				g.By("Pipeline with env vars and git repo source"), b) include this in our initial list of tests we
+				want to move out of openshift/origin and into the openshift/jenkins* repos
 
 				g.By("should propagate env vars to bc", func() {
 					g.By(fmt.Sprintf("creating git repo %v", envVarsPipelineGitRepoBuildConfig))
@@ -435,7 +439,7 @@ var _ = g.Describe("[sig-devex][Feature:Jenkins][Slow] Jenkins repos e2e openshi
 					o.Expect(len(envs)).To(o.Equal(1))
 					o.Expect(envs[0].Name).To(o.Equal("FOO1"))
 					o.Expect(envs[0].Value).To(o.Equal("BAR1"))
-				})
+				})*/
 
 				g.By("Blue-green pipeline")
 


### PR DESCRIPTION
See https://github.com/openshift/jenkins/pull/1297 for the tl;dr

But basically, the commented out test alway fails with

```
Cloning the remote Git repository
Cloning repository /tmp/test-build-app-pipeline544874952/test-build-app-pipeline.git
 > git init /var/lib/jenkins/jobs/e2e-test-jenkins-pipeline-9bmz9/jobs/e2e-test-jenkins-pipeline-9bmz9-test-build-app-pipeline/workspace@script # timeout=10
Fetching upstream changes from /tmp/test-build-app-pipeline544874952/test-build-app-pipeline.git
 > git --version # timeout=10
 > git --version # 'git version 2.27.0'
 > git fetch --tags --force --progress -- /tmp/test-build-app-pipeline544874952/test-build-app-pipeline.git +refs/heads/*:refs/remotes/origin/* # timeout=10
ERROR: Error cloning remote repo 'origin'
hudson.plugins.git.GitException: Command "git fetch --tags --force --progress -- /tmp/test-build-app-pipeline544874952/test-build-app-pipeline.git +refs/heads/*:refs/remotes/origin/*" returned status code 128:
stdout: 
stderr: fatal: '/tmp/test-build-app-pipeline544874952/test-build-app-pipeline.git' does not appear to be a git repository
fatal: Could not read from remote repository.
```

since the local repo is created in the test pod, not the jenkins pod.

The validation of bc updates for env vars when the test fails so early is not what we are after.

Short term: commenting out this test to help unblock pulling in sync plugin updates.

Immediately after: I'm moving this test from a locally created repo to an actual https://github.com/openshift repo, where we can then validate the actual end to end scenario of an 

`oc new-app <repo with jenkinsfile> --strategy=pipeline --build-env=FOO1=BAR1`

actually working

/assign @coreydaley 