### PR TITLE
pkg/synthetictests: add etcd client connection closing to known events

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -119,6 +119,10 @@ var knownEventsBugs = []knownProblem{
 		Regexp: regexp.MustCompile(`ns/openshift-etcd pod/etcd-quorum-guard-[a-z0-9-]+ node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: `),
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2000234",
 	},
+	{
+		Regexp: regexp.MustCompile("ns/openshift-etcd-operator namespace/openshift-etcd-operator -.*rpc error: code = Canceled desc = grpc: the client connection is closing.*"),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
+	},
 	//{ TODO this should only be skipped for single-node
 	//	name:    "single=node-storage",
 	//  BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1990662


### PR DESCRIPTION
Since it's blocking merges, adding this event to the known events list while we investigate how to clean them up.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2006975
https://search.ci.openshift.org/?search=EtcdEndpointsDegraded%3A+rpc+error%3A+code+%3D+Canceled+desc+%3D+grpc%3A+the+client+connection+is+closing&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

/cc @hexfusion @bparees 