### PR TITLE
Bug 1941224: pkg/synthetictests/operators: Drop Progressing from "stable" transition checks

### DIFF
--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -14,7 +14,7 @@ import (
 )
 
 func testStableSystemOperatorStateTransitions(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
-	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded, configv1.OperatorProgressing})
+	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded})
 }
 
 func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {


### PR DESCRIPTION
There's currently a lack of consensus about whether going `Progressing=True` on things like "my DaemonSet is scaling as my cluster node set scales" is [helpful truth][1] (openshift/api#935) or distracting noise.  But we don't have any `Progressing=True` alerts, we do have `ClusterOperatorDown` and `ClusterOperatorDegraded` alerts, and they go off when components go `Available=False` and `Degraded=True` on updates.  Until those get sorted out, we don't have the energy to push for `Progressing` consensus, so this commit drops the:

    clusteroperator/... should not change condition/Progressing

noise to make it easier for folks to focus on the more important condition changes.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1940286#c5
[2]: https://github.com/openshift/api/pull/935