### PR TITLE
Bug 2024766: test/e2e/upgrade: Bump durationToSoftFailure by 15m for minor updates

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/origin/test/e2e/upgrade/manifestdelete"
 	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/prometheus"
+	"github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 	"github.com/openshift/origin/test/extended/util/disruption/frontends"
@@ -301,6 +302,13 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			//   https://bugzilla.redhat.com/show_bug.cgi?id=1942164
 			durationToSoftFailure = baseDurationToSoftFailure + (15 * time.Minute)
 		}
+	}
+
+	if cv, err := c.ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{}); err != nil {
+		return err
+	} else if util.GetMajorMinor(version.Version.String()) != util.GetMajorMinor(cv.Status.Desired.Version) {
+		framework.Logf("Upgrade from %s to %s changes the major.minor, so allowing an additional 15 minutes", cv.Status.Desired.Version, version.Version.String())
+		durationToSoftFailure += 15 * time.Minute
 	}
 
 	framework.Logf("Starting upgrade to version=%s image=%s attempt=%s", version.Version.String(), version.NodeImage, uid)

--- a/test/extended/util/adminack.go
+++ b/test/extended/util/adminack.go
@@ -123,20 +123,20 @@ func getCurrentVersion(ctx context.Context, config *restclient.Config) string {
 	return ""
 }
 
-// getEffectiveMinor attempts to do a simple parse of the version provided.  If it does not parse, the value is considered
+// GetMajorMinor attempts to do a simple parse of the version provided.  If it does not parse, the value is considered
 // an empty string, which works for a comparison for equivalence.
-func getEffectiveMinor(version string) string {
+func GetMajorMinor(version string) string {
 	splits := strings.Split(version, ".")
 	if len(splits) < 2 {
 		return ""
 	}
-	return splits[1]
+	return strings.Join(splits[:2], ".")
 }
 
 func gateApplicableToCurrentVersion(gateAckVersion string, currentVersion string) bool {
 	parts := strings.Split(gateAckVersion, "-")
-	ackMinor := getEffectiveMinor(parts[1])
-	cvMinor := getEffectiveMinor(currentVersion)
+	ackMinor := GetMajorMinor(parts[1])
+	cvMinor := GetMajorMinor(currentVersion)
 	if ackMinor == cvMinor {
 		return true
 	}


### PR DESCRIPTION
Because these are often running over their existing caps:

```console
$ w3m -dump -cols 200 'https://search.ci.openshift.org/?maxAge=96h&type=junit&name=release-master-ci&search=cluster+upgrade+should+complete+in' | grep 'failures match' | grep -v rehearse | sort -V
periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade (all) - 37 runs, 46% failed, 6% of failures match = 3% impact
periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-ovn-upgrade (all) - 4 runs, 100% failed, 100% of failures match = 100% impact
periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-azure-upgrade (all) - 4 runs, 75% failed, 33% of failures match = 25% impact
periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-ovn-upgrade (all) - 2 runs, 100% failed, 100% of failures match = 100% impact
periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-gcp-upgrade (all) - 37 runs, 70% failed, 58% of failures match = 41% impact
periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-openstack-upgrade (all) - 1 runs, 100% failed, 100% of failures match = 100% impact
periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-ovirt-upgrade (all) - 16 runs, 69% failed, 18% of failures match = 13% impact
periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-vsphere-upgrade (all) - 9 runs, 33% failed, 67% of failures match = 22% impact
periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-azure-ovn-upgrade (all) - 4 runs, 100% failed, 25% of failures match = 25% impact
periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-gcp-ovn-upgrade (all) - 2 runs, 50% failed, 100% of failures match = 50% impact
periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-gcp-upgrade (all) - 4 runs, 50% failed, 100% of failures match = 50% impact
periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-openstack-upgrade (all) - 4 runs, 100% failed, 50% of failures match = 50% impact
periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-ovirt-upgrade (all) - 16 runs, 50% failed, 25% of failures match = 13% impact
periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-azure-upgrade (all) - 281 runs, 97% failed, 0% of failures match = 0% impact
periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-openstack-upgrade (all) - 2 runs, 100% failed, 50% of failures match = 50% impact
```

A 15m bump will help a bit, although some will still overshoot:

```console
$ w3m -dump -cols 200 'https://search.ci.openshift.org/?maxAge=96h&type=junit&name=release-master-ci&search=cluster+upgrade+should+complete+in' | sed -n 's/.*took too long: //p' | sort -n
75.34 minutes
75.34 minutes
...
129.51 minutes
```

giving 25 runs in the 70s and 8 runs in the 80s that would move to passing.  There are also 4 runs in the 90s and 8 over 100 which would still probably be failing (unless they are also getting the AWS or OVN bumps).
