### PR TITLE
Fix regex pattern for `DeploymentAwaitingCancellation` event

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -69,7 +69,7 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`ns/e2e-persistent-local-volumes-test-[0-9]+ pod/pod-[a-z0-9.-]+ reason/FailedScheduling`),
 
 	// various DeploymentConfig tests trigger this by canceling multiple rollouts
-	regexp.MustCompile(`.*reason/DeploymentAwaitingCancellation Deployment of version [0-9].+ awaiting cancellation of older running deployments`),
+	regexp.MustCompile(`.*reason/DeploymentAwaitingCancellation Deployment of version [0-9]+ awaiting cancellation of older running deployments`),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{


### PR DESCRIPTION
Fix regex expression for the allowed repeated pattern for `DeploymentAwaitingCancellation` event