### PR TITLE
Bug 1992596: cli: use ubi8/ruby-27

### DIFF
--- a/test/extended/cli/builds.go
+++ b/test/extended/cli/builds.go
@@ -85,7 +85,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		o.Expect(oc.Run("delete").Args("all", "--all").Execute()).NotTo(o.HaveOccurred())
 
 		g.By("build from git with output to ImageStreamTag")
-		out, err = oc.Run("new-build").Args("quay.io/centos7/ruby-26-centos7", "https://github.com/openshift/ruby-hello-world.git").Output()
+		out, err = oc.Run("new-build").Args("registry.access.redhat.com/ubi8/ruby-27", "https://github.com/openshift/ruby-hello-world.git").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(getExpectedBCOutputMatcher("ruby-hello-world", "ruby-hello-world"))
 		o.Expect(getBCSourceType(oc, "ruby-hello-world")).To(o.Equal("Git"))


### PR DESCRIPTION
In 4.9 we have put a great deal of effort into making the testsuites 
pass on all architectures, including the newly added ARM, by using ubi8 
images.  https://github.com/openshift/origin/pull/26141 fails on 
non-x86_64 architectures due to use of a centos7 image which is not 
multi-arch enabled.  In addition, ruby-hello-world is currently using 
ruby-27.

/cc @atiratree @adambkaplan @soltysh
