### PR TITLE
kubeconfigs: fix capture loop variable in closure

### DIFF
--- a/test/extended/apiserver/kubeconfigs.go
+++ b/test/extended/apiserver/kubeconfigs.go
@@ -21,12 +21,13 @@ var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] local ku
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("apiserver")
 
-	for _, kubeconfig := range []string{
+	for _, kc := range []string{
 		"localhost.kubeconfig",
 		"lb-ext.kubeconfig",
 		"lb-int.kubeconfig",
 		"localhost-recovery.kubeconfig",
 	} {
+		kubeconfig := kc
 		g.It(fmt.Sprintf("%q should be present on all masters and work", kubeconfig), func() {
 			masterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
 				LabelSelector: `node-role.kubernetes.io/master`,


### PR DESCRIPTION
Current implementation checks always the same kubeconfig file `localhost-recovery.kubeconfig` for all the cases.

See for example https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6/1453817495201779712, where logs for the `lb-int` case report shows `localhost-recovery.kubeconfig` is used instead:

```
...
oc --kubeconfig /etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost-recovery.kubeconfig get namespace kube-system
...
```