### PR TITLE
Bug 1969471:  HAProxy tests in sdn-network-stress job are flaky

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -257,7 +257,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			}()
 
 			o.Expect(wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
-				contents, err := getBearerTokenURLViaPod(ns, execPod.Name, fmt.Sprintf("%s/api/v1/targets", prometheusURL), token)
+				contents, err := getBearerTokenURLViaPod(ns, execPod.Name, fmt.Sprintf("%s/api/v1/targets?state=active", prometheusURL), token)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				targets := &promTargets{}


### PR DESCRIPTION
This PR is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1969471

Verification steps:

1. Created cluster-bot  4.9.0-0.nightly-2021-08-07-175228 on aws
2. Executed the script [1] - noticed failures after a couple of runs
3. Updated and compiled the openshift-tests with the updated url call for prometheus
4. Executed the script [1] twice and noticed no failures

The proposed solution is really simple, it ensures that only active  targets are looked at restricting the amount of data returning from the prometheus call.

[1] `set -e; for x in {1..100}; do ./openshift-tests run-test '[sig-network][Feature:Router] The HAProxy router should enable openshift-monitoring to pull metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]'; if [ "$?" -ne 0 ]; then break; fi; sleep 5; done || exit 1`