### PR TITLE
Fix sno resiliency test

### DIFF
--- a/test/extended/apiserver/resiliency.go
+++ b/test/extended/apiserver/resiliency.go
@@ -92,10 +92,11 @@ var _ = ginkgo.Describe("[Conformance][sig-sno][Serial] Cluster", func() {
 			fmt.Sprintf("Total time of disruption is %v which is more than 40 seconds. ", disruptionDuration)+
 				"Actual SLO for this is 60 seconds, yet we want to be notified about major regressions")
 
-		ginkgo.It("with no pods restarts during API disruption", func() {
-			names := GetRestartedPods(c, restartingContainers)
-			gomega.Expect(len(names)).To(gomega.Equal(0), "Some pods in got restarted during kube-apiserver rollout: %s", strings.Join(names, ", "))
-		})
+		ginkgo.By("Expecting no pod restarts during API disruption")
+		names := GetRestartedPods(c, restartingContainers)
+		gomega.
+			Expect(len(names)).
+			To(gomega.Equal(0), fmt.Sprintf("Some pods got restarted during kube-apiserver rollout: %s", strings.Join(names, ", ")))
 	})
 
 })

--- a/test/extended/apiserver/resiliency.go
+++ b/test/extended/apiserver/resiliency.go
@@ -3,13 +3,14 @@ package apiserver
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/origin/test/extended/operators"
 	"io/ioutil"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/openshift/origin/test/extended/operators"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"


### PR DESCRIPTION
Running the `sig-sno serial` test locally was failing due to ginkgo error `You may only call It from within a Describe, Context or When`. Updated test to remove nested `It` call.