### PR TITLE
WIP distruption: display disruption time which lasts less than a second

### DIFF
--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -313,10 +313,10 @@ func createTestFrameworks(tests []upgrades.Test) map[string]*framework.Framework
 // if the sum of the intervals is greater than 1m, or report a flake if any interval is found.
 func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Duration, events monitorapi.Intervals, reason string) {
 	FrameworkEventIntervals(f, events)
-	duration := events.Duration(0, 1*time.Second)
+	duration := events.Duration(0, 1*time.Millisecond)
 	describe := events.Strings()
 	if percent := float64(duration) / float64(total); percent > tolerate {
-		framework.Failf("%s for at least %s of %s (%0.0f%%):\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
+		framework.Failf("%s for at least %s of %s (%0.0f%%):\n\n%s", reason, duration.Truncate(time.Millisecond), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
 	} else if duration > 0 {
 		FrameworkFlakef(f, "%s for at least %s of %s (%0.0f%%), this is currently sufficient to pass the test/job but not considered completely correct:\n\n%s", reason, duration.Truncate(time.Second), total.Truncate(time.Second), percent*100, strings.Join(describe, "\n"))
 	}


### PR DESCRIPTION
Less than second disruption is not tolerated on most platforms. In this case error message would show 'API "foo" was unreachable during disruption  for at least 0s", which is confusing.

This change updates duration to milliseconds so that error message would be more precise.

Example job with subsecond disruption - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1446200416613175296
>API "openshift-api-available-reused-connections" was unreachable during disruption (AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804) for at least 0s of 1h7m47s (0%):