### PR TITLE
track the final state of pods and events from e2e tests for later debugging

### DIFF
--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -37,6 +37,10 @@ func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Int
 			}
 			rv := events.ResourceVersion
 
+			for i := range events.Items {
+				m.RecordResource("events", &events.Items[i])
+			}
+
 			for expired := false; !expired; {
 				w, err := client.CoreV1().Events("").Watch(ctx, metav1.ListOptions{ResourceVersion: rv})
 				if err != nil {
@@ -60,6 +64,7 @@ func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Int
 							if !ok {
 								continue
 							}
+							m.RecordResource("events", obj)
 
 							t := obj.LastTimestamp.Time
 							if t.IsZero() {

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
-
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
@@ -95,8 +94,9 @@ func TestMonitor_Events(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &Monitor{
-				events:  tt.events,
-				samples: tt.samples,
+				events:            tt.events,
+				samples:           tt.samples,
+				recordedResources: monitorapi.ResourcesMap{},
 			}
 			if got := m.Intervals(tt.from, tt.to); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%s", diff.ObjectReflectDiff(tt.want, got))

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -6,6 +6,19 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	// ObservedUpdateCountAnnotation is an annotation added locally (in the monitor only), that tracks how many updates
+	// we've seen to this resource.  This is useful during post-processing for determining if we have a hot resource.
+	ObservedUpdateCountAnnotation = "monitor.openshift.io/observed-update-count"
+
+	// ObservedRecreationCountAnnotation is an annotation added locally (in the monitor only), that tracks how many
+	// time a resource has been recreated.  The internal cache doesn't remove an entry on delete.
+	// This is useful during post-processing for determining if we have a hot resource.
+	ObservedRecreationCountAnnotation = "monitor.openshift.io/observed-recreation-count"
 )
 
 type EventLevel int
@@ -263,3 +276,6 @@ func (intervals Intervals) Clamp(from, to time.Time) {
 		}
 	}
 }
+
+type InstanceMap map[string]runtime.Object
+type ResourcesMap map[string]InstanceMap

--- a/pkg/monitor/noop.go
+++ b/pkg/monitor/noop.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type noOpMonitor struct {
@@ -13,6 +14,7 @@ func NewNoOpMonitor() Recorder {
 	return &noOpMonitor{}
 }
 
+func (*noOpMonitor) RecordResource(resourceType string, obj runtime.Object)        {}
 func (*noOpMonitor) Record(conditions ...monitorapi.Condition)                     {}
 func (*noOpMonitor) RecordAt(t time.Time, conditions ...monitorapi.Condition)      {}
 func (*noOpMonitor) StartInterval(t time.Time, condition monitorapi.Condition) int { return 0 }

--- a/pkg/monitor/pod.go
+++ b/pkg/monitor/pod.go
@@ -350,6 +350,8 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 				if !ok {
 					return
 				}
+				m.RecordResource("pods", pod)
+
 				// filter out old pods so our monitor doesn't send a big chunk
 				// of pod creations
 				if pod.CreationTimestamp.Time.Before(startTime) {
@@ -366,6 +368,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 				if !ok {
 					return
 				}
+				m.RecordResource("pods", pod)
 				for _, fn := range podDeleteFns {
 					m.Record(fn(pod)...)
 				}
@@ -375,6 +378,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 				if !ok {
 					return
 				}
+				m.RecordResource("pods", pod)
 				oldPod, ok := old.(*corev1.Pod)
 				if !ok {
 					return

--- a/pkg/monitor/serialization/resource.go
+++ b/pkg/monitor/serialization/resource.go
@@ -1,0 +1,75 @@
+package monitorserialization
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kube-openapi/pkg/util/sets"
+)
+
+func InstanceMapToFile(filename string, resourceType string, instances monitorapi.InstanceMap) error {
+	namespaceToKeys := map[string]sets.String{}
+	for key, obj := range instances {
+		ns := "---missing|metadata---"
+		metadata, err := meta.Accessor(obj)
+		if err == nil {
+			ns = metadata.GetNamespace()
+		}
+
+		if _, ok := namespaceToKeys[ns]; !ok {
+			namespaceToKeys[ns] = sets.String{}
+		}
+		namespaceToKeys[ns].Insert(key)
+	}
+
+	nsToItems := map[string]*unstructured.UnstructuredList{}
+	for _, ns := range sets.StringKeySet(namespaceToKeys).List() {
+		nsList := &unstructured.UnstructuredList{}
+		for _, instanceKey := range namespaceToKeys[ns].List() {
+			instanceMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(instances[instanceKey])
+			if err != nil {
+				return err
+			}
+			nsList.Items = append(
+				nsList.Items,
+				unstructured.Unstructured{
+					Object: instanceMap,
+				},
+			)
+		}
+		nsToItems[ns] = nsList
+	}
+
+	byteBuffer := &bytes.Buffer{}
+	zipWriter := zip.NewWriter(byteBuffer)
+
+	for namespace, nsItems := range nsToItems {
+		json, err := json.MarshalIndent(nsItems, "", "  ")
+		if err != nil {
+			return err
+		}
+		nsWriter, err := zipWriter.Create(filepath.Join(namespace, resourceType+".json"))
+		if err != nil {
+			return err
+		}
+		if _, err := nsWriter.Write(json); err != nil {
+			return err
+		}
+	}
+
+	if err := zipWriter.Flush(); err != nil {
+		return err
+	}
+	if err := zipWriter.Close(); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filename, byteBuffer.Bytes(), 0644)
+}

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type IntervalCreationFunc func(intervals monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals
@@ -13,9 +14,15 @@ type SamplerFunc func(time.Time) []*monitorapi.Condition
 type Interface interface {
 	Intervals(from, to time.Time) monitorapi.Intervals
 	Conditions(from, to time.Time) monitorapi.Intervals
+	CurrentResourceState() monitorapi.ResourcesMap
 }
 
 type Recorder interface {
+	// RecordResource stores a resource for later serialization.  Deletion is not tracked, so this can be used
+	// to determine the final state of resource that are deleted in a namespace.
+	// Annotations are added to indicate number of updates and the number of recreates.
+	RecordResource(resourceType string, obj runtime.Object)
+
 	Record(conditions ...monitorapi.Condition)
 	RecordAt(t time.Time, conditions ...monitorapi.Condition)
 

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -386,6 +386,15 @@ func (opt *Options) Run(suite *TestSuite) error {
 		} else {
 			fmt.Fprintf(opt.ErrOut, "error: Failed to write event html: %v\n", err)
 		}
+
+		// write out the current state of resources that we explicitly tracked.
+		resourcesMap := m.CurrentResourceState()
+		for resourceType, instanceMap := range resourcesMap {
+			targetFile := fmt.Sprintf("resource-%s%s.zip", resourceType, timeSuffix)
+			if err = monitorserialization.InstanceMapToFile(filepath.Join(opt.JUnitDir, targetFile), resourceType, instanceMap); err != nil {
+				fmt.Fprintf(opt.ErrOut, "error: Failed to write %q: %v\n", targetFile, err)
+			}
+		}
 	}
 
 	if len(events) > 0 {


### PR DESCRIPTION
The final states here should be stored and held in artifacts, where we can then argue over size, utility, and display.