### PR TITLE
Bug 1942164: Fix time calc ordering for upgrades

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -283,7 +283,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 		// due to https://bugzilla.redhat.com/show_bug.cgi?id=1943804 upgrades take ~12 extra minutes on AWS
 		// and see commit d69db34a816f3ce8a9ab567621d145c5cd2d257f which notes that some AWS upgrades can
 		// take close to 105 minutes total (75 is base duration, so adding 30 more if it's AWS)
-		durationToSoftFailure = (baseDurationToSoftFailure + 30) * time.Minute
+		durationToSoftFailure = baseDurationToSoftFailure + (30 * time.Minute)
 	} else {
 		// if the cluster is on AWS we've already bumped the timeout enough, but if not we need to check if
 		// the CNI is OVN and increase our timeout for that
@@ -294,7 +294,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			// some extra context to this increase which links to a jira showing which operators take longer:
 			// compared to OpenShiftSDN:
 			//   https://bugzilla.redhat.com/show_bug.cgi?id=1942164
-			durationToSoftFailure = (baseDurationToSoftFailure + 15) * time.Minute
+			durationToSoftFailure = baseDurationToSoftFailure + (15 * time.Minute)
 		}
 	}
 
@@ -442,7 +442,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			upgradeEnded := time.Now()
 			upgradeDuration := upgradeEnded.Sub(upgradeStarted)
 			if upgradeDuration > durationToSoftFailure {
-				disruption.RecordJUnitResult(f, fmt.Sprintf("[sig-cluster-lifecycle] cluster upgrade should complete in %v minutes", durationToSoftFailure), upgradeDuration, fmt.Sprintf("%s to %s took too long: %0.2f minutes", action, versionString(desired), upgradeDuration.Minutes()))
+				disruption.RecordJUnitResult(f, fmt.Sprintf("[sig-cluster-lifecycle] cluster upgrade should complete in %0.2f minutes", durationToSoftFailure.Minutes()), upgradeDuration, fmt.Sprintf("%s to %s took too long: %0.2f minutes", action, versionString(desired), upgradeDuration.Minutes()))
 			} else {
 				disruption.RecordJUnitResult(f, fmt.Sprintf("[sig-cluster-lifecycle] cluster upgrade should complete in %v minutes", durationToSoftFailure), upgradeDuration, "")
 			}


### PR DESCRIPTION
The original PR https://github.com/openshift/origin/pull/26202 use
parens in the wrong place and the actual time calcs were happening
wrong and garbage values were being used, like this job [0] where
the test output looked like:
  : [sig-cluster-lifecycle] cluster upgrade should complete in -1386946h6m26.707003392s minutes

This should fix that.

[0] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-gcp-ovn-upgrade/1414923427529101312

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>