### PR TITLE
RBAC default rules test: allow new configmap to authenticated users

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -157,7 +157,8 @@ var (
 			},
 			"openshift-config-managed": {
 				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("configmaps").Names("console-public").RuleOrDie(),
-				rbacv1helpers.NewRule(read...).Groups("").Resources("configmaps").Names("oauth-serving-cert", "openshift-network-features").RuleOrDie(),
+				rbacv1helpers.NewRule(read...).Groups("").Resources("configmaps").Names("oauth-serving-cert").RuleOrDie(),
+				rbacv1helpers.NewRule("get").Groups("").Resources("configmaps").Names("openshift-network-features").RuleOrDie(),
 			},
 			"kube-system": {
 				// this allows every authenticated user to use in-cluster client certificate termination


### PR DESCRIPTION
This PR is blocking [this other PR from the Cluster Network Operator](https://github.com/openshift/cluster-network-operator/pull/1204), as [it fails](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-network-operator/1204/pull-ci-openshift-cluster-network-operator-master-e2e-gcp/1446099339481976832) because it is introducing [a new configmap that should be available to any user](https://github.com/openshift/cluster-network-operator/pull/1204/files#diff-a24a952ab1c255c51a8ba6578ec06e2275065381764356ca304bc8d406fb504fR9-R15).

> Context: [Expose Network Features RFE](https://github.com/openshift/enhancements/blob/master/enhancements/console/expose-network-features.md).
>
> The console requires to know the network type capabilities to show/hide some Network Policy form fields as a function of the CNI type. Currently, this only works for users with privileges to retrieve the CNI type.
>
> To allow this functionality to be available to any user, the linked enhancement document agrees that the information about the required network capabilities will be added to a new `openshift-network-features` `ConfigMap`, created by the CNO, readable by any `system:authenticated` user.