### PR TITLE
cli: use ProxyFromEnvironment for requests

### DIFF
--- a/test/extended/cli/basics.go
+++ b/test/extended/cli/basics.go
@@ -188,6 +188,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 				TLSClientConfig: &tls.Config{
 					RootCAs: rootCAs,
 				},
+				Proxy: http.ProxyFromEnvironment,
 			}
 		}
 


### PR DESCRIPTION
In our CI, there are several jobs including baremetal that execute
tests through an HTTP proxy. Whenever our tests use an http client,
the transport should be set to use the ProxyFromEnvironment.

The test `[sig-cli] oc basics can get version information from API` is
now failing and blocking payloads, as when there's a CA present the test
builds it's own transport without proxy settings.

This test was added in https://github.com/openshift/origin/pull/26589.
