### PR TITLE
Fix 'oc expose can ensure the expose command' for custom service cidrs

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -34151,7 +34151,6 @@ metadata:
   resourceVersion: "1"
   uid: 19cff995-5546-11e5-9f57-080027c5bfa9
 spec:
-  clusterIP: 172.30.0.100
   ports:
   - nodePort: 0
     port: 443
@@ -35830,7 +35829,6 @@ items:
     resourceVersion: "259"
     uid: 024d82eb-7193-11e5-b84d-080027c5bfa9
   spec:
-    clusterIP: 172.30.182.32
     ports:
     - name: web
       port: 5432

--- a/test/extended/testdata/cmd/test/cmd/testdata/external-service.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/external-service.yaml
@@ -7,7 +7,6 @@ metadata:
   resourceVersion: "1"
   uid: 19cff995-5546-11e5-9f57-080027c5bfa9
 spec:
-  clusterIP: 172.30.0.100
   ports:
   - nodePort: 0
     port: 443

--- a/test/extended/testdata/cmd/test/cmd/testdata/multiport-service.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/multiport-service.yaml
@@ -11,7 +11,6 @@ items:
     resourceVersion: "259"
     uid: 024d82eb-7193-11e5-b84d-080027c5bfa9
   spec:
-    clusterIP: 172.30.182.32
     ports:
     - name: web
       port: 5432


### PR DESCRIPTION
Hypershift uses a different service network, which results in the test
failing as it can not create the services because they have clusterIPs
in the wrong cidr.

From all that I can tell the value of those clusterIPs doesn't need to
be passed and is not asserted anywhere, hence just remove it. I've
tested that the test now passes on both standard self-hosted and
hypershift clusters.

Ref https://issues.redhat.com/browse/HOSTEDCP-257