### PR TITLE
Alter junit test suite names for jobs with multiple junit xmls.

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -296,7 +296,7 @@ func newRunCommand() *cobra.Command {
 				if !opt.DryRun {
 					fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 				}
-				err = opt.Run(&suite.TestSuite)
+				err = opt.Run(&suite.TestSuite, "openshift-tests")
 				if suite.PostSuite != nil {
 					suite.PostSuite(opt)
 				}
@@ -361,7 +361,7 @@ func newRunUpgradeCommand() *cobra.Command {
 				if !opt.DryRun {
 					fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 				}
-				err = opt.Run(&suite.TestSuite)
+				err = opt.Run(&suite.TestSuite, "openshift-tests-upgrade")
 				if suite.PostSuite != nil {
 					suite.PostSuite(opt)
 				}

--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
-// upgradeSuites are all known upgade test suites this binary should run
+// upgradeSuites are all known upgrade test suites this binary should run
 var upgradeSuites = testSuites{
 	{
 		TestSuite: ginkgo.TestSuite{

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -111,7 +111,7 @@ func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite,
 	return suite, nil
 }
 
-func (opt *Options) Run(suite *TestSuite) error {
+func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 	if len(opt.Regex) > 0 {
 		if err := filterWithRegex(suite, opt.Regex); err != nil {
 			return err
@@ -456,7 +456,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 	}
 
 	if len(opt.JUnitDir) > 0 {
-		if err := writeJUnitReport("junit_e2e", "openshift-tests", tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
+		if err := writeJUnitReport("junit_e2e", junitSuiteName, tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
 			fmt.Fprintf(opt.Out, "error: Unable to write e2e JUnit results: %v", err)
 		}
 	}


### PR DESCRIPTION
It appears that on upgrade jobs where we invoke openshift-tests multiple
times (pre/post upgrade etc), the resulting two junit xml files are
merged by testgrid, and may contain the same test names. Testgrid then
mistakenly marks a test as a flake when in fact, one of them was a fatal
failure. This ultimately led to sippy showing massively successful test
pass rates when in fact we were failing almost all of the time.

This change attempts to address by using different junit test suite
names for different openshift-tests sub-commands.

In the case of the upgrade suite we're chasing problems in, we run:

openshift-tests run-upgrade all
openshift-tests run openshift/conformance/parallel

Hopefully this change will differentiate the tests sufficiently in
testgrid and sippy.
