### PR TITLE
test/extended: label privileged namespaces

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -259,7 +259,15 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, kubeConfig *restclient.Config, e
 
 	client := &allClient{dynamicClient: dynamic.NewForConfigOrDie(kubeConfig)}
 
-	if _, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), &kapiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TestNamespace}}, metav1.CreateOptions{}); err != nil {
+	if _, err := kubeClient.CoreV1().Namespaces().Create(
+		context.Background(),
+		&kapiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TestNamespace, Labels: map[string]string{
+			"pod-security.kubernetes.io/enforce": "privileged",
+			"pod-security.kubernetes.io/audit":   "privileged",
+			"pod-security.kubernetes.io/warn":    "privileged",
+		}}},
+		metav1.CreateOptions{},
+	); err != nil {
 		t.Fatalf("error creating test namespace: %#v", err)
 	}
 	defer func() {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -27124,6 +27124,7 @@ export KUBECONFIG=/kubeconfig
 
 namespace="cmd-${TEST_NAME}"
 oc new-project "${namespace}"
+oc label ns "${namespace}" pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged
 `)
 
 func testExtendedTestdataCmdHackLibInitShBytes() ([]byte, error) {

--- a/test/extended/testdata/cmd/hack/lib/init.sh
+++ b/test/extended/testdata/cmd/hack/lib/init.sh
@@ -80,3 +80,4 @@ export KUBECONFIG=/kubeconfig
 
 namespace="cmd-${TEST_NAME}"
 oc new-project "${namespace}"
+oc label ns "${namespace}" pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -219,6 +219,55 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 		labels["security.openshift.io/disable-securitycontextconstraints"] = "true"
 	}
 
+	for _, privilegedNamespacePrefix := range []string{
+		"default",
+		"e2e-csi-mock-volumes",
+		"e2e-disruption",
+		"e2e-downward-api",
+		"e2e-ephemeral",
+		"e2e-hostpath",
+		"e2e-k8s-nettest",
+		"e2e-kubelet-etc-hosts",
+		"e2e-mount-propagation",
+		"e2e-multivolume",
+		"e2e-network-policy",
+		"e2e-persistent-local-volumes-test",
+		"e2e-privileged-pod",
+		"e2e-provisioning",
+		"e2e-pv",
+		"e2e-sched-pred",
+		"e2e-sctp",
+		"e2e-security-context",
+		"e2e-services",
+		"e2e-snapshotting",
+		"e2e-statefulset",
+		"e2e-sysctl",
+		"e2e-test-apiserver",
+		"e2e-test-build-dockerfile-env",
+		"e2e-test-build-pruning",
+		"e2e-test-build-service",
+		"e2e-test-build-sti-labels",
+		"e2e-test-cli-build-revision",
+		"e2e-test-docker-build-pullsecret",
+		"e2e-test-image-change-build-trigger",
+		"e2e-test-image-oc-tag",
+		"e2e-test-ldap-group-sync",
+		"e2e-test-new-app",
+		"e2e-test-oauth-ldap-idp",
+		"e2e-test-registry-signing",
+		"e2e-test-scc",
+		"e2e-test-templates",
+		"e2e-volume",
+		"e2e-volume-expand",
+		"e2e-volumemode",
+	} {
+		if strings.HasPrefix(baseName, privilegedNamespacePrefix) {
+			labels["pod-security.kubernetes.io/enforce"] = "privileged"
+			labels["pod-security.kubernetes.io/warn"] = "privileged"
+			labels["pod-security.kubernetes.io/audit"] = "privileged"
+		}
+	}
+
 	ns, err := e2e.CreateTestingNS(baseName, c, labels)
 	if err != nil {
 		return ns, err


### PR DESCRIPTION
This sets privileged podsecurity labels for e2e test namespaces who create privileged pods:

```
$ zcat *-audit.log.gz | jq  '. | select((.annotations | has("pod-security.kubernetes.io/audit"))) | {objectRef: (.objectRef.namespace + "/" + .objectRef.resource + "/"+ .objectRef.name), podSecurityReason: .annotations["pod-security.kubernetes.io/audit"]}' | jq -s --sort-keys '. | unique' 
[
  {
    "objectRef": "e2e-disruption-2951/replicasets/rs",
    "podSecurityReason": "hostPort (container \"donothing\" uses hostPort 5555)"
  },
  {
    "objectRef": "e2e-provisioning-6463/pods/",
    "podSecurityReason": "host namespaces (hostNetwork=true), hostPath volumes (volume \"rootfs\"), privileged (container \"agnhost-container\" must not set securityContext.privileged=true)"
  },
  {
    "objectRef": "e2e-test-ldap-group-sync-zwk5k/deployments/openldap-server",
    "podSecurityReason": "privileged (container \"openldap-server\" must not set securityContext.privileged=true)"
  },
  {
    "objectRef": "e2e-test-ldap-group-sync-zwk5k/pods/",
    "podSecurityReason": "privileged (container \"openldap-server\" must not set securityContext.privileged=true)"
  },
  {
    "objectRef": "e2e-test-ldap-group-sync-zwk5k/replicasets/openldap-server-6478865db",
    "podSecurityReason": "privileged (container \"openldap-server\" must not set securityContext.privileged=true)"
  },
  {
    "objectRef": "etcdstoragepathtestnamespace/pods/build1g-build",
    "podSecurityReason": "hostPath volumes (volumes \"buildcachedir\", \"node-pullsecrets\"), privileged (container \"docker-build\" must not set securityContext.privileged=true)"
  },
]
```

/cc @deads2k @stlaz 