### PR TITLE
Added 2 Whereabouts e2e tests

### DIFF
--- a/test/extended/networking/whereabouts.go
+++ b/test/extended/networking/whereabouts.go
@@ -1,0 +1,171 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+var _ = g.Describe("[sig-network][Feature:Whereabouts]", func() {
+
+	oc := exutil.NewCLI("whereabouts-e2e")
+
+	// Whereabouts is already installed in Origin. These tests aims to verify the integrity of the installation.
+
+	g.It("should use whereabouts net-attach-def to limit IP ranges for newly created pods", func() {
+		var err error
+
+		f := oc.KubeFramework()
+		podName := "whereabouts-pod-"
+		ns := f.Namespace.Name
+
+		g.By("creating a whereabouts net-attach-def using bridgeCNI")
+		nad_yaml := exutil.FixturePath("testdata", "net-attach-defs", "whereabouts-nad.yml")
+		g.By(fmt.Sprintf("calling oc create -f %s", nad_yaml))
+		err = oc.AsAdmin().Run("create").Args("-f", nad_yaml).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred(), "created net-attach-def")
+
+		g.By("launching pods with annotations to use the net-attach-def")
+		annotation := map[string]string{
+			"k8s.v1.cni.cncf.io/networks": "wa-conf",
+		}
+		// First three pods should come up without issue.
+		testPod := frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+			pod.ObjectMeta.Annotations = annotation
+		})
+		testPod2 := frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+			pod.ObjectMeta.Annotations = annotation
+		})
+		testPod3 := frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+			pod.ObjectMeta.Annotations = annotation
+		})
+		// Fourth pod should not come up.
+		fmt.Println("...creating 4th exec pod, expecting failure due to IPAM")
+		ExecPodSpec := e2epod.NewAgnhostPod(ns, "", nil, nil, nil)
+		ExecPodSpec.ObjectMeta.GenerateName = podName
+		ExecPodSpec.ObjectMeta.Annotations = annotation
+		f.ClientSet.CoreV1().Pods(ns).Create(context.TODO(), ExecPodSpec, metav1.CreateOptions{})
+		time.Sleep(30 * time.Second)
+
+		g.By("checking that additional pods do not come up when range is exhausted")
+		output, err := oc.AsAdmin().Run("get").Args("pods").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		getPodArr := strings.Split(output, "\n")
+		failedPodCount := 0
+		for _, v := range getPodArr {
+			if strings.Contains(v, "ContainerCreating") {
+				failedPodCount++
+				if failedPodCount > 1 {
+					break
+				}
+			}
+		}
+		o.Expect(failedPodCount).To(o.Equal(1))
+		fmt.Println(output)
+
+		g.By("checking that successfully started pods are within IP range")
+		// pod 1 ip check
+		output, err = oc.AsAdmin().Run("exec").Args(testPod.Name, "--", "ip", "a").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(output)
+		o.Expect(output).Should(o.ContainSubstring("192.168.2.228"))
+		// pod 1 annotation check
+		output, err = oc.AsAdmin().Run("describe").Args("pod", testPod.Name).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(output)
+		o.Expect(output).Should(o.ContainSubstring("192.168.2.228"))
+		// pod 2 ip check
+		output, err = oc.AsAdmin().Run("exec").Args(testPod2.Name, "--", "ip", "a").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(output)
+		o.Expect(output).Should(o.ContainSubstring("192.168.2.229"))
+		// pod 2 annotation check
+		output, err = oc.AsAdmin().Run("describe").Args("pod", testPod2.Name).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(output)
+		o.Expect(output).Should(o.ContainSubstring("192.168.2.229"))
+		// pod 3 ip check
+		output, err = oc.AsAdmin().Run("exec").Args(testPod3.Name, "--", "ip", "a").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(output)
+		o.Expect(output).Should(o.ContainSubstring("192.168.2.230"))
+		// pod 3 annotation check
+		output, err = oc.AsAdmin().Run("describe").Args("pod", testPod3.Name).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(output)
+		o.Expect(output).Should(o.ContainSubstring("192.168.2.230"))
+
+	})
+
+	g.It("should assign unique IP addresses to each pod in the event of a race condition case", func() {
+		// steps for the test
+		// 1. create sleepy pod
+		// 2. create awake pod
+		// 3. check if both pods have unique ip
+		var err error
+
+		f := oc.KubeFramework()
+		podName := "whereabouts-pod-"
+		ns := f.Namespace.Name
+
+		g.By("creating a whereabouts net-attach-def that invokes sleep")
+		nad_yaml := exutil.FixturePath("testdata", "net-attach-defs", "whereabouts-race-sleepy.yml")
+		g.By(fmt.Sprintf("calling oc create -f %s", nad_yaml))
+		err = oc.AsAdmin().Run("create").Args("-f", nad_yaml).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred(), "created net-attach-def")
+
+		g.By("creating a whereabouts net-attach-def that does not invoke sleep")
+		nad_yaml = exutil.FixturePath("testdata", "net-attach-defs", "whereabouts-race-awake.yml")
+		g.By(fmt.Sprintf("calling oc create -f %s", nad_yaml))
+		err = oc.AsAdmin().Run("create").Args("-f", nad_yaml).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred(), "created net-attach-def")
+
+		g.By("launching pods with annotations to use the net-attach-defs")
+		annotation := map[string]string{
+			"k8s.v1.cni.cncf.io/networks": "wa-sleepy-conf",
+		}
+		sleepyPod := frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+			pod.ObjectMeta.Annotations = annotation
+			pod.ObjectMeta.Name = "sleepy-pod"
+		})
+
+		annotation = map[string]string{
+			"k8s.v1.cni.cncf.io/networks": "wa-awake-conf",
+		}
+		awakePod := frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+			pod.ObjectMeta.Annotations = annotation
+			pod.ObjectMeta.Name = "awake-pod"
+		})
+
+		g.By("checking that both pods are running with unique IP addresses")
+		pod1_ip, err := oc.AsAdmin().Run("exec").Args(sleepyPod.Name, "--", "ip", "a").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(pod1_ip)
+
+		pod2_ip, err := oc.AsAdmin().Run("exec").Args(awakePod.Name, "--", "ip", "a").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(pod2_ip)
+
+		pod1_desc, err := oc.AsAdmin().Run("describe").Args("pod", sleepyPod.Name).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(pod1_desc)
+
+		pod2_desc, err := oc.AsAdmin().Run("describe").Args("pod", awakePod.Name).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		fmt.Println(pod2_desc)
+
+		// check that IP addresses for both pods are unique.
+		o.Expect(pod1_ip).ShouldNot(o.Equal(pod2_ip))
+		o.Expect(pod1_desc).ShouldNot(o.Equal(pod2_desc))
+
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -436,6 +436,9 @@
 // test/extended/testdata/multi-namespace-pipeline.yaml
 // test/extended/testdata/multi-namespace-template.yaml
 // test/extended/testdata/net-attach-defs/bridge-nad.yml
+// test/extended/testdata/net-attach-defs/whereabouts-nad.yml
+// test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml
+// test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml
 // test/extended/testdata/oauthserver/cabundle-cm.yaml
 // test/extended/testdata/oauthserver/oauth-network.yaml
 // test/extended/testdata/oauthserver/oauth-pod.yaml
@@ -48216,6 +48219,122 @@ func testExtendedTestdataNetAttachDefsBridgeNadYml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataNetAttachDefsWhereaboutsNadYml = []byte(`apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: wa-conf
+spec: 
+  config: '{
+	"cniVersion": "0.3.0",
+	"name": "whereaboutstestbridge",
+	"type": "bridge",
+	"bridge": "watestbr0",
+	"isDefaultGateway": true,
+	"forceAddress": false,
+	"ipMasq": true,
+	"hairpinMode": true,
+	"ipam": {
+		"type": "whereabouts",
+		"range": "192.168.2.225/29",
+		"exclude": [
+		  "192.168.2.225/30"
+		],
+		"log_file": "/tmp/whereabouts.log",
+    "log_level": "debug" 
+	}
+}'`)
+
+func testExtendedTestdataNetAttachDefsWhereaboutsNadYmlBytes() ([]byte, error) {
+	return _testExtendedTestdataNetAttachDefsWhereaboutsNadYml, nil
+}
+
+func testExtendedTestdataNetAttachDefsWhereaboutsNadYml() (*asset, error) {
+	bytes, err := testExtendedTestdataNetAttachDefsWhereaboutsNadYmlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/net-attach-defs/whereabouts-nad.yml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml = []byte(`apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: wa-awake-conf
+spec:
+  config: '{
+  "cniVersion": "0.3.0",
+  "name": "whereaboutsexample",
+  "type": "bridge",
+  "bridge": "watestbr1",
+  "isDefaultGateway": true,
+  "forceAddress": false,
+  "ipMasq": true,
+  "hairpinMode": true,
+  "ipam": {
+    "type": "whereabouts",
+    "range": "192.168.2.240/28",
+    "log_file": "/tmp/whereabouts.log",
+    "log_level": "debug" 
+  }
+}'
+`)
+
+func testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYmlBytes() ([]byte, error) {
+	return _testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml, nil
+}
+
+func testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml() (*asset, error) {
+	bytes, err := testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYmlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml = []byte(`apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: wa-sleepy-conf
+spec:
+  config: '{
+  "cniVersion": "0.3.0",
+  "name": "whereaboutsexample",
+  "type": "bridge",
+  "bridge": "watestbr1",
+  "isDefaultGateway": true,
+  "forceAddress": false,
+  "ipMasq": true,
+  "hairpinMode": true,
+  "ipam": {
+    "type": "whereabouts",
+    "sleep_for_race": 5,
+    "range": "192.168.2.240/28",
+    "log_file": "/tmp/whereabouts.log",
+    "log_level": "debug"
+  }
+}'`)
+
+func testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYmlBytes() ([]byte, error) {
+	return _testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml, nil
+}
+
+func testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml() (*asset, error) {
+	bytes, err := testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYmlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataOauthserverCabundleCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -53802,6 +53921,9 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/multi-namespace-pipeline.yaml":                                                   testExtendedTestdataMultiNamespacePipelineYaml,
 	"test/extended/testdata/multi-namespace-template.yaml":                                                   testExtendedTestdataMultiNamespaceTemplateYaml,
 	"test/extended/testdata/net-attach-defs/bridge-nad.yml":                                                  testExtendedTestdataNetAttachDefsBridgeNadYml,
+	"test/extended/testdata/net-attach-defs/whereabouts-nad.yml":                                             testExtendedTestdataNetAttachDefsWhereaboutsNadYml,
+	"test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml":                                      testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml,
+	"test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml":                                     testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml,
 	"test/extended/testdata/oauthserver/cabundle-cm.yaml":                                                    testExtendedTestdataOauthserverCabundleCmYaml,
 	"test/extended/testdata/oauthserver/oauth-network.yaml":                                                  testExtendedTestdataOauthserverOauthNetworkYaml,
 	"test/extended/testdata/oauthserver/oauth-pod.yaml":                                                      testExtendedTestdataOauthserverOauthPodYaml,
@@ -54545,7 +54667,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"multi-namespace-pipeline.yaml": {testExtendedTestdataMultiNamespacePipelineYaml, map[string]*bintree{}},
 				"multi-namespace-template.yaml": {testExtendedTestdataMultiNamespaceTemplateYaml, map[string]*bintree{}},
 				"net-attach-defs": {nil, map[string]*bintree{
-					"bridge-nad.yml": {testExtendedTestdataNetAttachDefsBridgeNadYml, map[string]*bintree{}},
+					"bridge-nad.yml":              {testExtendedTestdataNetAttachDefsBridgeNadYml, map[string]*bintree{}},
+					"whereabouts-nad.yml":         {testExtendedTestdataNetAttachDefsWhereaboutsNadYml, map[string]*bintree{}},
+					"whereabouts-race-awake.yml":  {testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml, map[string]*bintree{}},
+					"whereabouts-race-sleepy.yml": {testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml, map[string]*bintree{}},
 				}},
 				"oauthserver": {nil, map[string]*bintree{
 					"cabundle-cm.yaml":   {testExtendedTestdataOauthserverCabundleCmYaml, map[string]*bintree{}},

--- a/test/extended/testdata/net-attach-defs/whereabouts-nad.yml
+++ b/test/extended/testdata/net-attach-defs/whereabouts-nad.yml
@@ -1,0 +1,24 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: wa-conf
+spec: 
+  config: '{
+	"cniVersion": "0.3.0",
+	"name": "whereaboutstestbridge",
+	"type": "bridge",
+	"bridge": "watestbr0",
+	"isDefaultGateway": true,
+	"forceAddress": false,
+	"ipMasq": true,
+	"hairpinMode": true,
+	"ipam": {
+		"type": "whereabouts",
+		"range": "192.168.2.225/29",
+		"exclude": [
+		  "192.168.2.225/30"
+		],
+		"log_file": "/tmp/whereabouts.log",
+    "log_level": "debug" 
+	}
+}'

--- a/test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml
+++ b/test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml
@@ -1,0 +1,21 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: wa-awake-conf
+spec:
+  config: '{
+  "cniVersion": "0.3.0",
+  "name": "whereaboutsexample",
+  "type": "bridge",
+  "bridge": "watestbr1",
+  "isDefaultGateway": true,
+  "forceAddress": false,
+  "ipMasq": true,
+  "hairpinMode": true,
+  "ipam": {
+    "type": "whereabouts",
+    "range": "192.168.2.240/28",
+    "log_file": "/tmp/whereabouts.log",
+    "log_level": "debug" 
+  }
+}'

--- a/test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml
+++ b/test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml
@@ -1,0 +1,22 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: wa-sleepy-conf
+spec:
+  config: '{
+  "cniVersion": "0.3.0",
+  "name": "whereaboutsexample",
+  "type": "bridge",
+  "bridge": "watestbr1",
+  "isDefaultGateway": true,
+  "forceAddress": false,
+  "ipMasq": true,
+  "hairpinMode": true,
+  "ipam": {
+    "type": "whereabouts",
+    "sleep_for_race": 5,
+    "range": "192.168.2.240/28",
+    "log_file": "/tmp/whereabouts.log",
+    "log_level": "debug"
+  }
+}'

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2337,6 +2337,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:Router] The HAProxy router should support reencrypt to services backed by a serving certificate automatically": "should support reencrypt to services backed by a serving certificate automatically [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network][Feature:Whereabouts] should assign unique IP addresses to each pod in the event of a race condition case": "should assign unique IP addresses to each pod in the event of a race condition case [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-network][Feature:Whereabouts] should use whereabouts net-attach-def to limit IP ranges for newly created pods": "should use whereabouts net-attach-def to limit IP ranges for newly created pods [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network][endpoints] admission blocks manual creation of EndpointSlices pointing to the cluster or service network": "blocks manual creation of EndpointSlices pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][endpoints] admission blocks manual creation of Endpoints pointing to the cluster or service network": "blocks manual creation of Endpoints pointing to the cluster or service network [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Created 2 e2e tests for whereabouts. 

The first makes 4 pods with a whereabouts IPAM that only allows 3 IP addresses. The expected result is that the first 3 come up successfully and the 4th pod doesn't.

The second makes 2 pods, one with a parameter to sleep for ~20 seconds~ 5 seconds (configurable via `whereabouts-race-sleepy.yml`, located in `test/extended/testdata/net-attach-defs`) after getting its IP address, and the second with no such parameter. The expected result is that a race condition should not occur on working code, and both pods should be assigned unique IPs.