### PR TITLE
record only known images test pass so we can get a percentage of passes

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -267,6 +267,12 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 					Output: fmt.Sprintf("Cluster accessed images that were not mirrored to the testing repository or already part of the cluster, see test/extended/util/image/README.md in the openshift/origin repo:\n\n%s", buf.String()),
 				},
 			})
+
+		} else {
+			// if the test passed, indicate that too.
+			tests = append(tests, &ginkgo.JUnitTestCase{
+				Name: "[sig-arch] Only known images used by tests",
+			})
 		}
 
 		return tests


### PR DESCRIPTION
lack of passes in addition to failures on this test impacted https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-gcp-sdn-upgrade-4.10-micro-release-openshift-release-analysis-aggregator/1443917511878774784

though the run was likely doomed overall.