### PR TITLE
Bug 2019516: Skip test 'clone repository using git:// protocol should clone using git:// if no proxy is configured'

### DIFF
--- a/test/extended/builds/clone_git_protocol.go
+++ b/test/extended/builds/clone_git_protocol.go
@@ -34,6 +34,13 @@ var _ = g.Describe("[sig-builds][Feature:Builds] clone repository using git:// p
 		})
 
 		g.It("should clone using git:// if no proxy is configured", func() {
+
+			if true {
+				// TODO:
+				g.Skip("test disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=2019433 and https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting: 'The unauthenticated git protocol on port 9418 is no longer supported'")
+				return
+			}
+
 			proxyConfigured, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			if proxyConfigured {


### PR DESCRIPTION
Test is no longer valid as github has deprecated unauthenticated git://
access. Will be backported to all releases back to 4.6.

See https://bugzilla.redhat.com/show_bug.cgi?id=2019433 for proper fix.
