### PR TITLE
Bug 2011895: Add synthetic test for cloud API throttling

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -37,6 +37,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testOperatorOSUpdateStartedEventRecorded(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 	tests = append(tests, testBackoffPullingRegistryRedhatImage(events)...)
+	tests = append(tests, testAPIQuotaEvents(events)...)
 
 	return tests
 }
@@ -66,6 +67,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testOperatorOSUpdateStartedEventRecorded(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 	tests = append(tests, testBackoffPullingRegistryRedhatImage(events)...)
+	tests = append(tests, testAPIQuotaEvents(events)...)
 
 	return tests
 }

--- a/pkg/synthetictests/storage.go
+++ b/pkg/synthetictests/storage.go
@@ -1,0 +1,53 @@
+package synthetictests
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+type throttlingMessage struct {
+	cloud   string
+	message *regexp.Regexp
+}
+
+var throttlingMessages = []*regexp.Regexp{
+	// GCE
+	regexp.MustCompile("googleapi: Error 403: Quota exceeded"),
+	// AWS
+	regexp.MustCompile("RequestLimitExceeded"),
+}
+
+func testAPIQuotaEvents(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-arch] cloud API quota should not be exceeded"
+
+	var matches []string
+	for i := range events {
+		event := events[i]
+		for _, msg := range throttlingMessages {
+			if msg.MatchString(event.Message) {
+				matches = append(matches, event.Message)
+			}
+		}
+	}
+
+	if len(matches) > 0 {
+		output := fmt.Sprintf("Underlying cloud was rate limiting OCP's API calls:\n%s", strings.Join(matches, "\n"))
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Output: output,
+				},
+			},
+			// Mark the test as a flake
+			{
+				Name: testName,
+			},
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
"[sig-arch] cloud API quota should not be exceeded" tells if OCP cluster under test encountered throttling from the underlyig cloud.

cc @openshift/storage @deads2k 