### PR TITLE
Set provider name when platform is vSphere

### DIFF
--- a/test/extended/util/cluster/cluster.go
+++ b/test/extended/util/cluster/cluster.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +166,8 @@ func LoadConfig(state *ClusterState) (*ClusterConfiguration, error) {
 	}
 
 	switch {
+	case state.PlatformStatus.VSphere != nil:
+		config.ProviderName = "vsphere"
 	case state.PlatformStatus.AWS != nil:
 		config.ProviderName = "aws"
 		config.Region = state.PlatformStatus.AWS.Region


### PR DESCRIPTION
Currently, on vSphere most storage tests are incorrectly skipped because the provider is not properly set on the test suite. This PR fixes that.

Without this patch:

```
$ export SINGLE_TEST='[sig-storage] In-tree Volumes [Driver: vsphere] [Testpattern: Dynamic PV (ext4)] volumes should store data [Suite:openshift/conformance/parallel] [Suite:k8s]'

$ ./openshift-tests run-test "$SINGLE_TEST"
(...)
skip [k8s.io/kubernetes@v1.22.1/test/e2e/storage/drivers/in_tree.go:1438]: Only supported for providers [vsphere] (not skeleton)
```

CC @openshift/storage


