### PR TITLE
[sig-arch] events should not repeat pathologically: append openshift-machine-api BZ into known event problems

### DIFF
--- a/pkg/synthetictests/events.go
+++ b/pkg/synthetictests/events.go
@@ -62,6 +62,10 @@ var knownEventProblems = []struct {
 		Regexp: regexp.MustCompile(`ns/openshift-network-diagnostics pod/network-check-target-[a-z0-9]+ node/[a-z0-9.-]+ - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net\.d/\. Has your network provider started\?`),
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
 	},
+	{
+		Regexp: regexp.MustCompile(`ns/openshift-machine-api machine/[a-z0-9.-]+ - reason/Updated Updated machine "[a-z0-9.-]+"`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1988992",
+	},
 }
 
 // we want to identify events based on the monitor because it is (currently) our only spot that tracks events over time


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1988992

https://testgrid.k8s.io/redhat-openshift-ocp-release-4.9-informing#periodic-ci-openshift-release-master-ci-4.9-e2e-azure-serial

From https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.9-e2e-azure-serial/1421911764836028416:

```
1 events happened too frequently

event happened 21 times, something is wrong: ns/openshift-machine-api machine/ci-op-c8k19g5q-52e47-6kzkj-worker-centralus1-xwg7l - reason/Updated Updated machine "ci-op-c8k19g5q-52e47-6kzkj-worker-centralus1-xwg7l"
```