### PR TITLE
prevent rare alert gathering panic

### DIFF
--- a/pkg/monitor/alerts.go
+++ b/pkg/monitor/alerts.go
@@ -162,6 +162,13 @@ func createEventIntervalsForAlerts(ctx context.Context, alerts prometheustypes.V
 				lastTime = nil
 			}
 
+			// now add the one for the last start time.  If we do not have a last time, it means we saw the start, but not
+			// the end.  We don't know when this alert ended, but our threshold time from above is five seconds so we will
+			// simply assign that here as "better than nothing"
+			if lastTime == nil {
+				t := alertStartTime.Add(5 * time.Second)
+				lastTime = &t
+			}
 			currAlertInterval := alertIntervalTemplate // shallow copy
 			currAlertInterval.From = *alertStartTime
 			currAlertInterval.To = *lastTime


### PR DESCRIPTION
found in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-aws-serial/1459871441305473024

This just does its best to fill in something for missing data.  We don't know the actual end, but we know we don't want to fail and that some alert has started.