### PR TITLE
Skip oc version test in disconnected

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1389,7 +1389,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc status returns expected help messages": "returns expected help messages [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc version check kubernetes version matches the io.openshift.build.versions label": "check kubernetes version matches the io.openshift.build.versions label [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc version check kubernetes version matches the io.openshift.build.versions label": "check kubernetes version matches the io.openshift.build.versions label [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/authentication.sh": "test/cmd/authentication.sh",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -155,6 +155,7 @@ var (
 			`\[sig-operator\] an end user can use OLM can subscribe to the operator`,
 			`\[sig-network\] Networking should provide Internet connection for containers`,
 			`\[sig-imageregistry\]\[Serial\]\[Suite:openshift/registry/serial\] Image signature workflow can push a signed image to openshift registry and verify it`,
+			`\[sig-cli\] oc version check kubernetes version matches the io.openshift.build.versions label`,
 
 			// Need to access non-cached images like ruby and mongodb
 			`\[sig-apps\]\[Feature:DeploymentConfig\] deploymentconfigs with multiple image change triggers should run a successful deployment with a trigger used by different containers`,


### PR DESCRIPTION
`[sig-cli] oc version check kubernetes version matches the io.openshift.build.versions label`
test tries to exec `oc image info` command in master nodes to compare
versions.

However, in disconnected configuration, this command can not access registry by
throwing `network is unreachable`.

This PR skips this test in disconnected.