### PR TITLE
Bug 2023238: Skipping Django Test until bug is fixed

### DIFF
--- a/test/extended/image_ecosystem/s2i_python.go
+++ b/test/extended/image_ecosystem/s2i_python.go
@@ -47,6 +47,9 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][python][Slow] hot deploy
 		g.Describe("Django example", func() {
 			g.It(fmt.Sprintf("should work with hot deploy"), func() {
 
+				// skipping this test for now until we figure out why is not
+				// passing on CI bz: 2023238
+				g.Skip("Skipping until bz_2023238 is fixed.")
 				err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By(fmt.Sprintf("calling oc new-app %s", djangoTemplate))


### PR DESCRIPTION
This is not fixing the bug it self but unblocking the CI pipeline
as a workaround. The fix for this bug will come from the python
image stream team, most likely, will send another PR to enable.