### PR TITLE
Bug 1960674: images: port image signature workflow test to OCP4/UBI8

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -51318,13 +51318,16 @@ items:
       - type: ConfigChange
     source:
       dockerfile: |
-        FROM quay.io/openshift/origin-control-plane:latest
-        RUN yum-config-manager --disable origin-local-release ||:
+        FROM quay.io/openshift/origin-cli:latest
+        WORKDIR /var/lib/origin
+        RUN yum config-manager \
+            --add-repo 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os/' \
+            --add-repo 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os/'
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
-            Key-Type: DSA \n\
-            Key-Length: 1024 \n\
+            Key-Type: RSA \n\
+            Key-Length: 2048 \n\
             Subkey-Type: ELG-E \n\
             Subkey-Length: 1024 \n\
             Name-Real: Joe Tester \n\
@@ -51339,7 +51342,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: quay.io/openshift/origin-control-plane:latest
+          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -16,13 +16,16 @@ items:
       - type: ConfigChange
     source:
       dockerfile: |
-        FROM quay.io/openshift/origin-control-plane:latest
-        RUN yum-config-manager --disable origin-local-release ||:
+        FROM quay.io/openshift/origin-cli:latest
+        WORKDIR /var/lib/origin
+        RUN yum config-manager \
+            --add-repo 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os/' \
+            --add-repo 'https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os/'
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
-            Key-Type: DSA \n\
-            Key-Length: 1024 \n\
+            Key-Type: RSA \n\
+            Key-Length: 2048 \n\
             Subkey-Type: ELG-E \n\
             Subkey-Length: 1024 \n\
             Name-Real: Joe Tester \n\
@@ -37,7 +40,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: quay.io/openshift/origin-control-plane:latest
+          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag


### PR DESCRIPTION
This fixes portability issues with this test, given that origin-control-plane:v3.11 (besides being obsolete) is only available for x86_64.  Also, copying the oc binary from the machine running the test into a container on the cluster would cause the test to fail when run on a different architecture, or when oc was built for a newer glibc. There was also no guarantee that the oc found on the test machine matched that of the payload being tested.

Instead, this uses the payload cli container, which is based on RHEL 8.  Because 4.y CI builds do not have any publicly accessible yum repos, UBI 8 is added manually to get skopeo and its dependencies. The rest of the changes are a consequence of adapting to the newer versions of gpg2 and skopeo.

v2: fix key type for RHEL 8 FIPS compatibility (see #26479 and #26485)

/assign @stbenjam
