### PR TITLE
Bug 2008114: Add role label to jenkins imagestream

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -43413,6 +43413,8 @@ func testExtendedTestdataImagestreamJenkinsSlavePodsYaml() (*asset, error) {
 var _testExtendedTestdataImagestreamtagJenkinsSlavePodsYaml = []byte(`apiVersion: v1
 kind: ImageStream
 metadata:
+  labels:
+    role: jenkins-slave
   name: slave-jenkins
 spec:
   tags:

--- a/test/extended/testdata/imagestreamtag-jenkins-slave-pods.yaml
+++ b/test/extended/testdata/imagestreamtag-jenkins-slave-pods.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ImageStream
 metadata:
+  labels:
+    role: jenkins-slave
   name: slave-jenkins
 spec:
   tags:


### PR DESCRIPTION
Add the role label to the Jenkins agent imagestream so the sync plugin
can pick up changes. Backport of changes for BZ 1925524.

Note that this change includes namings that violate inclusive language
standards. This is to maintain backwards compatibility with prior
versions of the sync plugin. Future versions of the sync plugin will
support more inclusive namings.