### PR TITLE
Hypershift: Skip Prometheus should have important platform topology metrics

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -684,6 +684,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 		})
 
 		g.It("should have important platform topology metrics", func() {
+			exutil.SkipIfExternalControlplaneTopology(oc, "topology metrics are not available for clusters with external controlPlaneTopology")
 			oc.SetupProject()
 			ns := oc.Namespace()
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/rest"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/framework/statefulset"
 	"k8s.io/kubernetes/test/utils/image"
 
@@ -2054,4 +2055,12 @@ func GetHypershiftManagementClusterConfigAndNamespace() (string, string, error) 
 	hypershiftManagementClusterNamespace = namespace
 
 	return hypershiftManagementClusterKubeconfig, hypershiftManagementClusterNamespace, nil
+}
+
+func SkipIfExternalControlplaneTopology(oc *CLI, reason string) {
+	controlPlaneTopology, err := GetControlPlaneTopology(oc)
+	o.ExpectWithOffset(1, err).NotTo(o.HaveOccurred())
+	if *controlPlaneTopology == configv1.ExternalTopologyMode {
+		skipper.Skipf(reason)
+	}
 }


### PR DESCRIPTION
None of these metrics exist there, as they come out of the apiserver
operator, require someone to manually install the cluster or are based
on etcd metrics.

Ref https://issues.redhat.com/browse/HOSTEDCP-257