### PR TITLE
disable flaky unidling test

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1727,7 +1727,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (when fully idled)": "should work with TCP (when fully idled) [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (while idling)": "should work with TCP (while idling) [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with TCP (while idling)": "should work with TCP (while idling) [Disabled:Broken] [Skipped:Network/OVNKubernetes]",
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should work with UDP": "should work with UDP [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -26,7 +26,6 @@ var (
 		"[Disabled:Unimplemented]": {},
 		// tests that rely on special configuration that we do not yet support
 		"[Disabled:SpecialConfig]": {},
-		// tests that rely on special configuration that we do not yet support
 		// tests that are known broken and need to be fixed upstream or in openshift
 		// always add an issue here
 		"[Disabled:Broken]": {
@@ -64,6 +63,9 @@ var (
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1996128
 			`\[sig-network\] \[Feature:IPv6DualStack\] should have ipv4 and ipv6 node podCIDRs`,
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=2004074
+			`\[sig-network-edge\]\[Feature:Idling\] Unidling should work with TCP \(while idling\)`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {},


### PR DESCRIPTION
This test was only just recently re-enabled after having been disabled for all of 4.x (#26155) but it seems that it's pretty flaky
