### PR TITLE
test: skip tests that won't work behind a proxy automatically

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1155,7 +1155,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] CLI can run inside of a busybox container": "can run inside of a busybox container [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 should support forwarding over websockets": "should support forwarding over websockets [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 should support forwarding over websockets": "should support forwarding over websockets [Skipped:Proxy] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 that expects NO client request should support a client that connects, sends DATA, and disconnects": "should support a client that connects, sends DATA, and disconnects [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -1163,7 +1163,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 that expects a client request should support a client that connects, sends NO DATA, and disconnects": "should support a client that connects, sends NO DATA, and disconnects [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on localhost should support forwarding over websockets": "should support forwarding over websockets [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on localhost should support forwarding over websockets": "should support forwarding over websockets [Skipped:Proxy] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on localhost that expects NO client request should support a client that connects, sends DATA, and disconnects": "should support a client that connects, sends DATA, and disconnects [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -1237,9 +1237,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] Kubectl client Simple pod should return command exit codes": "should return command exit codes [Flaky] [Suite:k8s]",
 
-	"[Top Level] [sig-cli] Kubectl client Simple pod should support exec through an HTTP proxy": "should support exec through an HTTP proxy [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-cli] Kubectl client Simple pod should support exec through an HTTP proxy": "should support exec through an HTTP proxy [Skipped:Proxy] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-cli] Kubectl client Simple pod should support exec through kubectl proxy": "should support exec through kubectl proxy [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-cli] Kubectl client Simple pod should support exec through kubectl proxy": "should support exec through kubectl proxy [Skipped:Proxy] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-cli] Kubectl client Simple pod should support exec using resource/name": "should support exec using resource/name [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -2431,9 +2431,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] Pods should support pod readiness gates [NodeFeature:PodReadinessGate]": "should support pod readiness gates [NodeFeature:PodReadinessGate] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-node] Pods should support remote command execution over websockets [NodeConformance] [Conformance]": "should support remote command execution over websockets [NodeConformance] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[Top Level] [sig-node] Pods should support remote command execution over websockets [NodeConformance] [Conformance]": "should support remote command execution over websockets [NodeConformance] [Conformance] [Skipped:Proxy] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-node] Pods should support retrieving logs from the container over websockets [NodeConformance] [Conformance]": "should support retrieving logs from the container over websockets [NodeConformance] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[Top Level] [sig-node] Pods should support retrieving logs from the container over websockets [NodeConformance] [Conformance]": "should support retrieving logs from the container over websockets [NodeConformance] [Conformance] [Skipped:Proxy] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-node] PreStop graceful pod terminated should wait until preStop hook completes the process": "graceful pod terminated should wait until preStop hook completes the process [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -144,6 +144,22 @@ var (
 		"[Skipped:ovirt]": {},
 		"[Skipped:gce]":   {},
 
+		// These tests are skipped when openshift-tests needs to use a proxy to reach the
+		// cluster -- either because the test won't work while proxied, or because the test
+		// itself is testing a functionality using it's own proxy.
+		"[Skipped:Proxy]": {
+			// These tests setup their own proxy, which won't work when we need to access the
+			// cluster through a proxy.
+			`\[sig-cli\] Kubectl client Simple pod should support exec through an HTTP proxy`,
+			`\[sig-cli\] Kubectl client Simple pod should support exec through kubectl proxy`,
+
+			// Kube currently uses the x/net/websockets pkg, which doesn't work with proxies.
+			// See: https://github.com/kubernetes/kubernetes/pull/103595
+			`\[sig-node\] Pods should support retrieving logs from the container over websockets`,
+			`\[sig-cli\] Kubectl Port forwarding With a server listening on localhost should support forwarding over websockets`,
+			`\[sig-cli\] Kubectl Port forwarding With a server listening on 0.0.0.0 should support forwarding over websockets`,
+			`\[sig-node\] Pods should support remote command execution over websockets`,
+		},
 		"[Skipped:SingleReplicaTopology]": {
 			`\[sig-apps\] Daemon set \[Serial\] should rollback without unnecessary restarts \[Conformance\]`,
 			`\[sig-node\] NoExecuteTaintManager Single Pod \[Serial\] doesn't evict pod with tolerations from tainted nodes`,


### PR DESCRIPTION
The vast majority of the tests we run work and run fine through
an HTTP proxy to reach the target cluster under test, however a
handful of tests don't work. This adds a configuration to
openshift-tests to see if given the current proxy environment, we
would use a proxy to reach the API server. If so, then we skip
tests annotated with `[Skip:Proxy]`.