### PR TITLE
Bug 1880738: Minimise test disruption by removing newest workers in scale down

### DIFF
--- a/test/extended/machines/workers.go
+++ b/test/extended/machines/workers.go
@@ -61,6 +61,17 @@ func machineName(item objx.Map) string {
 	return item.Get("metadata.name").String()
 }
 
+func creationTimestamp(item objx.Map) time.Time {
+	creationString := item.Get("metadata.creationTimestamp").String()
+	creation, err := time.Parse(time.RFC3339, creationString)
+	if err != nil {
+		// This should never happen as we always read creation timestamps
+		// set by the Kube API server which sets timestamps to the RFC3339 format.
+		panic(err)
+	}
+	return creation
+}
+
 // nodeNames returns the names of nodes
 func nodeNames(nodes []corev1.Node) sets.String {
 	result := sets.NewString()


### PR DESCRIPTION
When a MachineSet is scaled down, it randomly picks a Machine to remove from the group.

When a Machine is removed, it may contain also remove some workload that is long running and part of a failed test. To preserve the logs for later investigation, we should attempt not to disturb any of the running pods.

To minimise disruption, we should scale down the worker node that is added to the MachineSet as part of the scale test. This PR marks the newly created Machines for deletion by the MachineSet controller on scale down. Once marked, these Machines will be removed first, minimising disruption to other workloads.