### PR TITLE
Bug 2021324: Change the order of Project creation and deletion

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -383,13 +383,13 @@ var (
 )
 
 var _ = g.Describe("[sig-cli] oc explain", func() {
-	defer g.GinkgoRecover()
-
 	oc := exutil.NewCLI("oc-explain")
+	defer g.GinkgoRecover()
 
 	crdTypes := append(baseCRDTypes, mcoTypes...)
 	crdTypes = append(crdTypes, autoscalingTypes...)
 	crdTypes = append(crdTypes, machineTypes...)
+
 	g.It("list uncovered GroupVersionResources", func() {
 		resourceMap := make(map[schema.GroupVersionResource]bool)
 		kubeClient := kclientset.NewForConfigOrDie(oc.AdminConfig())
@@ -437,13 +437,27 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 		}
 	})
 
+})
+
+var _ = g.Describe("[sig-cli] oc explain", func() {
+	oc := exutil.NewCLI("oc-explain")
+	defer g.GinkgoRecover()
+
 	g.It("should contain spec+status for builtinTypes", func() {
 		for _, bt := range builtinTypes {
 			e2e.Logf("Checking %s...", bt)
 			o.Expect(verifySpecStatusExplain(oc, nil, bt)).NotTo(o.HaveOccurred())
 		}
 	})
+})
 
+var _ = g.Describe("[sig-cli] oc explain", func() {
+	oc := exutil.NewCLI("oc-explain")
+	defer g.GinkgoRecover()
+
+	crdTypes := append(baseCRDTypes, mcoTypes...)
+	crdTypes = append(crdTypes, autoscalingTypes...)
+	crdTypes = append(crdTypes, machineTypes...)
 	g.It("should contain proper spec+status for CRDs", func() {
 		crdClient := apiextensionsclientset.NewForConfigOrDie(oc.AdminConfig())
 		crdTypesTest := crdTypes
@@ -455,6 +469,11 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 			o.Expect(verifyCRDSpecStatusExplain(oc, crdClient, ct)).NotTo(o.HaveOccurred())
 		}
 	})
+})
+
+var _ = g.Describe("[sig-cli] oc explain", func() {
+	oc := exutil.NewCLI("oc-explain")
+	defer g.GinkgoRecover()
 
 	g.It("should contain proper fields description for special types", func() {
 		for _, st := range specialTypes {

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -114,6 +114,7 @@ func NewCLI(project string) *CLI {
 	cli.withoutNamespace = false
 	// create our own project
 	g.BeforeEach(func() { _ = cli.SetupProject() })
+	g.AfterEach(cli.TeardownProject)
 	return cli
 }
 
@@ -137,9 +138,8 @@ func NewCLIWithoutNamespace(project string) *CLI {
 		adminConfigPath:  KubeConfigPath(),
 		withoutNamespace: true,
 	}
-	g.AfterEach(cli.TeardownProject)
-	g.AfterEach(cli.kubeFramework.AfterEach)
 	g.BeforeEach(cli.kubeFramework.BeforeEach)
+	g.AfterEach(cli.kubeFramework.AfterEach)
 	return cli
 }
 


### PR DESCRIPTION
Current ordering of Project creation and teardown is causing some
timing issues resulting in the namespace to be deleted while it is
still in use by a test.