### PR TITLE
Remove HighlyAvailableWorkloadIncorrectlySpread alert

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -97,16 +97,6 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			},
 		},
 		{
-			// Should be removed one release after the attached bugzilla is fixed.
-			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
-		},
-		{
-			// Should be removed one release after the attached bugzilla is fixed.
-			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
-		},
-		{
 			// Should be removed one release after the attached bugzilla is fixed, or after that bug is fixed in a backport to the previous minor.
 			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
 			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1985073",

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -320,14 +320,6 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 					return framework.ProviderIs("gce")
 				},
 			},
-			{
-				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
-			},
-			{
-				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
-			},
 		}
 		allowedFiringAlerts := helper.MetricConditions{
 			{


### PR DESCRIPTION
Since https://github.com/openshift/cluster-monitoring-operator/pull/1437 is removing the HighlyAvailableWorkloadIncorrectlySpread alert, we can now remove it from the exception list.