### PR TITLE
Bug 1991507: kubectl: mark exit codes test flaky until 1.22 rebase

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1235,7 +1235,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] Kubectl client Simple pod should handle in-cluster config": "should handle in-cluster config [Disabled:Broken] [Suite:k8s]",
 
-	"[Top Level] [sig-cli] Kubectl client Simple pod should return command exit codes": "should return command exit codes [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-cli] Kubectl client Simple pod should return command exit codes": "should return command exit codes [Flaky] [Suite:k8s]",
 
 	"[Top Level] [sig-cli] Kubectl client Simple pod should support exec through an HTTP proxy": "should support exec through an HTTP proxy [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -131,6 +131,9 @@ var (
 		// tests that are known flaky
 		"[Flaky]": {
 			`openshift mongodb replication creating from a template`, // flaking on deployment
+
+			// BZ https://bugzilla.redhat.com/show_bug.cgi?id=1991507
+			`Kubectl client Simple pod should return command exit codes`,
 		},
 		// tests that must be run without competition
 		"[Serial]":        {},


### PR DESCRIPTION
`oc` vendored 1.22 already, and appears to have caused this
test to start [failing about 30-35% of the time](http://sippy-stbenjam-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com/sippy-ng/tests/4.9/details?showFull=1&test=%5Bsig-cli%5D%20Kubectl%20client%20Simple%20pod%20should%20return%20command%20exit%20codes%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D%20%5BSuite%3Ak8s%5D). We can add it
back once we get the fix from uptsream[1].

[1] https://github.com/kubernetes/kubernetes/pull/101295