### PR TITLE
pkg/synthetictests: add toleration for missing versioned etcd-endpoints cm during upgrade

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -97,6 +97,9 @@ var allowedUpgradeRepeatedEventPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`ns/openshift-etcd pod/etcd-quorum-guard-[a-z0-9-]+ node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: `),
 	// etcd can have unhealthy members during an upgrade
 	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/UnhealthyEtcdMember unhealthy members: .*`),
+	// etcd-operator began to version etcd-endpoints configmap in 4.10 as part of static-pod-resource. During upgrade existing revisions will not contain the resource.
+	// The condition reconciles with the next revision which the result of the upgrade. TODO(hexfusion) remove in 4.11
+	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/RequiredInstallerResourcesMissing configmaps: etcd-endpoints-[0-9]+`),
 }
 
 var knownEventsBugs = []knownProblem{


### PR DESCRIPTION
In 4.10 the cluster-etcd operator will begin to version the etcd-endpoints cm resource as part of its static pod resources. During upgrade the installer controller can complain that the resource doesn't exist for the existing version. This can result in a few events as the controller requeues. This issue will resolve with the creation of the next revision which is the result of the upgrade itself.  Thus expected, transient, and benign.

cc @hasbro17  

ref: https://github.com/openshift/cluster-etcd-operator/pull/701#issuecomment-966455818

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>