### PR TITLE
e2echart: show time in timeline as UTC

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -315,7 +315,7 @@
             '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes
             '#3cb043', '#ceba76', '#ffa500', '#d0312d', // tests
             '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
-    myChart.data(timelineGroups).zQualitative(true).enableAnimations(false).leftMargin(240).rightMargin(550).maxLineHeight(20).maxHeight(10000).zColorScale(ordinalScale).onSegmentClick(segmentFunc)
+    myChart.data(timelineGroups).zQualitative(true).enableAnimations(false).leftMargin(240).rightMargin(550).maxLineHeight(20).maxHeight(10000).zColorScale(ordinalScale).onSegmentClick(segmentFunc).useUtc(true)
     (el);
 
     // force a minimum width for smaller devices (which otherwise get an unusable display)

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53278,7 +53278,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes
             '#3cb043', '#ceba76', '#ffa500', '#d0312d', // tests
             '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
-    myChart.data(timelineGroups).zQualitative(true).enableAnimations(false).leftMargin(240).rightMargin(550).maxLineHeight(20).maxHeight(10000).zColorScale(ordinalScale).onSegmentClick(segmentFunc)
+    myChart.data(timelineGroups).zQualitative(true).enableAnimations(false).leftMargin(240).rightMargin(550).maxLineHeight(20).maxHeight(10000).zColorScale(ordinalScale).onSegmentClick(segmentFunc).useUtc(true)
     (el);
 
     // force a minimum width for smaller devices (which otherwise get an unusable display)


### PR DESCRIPTION
Force time displayed on timeline charts to be UTC, so that message timestamps would be easier to correlate with displayed timelines