### PR TITLE
Bug 2001441: must-gather: Ignore startup logs in kube-apiserver audit logs

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -204,6 +204,8 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 					fileName := filepath.Base(path)
 					if (strings.Contains(fileName, "-termination-") && strings.HasSuffix(fileName, ".log.gz")) ||
 						strings.HasSuffix(fileName, "termination.log.gz") ||
+						(strings.Contains(fileName, "-startup-") && strings.HasSuffix(fileName, ".log.gz")) ||
+						strings.HasSuffix(fileName, "startup.log.gz") ||
 						fileName == ".lock" ||
 						fileName == "lock.log" {
 						// these are expected, but have unstructured log format


### PR DESCRIPTION
The test started to fail in the SNO CI after this PR adding this log got merged
https://github.com/openshift/cluster-kube-apiserver-operator/pull/1219