### PR TITLE
Bug 2000589: Revert "Re-enable crictl node test"

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2605,7 +2605,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] [Feature:Example] Secret should create a pod that reads a secret": "should create a pod that reads a secret [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-node] crictl should be able to run crictl on the node": "should be able to run crictl on the node [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-node] crictl should be able to run crictl on the node": "should be able to run crictl on the node [Disabled:Broken] [Suite:k8s]",
 
 	"[Top Level] [sig-node] kubelet Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s.": "kubelet should be able to delete 10 pods per node in 1m0s. [Serial] [Suite:openshift/conformance/serial] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -44,6 +44,9 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1952460
 			`\[sig-network\] Firewall rule control plane should not expose well-known ports`,
 
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1952457
+			`\[sig-node\] crictl should be able to run crictl on the node`,
+
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1945091
 			`\[Feature:GenericEphemeralVolume\]`,
 


### PR DESCRIPTION
Reverts openshift/origin#26320 since the test does not get excluded in the periodics.

