### PR TITLE
Bug 1826225: test/extended/router: Enable edge-terminated gRPC

### DIFF
--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -135,15 +135,11 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			}
 
 			for _, routeType := range []routev1.TLSTerminationType{
+				"h2c",
 				routev1.TLSTerminationEdge,
 				routev1.TLSTerminationReencrypt,
 				routev1.TLSTerminationPassthrough,
 			} {
-				if routeType == routev1.TLSTerminationEdge {
-					e2e.Logf("skipping %v tests - needs https://github.com/openshift/router/pull/104", routeType)
-					continue
-				}
-
 				var addrs []string
 
 				if len(shardService.Status.LoadBalancer.Ingress[0].Hostname) > 0 {
@@ -180,6 +176,11 @@ func grpcExecTestCases(oc *exutil.CLI, routeType routev1.TLSTerminationType, tim
 		Port:     443,
 		UseTLS:   true,
 		Insecure: true,
+	}
+
+	if routeType == "h2c" {
+		dialParams.Port = 80
+		dialParams.UseTLS = false
 	}
 
 	for _, name := range testCases {

--- a/test/extended/testdata/router/router-grpc-interop-routes.yaml
+++ b/test/extended/testdata/router/router-grpc-interop-routes.yaml
@@ -9,13 +9,28 @@ objects:
 - apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
+    name: grpc-interop-h2c
+    labels:
+      type: ${TYPE}
+  spec:
+    host: grpc-interop-h2c.${DOMAIN}
+    port:
+      targetPort: 1110
+    to:
+      kind: Service
+      name: grpc-interop
+      weight: 100
+    wildcardPolicy: None
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
     name: grpc-interop-edge
     labels:
       type: ${TYPE}
   spec:
     host: grpc-interop-edge.${DOMAIN}
     port:
-      targetPort: 8443
+      targetPort: 1110
     tls:
       termination: edge
       insecureEdgeTerminationPolicy: Redirect

--- a/test/extended/testdata/router/router-grpc-interop.yaml
+++ b/test/extended/testdata/router/router-grpc-interop.yaml
@@ -13,10 +13,15 @@ objects:
     selector:
       app: grpc-interop
     ports:
-      - port: 8443
-        name: https
-        targetPort: 8443
-        protocol: TCP
+    - appProtocol: h2c
+      name: h2c
+      port: 1110
+      protocol: TCP
+      targetPort: 1110
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
 - apiVersion: v1
   kind: Pod
   metadata:
@@ -29,7 +34,11 @@ objects:
       name: server
       command: ["ingress-operator", "serve-grpc-test-server"]
       ports:
+      - containerPort: 1110
+        name: h2c
+        protocol: TCP
       - containerPort: 8443
+        name: https
         protocol: TCP
       volumeMounts:
       - mountPath: /etc/serving-cert


### PR DESCRIPTION
Enable the grpc-interop with edge-terminated route test, using the service's `spec.ports[*].appProtocol` field to specify that the backend pod expects h2c (cleartext HTTP/2) connections.  Add a test that uses h2c on both the frontend and the backend.

* `test/extended/router/grpc-interop.go`: Add a test that uses h2c on the frontend and backend.  Delete the skip for the edge-terminated route.
* `test/extended/testdata/router/router-grpc-interop-routes.yaml`: Add a non-TLS route.  Use target port 1110 for the edge-terminated route.
* `test/extended/testdata/router/router-grpc-interop.yaml`: Add port 1110 for gRPC over h2c to the grpc-interop service and pod container spec.
* `test/extended/testdata/bindata.go`: Update.

---

Requires https://github.com/openshift/router/pull/328.