### PR TITLE
fix: add proxy support to OAuthServer tests

### DIFF
--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -381,6 +381,7 @@ func oauthHTTPRequest(caCerts *x509.CertPool, oauthBaseURL, endpoint, token stri
 		TLSClientConfig: &tls.Config{
 			RootCAs: caCerts,
 		},
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	if cert != nil {


### PR DESCRIPTION
OAuthServer tests do not use the proxy settings defined in the environment, if presents.
This is currently required to run remotely the tests through a proxy, for the metal-ipi platform (see https://github.com/openshift/release/pull/19987)