### PR TITLE
Bug 2022797: Switch the cluster-role-reapers test to Serial

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -332,7 +332,8 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args("-f", "-").InputString(policyRoles).Execute()
 	})
 
-	g.It("cluster-role-reapers", func() {
+	// "oc adm prune auth clusterrole/edit" is a disruptive command and needs to be run in a Serial test
+	g.It("cluster-role-reapers [Serial]", func() {
 		clusterRole := gen.GenerateName("basic-user2-")
 		clusterBinding := gen.GenerateName("basic-users2-")
 		policyClusterRoles, _, err := ocns.Run("process").Args("-f", policyClusterRolesPath, "-p", fmt.Sprintf("ROLE_NAME=%s", clusterRole), "-p", fmt.Sprintf("BINDING_NAME=%s", clusterBinding)).Outputs()

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1277,7 +1277,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc adm build-chain": "build-chain [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm cluster-role-reapers": "cluster-role-reapers [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm cluster-role-reapers [Serial]": "cluster-role-reapers [Serial] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-cli] oc adm groups": "groups [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
    Switch the cluster-role-reapers test to Serial
    
    This test run the cli command
    "oc adm prune auth clusterrole/edit"
    which prunes out the rolebindings for the other test that
    are running at the same time.
