### PR TITLE
Bug 2019375: tests: skip some tests for proxy

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1783,11 +1783,11 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] DNS should provide DNS for services  [Conformance]": "should provide DNS for services  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-network] DNS should provide DNS for the cluster  [Conformance]": "should provide DNS for the cluster  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[Top Level] [sig-network] DNS should provide DNS for the cluster  [Conformance]": "should provide DNS for the cluster  [Conformance] [Skipped:Proxy] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-network] DNS should provide DNS for the cluster [Provider:GCE]": "should provide DNS for the cluster [Provider:GCE] [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-network] DNS should provide DNS for the cluster [Provider:GCE]": "should provide DNS for the cluster [Provider:GCE] [Skipped:Proxy] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-network] DNS should resolve DNS of partial qualified names for services [LinuxOnly] [Conformance]": "should resolve DNS of partial qualified names for services [LinuxOnly] [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[Top Level] [sig-network] DNS should resolve DNS of partial qualified names for services [LinuxOnly] [Conformance]": "should resolve DNS of partial qualified names for services [LinuxOnly] [Conformance] [Skipped:Proxy] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-network] DNS should resolve DNS of partial qualified names for the cluster [LinuxOnly]": "should resolve DNS of partial qualified names for the cluster [LinuxOnly] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -105,6 +105,14 @@ var (
 			`\[sig-cli\] Kubectl Port forwarding With a server listening on localhost should support forwarding over websockets`,
 			`\[sig-cli\] Kubectl Port forwarding With a server listening on 0.0.0.0 should support forwarding over websockets`,
 			`\[sig-node\] Pods should support remote command execution over websockets`,
+
+			// These tests are flacky and require internet access
+			// See https://bugzilla.redhat.com/show_bug.cgi?id=2019375
+			`\[sig-builds\]\[Feature:Builds\] build can reference a cluster service with a build being created from new-build should be able to run a build that references a cluster service`,
+			`\[sig-builds\]\[Feature:Builds\] oc new-app should succeed with a --name of 58 characters`,
+			`\[sig-network\] DNS should resolve DNS of partial qualified names for services`,
+			`\[sig-arch\] Only known images used by tests`,
+			`\[sig-network\] DNS should provide DNS for the cluster`,
 		},
 		"[Skipped:SingleReplicaTopology]": {
 			`\[sig-apps\] Daemon set \[Serial\] should rollback without unnecessary restarts \[Conformance\]`,


### PR DESCRIPTION
Some tests are known to be unstable since they need Internet access and
therefor cause issue when running behind a secured proxy.

Let's skip them for now.
