### PR TITLE
olm: enable test on arm64

### DIFF
--- a/test/extended/olm/olm.go
+++ b/test/extended/olm/olm.go
@@ -163,6 +163,8 @@ func archHasDefaultIndex(oc *exutil.CLI) bool {
 		switch node.Status.NodeInfo.Architecture {
 		case "amd64":
 			return true
+		case "arm64":
+			return true
 		case "ppc64le":
 			return true
 		case "s390x":


### PR DESCRIPTION
The default indexes are now available for arm64, and installed by
https://github.com/operator-framework/operator-marketplace/pull/420

/cc @timflannagan 
/assign @kevinrizza 
