### PR TITLE
test/extended/util/openshift/clusterversionoperator: Delegate admin-ack ownership

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  cluster-version-operator-test-case-approvers:
+  - LalatenduMohanty
+  - jottofar
+  - vrutkovs
+  - wking
+  cluster-version-operator-test-case-reviewers:
+  - LalatenduMohanty
+  - jottofar
+  - vrutkovs
+  - wking

--- a/test/e2e/upgrade/adminack/OWNERS
+++ b/test/e2e/upgrade/adminack/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- cluster-version-operator-test-case-approvers
+reviewers:
+- cluster-version-operator-test-case-reviewers

--- a/test/e2e/upgrade/adminack/adminack.go
+++ b/test/e2e/upgrade/adminack/adminack.go
@@ -7,6 +7,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/openshift/clusterversionoperator"
 
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -42,7 +43,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	ctx := context.Background()
 
-	adminAckTest := &exutil.AdminAckTest{Oc: t.oc, Config: t.config}
+	adminAckTest := &clusterversionoperator.AdminAckTest{Oc: t.oc, Config: t.config}
 	adminAckTest.Test(ctx)
 }
 

--- a/test/extended/adminack/OWNERS
+++ b/test/extended/adminack/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- cluster-version-operator-test-case-approvers
+reviewers:
+- cluster-version-operator-test-case-reviewers

--- a/test/extended/adminack/adminack.go
+++ b/test/extended/adminack/adminack.go
@@ -7,6 +7,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/openshift/clusterversionoperator"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -21,7 +22,7 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			ctx := context.Background()
 
-			adminAckTest := &exutil.AdminAckTest{Oc: oc, Config: config}
+			adminAckTest := &clusterversionoperator.AdminAckTest{Oc: oc, Config: config}
 			adminAckTest.Test(ctx)
 		})
 	})

--- a/test/extended/util/openshift/clusterversionoperator/OWNERS
+++ b/test/extended/util/openshift/clusterversionoperator/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- cluster-version-operator-test-case-approvers
+reviewers:
+- cluster-version-operator-test-case-reviewers

--- a/test/extended/util/openshift/clusterversionoperator/adminack.go
+++ b/test/extended/util/openshift/clusterversionoperator/adminack.go
@@ -1,4 +1,5 @@
-package util
+// Package clusterversionoperator contains utilities for exercising the cluster-version operator.
+package clusterversionoperator
 
 import (
 	"context"
@@ -16,11 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 // AdminAckTest contains artifacts used during test
 type AdminAckTest struct {
-	Oc     *CLI
+	Oc     *exutil.CLI
 	Config *restclient.Config
 }
 
@@ -143,7 +146,7 @@ func gateApplicableToCurrentVersion(gateAckVersion string, currentVersion string
 	return false
 }
 
-func getAdminGatesConfigMap(ctx context.Context, oc *CLI) (*corev1.ConfigMap, string) {
+func getAdminGatesConfigMap(ctx context.Context, oc *exutil.CLI) (*corev1.ConfigMap, string) {
 	cm, err := oc.AdminKubeClient().CoreV1().ConfigMaps("openshift-config-managed").Get(ctx, "admin-gates", metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -155,7 +158,7 @@ func getAdminGatesConfigMap(ctx context.Context, oc *CLI) (*corev1.ConfigMap, st
 	return cm, ""
 }
 
-func getAdminAcksConfigMap(ctx context.Context, oc *CLI) (*corev1.ConfigMap, string) {
+func getAdminAcksConfigMap(ctx context.Context, oc *exutil.CLI) (*corev1.ConfigMap, string) {
 	cm, err := oc.AdminKubeClient().CoreV1().ConfigMaps("openshift-config").Get(ctx, "admin-acks", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Sprintf("Error accessing configmap openshift-config/admin-acks, err=%v", err)
@@ -185,7 +188,7 @@ func upgradeableExplicitlyFalse(ctx context.Context, config *restclient.Config) 
 }
 
 // setAdminGate gets the admin ack configmap and then updates it with given gate name and given value.
-func setAdminGate(ctx context.Context, gateName string, gateValue string, oc *CLI) string {
+func setAdminGate(ctx context.Context, gateName string, gateValue string, oc *exutil.CLI) string {
 	ackCm, errMsg := getAdminAcksConfigMap(ctx, oc)
 	if len(errMsg) != 0 {
 		framework.Failf(errMsg)


### PR DESCRIPTION
So folks don't think Oleg is responsible for these, despite his test/extended/util/OWNERS entry.  Per Ben, he was only added as a starting point to deal w/ the fact that every team gets bottlenecked on approval whenever they touch something that impacts generated code.  This commit restructures so that [existing cluster-version operator approvers][1] (or other folks the origin maintainers want to use instead) can update these test-cases without needing to pull in more generic test-framework review and approval.

[1]: https://github.com/openshift/cluster-version-operator/blob/bc972aafe17f22b0f7f9f6552a327196c77dddf8/OWNERS#L3-L7