### PR TITLE
oauth-server certs e2e: add RBAC rule to be able to read the distributed cert in a CM

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -157,6 +157,7 @@ var (
 			},
 			"openshift-config-managed": {
 				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("configmaps").Names("console-public").RuleOrDie(),
+				rbacv1helpers.NewRule(read...).Groups("").Resources("configmaps").Names("oauth-serving-cert").RuleOrDie(),
 			},
 			"kube-system": {
 				// this allows every authenticated user to use in-cluster client certificate termination


### PR DESCRIPTION
/assign @slaskawi 
/cc @deads2k 

the role is getting added in https://github.com/openshift/cluster-authentication-operator/pull/464