### PR TITLE
write disruption data

### DIFF
--- a/pkg/monitor/monitorapi/disruption.go
+++ b/pkg/monitor/monitorapi/disruption.go
@@ -1,0 +1,34 @@
+package monitorapi
+
+import (
+	"strings"
+	"time"
+)
+
+// BackendDisruptionSeconds return duration disrupted, disruptionMessages, and New or Reused
+func BackendDisruptionSeconds(locator string, events Intervals) (time.Duration, []string, string) {
+	disruptionEvents := events.Filter(
+		func(i EventInterval) bool {
+			if i.Locator != locator {
+				return false
+			}
+			if !strings.Contains(i.Message, "stopped responding") {
+				return false
+			}
+			return true
+		},
+	)
+	disruptionMessages := disruptionEvents.Strings()
+	connectionType := "Unknown"
+	for _, disruptionMessage := range disruptionMessages {
+		switch {
+		case strings.Contains(disruptionMessage, "over reusedconnections"):
+			connectionType = "Reused"
+		case strings.Contains(disruptionMessage, "over new connections"):
+			connectionType = "New"
+		default:
+			connectionType = "Unknown"
+		}
+	}
+	return disruptionEvents.Duration(0, 1*time.Second), disruptionMessages, connectionType
+}

--- a/pkg/monitor/write_job_run_data.go
+++ b/pkg/monitor/write_job_run_data.go
@@ -1,0 +1,46 @@
+package monitor
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+	"github.com/openshift/origin/test/extended/testdata"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// WriteRunDataToArtifactsDir attempts to write useful run data to the specified directory.
+func WriteRunDataToArtifactsDir(artifactDir string, monitor *Monitor, events monitorapi.Intervals, timeSuffix string) error {
+	errors := []error{}
+	if err := monitorserialization.EventsToFile(filepath.Join(artifactDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)), events); err != nil {
+		errors = append(errors, err)
+	} else {
+	}
+	if err := monitorserialization.EventsIntervalsToFile(filepath.Join(artifactDir, fmt.Sprintf("e2e-intervals%s.json", timeSuffix)), events); err != nil {
+		errors = append(errors, err)
+	}
+	if eventIntervalsJSON, err := monitorserialization.EventsIntervalsToJSON(events); err == nil {
+		e2eChartTemplate := testdata.MustAsset("e2echart/e2e-chart-template.html")
+		e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)
+		e2eChartHTMLPath := filepath.Join(artifactDir, fmt.Sprintf("e2e-intervals%s.html", timeSuffix))
+		if err := ioutil.WriteFile(e2eChartHTMLPath, e2eChartHTML, 0644); err != nil {
+			errors = append(errors, err)
+		}
+	} else {
+		errors = append(errors, err)
+	}
+
+	// write out the current state of resources that we explicitly tracked.
+	resourcesMap := monitor.CurrentResourceState()
+	for resourceType, instanceMap := range resourcesMap {
+		targetFile := fmt.Sprintf("resource-%s%s.zip", resourceType, timeSuffix)
+		if err := monitorserialization.InstanceMapToFile(filepath.Join(artifactDir, targetFile), resourceType, instanceMap); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
+}

--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -16,9 +16,7 @@ const (
 )
 
 func testServerAvailability(locator string, events monitorapi.Intervals, duration time.Duration) []*ginkgo.JUnitTestCase {
-	events = events.Filter(func(i monitorapi.EventInterval) bool { return i.Locator == locator })
-	errDuration := events.Duration(0, 1*time.Second)
-	errMessages := events.Strings()
+	errDuration, errMessages, _ := monitorapi.BackendDisruptionSeconds(locator, events)
 
 	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)
 	successTest := &ginkgo.JUnitTestCase{

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -15,8 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/openshift/origin/test/extended/testdata"
-
 	"github.com/onsi/ginkgo/config"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -379,30 +377,8 @@ func (opt *Options) Run(suite *TestSuite) error {
 	events.Clamp(start, end)
 
 	if len(opt.JUnitDir) > 0 {
-		if err = monitorserialization.EventsToFile(filepath.Join(opt.JUnitDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)), events); err != nil {
-			fmt.Fprintf(opt.ErrOut, "error: Failed to write event html: %v\n", err)
-		}
-		if err = monitorserialization.EventsIntervalsToFile(filepath.Join(opt.JUnitDir, fmt.Sprintf("e2e-intervals%s.json", timeSuffix)), events); err != nil {
-			fmt.Fprintf(opt.ErrOut, "error: Failed to write event html: %v\n", err)
-		}
-		if eventIntervalsJSON, err := monitorserialization.EventsIntervalsToJSON(events); err == nil {
-			e2eChartTemplate := testdata.MustAsset("e2echart/e2e-chart-template.html")
-			e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)
-			e2eChartHTMLPath := filepath.Join(opt.JUnitDir, fmt.Sprintf("e2e-intervals%s.html", timeSuffix))
-			if err := ioutil.WriteFile(e2eChartHTMLPath, e2eChartHTML, 0644); err != nil {
-				fmt.Fprintf(opt.ErrOut, "error: Failed to write event html: %v\n", err)
-			}
-		} else {
-			fmt.Fprintf(opt.ErrOut, "error: Failed to write event html: %v\n", err)
-		}
-
-		// write out the current state of resources that we explicitly tracked.
-		resourcesMap := m.CurrentResourceState()
-		for resourceType, instanceMap := range resourcesMap {
-			targetFile := fmt.Sprintf("resource-%s%s.zip", resourceType, timeSuffix)
-			if err = monitorserialization.InstanceMapToFile(filepath.Join(opt.JUnitDir, targetFile), resourceType, instanceMap); err != nil {
-				fmt.Fprintf(opt.ErrOut, "error: Failed to write %q: %v\n", targetFile, err)
-			}
+		if err := monitor.WriteRunDataToArtifactsDir(opt.JUnitDir, m, events, timeSuffix); err != nil {
+			fmt.Fprintf(opt.ErrOut, "error: Failed to write run-data: %v\n", err)
 		}
 	}
 


### PR DESCRIPTION
write a data file that can be consumed by aggregation instead of parsing out of junit.

/hold

holding so that we can see the content is correct.  There is a followup needed to fix the four different ways we have to watch for disruption today. I didn't make it worse, but I think it's time to make it better.

/assign @stbenjam 