### PR TITLE
Bug 1992596: e2e/cli: More basicresources.sh

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -244,6 +244,7 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 			if !ok {
 				byImage = sets.NewString()
 				pulls[image] = byImage
+				fmt.Printf("[sig-arch] unknown image: %s\n", image)
 			}
 			byImage.Insert(event.Locator)
 		}

--- a/test/extended/cli/basics.go
+++ b/test/extended/cli/basics.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	k8simage "k8s.io/kubernetes/test/utils/image"
+)
+
+var _ = g.Describe("[sig-cli] oc basics", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc                   = exutil.NewCLI("oc-basics")
+		cmdTestData          = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata")
+		mixedAPIVersionsFile = exutil.FixturePath("testdata", "mixed-api-versions.yaml")
+		oauthAccessTokenFile = filepath.Join(cmdTestData, "oauthaccesstoken.yaml")
+	)
+
+	g.It("can create and interact with a list of resources", func() {
+		file, err := replaceImageInFile(mixedAPIVersionsFile, "openshift/hello-openshift", k8simage.GetE2EImage(k8simage.EchoServer))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer os.Remove(file)
+
+		err = oc.Run("create").Args("-f", file).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err := oc.Run("get").Args("-f", file, "-o", "yaml").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("v1-job"))
+
+		err = oc.Run("label").Args("-f", file, "mylabel=a").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.Run("annotate").Args("-f", file, "myannotation=b").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err = oc.Run("get").Args("-f", file, `--output=jsonpath="{..metadata.labels.mylabel}"`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("a a a a"))
+
+		out, err = oc.Run("get").Args("-f", file, `--output=jsonpath="{..metadata.annotations.myannotation}"`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("b b b b"))
+
+		err = oc.Run("delete").Args("-f", file).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("can create deploymentconfig and clusterquota", func() {
+		nginx := k8simage.GetE2EImage(k8simage.Nginx)
+
+		err := oc.Run("create").Args("dc", "my-nginx", "--image="+nginx).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.Run("delete").Args("dc", "my-nginx").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// need admin here
+		ocAdmin := oc.AsAdmin()
+		err = ocAdmin.Run("create").Args("clusterquota", "limit-bob", "--project-label-selector=openshift.io/requestor=user-bob", "--hard=pods=10").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = ocAdmin.Run("delete").Args("clusterquota", "limit-bob").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("can patch resources", func() {
+		// need admin here
+		ocAdmin := oc.AsAdmin()
+
+		err := ocAdmin.Run("adm").Args("groups", "new", "patch-group").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = ocAdmin.Run("patch").Args("group", "patch-group", "-p", `users: ["myuser"]`, "--loglevel=8").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err := ocAdmin.Run("get").Args("group", "patch-group", "-o", "yaml").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("myuser"))
+
+		err = ocAdmin.Run("patch").Args("group", "patch-group", "-p", `users: []`, "--loglevel=8").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// apply same patch twice results in "not patched" text
+		out, err = ocAdmin.Run("patch").Args("group", "patch-group", "-p", `users: []`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring(`patched (no change)`))
+
+		// applying an invalid patch results in exit code 1 with error text
+		out, err = ocAdmin.Run("patch").Args("group", "patch-group", "-p", `users: ""`).Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring(`cannot restore slice from string`))
+
+		out, err = ocAdmin.Run("get").Args("group", "patch-group", "-o", "yaml").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("users: []"))
+
+		err = ocAdmin.Run("delete").Args("group", "patch-group").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("can describe an OAuth access token", func() {
+		// need admin here
+		ocAdmin := oc.AsAdmin()
+
+		err := ocAdmin.Run("create").Args("-f", oauthAccessTokenFile).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err := ocAdmin.Run("describe").Args("oauthaccesstoken", "sha256~efaca6fab897953ffcb4f857eb5cbf2cf3a4c33f1314b4922656303426b1cfc9").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("efaca6fab897953ffcb4f857eb5cbf2cf3a4c33f1314b4922656303426b1cfc9"))
+
+		err = ocAdmin.Run("delete").Args("oauthaccesstoken", "sha256~efaca6fab897953ffcb4f857eb5cbf2cf3a4c33f1314b4922656303426b1cfc9").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})

--- a/test/extended/testdata/cmd/test/cmd/testdata/multiport-service.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/multiport-service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-10-13T10:13:11Z
+    labels:
+      test: missing-route-port
+    name: frontend
+    resourceVersion: "259"
+    uid: 024d82eb-7193-11e5-b84d-080027c5bfa9
+  spec:
+    clusterIP: 172.30.182.32
+    ports:
+    - name: web
+      port: 5432
+      protocol: TCP
+      targetPort: 8080
+    - name: web2
+      port: 5433
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: frontend
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}

--- a/test/extended/testdata/cmd/test/cmd/testdata/oauthaccesstoken.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/oauthaccesstoken.yaml
@@ -1,0 +1,11 @@
+apiVersion: oauth.openshift.io/v1
+clientName: openshift-challenging-client
+expiresIn: 15552000
+kind: OAuthAccessToken
+metadata:
+  name: sha256~efaca6fab897953ffcb4f857eb5cbf2cf3a4c33f1314b4922656303426b1cfc9
+redirectURI: https://localhost:8443/oauth/token/implicit
+userName: test
+userUID: 322b236b-22b9-11e6-b307-080027242396
+scopes:
+  - user:info

--- a/test/extended/testdata/mixed-api-versions.yaml
+++ b/test/extended/testdata/mixed-api-versions.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      description: v1 Secret - used to test v1 negotiation of k8s objects
+    name: v1-secret
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      description: v1 Route - used to test v1 negotiation of origin objects
+    name: v1-route
+  spec:
+    to:
+      kind: Service
+      name: test
+
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    annotations:
+      description: v1 Job - used to test v1 negotiation of group k8s objects
+    name: v1-job
+  spec:
+    template:
+      metadata:
+        labels:
+          run: v1-job
+      spec:
+        containers:
+        - image: openshift/hello-openshift
+          name: hello-container
+        restartPolicy: Never
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    annotations:
+      description: v1 ConfigMap - used to test v1 negotiation of k8s objects
+    name: v1-configmap

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1311,6 +1311,14 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc annotate pod": "pod [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-cli] oc basics can create and interact with a list of resources": "can create and interact with a list of resources [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-cli] oc basics can create deploymentconfig and clusterquota": "can create deploymentconfig and clusterquota [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-cli] oc basics can describe an OAuth access token": "can describe an OAuth access token [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-cli] oc basics can patch resources": "can patch resources [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-cli] oc builds complex build start-build": "start-build [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc builds complex build webhooks CRUD": "webhooks CRUD [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Moved more of the basicresources.sh over to Go tests, restored a missing fixture, and provide a way to replace images used in fixtures to ensure we always use known images.