### PR TITLE
Added E2E test for multus-cni

### DIFF
--- a/test/extended/networking/multus.go
+++ b/test/extended/networking/multus.go
@@ -1,0 +1,51 @@
+package networking
+
+import (
+	"fmt"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	v1 "k8s.io/api/core/v1"
+	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+var _ = g.Describe("[sig-network][Feature:Multus]", func() {
+	var oc *exutil.CLI
+	var ns string // namespace
+
+	oc = exutil.NewCLI("multus-e2e")
+
+	f := oc.KubeFramework()
+	podName := "multus-test-pod-"
+
+	// Multus is already installed on origin. These tests aims to verify the integrity of the installation.
+
+	g.It("should use multus to create net1 device from network-attachment-definition", func() {
+		var err error
+		ns = f.Namespace.Name
+
+		g.By("creating a net-attach-def using bridgeCNI")
+		nad_yaml := exutil.FixturePath("testdata", "net-attach-defs", "bridge-nad.yml")
+		g.By(fmt.Sprintf("calling oc create -f %s", nad_yaml))
+		err = oc.AsAdmin().Run("create").Args("-f", nad_yaml).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred(), "created net-attach-def")
+
+		g.By("launching pod with an annotation to use the net-attach-def")
+		annotation := map[string]string{
+			"k8s.v1.cni.cncf.io/networks": "bridge-nad",
+		}
+		testPod := frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+			pod.ObjectMeta.Annotations = annotation
+		})
+
+		g.By("checking for net1 interface on pod")
+		output, err := oc.AsAdmin().Run("exec").Args(testPod.Name, "--", "ip", "a", "show", "dev", "net1").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(output)
+		o.Expect(output).Should(o.ContainSubstring("net1"))
+		o.Expect(output).Should(o.ContainSubstring("inet 10.10.0.1/24"))
+	})
+
+	// TODO: additional multus tests (see https://issues.redhat.com/browse/SDN-1180)
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -435,6 +435,7 @@
 // test/extended/testdata/marketplace/opsrc/02-opsrc.yaml
 // test/extended/testdata/multi-namespace-pipeline.yaml
 // test/extended/testdata/multi-namespace-template.yaml
+// test/extended/testdata/net-attach-defs/bridge-nad.yml
 // test/extended/testdata/oauthserver/cabundle-cm.yaml
 // test/extended/testdata/oauthserver/oauth-network.yaml
 // test/extended/testdata/oauthserver/oauth-pod.yaml
@@ -48457,6 +48458,40 @@ func testExtendedTestdataMultiNamespaceTemplateYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataNetAttachDefsBridgeNadYml = []byte(`apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-nad
+spec: 
+  config: '{
+	"name": "multustestbridge",
+	"type": "bridge",
+	"bridge": "multustestbr0",
+	"isDefaultGateway": true,
+	"forceAddress": false,
+	"ipMasq": true,
+	"hairpinMode": true,
+	"ipam": {
+		"type": "static",
+		"addresses": [{"address": "10.10.0.1/24"}]
+	}
+}'`)
+
+func testExtendedTestdataNetAttachDefsBridgeNadYmlBytes() ([]byte, error) {
+	return _testExtendedTestdataNetAttachDefsBridgeNadYml, nil
+}
+
+func testExtendedTestdataNetAttachDefsBridgeNadYml() (*asset, error) {
+	bytes, err := testExtendedTestdataNetAttachDefsBridgeNadYmlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/net-attach-defs/bridge-nad.yml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataOauthserverCabundleCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -53962,6 +53997,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/marketplace/opsrc/02-opsrc.yaml":                                                 testExtendedTestdataMarketplaceOpsrc02OpsrcYaml,
 	"test/extended/testdata/multi-namespace-pipeline.yaml":                                                   testExtendedTestdataMultiNamespacePipelineYaml,
 	"test/extended/testdata/multi-namespace-template.yaml":                                                   testExtendedTestdataMultiNamespaceTemplateYaml,
+	"test/extended/testdata/net-attach-defs/bridge-nad.yml":                                                  testExtendedTestdataNetAttachDefsBridgeNadYml,
 	"test/extended/testdata/oauthserver/cabundle-cm.yaml":                                                    testExtendedTestdataOauthserverCabundleCmYaml,
 	"test/extended/testdata/oauthserver/oauth-network.yaml":                                                  testExtendedTestdataOauthserverOauthNetworkYaml,
 	"test/extended/testdata/oauthserver/oauth-pod.yaml":                                                      testExtendedTestdataOauthserverOauthPodYaml,
@@ -54704,6 +54740,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				}},
 				"multi-namespace-pipeline.yaml": {testExtendedTestdataMultiNamespacePipelineYaml, map[string]*bintree{}},
 				"multi-namespace-template.yaml": {testExtendedTestdataMultiNamespaceTemplateYaml, map[string]*bintree{}},
+				"net-attach-defs": {nil, map[string]*bintree{
+					"bridge-nad.yml": {testExtendedTestdataNetAttachDefsBridgeNadYml, map[string]*bintree{}},
+				}},
 				"oauthserver": {nil, map[string]*bintree{
 					"cabundle-cm.yaml":   {testExtendedTestdataOauthserverCabundleCmYaml, map[string]*bintree{}},
 					"oauth-network.yaml": {testExtendedTestdataOauthserverOauthNetworkYaml, map[string]*bintree{}},

--- a/test/extended/testdata/net-attach-defs/bridge-nad.yml
+++ b/test/extended/testdata/net-attach-defs/bridge-nad.yml
@@ -1,0 +1,18 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-nad
+spec: 
+  config: '{
+	"name": "multustestbridge",
+	"type": "bridge",
+	"bridge": "multustestbr0",
+	"isDefaultGateway": true,
+	"forceAddress": false,
+	"ipMasq": true,
+	"hairpinMode": true,
+	"ipam": {
+		"type": "static",
+		"addresses": [{"address": "10.10.0.1/24"}]
+	}
+}'

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2231,6 +2231,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services when using OpenshiftSDN in a mode that isolates namespaces by default should prevent connections to pods in different namespaces on the same node via service IPs": "should prevent connections to pods in different namespaces on the same node via service IPs [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network][Feature:Multus] should use multus to create net1 device from network-attachment-definition": "should use multus to create net1 device from network-attachment-definition [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network][Feature:Network Policy Audit logging] when using openshift ovn-kubernetes should ensure acl logs are created and correct": "should ensure acl logs are created and correct [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:Router] The HAProxy router converges when multiple routers are writing conflicting status": "converges when multiple routers are writing conflicting status [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This test performs a similar test to the upstream multus-cni E2E test...
- Creates a net-attach-def
- Creates a pod with an annotation that refers to the net-attach-def
- Checks for newly created net1 interface and passes test if found

Feedback on the test contents/structure is welcome =)