### PR TITLE
test/e2e/upgrade/alert/alert.go: indent alert labels

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -187,7 +187,7 @@ count_over_time(ALERTS{alertstate="firing",severity!="info",alertname!~"Watchdog
 	o.Expect(err).NotTo(o.HaveOccurred(), "unable to check firing alerts during upgrade")
 	for _, series := range result.Data.Result {
 		labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
-		violation := fmt.Sprintf("alert %s fired for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
+		violation := fmt.Sprintf("alert %s fired for %s seconds with labels:\n%s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
 		if cause := firingAlertsWithBugs.Matches(series); cause != nil {
 			knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
 		} else {

--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -120,7 +120,11 @@ func (c MetricConditions) Matches(sample *model.Sample) *MetricCondition {
 }
 
 func LabelsAsSelector(l model.LabelSet) string {
-	return l.String()
+	indentedLabels, err := json.MarshalIndent(l, "", "  ")
+	if err != nil {
+		return l.String()
+	}
+	return string(indentedLabels)
 }
 
 func StripLabels(m model.Metric, names ...string) model.LabelSet {


### PR DESCRIPTION
Marshal labels as json and print the result with indent for better readability