### PR TITLE
Bug 1998029: CustomNoUpgrade should not fire no-upgrade failures

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -259,6 +259,5 @@ func isKubeAPIUpgradableNoUpgradeCondition(cond configv1.ClusterOperatorStatusCo
 	return (cond.Reason == "FeatureGates_RestrictedFeatureGates_TechPreviewNoUpgrade" ||
 		cond.Reason == "FeatureGates_RestrictedFeatureGates_CustomNoUpgrade") &&
 		cond.Status == "False" &&
-		cond.Type == "Upgradeable" &&
-		cond.Message == "FeatureGatesUpgradeable: \"TechPreviewNoUpgrade\" and \"CustomNoUpgrades\" do not allow updates"
+		cond.Type == "Upgradeable"
 }


### PR DESCRIPTION
Fixup of 5fb0f9967c1a923b72f4929a344bd35b73f56675 (https://github.com/openshift/origin/pull/26430)

The commit that is being fixed-up introduced a check against a message
that is not implemented anywhere, thus rendering the function
`isKubeAPIUpgradableNoUpgradeCondition` unusable.

This patch removes the check on the condition message.

/cc JoelSpeed
/assign deads2k