### PR TITLE
Bug 1952457: Re-enable crictl node test

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2603,7 +2603,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] [Feature:Example] Secret should create a pod that reads a secret": "should create a pod that reads a secret [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-node] crictl should be able to run crictl on the node": "should be able to run crictl on the node [Disabled:Broken] [Suite:k8s]",
+	"[Top Level] [sig-node] crictl should be able to run crictl on the node": "should be able to run crictl on the node [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-node] kubelet Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s.": "kubelet should be able to delete 10 pods per node in 1m0s. [Serial] [Suite:openshift/conformance/serial] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -43,9 +43,6 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1952460
 			`\[sig-network\] Firewall rule control plane should not expose well-known ports`,
 
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1952457
-			`\[sig-node\] crictl should be able to run crictl on the node`,
-
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1945091
 			`\[Feature:GenericEphemeralVolume\]`,
 


### PR DESCRIPTION
The corresponding upstream PR has been merged which should make the test
more robust: https://github.com/kubernetes/kubernetes/pull/101866

This means we can now re-enable the test for the Kubernetes `master`.
