### PR TITLE
add alerts to tracked metadata

### DIFF
--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -61,3 +61,33 @@ func OperatorFromLocator(locator string) (string, bool) {
 	parts := strings.SplitN(strings.TrimPrefix(locator, "clusteroperator/"), " ", 2)
 	return parts[0], true
 }
+
+func LocatorParts(locator string) map[string]string {
+	parts := map[string]string{}
+
+	tags := strings.Split(locator, " ")
+	for _, tag := range tags {
+		keyValue := strings.SplitN(tag, "/", 2)
+		if len(keyValue) == 1 {
+			parts[keyValue[0]] = ""
+		} else {
+			parts[keyValue[0]] = keyValue[1]
+		}
+	}
+
+	return parts
+}
+
+func NamespaceFrom(locatorParts map[string]string) string {
+	if ns, ok := locatorParts["ns"]; ok {
+		return ns
+	}
+	if ns, ok := locatorParts["namespace"]; ok {
+		return ns
+	}
+	return ""
+}
+
+func AlertFrom(locatorParts map[string]string) string {
+	return locatorParts["alert"]
+}

--- a/pkg/monitor/write_job_run_data.go
+++ b/pkg/monitor/write_job_run_data.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
@@ -46,6 +48,11 @@ func WriteRunDataToArtifactsDir(artifactDir string, monitor *Monitor, events mon
 
 	backendDisruption := computeDisruptionData(events)
 	if err := writeDisruptionData(filepath.Join(artifactDir, fmt.Sprintf("backend-disruption%s.json", timeSuffix)), backendDisruption); err != nil {
+		errors = append(errors, err)
+	}
+
+	alertData := computeAlertData(events)
+	if err := writeAlertData(filepath.Join(artifactDir, fmt.Sprintf("alerts%s.json", timeSuffix)), alertData); err != nil {
 		errors = append(errors, err)
 	}
 
@@ -90,4 +97,132 @@ func computeDisruptionData(events monitorapi.Intervals) *BackendDisruptionList {
 	}
 
 	return ret
+}
+
+type AlertList struct {
+	// Alerts is keyed by name to make the consumption easier
+	Alerts []Alert
+}
+
+// name and namespace are consistent (usually) for every CI run
+type AlertKey struct {
+	Name      string
+	Namespace string
+	Level     AlertLevel
+}
+
+type AlertKeyByAlert []AlertKey
+
+func (a AlertKeyByAlert) Len() int      { return len(a) }
+func (a AlertKeyByAlert) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a AlertKeyByAlert) Less(i, j int) bool {
+	if strings.Compare(a[i].Name, a[j].Name) < 0 {
+		return true
+	}
+	if strings.Compare(a[i].Namespace, a[j].Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(string(a[i].Level), string(a[j].Level)) < 0 {
+		return true
+	}
+
+	return false
+}
+
+type AlertLevel string
+
+var (
+	UnknownAlertLevel  AlertLevel = "Unknown"
+	WarningAlertLevel  AlertLevel = "Warning"
+	CriticalAlertLevel AlertLevel = "Critical"
+)
+
+type Alert struct {
+	AlertKey `json:",inline"`
+	Duration metav1.Duration
+}
+
+type AlertByKey []Alert
+
+func (a AlertByKey) Len() int      { return len(a) }
+func (a AlertByKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a AlertByKey) Less(i, j int) bool {
+	if strings.Compare(a[i].Name, a[j].Name) < 0 {
+		return true
+	}
+	if strings.Compare(a[i].Namespace, a[j].Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(string(a[i].Level), string(a[j].Level)) < 0 {
+		return true
+	}
+
+	return false
+}
+
+func writeAlertData(filename string, alertData *AlertList) error {
+	jsonContent, err := json.MarshalIndent(alertData, "", "    ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filename, jsonContent, 0644)
+}
+
+func getAlertLevelFromEvent(event monitorapi.EventInterval) AlertLevel {
+	if event.Level == monitorapi.Error {
+		return CriticalAlertLevel
+	}
+	if event.Level == monitorapi.Warning {
+		return WarningAlertLevel
+	}
+	return UnknownAlertLevel
+}
+
+func computeAlertData(events monitorapi.Intervals) *AlertList {
+	alertEvents := events.Filter(
+		func(eventInterval monitorapi.EventInterval) bool {
+			locator := monitorapi.LocatorParts(eventInterval.Locator)
+			alertName := monitorapi.AlertFrom(locator)
+			if len(alertName) == 0 {
+				return false
+			}
+			if alertName == "Watchdog" {
+				return false
+			}
+			// skip everything but warning and critical
+			if getAlertLevelFromEvent(eventInterval) == UnknownAlertLevel {
+				return false
+			}
+			return true
+		},
+	)
+
+	alertMap := map[AlertKey]*Alert{}
+	for _, alertInterval := range alertEvents {
+		alertLocator := monitorapi.LocatorParts(alertInterval.Locator)
+		alertKey := AlertKey{
+			Name:      monitorapi.AlertFrom(alertLocator),
+			Namespace: monitorapi.NamespaceFrom(alertLocator),
+			Level:     getAlertLevelFromEvent(alertInterval),
+		}
+		alert, ok := alertMap[alertKey]
+		if !ok {
+			alert = &Alert{
+				AlertKey: alertKey,
+			}
+		}
+		//the same alert can fire multiple times, so we add all the durations together
+		alert.Duration = metav1.Duration{Duration: alert.Duration.Duration + alertInterval.To.Sub(alertInterval.From)}
+		alertMap[alertKey] = alert
+	}
+
+	alertList := []Alert{}
+	for _, alert := range alertMap {
+		alertList = append(alertList, *alert)
+	}
+	sort.Stable(AlertByKey(alertList))
+
+	return &AlertList{
+		Alerts: alertList,
+	}
 }


### PR DESCRIPTION
builds on https://github.com/openshift/origin/pull/26548

This tracks the duration of alerts firing for later aggregation.  This will allow us to latch progress on reducing the number of firing alerts in our CI clusters.

