### PR TITLE
Disable app behind service lb with pdb disruption test on single-node

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -54,6 +54,10 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	if infra.Status.PlatformStatus.Type == configv1.OvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.KubevirtPlatformType || infra.Status.PlatformStatus.Type == configv1.LibvirtPlatformType || infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType || infra.Status.PlatformStatus.Type == configv1.BareMetalPlatformType {
 		t.unsupportedPlatform = true
 	}
+	// single node clusters are not supported because the replication controller has 2 replicas with anti-affinity for running on the same node.
+	if infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode {
+		t.unsupportedPlatform = true
+	}
 	if t.unsupportedPlatform {
 		return
 	}


### PR DESCRIPTION
The replication controller created by this test has 2 replicas with anti-affinity for
running on the same node, so it never becomes ready and times out on single-node clusters

This commit disables this test on single-node clusters