### PR TITLE
Bug 2026806: test/e2e/upgrade/adminack: Poll gates for duration of update

### DIFF
--- a/test/e2e/upgrade/adminack/adminack.go
+++ b/test/e2e/upgrade/adminack/adminack.go
@@ -2,6 +2,7 @@ package adminack
 
 import (
 	"context"
+	"time"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -43,7 +44,14 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	ctx := context.Background()
 
-	adminAckTest := &clusterversionoperator.AdminAckTest{Oc: t.oc, Config: t.config}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-done
+		cancel()
+	}()
+
+	adminAckTest := &clusterversionoperator.AdminAckTest{Oc: t.oc, Config: t.config, Poll: 10 * time.Minute}
 	adminAckTest.Test(ctx)
 }
 

--- a/test/extended/util/openshift/clusterversionoperator/adminack.go
+++ b/test/extended/util/openshift/clusterversionoperator/adminack.go
@@ -25,6 +25,7 @@ import (
 type AdminAckTest struct {
 	Oc     *exutil.CLI
 	Config *restclient.Config
+	Poll   time.Duration
 }
 
 const adminAckGateFmt string = "^ack-[4-5][.]([0-9]{1,})-[^-]"
@@ -39,6 +40,24 @@ var adminAckGateRegexp = regexp.MustCompile(adminAckGateFmt)
 // admin-acks configmap to ack the given admin-ack gate. Once all gates have been ack'ed, the test waits for the
 // Upgradeable condition to change to true.
 func (t *AdminAckTest) Test(ctx context.Context) {
+	if t.Poll == 0 {
+		t.test(ctx, nil)
+		return
+	}
+
+	exercisedGates := map[string]struct{}{}
+	if err := wait.PollImmediateUntilWithContext(ctx, t.Poll, func(ctx context.Context) (bool, error) {
+		t.test(ctx, exercisedGates)
+		return false, nil
+	}); err == nil || err == wait.ErrWaitTimeout {
+		return
+	} else {
+		framework.Fail(err.Error())
+	}
+}
+
+func (t *AdminAckTest) test(ctx context.Context, exercisedGates map[string]struct{}) {
+	exists := struct{}{}
 
 	gateCm, errMsg := getAdminGatesConfigMap(ctx, t.Oc)
 	if len(errMsg) != 0 {
@@ -56,6 +75,11 @@ func (t *AdminAckTest) Test(ctx context.Context) {
 	currentVersion := getCurrentVersion(ctx, t.Config)
 	var msg string
 	for k, v := range gateCm.Data {
+		if exercisedGates != nil {
+			if _, ok := exercisedGates[k]; ok {
+				continue
+			}
+		}
 		ackVersion := adminAckGateRegexp.FindString(k)
 		if ackVersion == "" {
 			framework.Failf(fmt.Sprintf("Configmap openshift-config-managed/admin-gates gate %s has invalid format; must comply with %q.", k, adminAckGateFmt))
@@ -87,6 +111,9 @@ func (t *AdminAckTest) Test(ctx context.Context) {
 		// Update admin ack configmap with ack
 		if errMsg = setAdminGate(ctx, k, "true", t.Oc); len(errMsg) != 0 {
 			framework.Failf(errMsg)
+		}
+		if exercisedGates != nil {
+			exercisedGates[k] = exists
 		}
 	}
 	if errMsg = waitForUpgradeable(ctx, t.Config); len(errMsg) != 0 {


### PR DESCRIPTION
Poking in [this job][1] for [rhbz#2026806][2]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.6-to-4.7-to-4.8-to-4.9-ci/1463537431096594432/artifacts/e2e-aws-upgrade/clusterversion.json | jq -r '.items[].status.conditions[] | .lastTransitionTime + " " + .type + "=" + .status + " " + (.reason // "-") + ": " + (.message // "-")'
2021-11-24T16:06:34Z RetrievedUpdates=False NoChannel: The update channel has not been configured.
2021-11-24T16:30:08Z Available=True -: Done applying 4.8.0-0.nightly-2021-11-24-020113
2021-11-24T19:32:46Z Failing=False -: -
2021-11-24T19:03:45Z Progressing=True ClusterOperatorUpdating: Working towards 4.9.0-0.ci-2021-11-24-092816: 205 of 738 done (27% complete), waiting on openshift-apiserver
2021-11-24T19:04:01Z Upgradeable=False AdminAckRequired: Kubernetes 1.22 and therefore OpenShift 4.9 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6329921 for details and instructions.
```

With:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.6-to-4.7-to-4.8-to-4.9-ci/1463537431096594432/artifacts/e2e-aws-upgrade/e2e.log | grep -i 'admin.ack\|Starting upgrade to version'
STEP: Building a namespace api object, basename check-for-admin-acks
STEP: Setting up admin ack test
Nov 24 16:30:38.400: INFO: Admin ack test setup complete
Nov 24 16:30:38.477: INFO: Skipping admin ack test. Admin ack is not in this baseline or contains no gates.
Nov 24 16:30:59.853: INFO: Starting upgrade to version= image=quay.io/openshift-release-dev/ocp-release:4.7.38-x86_64 attempt=bf6292d3-ef4a-4197-b709-fbae573add46
Nov 24 17:36:50.997: INFO: Starting upgrade to version= image=registry.ci.openshift.org/ocp/release:4.8.0-0.nightly-2021-11-24-020113 attempt=07151322-099a-479f-864f-ef7945aebcd0
Nov 24 19:03:32.205: INFO: Starting upgrade to version= image=registry.ci.openshift.org/ocp/release:4.9.0-0.ci-2021-11-24-092816 attempt=f4750aac-11f3-4d12-a5c6-6860a376bf3e
```

So the admin-ack test-case ran as a one-shot at the beginning of the test, but there was no gate to ack for that 4.6 release.  Then the cluster updated through 4.7 to 4.8, where it picked up the `ack-4.8-kube-1.22-api-removals-in-4.9` gate.  The old, one-shot admin-ack test case was long gone by this time, so the gate remained un-acked, and the requested update to 4.9 hung on the failing `Upgradeable=False` precondition.

With this commit, the non-update admin-ack test-case remains one-shot, but the update admin-ack test-case moves to polling every 10 minutes, and wiggling any new gates it sees that are applicable to the current release (still based on the latest completed history entry).  So now the 4.6 -> ... -> 4.9 job will, at some poll after completing 4.8, notice and set the new `ack-4.8-kube-1.22-api-removals-in-4.9` gate, and unblock the update to 4.9.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.6-to-4.7-to-4.8-to-4.9-ci/1463537431096594432
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2026806