### PR TITLE
oauth/requestheaders: escape semicolon in URI

### DIFF
--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -264,7 +264,7 @@ func testBrowserClientRedirectsProperly(caCerts *x509.CertPool, oauthServerURL s
 	})
 
 	g.By("/authorize - browser-client - anonymous: specify the request header provider in the query", func() {
-		testedEndpoint := "/oauth/authorize?client_id=openshift-browser-client&response_type=token;idp=test-request-header"
+		testedEndpoint := "/oauth/authorize?client_id=openshift-browser-client&response_type=token&idp=test-request-header"
 		resp := oauthHTTPRequestOrFail(caCerts, oauthServerURL, testedEndpoint, "", nil, nil)
 		respDump, err := httputil.DumpResponse(resp, false)
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
There's an errant semicolon in one of the test cases in
oauth/requestheaders.go. Prior to 1.17, go handled this behavior and
treated it like a &.  However, go's behavior has changed in 1.17[1]:

    The net/url and net/http packages used to accept ";" (semicolon) as a
    setting separator in URL queries, in addition to "&" (ampersand). Now,
    settings with non-percent-encoded semicolons are rejected and net/http
    servers will log a warning to Server.ErrorLog when encountering one in
    a request URL.

    For example, before Go 1.17 the Query method of the URL
    example?a=1;b=2&c=3 would have returned map[a:[1] b:[2] c:[3]], while
    now it returns map[c:[3]].

In go 1.17, the request is now parsed differently so the server returns
400 (bad request).

[1] https://golang.org/doc/go1.17#semicolons