### PR TITLE
Fix TestFIPS on Hypershift

### DIFF
--- a/test/extended/security/fips.go
+++ b/test/extended/security/fips.go
@@ -8,6 +8,7 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,12 +20,21 @@ const (
 )
 
 func validateFIPSOnNode(oc *exutil.CLI, fipsExpected bool, node *corev1.Node) error {
-	command := []string{"cat", fipsFile}
-	out, err := exutil.ExecCommandOnMachineConfigDaemon(oc.AdminKubeClient(), oc, node, command)
+	// The oc debug output prints a bunch of info messages and possible warnings (the latter can not be disabled).
+	// Echo a prefix to be able to identify the line with our output.
+	const commandLineIdentifierPrefix = "fips-command"
+	out, err := oc.AsAdmin().Run("debug").Args("node/"+node.Name, "--", "/bin/bash", "-c", "echo -n "+commandLineIdentifierPrefix+" && cat "+fipsFile).Output()
 	if err != nil {
 		return err
 	}
-	nodeFips, err := strconv.ParseBool(strings.TrimSuffix(string(out), "\n"))
+	var outFiltered string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, commandLineIdentifierPrefix) {
+			outFiltered = strings.TrimPrefix(line, commandLineIdentifierPrefix)
+			break
+		}
+	}
+	nodeFips, err := strconv.ParseBool(outFiltered)
 	if err != nil {
 		return fmt.Errorf("Error parsing %s on node %s: %v", fipsFile, node.Name, err)
 	}
@@ -39,17 +49,23 @@ var _ = g.Describe("[sig-arch] [Conformance] FIPS", func() {
 	oc := exutil.NewCLI("fips")
 
 	g.It("TestFIPS", func() {
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		clusterAdminKubeClientset := oc.AdminKubeClient()
 		isFIPS, err := exutil.IsFIPS(clusterAdminKubeClientset.CoreV1())
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		// fetch one control plane and one worker, and validate FIPS state on it
-		masterNodes, err := clusterAdminKubeClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/master",
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		masterNode := &masterNodes.Items[0]
-		err = validateFIPSOnNode(oc, isFIPS, masterNode)
+		// fetch one control plane and one worker, and validate FIPS state on it.
+		// skip the controlplane node verification when external controlPlaneTopology as
+		// there are no controlplane nodes.
+		if *controlPlaneTopology != configv1.ExternalTopologyMode {
+			masterNodes, err := clusterAdminKubeClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+				LabelSelector: "node-role.kubernetes.io/master",
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			masterNode := &masterNodes.Items[0]
+			err = validateFIPSOnNode(oc, isFIPS, masterNode)
+		}
 		o.Expect(err).NotTo(o.HaveOccurred())
 		workerNodes, err := clusterAdminKubeClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
 			LabelSelector: "node-role.kubernetes.io/worker",


### PR DESCRIPTION
There are two changes needed:
* Don't test master nodes, as there are none
* Don't execute the command in the machine-config-daemon, but in an oc
  debug pod. The only reason the machine-config-daemon was originaly
  used is convenience, the test command can be executed in any pod as
  long as its on the right node

Ref regarding "can be executed in any pod": https://coreos.slack.com/archives/C999USB0D/p1638981587077200?thread_ts=1638981423.077100&cid=C999USB0D

/assign @bparees 