### PR TITLE
test/extended/operators: New staff-engineer OWNERS

### DIFF
--- a/test/extended/operators/OWNERS
+++ b/test/extended/operators/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- bparees
+- deads2k
+- mfojtik
+- sdodson
+approvers:
+- bparees
+- deads2k
+- mfojtik
+- sdodson


### PR DESCRIPTION
The OLM bits and their approvers moved out in 0386cd5b52 (#26500).  The remaining tests in this directory are a bit of a muddle:

```console
$ git --no-pager grep -h 'Describe(\|It(' test/extended/operators
var _ = g.Describe("[sig-storage] Managed cluster should", func() {
        g.It("have no crashlooping recycler pods over four minutes", func() {
/*var _ = g.Describe("[sig-arch] Managed cluster should", func() {
        g.It("have no crashlooping pods in core namespaces over four minutes", func() {
var _ = g.Describe("[sig-arch] ClusterOperators", func() {
var _ = g.Describe("[sig-arch] Managed cluster", func() {
        g.It("should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent", func() {
var _ = Describe("[sig-arch] Managed cluster", func() {
        It("should ensure pods use downstream images from our release image with proper ImagePullPolicy", func() {
...
```

The approver set I'm using was recommended by @bparees, and makes sense as a collection of staff-engineers with an interest in origin suite health.  Ben suggested Git history for the reviewer set, but of the folks towards the bottom of:

```console
$ git shortlog -se test/extended/operators | sort -n
```

nobody other than Clayton was jumping out at me as having the breadth to review the scope of the directory (e.g. I'm there, but I certainly don't have opinions on downstream images or recycler pods).