### PR TITLE
Use PlatformStatus Type instead deprecated Platform

### DIFF
--- a/test/extended/baremetal/hosts.go
+++ b/test/extended/baremetal/hosts.go
@@ -25,7 +25,7 @@ func skipIfNotBaremetal(oc *exutil.CLI) {
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	if infra.Status.Platform != configv1.BareMetalPlatformType {
+	if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
 		e2eskipper.Skipf("No baremetal platform detected")
 	}
 }


### PR DESCRIPTION
Platform is deprecated. Instead it is suggested using `PlatformStatus.Type`. This PR makes this change for baremetalhosts tests.