### PR TITLE
Bug 2023631: Create new-project without updating kubeconfig

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -292,21 +292,21 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.ContainSubstring(`cannot list resource "rolebindings" in API group "rbac.authorization.k8s.io"`))
 
 		g.By("Test that scoped storage-admin now an admin in project foo")
-		o.Expect(oc.Run("new-project").Args("--as=storage-adm2", "--as-group=system:authenticated:oauth", "--as-group=sytem:authenticated", "policy-can-i").Execute()).NotTo(o.HaveOccurred())
+		o.Expect(oc.Run("new-project").Args("--skip-config-write=true", "--as=storage-adm2", "--as-group=system:authenticated:oauth", "--as-group=sytem:authenticated", "policy-can-i").Execute()).NotTo(o.HaveOccurred())
 
-		out, err = oc.Run("auth", "can-i").Args("--as=storage-adm2", "create", "pod", "--all-namespaces").Output()
+		out, err = oc.Run("auth", "can-i").Args("--namespace=policy-can-i", "--as=storage-adm2", "create", "pod", "--all-namespaces").Output()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(out).To(o.HaveSuffix("no"))
 
-		out, err = oc.Run("auth", "can-i").Args("--as=storage-adm2", "create", "pod").Output()
+		out, err = oc.Run("auth", "can-i").Args("--namespace=policy-can-i", "--as=storage-adm2", "create", "pod").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.HaveSuffix("yes"))
 
-		out, err = oc.Run("auth", "can-i").Args("--as=storage-adm2", "create", "pvc").Output()
+		out, err = oc.Run("auth", "can-i").Args("--namespace=policy-can-i", "--as=storage-adm2", "create", "pvc").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.HaveSuffix("yes"))
 
-		out, err = oc.Run("auth", "can-i").Args("--as=storage-adm2", "create", "endpoints").Output()
+		out, err = oc.Run("auth", "can-i").Args("--namespace=policy-can-i", "--as=storage-adm2", "create", "endpoints").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.HaveSuffix("yes"))
 


### PR DESCRIPTION
    Create new-project without updating kubeconfig
    
    "oc new-project" writes out a new kubconfig file
    effecting the outcomes of other tests running in
    parallel.
    
    There is at least 2 problems with this
    1. kubeconfig is left empty for a short moment which
    causes a problem if any other test takes a copy while blank.
    e.g. any test that call CLI.UserConfig() or CLI.AdminConfig()
    2. the current namespace of kubeconfig if changed by "oc new-project"
    which effects any test currently using it to access the cluster.
