### PR TITLE
Bug 2025722: test/e2e/upgrade: Bump durationToSoftFailure by 15m for minor updates

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/origin/test/e2e/upgrade/manifestdelete"
 	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/prometheus"
+	"github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 	"github.com/openshift/origin/test/extended/util/disruption/frontends"
@@ -298,6 +299,13 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			//   https://bugzilla.redhat.com/show_bug.cgi?id=1942164
 			durationToSoftFailure = baseDurationToSoftFailure + (15 * time.Minute)
 		}
+	}
+
+	if cv, err := c.ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{}); err != nil {
+		return err
+	} else if util.GetMajorMinor(version.Version.String()) != util.GetMajorMinor(cv.Status.Desired.Version) {
+		framework.Logf("Upgrade from %s to %s changes the major.minor, so allowing an additional 15 minutes", cv.Status.Desired.Version, version.Version.String())
+		durationToSoftFailure += 15 * time.Minute
 	}
 
 	framework.Logf("Starting upgrade to version=%s image=%s attempt=%s", version.Version.String(), version.NodeImage, uid)

--- a/test/extended/util/adminack.go
+++ b/test/extended/util/adminack.go
@@ -123,20 +123,20 @@ func getCurrentVersion(ctx context.Context, config *restclient.Config) string {
 	return ""
 }
 
-// getEffectiveMinor attempts to do a simple parse of the version provided.  If it does not parse, the value is considered
+// GetMajorMinor attempts to do a simple parse of the version provided.  If it does not parse, the value is considered
 // an empty string, which works for a comparison for equivalence.
-func getEffectiveMinor(version string) string {
+func GetMajorMinor(version string) string {
 	splits := strings.Split(version, ".")
 	if len(splits) < 2 {
 		return ""
 	}
-	return splits[1]
+	return strings.Join(splits[:2], ".")
 }
 
 func gateApplicableToCurrentVersion(gateAckVersion string, currentVersion string) bool {
 	parts := strings.Split(gateAckVersion, "-")
-	ackMinor := getEffectiveMinor(parts[1])
-	cvMinor := getEffectiveMinor(currentVersion)
+	ackMinor := GetMajorMinor(parts[1])
+	cvMinor := GetMajorMinor(currentVersion)
 	if ackMinor == cvMinor {
 		return true
 	}


### PR DESCRIPTION
Manually picking #26621 back to 4.9.