### PR TITLE
Bug 1999159: Remove Evan's GH handle from OWNERS

### DIFF
--- a/test/extended/operators/OWNERS
+++ b/test/extended/operators/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - ecordell
   - njhale
   - kevinrizza
   - benluddy
@@ -12,7 +11,6 @@ reviewers:
   - joelanford
   - timflannagan
 approvers:
-  - ecordell
   - njhale
   - kevinrizza
   - benluddy


### PR DESCRIPTION
Remove Evan's handle from test/extended/operators/OWNERS.