### PR TITLE
tests/extended/builds: handle new step logging

### DIFF
--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -3,6 +3,7 @@ package builds
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -81,9 +82,9 @@ COPY --from=%[2]s /bin/ping /test/
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(s).ToNot(o.ContainSubstring("--> FROM scratch"))
 		o.Expect(s).ToNot(o.ContainSubstring("FROM busybox"))
-		o.Expect(s).To(o.ContainSubstring(fmt.Sprintf("STEP 1: FROM %s AS test", image.ShellImage())))
+		o.Expect(s).To(o.MatchRegexp("(\\[1/2\\] STEP 1/2|STEP 1): FROM %s AS test", regexp.QuoteMeta(image.ShellImage())))
 		o.Expect(s).To(o.ContainSubstring("COPY --from"))
-		o.Expect(s).To(o.ContainSubstring(fmt.Sprintf("\"OPENSHIFT_BUILD_NAMESPACE\"=\"%s\"", oc.Namespace())))
+		o.Expect(s).To(o.ContainSubstring("\"OPENSHIFT_BUILD_NAMESPACE\"=\"%s\"", oc.Namespace()))
 		e2e.Logf("Build logs:\n%s", result)
 
 		c := oc.KubeFramework().PodClient()


### PR DESCRIPTION
Buildah 1.22 modifies how steps are logged for builds.  While older builds would see
```
STEP 1: FROM ... AS test
```
in our multistage build test, 1.22 and later will produce
```
[1/2] STEP 1/2: FROM ... AS test
```
in the first stage of a two-stage build, when the first stage has two instructions in it.  Update our expectations to accept either version.