### PR TITLE
bug 1989961: refine apiserver downtime sampling and calculations

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -131,12 +131,19 @@ func (intervals Intervals) Strings() []string {
 // Duration returns the sum of all intervals in the range. If To is less than or
 // equal to From, defaultDuration is used instead (use Clamp() if open intervals
 // should be not considered instant).
-func (intervals Intervals) Duration(defaultDuration time.Duration) time.Duration {
+// minDuration is the smallest duration to add.  If a duration is less than the minDuration,
+// then the minDuration is used instead.  This is useful for measuring samples.
+// For example, consider a case of one second polling for server availability.
+// If a sample fails, you don't definitively know whether it was down just after t-1s or just before t.
+// On average, it would be 500ms, but a useful minimum in this case could be 1s.
+func (intervals Intervals) Duration(defaultDuration, minDuration time.Duration) time.Duration {
 	var duration time.Duration
 	for _, interval := range intervals {
 		d := interval.To.Sub(interval.From)
 		if d <= 0 {
 			duration += defaultDuration
+		} else if d < minDuration {
+			d += minDuration
 		} else {
 			duration += d
 		}

--- a/pkg/monitor/sampler.go
+++ b/pkg/monitor/sampler.go
@@ -39,9 +39,14 @@ func (s *sampler) run(ctx context.Context) {
 	var lastInterval int = -1
 	for {
 		success := s.isAvailable()
+		// the sampleFn may take a significant period of time to run.  In such a case, we want our start interval
+		// for when a failure started to be the time when the request was first made, not the time when the call
+		// returned.  Imagine a timeout set on a DNS lookup of 30s: when the GET finally fails and returns, the outage
+		// was actually 30s before.
+		startTime := time.Now().UTC()
 		condition, ok := s.sampleFn(success)
 		if condition != nil {
-			s.recorder.Record(*condition)
+			s.recorder.RecordAt(startTime, *condition)
 		}
 		if s.onFailing != nil {
 			switch {
@@ -50,7 +55,7 @@ func (s *sampler) run(ctx context.Context) {
 					s.recorder.EndInterval(lastInterval, time.Now().UTC())
 				}
 			case success && !ok:
-				lastInterval = s.recorder.StartInterval(time.Now().UTC(), *s.onFailing)
+				lastInterval = s.recorder.StartInterval(startTime, *s.onFailing)
 			}
 		}
 		s.setAvailable(ok)

--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -17,7 +17,7 @@ const (
 
 func testServerAvailability(locator string, events monitorapi.Intervals, duration time.Duration) []*ginkgo.JUnitTestCase {
 	events = events.Filter(func(i monitorapi.EventInterval) bool { return i.Locator == locator })
-	errDuration := events.Duration(0)
+	errDuration := events.Duration(0, 1*time.Second)
 	errMessages := events.Strings()
 
 	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -308,17 +308,6 @@ func createTestFrameworks(tests []upgrades.Test) map[string]*framework.Framework
 	return testFrameworks
 }
 
-// minimumDuration rounds to the minimum disruption experienced. For
-// values less than 1 second, we return the exact millis but otherwise
-// we don't care and truncate to seconds.
-func minimumDuration(duration time.Duration) time.Duration {
-	if duration < time.Second {
-		return duration
-	} else {
-		return duration.Truncate(time.Second)
-	}
-}
-
 // ExpectNoDisruption fails if the sum of the duration of all events exceeds tolerate as a fraction ([0-1]) of total, reports a
 // disruption flake if any disruption occurs, and uses reason to prefix the message. I.e. tolerate 0.1 of 10m total will fail
 // if the sum of the intervals is greater than 1m, or report a flake if any interval is found.
@@ -327,9 +316,9 @@ func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Dur
 	duration := events.Duration(0, 1*time.Second)
 	describe := events.Strings()
 	if percent := float64(duration) / float64(total); percent > tolerate {
-		framework.Failf("%s for at least %v of %v (%0.0f%%):\n\n%s", reason, minimumDuration(duration), minimumDuration(total), percent*100, strings.Join(describe, "\n"))
+		framework.Failf("%s for at least %s of %s (%0.0f%%):\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
 	} else if duration > 0 {
-		FrameworkFlakef(f, "%s for at least %v of %v (%0.0f%%), this is currently sufficient to pass the test/job but not considered completely correct:\n\n%s", reason, minimumDuration(duration), minimumDuration(total), percent*100, strings.Join(describe, "\n"))
+		FrameworkFlakef(f, "%s for at least %s of %s (%0.0f%%), this is currently sufficient to pass the test/job but not considered completely correct:\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
 	}
 }
 

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -324,7 +324,7 @@ func minimumDuration(duration time.Duration) time.Duration {
 // if the sum of the intervals is greater than 1m, or report a flake if any interval is found.
 func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Duration, events monitorapi.Intervals, reason string) {
 	FrameworkEventIntervals(f, events)
-	duration := events.Duration(0)
+	duration := events.Duration(0, 1*time.Second)
 	describe := events.Strings()
 	if percent := float64(duration) / float64(total); percent > tolerate {
 		framework.Failf("%s for at least %v of %v (%0.0f%%):\n\n%s", reason, minimumDuration(duration), minimumDuration(total), percent*100, strings.Join(describe, "\n"))


### PR DESCRIPTION
Downtime calculations didn't consider the average downtime *before* detection, so a minimum value is required.  This value is different than cases where the value is actually zero.

The intervals also calculated the startTime of a failure from when the failed request returned as opposed to when the failed request was originally made.  This can result in short downtime calculations, when the actual downtime was significant.