### PR TITLE
Bug 1981246: [4.8]: test/e2e: allow workload incorrectly spread alert

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -96,6 +96,16 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 				return framework.ProviderIs("gce")
 			},
 		},
+		{
+			// Should be removed one release after the attached bugzilla is fixed.
+			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
+		},
+		{
+			// Should be removed one release after the attached bugzilla is fixed.
+			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
+		},
 	}
 
 	pendingAlertsWithBugs := helper.MetricConditions{

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -85,6 +85,14 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 					return framework.ProviderIs("gce")
 				},
 			},
+			{
+				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
+				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
+			},
+			{
+				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
+				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
+			},
 		}
 		allowedFiringAlerts := helper.MetricConditions{
 			{


### PR DESCRIPTION
Backport of #26305 to release-4.8.

This is not a blocker so it can wait for 4.8.z before being merged.
Also, the best would be to merge this PR before https://github.com/openshift/cluster-monitoring-operator/pull/1276 since once added to 4.8, the alert will fire from time to time and thus make the e2e tests fail.