### PR TITLE
OLM should have imagePullPolicy: Fix when ExternalControlplane

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2025,3 +2025,33 @@ func GetControlPlaneTopology(ocClient *CLI) (*configv1.TopologyMode, error) {
 	}
 	return ControlPlaneTopology, nil
 }
+
+const (
+	hypershiftManagementClusterKubeconfigEnvVar = "HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG"
+	hypershiftManagementClusterNamespaceEnvVar  = "HYPERSHIFT_MANAGEMENT_CLUSTER_NAMESPACE"
+)
+
+var (
+	hypershiftManagementClusterKubeconfig string
+	hypershiftManagementClusterNamespace  string
+	hypershiftMutex                       sync.Mutex
+)
+
+func GetHypershiftManagementClusterConfigAndNamespace() (string, string, error) {
+	hypershiftMutex.Lock()
+	defer hypershiftMutex.Unlock()
+
+	if hypershiftManagementClusterKubeconfig == "" && hypershiftManagementClusterNamespace != "" {
+		return hypershiftManagementClusterKubeconfig, hypershiftManagementClusterNamespace, nil
+	}
+
+	kubeconfig, namespace := os.Getenv(hypershiftManagementClusterKubeconfigEnvVar), os.Getenv(hypershiftManagementClusterNamespaceEnvVar)
+	if kubeconfig == "" || namespace == "" {
+		return "", "", fmt.Errorf("both the %s and the %s env var must be set", hypershiftManagementClusterKubeconfigEnvVar, hypershiftManagementClusterNamespaceEnvVar)
+	}
+
+	hypershiftManagementClusterKubeconfig = kubeconfig
+	hypershiftManagementClusterNamespace = namespace
+
+	return hypershiftManagementClusterKubeconfig, hypershiftManagementClusterNamespace, nil
+}


### PR DESCRIPTION
These run in the hypershift management cluster so:
* Add code to get a client for that cluster and find the correct namespace
* Update the tests to check for the controlplanetoplogy and if its external, use the code from the first commit to talk to the correct cluster

Ref https://issues.redhat.com/browse/HOSTEDCP-257