### PR TITLE
BUILD-278: account for cgroup v2 swap file only having swap for its amount, while cgroup v1 has memory+swap for its amount

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17485,14 +17485,19 @@ echo "cgroupv1Val is ${cgroupv1Val}"
 if [ "$cgroupv1Val" = "419430400" ]; then
   echo "MEMORYSWAP=${cgroupv1Val}"
 else
+  # ok swap is treated differently between cgroup v1 and v2.  In v1, memory.memsw.limit_in_bytes
+  # is memory+swap.  In v2, memory.swap.max is just swap.  So with our quota in place, we will
+  # find a memory.swap.max file with a value of '0' instead of 'max'.
   memory_swap_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.swap.max)
   for item in ${memory_swap_max_list};
   do
     echo "${item}"
     cgroupv2Val=$(cat "${item}")
     echo "cgroupv2Val is ${cgroupv2Val}"
-    if [ "$cgroupv2Val" = "419430400" ]; then
-      echo "MEMORYSWAP=${cgroupv2Val}"
+    if [ "$cgroupv2Val" = "0" ]; then
+      # so that our associated ginkgo test case does not have to distinguish between cgroup v1
+      # and v2, we echo the expected v1 string when we find a memory.swap.max file with '0' in it.
+      echo "MEMORYSWAP=419430400"
     fi
   done
 fi

--- a/test/extended/testdata/builds/build-quota/.s2i/bin/assemble
+++ b/test/extended/testdata/builds/build-quota/.s2i/bin/assemble
@@ -25,14 +25,19 @@ echo "cgroupv1Val is ${cgroupv1Val}"
 if [ "$cgroupv1Val" = "419430400" ]; then
   echo "MEMORYSWAP=${cgroupv1Val}"
 else
+  # ok swap is treated differently between cgroup v1 and v2.  In v1, memory.memsw.limit_in_bytes
+  # is memory+swap.  In v2, memory.swap.max is just swap.  So with our quota in place, we will
+  # find a memory.swap.max file with a value of '0' instead of 'max'.
   memory_swap_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.swap.max)
   for item in ${memory_swap_max_list};
   do
     echo "${item}"
     cgroupv2Val=$(cat "${item}")
     echo "cgroupv2Val is ${cgroupv2Val}"
-    if [ "$cgroupv2Val" = "419430400" ]; then
-      echo "MEMORYSWAP=${cgroupv2Val}"
+    if [ "$cgroupv2Val" = "0" ]; then
+      # so that our associated ginkgo test case does not have to distinguish between cgroup v1
+      # and v2, we echo the expected v1 string when we find a memory.swap.max file with '0' in it.
+      echo "MEMORYSWAP=419430400"
     fi
   done
 fi


### PR DESCRIPTION
For those at RH, see https://coreos.slack.com/archives/C02258G4S79/p1629139934121300 for the tl;dr between @nalind and myself

summary: the cgroup swap files mean different things (memory+swap in v1, just swap in v2) our our build quota tests needs to account for this

/assign @adambkaplan 
or 
/assign @coreydaley 

whoever has the more immediate cycles.  Feel free to unassign as needed.

shellcheck:

```
gmontero ~/go/src/github.com/openshift/origin  (possible-cgroupv2-shell-solution-2)$ shellcheck test/extended/testdata/builds/build-quota/.s2i/bin/assemble 
gmontero ~/go/src/github.com/openshift/origin  (possible-cgroupv2-shell-solution-2)$ 
```

/assign @bparees 
if you are still amenable to adding valid bz label so I can then test against this in https://github.com/openshift/builder/pull/252

fingers crossed last iteration on this