### PR TITLE
ignore ClusterNotUpgradeable alert on a TechPreviewNoUpgrade cluster

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -341,11 +341,16 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		}
 
 		if isTechPreviewCluster(oc) {
-			allowedFiringAlerts = append(allowedFiringAlerts, helper.MetricCondition{
-				Selector: map[string]string{"alertname": "TechPreviewNoUpgrade"},
-				Text:     "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been installed",
-			},
-			)
+			allowedFiringAlerts = append(
+				allowedFiringAlerts,
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": "TechPreviewNoUpgrade"},
+					Text:     "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been installed",
+				},
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": "ClusterNotUpgradeable"},
+					Text:     "Allow testing of ClusterNotUpgradeable clusters, this will only fire when a FeatureGate has been installed",
+				})
 		}
 
 		pendingAlertsWithBugs := helper.MetricConditions{}


### PR DESCRIPTION
the e2e-aws-builds-techpreview test failed because the ClusterNotUpgradeable alert was fired.
On a TechPreviewNoUpgrade cluster we must ignore the ClusterNotUpgradeable alert
fired by the Kube API Operator. the same as the TechPreviewNoUpgrade alert

I already fix a test for this, https://github.com/openshift/origin/pull/26515, but the alert is still fired in current test we are fixing with the current PR