### PR TITLE
#26521 add newline at the end of each command execution

### DIFF
--- a/tools/etcdhelper/etcdhelper.go
+++ b/tools/etcdhelper/etcdhelper.go
@@ -134,6 +134,7 @@ func getKey(client *clientv3.Client, key string) error {
 			fmt.Fprintf(os.Stderr, "WARN: unable to encode %s: %v\n", kv.Key, err)
 			continue
 		}
+		println()
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: 王凯 <wangkai05@bilibili.com>

The etcdhelper is helpful when i study K8s in deep, for making etcdhelper more user-friendly, A newline at the end of output.