### PR TITLE
Add 'DeploymentAwaitingCancellation' as an allowed repeated event

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -67,6 +67,9 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 	// PersistentVolumes-local tests should not run the pod when there is a volume node
 	// affinity and node selector conflicts.
 	regexp.MustCompile(`ns/e2e-persistent-local-volumes-test-[0-9]+ pod/pod-[a-z0-9.-]+ reason/FailedScheduling`),
+
+	// various DeploymentConfig tests trigger this by canceling multiple rollouts
+	regexp.MustCompile(`.*reason/DeploymentAwaitingCancellation Deployment of version [0-9].+ awaiting cancellation of older running deployments`),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{


### PR DESCRIPTION
we're hitting this one a lot and i don't think it is indicative of an actual underlying problem (it results from queuing up multiple rollouts and cancelations, which the deploymentconfig tests do)

https://search.ci.openshift.org/?search=DeploymentAwaitingCancellation+Deployment+of+version+2+awaiting+cancellation+of+older+running+deployments&maxAge=12h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
