### PR TITLE
Bug 2021141: Cluster should allow a fast rollout of kube-apiserver is…

### DIFF
--- a/test/extended/apiserver/resiliency.go
+++ b/test/extended/apiserver/resiliency.go
@@ -36,7 +36,7 @@ var _ = ginkgo.Describe("[Conformance][sig-sno][Serial] Cluster", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("cluster-resiliency")
 
-	ginkgo.It("should allow a fast rollout of kube-apiserver", func() {
+	ginkgo.It("should allow a fast rollout of kube-apiserver with no pods restarts during API disruption", func() {
 		controlPlaneTopology, _ := single_node.GetTopologies(f)
 
 		if controlPlaneTopology != configv1.SingleReplicaTopologyMode {
@@ -91,10 +91,9 @@ var _ = ginkgo.Describe("[Conformance][sig-sno][Serial] Cluster", func() {
 			fmt.Sprintf("Total time of disruption is %v which is more than 40 seconds. ", disruptionDuration)+
 				"Actual SLO for this is 60 seconds, yet we want to be notified about major regressions")
 
-		ginkgo.It("with no pods restarts during API disruption", func() {
-			names := GetRestartedPods(c, restartingContainers)
-			gomega.Expect(len(names)).To(gomega.Equal(0), "Some pods in got restarted during kube-apiserver rollout: %s", strings.Join(names, ", "))
-		})
+		ginkgo.By("with no pods restarts during API disruption")
+		names := GetRestartedPods(c, restartingContainers)
+		gomega.Expect(len(names)).To(gomega.Equal(0), "Some pods in got restarted during kube-apiserver rollout: %s", strings.Join(names, ", "))
 	})
 
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -15,7 +15,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"localhost.kubeconfig\" should be present on all masters and work": "\"localhost.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [Conformance][sig-sno][Serial] Cluster should allow a fast rollout of kube-apiserver": "should allow a fast rollout of kube-apiserver [Suite:openshift/conformance/serial/minimal]",
+	"[Top Level] [Conformance][sig-sno][Serial] Cluster should allow a fast rollout of kube-apiserver with no pods restarts during API disruption": "should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [Suite:openshift/conformance/serial/minimal]",
 
 	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP": "test RequestHeaders IdP [Suite:openshift/conformance/serial]",
 


### PR DESCRIPTION
… failing on single node

Replaced `ginkgo.It` with `ginkgo.By` and updated the test title 