### PR TITLE
[WIP] [DNM] Add generic internet egress check alongside API endpoints

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -55,6 +55,7 @@ func AllTests() []upgrades.Test {
 		controlplane.NewKubeAvailableWithConnectionReuseTest(),
 		controlplane.NewOpenShiftAvailableWithConnectionReuseTest(),
 		controlplane.NewOAuthAvailableWithConnectionReuseTest(),
+		controlplane.NewInternetEgressRemainsAvailable(),
 		&manifestdelete.UpgradeTest{},
 		&alert.UpgradeTest{},
 		&frontends.AvailableTest{},

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -72,6 +72,15 @@ func NewOAuthAvailableWithConnectionReuseTest() upgrades.Test {
 	}
 }
 
+// NewInternetEgressRemainsAvailable tests that outbound internet access remains available from the CI cluster.
+func NewInternetEgressRemainsAvailable() upgrades.Test {
+	return &availableTest{
+		testName:        "[sig-api-machinery] Internet egress remains available to openshift-tests during test",
+		name:            "internet-egress-remains-available",
+		startMonitoring: monitor.StartInternetEgressRemainsAvailable,
+	}
+}
+
 type availableTest struct {
 	// testName is the name to show in unit
 	testName string


### PR DESCRIPTION
There's a possibility the API disruption tests are failing because of
the environment inside the cluster from where openshift-tests is running
instead of on the target cluster under test.  We've noticed an uptick in
failures across multiple releases starting around the same time, on
separate platforms, with no obvious commits to point to.

This adds a check for a generic internet URL (neverssl.com is small, and
fit-for-purpose as a general check for connectivity).