### PR TITLE
Bug 2002543: must-gather: Ignore startup logs in kube-apiserver audit logs

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -204,6 +204,8 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 					fileName := filepath.Base(path)
 					if (strings.Contains(fileName, "-termination-") && strings.HasSuffix(fileName, ".log.gz")) ||
 						strings.HasSuffix(fileName, "termination.log.gz") ||
+						(strings.Contains(fileName, "-startup-") && strings.HasSuffix(fileName, ".log.gz")) ||
+						strings.HasSuffix(fileName, "startup.log.gz") ||
 						fileName == ".lock" ||
 						fileName == "lock.log" {
 						// these are expected, but have unstructured log format


### PR DESCRIPTION
This is a cherry-pick of #26450