### PR TITLE
Bug 1960674: images: port image signature workflow test to OCP4/UBI8

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -51491,8 +51491,11 @@ items:
       - type: ConfigChange
     source:
       dockerfile: |
-        FROM quay.io/openshift/origin-control-plane:latest
-        RUN yum-config-manager --disable origin-local-release ||:
+        FROM quay.io/openshift/origin-cli:latest
+        WORKDIR /var/lib/origin
+        RUN yum config-manager \
+            --add-repo 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os/' \
+            --add-repo 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os/'
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
@@ -51512,7 +51515,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: quay.io/openshift/origin-control-plane:latest
+          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -16,8 +16,11 @@ items:
       - type: ConfigChange
     source:
       dockerfile: |
-        FROM quay.io/openshift/origin-control-plane:latest
-        RUN yum-config-manager --disable origin-local-release ||:
+        FROM quay.io/openshift/origin-cli:latest
+        WORKDIR /var/lib/origin
+        RUN yum config-manager \
+            --add-repo 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os/' \
+            --add-repo 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os/'
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
@@ -37,7 +40,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: quay.io/openshift/origin-control-plane:latest
+          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag


### PR DESCRIPTION
This fixes portability issues with this test, given that origin-control-plane:3.11 (besides being obsolete) is only available for x86_64.  Also, copying the oc binary from the machine running the test into a container on the cluster would cause the test to fail when run on a different architecture, or when oc was built for a newer glibc.  There was also no guarantee that the oc found on the test machine matched that of the payload being tested.

Instead, this uses the payload cli container, which inherits UBI 8.  The rest of the changes are a consequence of adapting to the newer versions of gpg2 and skopeo.
