### PR TITLE
Bug 2020611: Reduce Test Focus for Jenkins

### DIFF
--- a/test/extended/builds/imagechangetriggers.go
+++ b/test/extended/builds/imagechangetriggers.go
@@ -13,7 +13,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Feature:Builds][Feature:Jenkins][Conformance] imagechangetriggers", func() {
+var _ = g.Describe("[Feature:Builds][Conformance] imagechangetriggers", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/builds/jenkins_autoprovision.go
+++ b/test/extended/builds/jenkins_autoprovision.go
@@ -10,7 +10,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Feature:Builds][Feature:Jenkins][Conformance] jenkins autoprovision", func() {
+var _ = g.Describe("[Feature:Builds][Feature:JenkinsAuto][Conformance] jenkins autoprovision", func() {
 	defer g.GinkgoRecover()
 	var (
 		envVarsPipelinePath = exutil.FixturePath("testdata", "samplepipeline-withenvs.yaml")


### PR DESCRIPTION
The current set of tests push the OpenShift cluster past its memory
limits. Removing the auto-provision and imagechange trigger tests from
the core Jenkins suite.