### PR TITLE
BUILD-278: search for correct memory.max file with cgroupv2 and build quota test

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17464,31 +17464,37 @@ var _testExtendedTestdataBuildsBuildQuotaS2iBinAssemble = []byte(`#!/bin/sh
 # output, so adding a sleep in an attempt to let the buildah log output
 # stop before the container output starts
 sleep 10
-echo "start search for cgroup memory files"
-find /sys/fs/cgroup -name memory.limit_in_bytes
-find /sys/fs/cgroup -name memory.max
-echo "end search for cgroup memory files"
 cgroupv1Val=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) || true
 echo "cgroupv1Val is ${cgroupv1Val}"
 if [ "$cgroupv1Val" = "419430400" ]; then
   echo "MEMORY=${cgroupv1Val}"
 else
-  cgroupv2Val=$(cat /sys/fs/cgroup/memory.max) || true
-  echo "cgroupv2Val is ${cgroupv2Val}"
-  if [ "$cgroupv2Val" = "419430400" ]; then
-    echo "MEMORY=${cgroupv2Val}"
-  fi
+  memory_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.max)
+  for item in ${memory_max_list};
+  do
+    echo "${item}"
+    cgroupv2Val=$(cat "${item}")
+    echo "cgroupv2Val is ${cgroupv2Val}"
+    if [ "$cgroupv2Val" = "419430400" ]; then
+      echo "MEMORY=${cgroupv2Val}"
+    fi
+  done
 fi
 cgroupv1Val=$(cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes) || true
 echo "cgroupv1Val is ${cgroupv1Val}"
 if [ "$cgroupv1Val" = "419430400" ]; then
   echo "MEMORYSWAP=${cgroupv1Val}"
 else
-  cgroupv2Val=$(cat /sys/fs/cgroup/memory.swap.max) || true
-  echo "cgroupv2Val is ${cgroupv2Val}"
-  if [ "$cgroupv2Val" = "419430400" ]; then
-    echo "MEMORYSWAP=${cgroupv2Val}"
-  fi
+  memory_swap_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.swap.max)
+  for item in ${memory_swap_max_list};
+  do
+    echo "${item}"
+    cgroupv2Val=$(cat "${item}")
+    echo "cgroupv2Val is ${cgroupv2Val}"
+    if [ "$cgroupv2Val" = "419430400" ]; then
+      echo "MEMORYSWAP=${cgroupv2Val}"
+    fi
+  done
 fi
 
 if [ -e /sys/fs/cgroup/cpuacct,cpu ]; then

--- a/test/extended/testdata/builds/build-quota/.s2i/bin/assemble
+++ b/test/extended/testdata/builds/build-quota/.s2i/bin/assemble
@@ -4,31 +4,37 @@
 # output, so adding a sleep in an attempt to let the buildah log output
 # stop before the container output starts
 sleep 10
-echo "start search for cgroup memory files"
-find /sys/fs/cgroup -name memory.limit_in_bytes
-find /sys/fs/cgroup -name memory.max
-echo "end search for cgroup memory files"
 cgroupv1Val=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) || true
 echo "cgroupv1Val is ${cgroupv1Val}"
 if [ "$cgroupv1Val" = "419430400" ]; then
   echo "MEMORY=${cgroupv1Val}"
 else
-  cgroupv2Val=$(cat /sys/fs/cgroup/memory.max) || true
-  echo "cgroupv2Val is ${cgroupv2Val}"
-  if [ "$cgroupv2Val" = "419430400" ]; then
-    echo "MEMORY=${cgroupv2Val}"
-  fi
+  memory_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.max)
+  for item in ${memory_max_list};
+  do
+    echo "${item}"
+    cgroupv2Val=$(cat "${item}")
+    echo "cgroupv2Val is ${cgroupv2Val}"
+    if [ "$cgroupv2Val" = "419430400" ]; then
+      echo "MEMORY=${cgroupv2Val}"
+    fi
+  done
 fi
 cgroupv1Val=$(cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes) || true
 echo "cgroupv1Val is ${cgroupv1Val}"
 if [ "$cgroupv1Val" = "419430400" ]; then
   echo "MEMORYSWAP=${cgroupv1Val}"
 else
-  cgroupv2Val=$(cat /sys/fs/cgroup/memory.swap.max) || true
-  echo "cgroupv2Val is ${cgroupv2Val}"
-  if [ "$cgroupv2Val" = "419430400" ]; then
-    echo "MEMORYSWAP=${cgroupv2Val}"
-  fi
+  memory_swap_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.swap.max)
+  for item in ${memory_swap_max_list};
+  do
+    echo "${item}"
+    cgroupv2Val=$(cat "${item}")
+    echo "cgroupv2Val is ${cgroupv2Val}"
+    if [ "$cgroupv2Val" = "419430400" ]; then
+      echo "MEMORYSWAP=${cgroupv2Val}"
+    fi
+  done
 fi
 
 if [ -e /sys/fs/cgroup/cpuacct,cpu ]; then


### PR DESCRIPTION
See https://github.com/openshift/builder/pull/252#issuecomment-897226011 and https://github.com/openshift/builder/pull/252#issuecomment-896891553 for rationale as to why we have to do this with cgroupv2 and privileged pods

per recent review conventions, wrt to bash, my invocation of spellcheck returned clean:

```shell
gmontero ~ $ shellcheck ~/go/src/github.com/openshift/origin/test/extended/testdata/builds/build-quota/.s2i/bin/assemble 
gmontero ~ $ 
```