### PR TITLE
Bug 1988828: fix test - reduce minimum size of expected files in must-gather tests

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -282,7 +282,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 			o.Expect(expectedFilePath).To(o.BeAnExistingFile())
 			stat, err := os.Stat(expectedFilePath)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			if size := stat.Size(); size < 50 {
+			if size := stat.Size(); size < 20 {
 				emptyFiles = append(emptyFiles, expectedFilePath)
 			}
 		}


### PR DESCRIPTION
The "oc adm must-gather" test in the e2e-aws-single-node suite is failing because
the openshift-apiserver.audit_logs_listing and oauth-apiserver.audit_logs_listing files content is only 38 bytes
while the test is expecting the size to be at least 50 bytes.
Since single node has just one host the file content is shorter.
This commit change the minimum required size to 20 bytes.

https://bugzilla.redhat.com/show_bug.cgi?id=1988828