### PR TITLE
[sig-arch][Late] operators should not create watch channels very often: be more verbose when failing the expected condition

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -414,7 +414,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 			return watchRequestCounts[i].count > watchRequestCounts[j].count
 		})
 
-		fail := false
+		operatorBoundExceeded := []string{}
 		for _, item := range watchRequestCounts {
 			operator := strings.Split(item.operator, ":")[3]
 			count, exists := upperBound[operator]
@@ -429,11 +429,11 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 			// In the worst case half of the requests will be put into each bucket. Thus, multiply the bound by 2
 			framework.Logf("operator=%v, watchrequestcount=%v, upperbound=%v, ratio=%v", operator, item.count, 2*count, float64(item.count)/float64(2*count))
 			if item.count > 2*count {
-				framework.Logf("Operator %v produces more watch requests than expected", operator)
-				fail = true
+				framework.Logf("Operator %q produces more watch requests than expected", operator)
+				operatorBoundExceeded = append(operatorBoundExceeded, fmt.Sprintf("Operator %q produces more watch requests than expected: watchrequestcount=%v, upperbound=%v, ratio=%v", operator, item.count, 2*count, float64(item.count)/float64(2*count)))
 			}
 		}
 
-		o.Expect(fail).NotTo(o.BeTrue())
+		o.Expect(operatorBoundExceeded).To(o.BeEmpty())
 	})
 })


### PR DESCRIPTION
Currently when checking the failed test through the spyglass summary one can see

```
fail [github.com/openshift/origin/test/extended/apiserver/api_requests.go:437]: Expected
    <bool>: true
not to be true
```

In order to see what's wrong one has to the stdout output. To make the user experience more friendly, let's change it to:

```
fail [github.com/openshift/origin/test/extended/apiserver/api_requests.go:437]: Expected
    <[]string | len:26, cap:32>: [
        "Operator \"ingress-operator\" produces more watch requests than expected: watchrequestcount=1000, upperbound=742, ratio=1.366120219",
        "Operator \"authentication-operator\" produces more watch requests than expected: watchrequestcount=900, upperbound=616, ratio=1.461038961",
    ]
to be empty
```