### PR TITLE
WIP- Add puma to s2i-environment-build-app

### DIFF
--- a/test/extended/testdata/builds/s2i-environment-build-app/Gemfile
+++ b/test/extended/testdata/builds/s2i-environment-build-app/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
+gem "puma"
 gem "rack"


### PR DESCRIPTION
With ruby 2.7, puma is required to run the web server used in the test.