### PR TITLE
Add initial support for controlplanetopology=external

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -43,6 +43,7 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster
 	context.AllowedNotReadyNodes = -1
 	context.MinStartupPods = -1
 	context.MaxNodesToGather = 0
+	context.ControlPlaneTopology = config.ControlPlaneTopology
 
 	// allow the CSI tests to access test data, but only briefly
 	// TODO: ideally CSI would not use any of these test methods

--- a/test/extended/util/cluster/cluster.go
+++ b/test/extended/util/cluster/cluster.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,6 +62,9 @@ type ClusterConfiguration struct {
 
 	// IsProxied determines whether we are accessing the cluster through an HTTP proxy
 	IsProxied bool
+
+	// ControlPlaneTopology describes the controlPlaneTopology
+	ControlPlaneTopology *configv1.TopologyMode
 }
 
 func (c *ClusterConfiguration) ToJSONString() string {
@@ -154,6 +158,7 @@ func LoadConfig(state *ClusterState) (*ClusterConfiguration, error) {
 		MultiZone:             zones.Len() > 1,
 		Zones:                 zones.List(),
 		SingleReplicaTopology: *state.ControlPlaneTopology == configv1.SingleReplicaTopologyMode,
+		ControlPlaneTopology:  state.ControlPlaneTopology,
 	}
 	if zones.Len() > 0 {
 		config.Zone = zones.List()[0]

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -70,9 +70,9 @@ func WaitForInternalRegistryHostname(oc *CLI) (string, error) {
 	foundOCMLogs := false
 	isOCMProgressing := true
 	podLogs := map[string]string{}
-	isIBMCloud := e2e.TestContext.Provider == ibmcloud.ProviderName
+	isExternalControlplane := e2e.TestContext.Provider == ibmcloud.ProviderName || (e2e.TestContext.ControlPlaneTopology != nil && *e2e.TestContext.ControlPlaneTopology == configv1.ExternalTopologyMode)
 	testImageStreamName := ""
-	if isIBMCloud {
+	if isExternalControlplane {
 		is := &imagev1.ImageStream{}
 		is.GenerateName = "internal-registry-test"
 		is, err := oc.AdminImageClient().ImageV1().ImageStreams("openshift").Create(context.Background(), is, metav1.CreateOptions{})
@@ -213,7 +213,7 @@ func WaitForInternalRegistryHostname(oc *CLI) (string, error) {
 		return false, nil
 	})
 
-	if !foundOCMLogs && !isIBMCloud {
+	if !foundOCMLogs && !isExternalControlplane {
 		e2e.Logf("dumping OCM pod logs since we never found the internal registry hostname and start build controller sequence")
 		for podName, podLog := range podLogs {
 			e2e.Logf("pod %s logs:\n%s", podName, podLog)

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/test_context.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/test_context.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/config"
+	configv1 "github.com/openshift/api/config/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -188,6 +189,9 @@ type TestContextType struct {
 
 	// SnapshotControllerHTTPPort the port used for communicating with the snapshot controller HTTP endpoint.
 	SnapshotControllerHTTPPort int
+
+	// ControlPlaneTopology describes the controlPlaneTopology
+	ControlPlaneTopology *configv1.TopologyMode
 }
 
 // NodeKillerConfig describes configuration of NodeKiller -- a utility to


### PR DESCRIPTION
In hypershift, the controlplane components are not selfhosted but run in a different cluster. This means that certain assertions like "find openshift-controller-manager pod and check if its log contains a specific line" can not work.

Luckily, the changes in behavior for this were already implemented for the IBMCloud provider, this PR is mostly about plugging the Controlplanetopology field through the testcontext and and treating a value of external identical to "ibmcloud" in util.WaitForInternalRegistryHostname (There will likely be more followups to switch behavior based on this).

/cc @csrwng 

Ref https://issues.redhat.com/browse/HOSTEDCP-257