### PR TITLE
OWNERS: Declare Bugzilla component

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -26,3 +26,7 @@ filters:
   "^vendor/.*":
     labels:
     - "vendor-update"
+
+# This is a Red Hat extension, mapping the Git repository to an OpenShift Bugzilla component:
+# https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform
+component: "Test Framework"


### PR DESCRIPTION
We just grew this component in Bugzilla, so declare it where [doozer][1] (and other consumers) can find it.

[1]: https://github.com/openshift/doozer/blob/231d240702a5c22da488fa241bc76df416acee6a/doozerlib/metadata.py#L288-L343