### PR TITLE
Bug 1961204: upgrade: skip early tests which verify events during install

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -16,6 +16,13 @@ import (
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
+func isStandardEarlyUpgradeTest(name string) bool {
+	if isStandardEarlyTest(name) && !strings.Contains(name, "during install") {
+		return true
+	}
+	return false
+}
+
 // upgradeSuites are all known upgade test suites this binary should run
 var upgradeSuites = testSuites{
 	{
@@ -25,7 +32,7 @@ var upgradeSuites = testSuites{
 		Run all tests.
 		`),
 			Matches: func(name string) bool {
-				if isStandardEarlyTest(name) {
+				if isStandardEarlyUpgradeTest(name) {
 					return true
 				}
 				return strings.Contains(name, "[Feature:ClusterUpgrade]") && !strings.Contains(name, "[Suite:k8s]")
@@ -42,7 +49,7 @@ var upgradeSuites = testSuites{
 		Run only the tests that verify the platform remains available.
 		`),
 			Matches: func(name string) bool {
-				if isStandardEarlyTest(name) {
+				if isStandardEarlyUpgradeTest(name) {
 					return true
 				}
 				return strings.Contains(name, "[Feature:ClusterUpgrade]") && !strings.Contains(name, "[Suite:k8s]")
@@ -59,7 +66,7 @@ var upgradeSuites = testSuites{
 	Don't run disruption tests.
 		`),
 			Matches: func(name string) bool {
-				if isStandardEarlyTest(name) {
+				if isStandardEarlyUpgradeTest(name) {
 					return true
 				}
 				return strings.Contains(name, "[Feature:ClusterUpgrade]") && !strings.Contains(name, "[Suite:k8s]")


### PR DESCRIPTION
Upgrade tests should ignore possible install errors during install. An example would be "should not have pod creation failures during install".

See https://search.ci.openshift.org/?search=should+not+have+pod+creation+failures+during+install&maxAge=48h&context=1&type=junit&name=.*upgrade.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Upgrade tests:
* [test upgrade 4.9 openshift/origin#26454 aws](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1434921954061586432)
* [test upgrade 4.9 openshift/origin#26454 gcp](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp/1434921967084900352)