### PR TITLE
Bug 1979962: Fix aws network stress tests

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -321,6 +321,10 @@ var staticSuites = testSuites{
 				if strings.Contains(name, "[Feature:NetworkPolicy]") {
 					return false
 				}
+				// Serial:Self are tests that can't be run in parallel with a copy of itself
+				if strings.Contains(name, "[Serial:Self]") {
+					return false
+				}
 				return (strings.Contains(name, "[Suite:openshift/conformance/") && strings.Contains(name, "[sig-network]")) || isStandardEarlyOrLateTest(name)
 			},
 			Parallelism:         60,

--- a/test/extended/networking/internal_ports.go
+++ b/test/extended/networking/internal_ports.go
@@ -35,7 +35,7 @@ const (
 var _ = ginkgo.Describe("[sig-network] Internal connectivity", func() {
 	f := framework.NewDefaultFramework("k8s-nettest")
 
-	ginkgo.It("for TCP and UDP on ports 9000-9999 is allowed", func() {
+	ginkgo.It("for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]", func() {
 		e2eskipper.SkipUnlessNodeCountIsAtLeast(2)
 		clientConfig := f.ClientConfig()
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1783,7 +1783,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] Firewall rule should have correct firewall rules for e2e cluster": "should have correct firewall rules for e2e cluster [Disabled:SpecialConfig] [Suite:k8s]",
 
-	"[Top Level] [sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]": "validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[Top Level] [sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance]": "validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance] [Serial:Self] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-network] Ingress API should support creating Ingress API operations [Conformance]": "should support creating Ingress API operations [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
@@ -1795,7 +1795,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] IngressClass [Feature:Ingress] should set default value on new IngressClass [Serial]": "should set default value on new IngressClass [Serial] [Suite:openshift/conformance/serial] [Suite:k8s]",
 
-	"[Top Level] [sig-network] Internal connectivity for TCP and UDP on ports 9000-9999 is allowed": "for TCP and UDP on ports 9000-9999 is allowed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network] Internal connectivity for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]": "for TCP and UDP on ports 9000-9999 is allowed [Serial:Self] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network] KubeProxy should set TCP CLOSE_WAIT timeout [Privileged]": "should set TCP CLOSE_WAIT timeout [Privileged] [Disabled:Broken] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -76,7 +76,11 @@ var (
 			`openshift mongodb replication creating from a template`, // flaking on deployment
 		},
 		// tests that must be run without competition
-		"[Serial]":        {},
+		"[Serial]": {},
+		// tests that can't be run in parallel with a copy of itself
+		"[Serial:Self]": {
+			`\[sig-network\] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol`,
+		},
 		"[Skipped:azure]": {},
 		"[Skipped:ovirt]": {},
 		"[Skipped:gce]":   {},


### PR DESCRIPTION
Failing job - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.9-e2e-aws-network-stress/1420053950479994880
The most often failing tests are:
```
[sig-network] Internal connectivity for TCP and UDP on ports 9000-9999 is allowed [Suite:openshift/conformance/parallel]
[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
```
Add [Serial:Self] label for tests that can't be run in parallel with a copy of itself, exclude these tests from "openshift/network/stress" suite.
"Internal connectivity for TCP and UDP on ports 9000-9999 is allowed" uses exclusive resources (node-role.kubernetes.io/master + ports 9000,9999) and can't be run in parallel with multiple copies
"HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol" also uses host ip + port
