### PR TITLE
Skip must-gather tests when running on Hypershift

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -37,6 +37,12 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 	})
 
 	g.It("runs successfully", func() {
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if *controlPlaneTopology == configv1.ExternalTopologyMode {
+			g.Skip("oc must-gather doesn't currently support external controlPlaneTopology")
+		}
+
 		tempDir, err := ioutil.TempDir("", "test.oc-adm-must-gather.")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer os.RemoveAll(tempDir)
@@ -96,6 +102,12 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 	})
 
 	g.It("runs successfully with options", func() {
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if *controlPlaneTopology == configv1.ExternalTopologyMode {
+			g.Skip("oc must-gather doesn't currently support external controlPlaneTopology")
+		}
+
 		tempDir, err := ioutil.TempDir("", "test.oc-adm-must-gather.")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer os.RemoveAll(tempDir)


### PR DESCRIPTION
Must gather creates a pod with a master role pod selector, but
Hypershift doesn't have master nodes. Additionally, a bunch of
controlplane components that the test expects to find in the must-gather
output run in the management cluster, so wont be there.

Ref https://issues.redhat.com/browse/HOSTEDCP-257

/cc @csrwng 