### PR TITLE
separate disruption sampling from the monitor sampler

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -95,6 +95,9 @@
     }
 
     function isEndpointConnectivity(eventInterval) {
+        if (!eventInterval.message.includes("stopped responding to GET requests")){
+            return false
+        }
         if (eventInterval.locator.includes("disruption/")) {
             return true
         }
@@ -105,19 +108,6 @@
             return true
         }
 
-        return false
-    }
-
-    function isAPIServerConnectivity(eventInterval) {
-        if (eventInterval.locator == "kube-apiserver-new-connection" || eventInterval.locator == "kube-apiserver-reused-connection") {
-            return true
-        }
-        if (eventInterval.locator == "oauth-apiserver-new-connection" || eventInterval.locator == "oauth-apiserver-reused-connection") {
-            return true
-        }
-        if (eventInterval.locator == "openshift-apiserver-new-connection" || eventInterval.locator == "openshift-apiserver-reused-connection") {
-            return true
-        }
         return false
     }
 
@@ -265,9 +255,6 @@
         }
         return 0
     })
-
-    timelineGroups.push({group: "apiserver-availability", data: []})
-    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerConnectivity)
 
     timelineGroups.push({group: "endpoint-availability", data: []})
     createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEndpointConnectivity)

--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -95,14 +95,17 @@
     }
 
     function isEndpointConnectivity(eventInterval) {
+        if (eventInterval.locator.includes("disruption/")) {
+            return true
+        }
         if (eventInterval.locator.startsWith("ns/e2e-k8s-service-lb-available")) {
             return true
         }
         if (eventInterval.locator.includes(" route/")) {
             return true
         }
-        return false
 
+        return false
     }
 
     function isAPIServerConnectivity(eventInterval) {

--- a/pkg/monitor/disruption_backend_sampler.go
+++ b/pkg/monitor/disruption_backend_sampler.go
@@ -139,7 +139,7 @@ func (b *BackendSampler) GetConnectionType() BackendConnectionType {
 
 func (b *BackendSampler) getTimeout() time.Duration {
 	if b.timeout == nil {
-		return 1 * time.Second
+		return 5 * time.Second
 	}
 	return *b.timeout
 }

--- a/pkg/monitor/disruption_backend_sampler.go
+++ b/pkg/monitor/disruption_backend_sampler.go
@@ -62,7 +62,7 @@ type routeCoordinates struct {
 	name      string
 }
 
-func NewAPIServerBackend(disruptionBackendName, path string, connectionType BackendConnectionType) *BackendSampler {
+func NewBackend(disruptionBackendName, path string, connectionType BackendConnectionType) *BackendSampler {
 	return &BackendSampler{
 		connectionType:        connectionType,
 		locator:               LocateDisruptionCheck(disruptionBackendName, connectionType),
@@ -123,6 +123,10 @@ func (b *BackendSampler) BodyMatches(body []byte) error {
 	}
 
 	return nil
+}
+
+func (b *BackendSampler) SetHost(host string) {
+	b.host = host
 }
 
 func (b *BackendSampler) GetDisruptionBackendName() string {

--- a/pkg/monitor/disruption_backend_sampler.go
+++ b/pkg/monitor/disruption_backend_sampler.go
@@ -1,0 +1,341 @@
+package monitor
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"regexp"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/client-go/tools/events"
+
+	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"k8s.io/client-go/transport"
+)
+
+// this entire file should be a separate package with disruption_***, but we are entanged because the sampler lives in monitor
+// and the things being started by the monitor are coupled into .Start.
+// we also got stuck on writing the disruption backends.  We need a way to track which disruption checks we have started,
+// so we can properly write out "zero"
+
+type BackendConnectionType string
+
+const (
+	NewConnectionType    BackendConnectionType = "new"
+	ReusedConnectionType BackendConnectionType = "reused"
+)
+
+type BackendSampler struct {
+	locator               string
+	disruptionBackendName string
+	connectionType        BackendConnectionType
+	host                  string
+	path                  string
+
+	routeCoordinates *routeCoordinates
+	initializeHost   sync.Once
+
+	bearerToken     string
+	bearerTokenFile string
+	timeout         *time.Duration
+	tlsConfig       *tls.Config
+
+	eventRecorder events.EventRecorder
+
+	expect       string
+	expectRegexp *regexp.Regexp
+}
+
+type routeCoordinates struct {
+	namespace string
+	name      string
+}
+
+func NewAPIServerBackend(disruptionBackendName, path string, connectionType BackendConnectionType) *BackendSampler {
+	return &BackendSampler{
+		connectionType:        connectionType,
+		locator:               LocateDisruptionCheck(disruptionBackendName, connectionType),
+		disruptionBackendName: disruptionBackendName,
+		path:                  path,
+	}
+}
+
+func NewRouteBackend(namespace, name, disruptionBackendName, path string, connectionType BackendConnectionType) *BackendSampler {
+	return &BackendSampler{
+		connectionType:        connectionType,
+		locator:               LocateRouteForDisruptionCheck(namespace, name, disruptionBackendName, connectionType),
+		disruptionBackendName: disruptionBackendName,
+		path:                  path,
+		routeCoordinates: &routeCoordinates{
+			namespace: namespace,
+			name:      name,
+		},
+	}
+}
+
+func (b *BackendSampler) WithHost(host string) *BackendSampler {
+	b.host = host
+	return b
+}
+
+func (b *BackendSampler) WithBearerTokenAuth(token, tokenFile string) *BackendSampler {
+	b.bearerToken = token
+	b.bearerTokenFile = tokenFile
+	return b
+}
+
+func (b *BackendSampler) WithTLSConfig(tlsConfig *tls.Config) *BackendSampler {
+	b.tlsConfig = tlsConfig
+	return b
+}
+
+func (b *BackendSampler) WithExpectedBody(expectedBody string) *BackendSampler {
+	b.expect = expectedBody
+	return b
+}
+
+func (b *BackendSampler) WithExpectedBodyRegex(expectedBodyRegex string) *BackendSampler {
+	b.expectRegexp = regexp.MustCompile(expectedBodyRegex)
+	return b
+}
+
+func (b *BackendSampler) SetEventRecorder(eventRecorder events.EventRecorder) {
+	b.eventRecorder = eventRecorder
+}
+
+func (b *BackendSampler) BodyMatches(body []byte) error {
+	switch {
+	case len(b.expect) != 0 && !bytes.Contains(body, []byte(b.expect)):
+		return fmt.Errorf("response did not contain the correct body contents: %q", string(body))
+	case b.expectRegexp != nil && !b.expectRegexp.MatchString(string(body)):
+		return fmt.Errorf("response did not contain the correct body contents: %q", string(body))
+	}
+
+	return nil
+}
+
+func (b *BackendSampler) GetDisruptionBackendName() string {
+	return b.disruptionBackendName
+}
+
+func (b *BackendSampler) GetLocator() string {
+	return b.locator
+}
+
+func (b *BackendSampler) GetConnectionType() BackendConnectionType {
+	return b.connectionType
+}
+
+func (b *BackendSampler) getTimeout() time.Duration {
+	if b.timeout == nil {
+		return 1 * time.Second
+	}
+	return *b.timeout
+}
+
+func (b *BackendSampler) GetURL() (string, error) {
+	var hostErr error
+	b.initializeHost.Do(func() {
+		if len(b.host) > 0 {
+			return
+		}
+		if b.routeCoordinates == nil {
+			hostErr = fmt.Errorf("no route coordinates to lookup host")
+			return
+		}
+		config, err := framework.LoadConfig()
+		if err != nil {
+			hostErr = err
+			return
+		}
+		client, err := routeclientset.NewForConfig(config)
+		if err != nil {
+			hostErr = err
+			return
+		}
+		route, err := client.RouteV1().Routes(b.routeCoordinates.namespace).Get(context.Background(), b.routeCoordinates.name, metav1.GetOptions{})
+		if err != nil {
+			hostErr = err
+			return
+		}
+		for _, ingress := range route.Status.Ingress {
+			if len(ingress.Host) > 0 {
+				b.host = fmt.Sprintf("https://%s", ingress.Host)
+				break
+			}
+		}
+	})
+	if hostErr != nil {
+		return "", hostErr
+	}
+	if len(b.host) == 0 {
+		return "", fmt.Errorf("missing URL")
+	}
+	return b.host + b.path, nil
+}
+
+func (b *BackendSampler) getTLSConfig() *tls.Config {
+	if b.tlsConfig == nil {
+		return &tls.Config{InsecureSkipVerify: true}
+	}
+	return b.tlsConfig
+}
+
+func (b *BackendSampler) wrapWithAuth(rt http.RoundTripper) (http.RoundTripper, error) {
+	if len(b.bearerToken) == 0 && len(b.bearerTokenFile) == 0 {
+		return rt, nil
+	}
+
+	if b.tlsConfig == nil {
+		return nil, fmt.Errorf("WithTLSConfig is required if you are providing a token")
+	}
+
+	return transport.NewBearerAuthWithRefreshRoundTripper(b.bearerToken, b.bearerTokenFile, rt)
+}
+
+func (b *BackendSampler) GetHTTPClient() (*http.Client, error) {
+	var httpTransport *http.Transport
+	switch b.GetConnectionType() {
+	case NewConnectionType:
+		httpTransport = &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   b.getTimeout(),
+				KeepAlive: -1, // this looks unnecessary to me, but it was set in other code.
+			}).Dial,
+			TLSClientConfig:     b.getTLSConfig(),
+			TLSHandshakeTimeout: b.getTimeout(),
+			DisableKeepAlives:   true, // this prevents connections from being reused
+			IdleConnTimeout:     b.getTimeout(),
+		}
+
+	case ReusedConnectionType:
+		httpTransport = &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: b.getTimeout(),
+			}).Dial,
+			TLSClientConfig:     b.getTLSConfig(),
+			TLSHandshakeTimeout: b.getTimeout(),
+			IdleConnTimeout:     b.getTimeout(),
+		}
+
+	default:
+		return nil, fmt.Errorf("unrecognized connection type")
+	}
+
+	roundTripper, err := b.wrapWithAuth(http.RoundTripper(httpTransport))
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{
+		Transport: roundTripper,
+	}
+
+	return httpClient, nil
+}
+
+// StartEndpointMonitoring sets up a client for the given BackendSampler and starts a
+// new sampler for the given monitor that uses the client to monitor
+// connectivity to the BackendSampler and reports any observed disruption.
+//
+// If disableConnectionReuse is false, the client reuses connections and detects
+// abrupt breaks in connectivity.  If disableConnectionReuse is true, the client
+// instead creates fresh connections so that it detects failures to establish
+// connections.
+func (b *BackendSampler) StartEndpointMonitoring(ctx context.Context, m *Monitor) error {
+	httpClient, err := b.GetHTTPClient()
+	if err != nil {
+		return err
+	}
+
+	url, err := b.GetURL()
+	if err != nil {
+		return err
+	}
+
+	go NewSampler(m, time.Second, func(previouslyAvailable bool) (condition *monitorapi.Condition, next bool) {
+		resp, getErr := httpClient.Get(url)
+		var body []byte
+		var bodyReadErr, sampleErr error
+		if getErr == nil {
+			body, bodyReadErr = ioutil.ReadAll(resp.Body)
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				framework.Logf("error closing body: %v: %v", b.locator, closeErr)
+			}
+		}
+
+		// we don't have an error, but the response code was an error, then we have to set an artificial error for the logic below to work.
+		switch {
+		case getErr != nil:
+			sampleErr = getErr
+		case bodyReadErr != nil:
+			sampleErr = getErr
+		case resp.StatusCode < 200 || resp.StatusCode > 399:
+			sampleErr = fmt.Errorf("error running request: %v: %v", resp.Status, string(body))
+		default:
+			if bodyMatchErr := b.BodyMatches(body); bodyMatchErr != nil {
+				sampleErr = bodyMatchErr
+			}
+		}
+		currentlyAvailable := sampleErr == nil
+
+		switch {
+		case currentlyAvailable && previouslyAvailable:
+			// we are continuing to function.  no condition change.
+			return nil, currentlyAvailable
+
+		case !currentlyAvailable && !previouslyAvailable:
+			// we are continuing to fail, no condition change.
+			return nil, currentlyAvailable
+
+		case currentlyAvailable && !previouslyAvailable:
+			message := DisruptionEndedMessage(b.GetLocator(), b.GetConnectionType())
+			framework.Logf(message)
+			if b.eventRecorder != nil {
+				b.eventRecorder.Eventf(
+					&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: b.disruptionBackendName}, nil,
+					v1.EventTypeNormal, "DisruptionEnded", "detected", message)
+			}
+			return &monitorapi.Condition{
+				Level:   monitorapi.Info,
+				Locator: b.GetLocator(),
+				Message: message,
+			}, currentlyAvailable
+
+		case !currentlyAvailable && previouslyAvailable:
+			message := DisruptionBeganMessage(b.GetLocator(), b.GetConnectionType(), sampleErr)
+			framework.Logf(message)
+			if b.eventRecorder != nil {
+				b.eventRecorder.Eventf(
+					&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: b.disruptionBackendName}, nil,
+					v1.EventTypeWarning, "DisruptionBegan", "detected", message)
+			}
+			return &monitorapi.Condition{
+				Level:   monitorapi.Error,
+				Locator: b.GetLocator(),
+				Message: message,
+			}, currentlyAvailable
+
+		default:
+			panic("math broke resulting in this weird error you need to find")
+		}
+
+	}).WhenFailing(ctx, &monitorapi.Condition{
+		Level:   monitorapi.Error,
+		Locator: b.GetLocator(),
+		Message: DisruptionContinuingMessage(b.GetLocator(), b.GetConnectionType(), fmt.Errorf("missing associated failure")),
+	})
+
+	return nil
+}

--- a/pkg/monitor/disruption_known_backends.go
+++ b/pkg/monitor/disruption_known_backends.go
@@ -1,0 +1,137 @@
+package monitor
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+// this entire file should be a separate package with disruption_***, but we are entanged because the sampler lives in monitor
+// and the things being started by the monitor are coupled into .Start.
+// we also got stuck on writing the disruption backends.  We need a way to track which disruption checks we have started,
+// so we can properly write out "zero"
+
+var (
+	LocatorKubeAPIServerNewConnection         = LocateDisruptionCheck("kube-api", NewConnectionType)
+	LocatorKubeAPIServerReusedConnection      = LocateDisruptionCheck("kube-api", ReusedConnectionType)
+	LocatorOpenshiftAPIServerNewConnection    = LocateDisruptionCheck("openshift-api", NewConnectionType)
+	LocatorOpenshiftAPIServerReusedConnection = LocateDisruptionCheck("openshift-api", ReusedConnectionType)
+	LocatorOAuthAPIServerNewConnection        = LocateDisruptionCheck("oauth-api", NewConnectionType)
+	LocatorOAuthAPIServerReusedConnection     = LocateDisruptionCheck("oauth-api", ReusedConnectionType)
+)
+
+// BackendDisruptionLocatorsToName maps from the locator name used to track disruption to the name used to recognize it in
+// the job aggregator.
+var BackendDisruptionLocatorsToName = map[string]string{
+	LocatorKubeAPIServerNewConnection:         "kube-api-new-connections",
+	LocatorOpenshiftAPIServerNewConnection:    "openshift-api-new-connections",
+	LocatorOAuthAPIServerNewConnection:        "oauth-api-new-connections",
+	LocatorKubeAPIServerReusedConnection:      "kube-api-reused-connections",
+	LocatorOpenshiftAPIServerReusedConnection: "openshift-api-reused-connections",
+	LocatorOAuthAPIServerReusedConnection:     "oauth-api-reused-connections",
+	LocateRouteForDisruptionCheck("openshift-authentication", "oauth-openshift", "ingress-to-oauth-server", NewConnectionType):    "ingress-to-oauth-server-new-connections",
+	LocateRouteForDisruptionCheck("openshift-authentication", "oauth-openshift", "ingress-to-oauth-server", ReusedConnectionType): "ingress-to-oauth-server-used-connections",
+	LocateRouteForDisruptionCheck("openshift-console", "console", "ingress-to-console", NewConnectionType):                        "ingress-to-console-new-connections",
+	LocateRouteForDisruptionCheck("openshift-console", "console", "ingress-to-console", ReusedConnectionType):                     "ingress-to-console-used-connections",
+	LocateRouteForDisruptionCheck("openshift-image-registry", "test-disruption", "image-registry", NewConnectionType):             "image-registry-new-connections",
+	LocateRouteForDisruptionCheck("openshift-image-registry", "test-disruption", "image-registry", ReusedConnectionType):          "image-registry-reused-connections",
+	LocateDisruptionCheck("service-loadbalancer-with-pdb", NewConnectionType):                                                     "service-load-balancer-with-pdb-new-connections",
+	LocateDisruptionCheck("service-loadbalancer-with-pdb", ReusedConnectionType):                                                  "service-load-balancer-with-pdb-reused-connections",
+}
+
+func startKubeAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
+	backendSampler, err := CreateKubeAPIMonitoringWithNewConnections(clusterConfig)
+	if err != nil {
+		return err
+	}
+	return backendSampler.StartEndpointMonitoring(ctx, m)
+}
+
+func startOpenShiftAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
+	backendSampler, err := CreateOpenShiftAPIMonitoringWithNewConnections(clusterConfig)
+	if err != nil {
+		return err
+	}
+	return backendSampler.StartEndpointMonitoring(ctx, m)
+}
+
+func startOAuthAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
+	backendSampler, err := CreateOAuthAPIMonitoringWithNewConnections(clusterConfig)
+	if err != nil {
+		return err
+	}
+	return backendSampler.StartEndpointMonitoring(ctx, m)
+}
+
+func startKubeAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
+	backendSampler, err := CreateKubeAPIMonitoringWithConnectionReuse(clusterConfig)
+	if err != nil {
+		return err
+	}
+	return backendSampler.StartEndpointMonitoring(ctx, m)
+}
+
+func startOpenShiftAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
+	backendSampler, err := CreateOpenShiftAPIMonitoringWithConnectionReuse(clusterConfig)
+	if err != nil {
+		return err
+	}
+	return backendSampler.StartEndpointMonitoring(ctx, m)
+}
+
+func startOAuthAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
+	backendSampler, err := CreateOAuthAPIMonitoringWithConnectionReuse(clusterConfig)
+	if err != nil {
+		return err
+	}
+	return backendSampler.StartEndpointMonitoring(ctx, m)
+}
+
+func CreateKubeAPIMonitoringWithNewConnections(clusterConfig *rest.Config) (*BackendSampler, error) {
+	return createAPIServerBackendSampler(clusterConfig, "kube-api", "/api/v1/namespaces/default", NewConnectionType)
+}
+
+func CreateOpenShiftAPIMonitoringWithNewConnections(clusterConfig *rest.Config) (*BackendSampler, error) {
+	// this request should never 404, but should be empty/small
+	return createAPIServerBackendSampler(clusterConfig, "openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams", NewConnectionType)
+}
+
+func CreateOAuthAPIMonitoringWithNewConnections(clusterConfig *rest.Config) (*BackendSampler, error) {
+	// this should be relatively small and should not ever 404
+	return createAPIServerBackendSampler(clusterConfig, "oauth-api", "/apis/oauth.openshift.io/v1/oauthclients", NewConnectionType)
+}
+
+func CreateKubeAPIMonitoringWithConnectionReuse(clusterConfig *rest.Config) (*BackendSampler, error) {
+	// default gets auto-created, so this should always exist
+	return createAPIServerBackendSampler(clusterConfig, "kube-api", "/api/v1/namespaces/default", ReusedConnectionType)
+}
+
+func CreateOpenShiftAPIMonitoringWithConnectionReuse(clusterConfig *rest.Config) (*BackendSampler, error) {
+	// this request should never 404, but should be empty/small
+	return createAPIServerBackendSampler(clusterConfig, "openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams", ReusedConnectionType)
+}
+
+func CreateOAuthAPIMonitoringWithConnectionReuse(clusterConfig *rest.Config) (*BackendSampler, error) {
+	// this should be relatively small and should not ever 404
+	return createAPIServerBackendSampler(clusterConfig, "oauth-api", "/apis/oauth.openshift.io/v1/oauthclients", ReusedConnectionType)
+}
+
+func createAPIServerBackendSampler(clusterConfig *rest.Config, disruptionBackendName, url string, connectionType BackendConnectionType) (*BackendSampler, error) {
+	kubeTransportConfig, err := clusterConfig.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+	tlsConfig, err := transport.TLSConfigFor(kubeTransportConfig)
+	if err != nil {
+		return nil, err
+	}
+	// default gets auto-created, so this should always exist
+	backendSampler :=
+		NewAPIServerBackend(disruptionBackendName, url, connectionType).
+			WithHost(clusterConfig.Host).
+			WithTLSConfig(tlsConfig).
+			WithBearerTokenAuth(kubeTransportConfig.BearerToken, kubeTransportConfig.BearerTokenFile)
+
+	return backendSampler, nil
+}

--- a/pkg/monitor/disruption_known_backends.go
+++ b/pkg/monitor/disruption_known_backends.go
@@ -128,7 +128,7 @@ func createAPIServerBackendSampler(clusterConfig *rest.Config, disruptionBackend
 	}
 	// default gets auto-created, so this should always exist
 	backendSampler :=
-		NewAPIServerBackend(disruptionBackendName, url, connectionType).
+		NewBackend(disruptionBackendName, url, connectionType).
 			WithHost(clusterConfig.Host).
 			WithTLSConfig(tlsConfig).
 			WithBearerTokenAuth(kubeTransportConfig.BearerToken, kubeTransportConfig.BearerTokenFile)

--- a/pkg/monitor/disruption_known_backends.go
+++ b/pkg/monitor/disruption_known_backends.go
@@ -45,7 +45,7 @@ func startKubeAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, c
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m)
+	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
 }
 
 func startOpenShiftAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
@@ -53,7 +53,7 @@ func startOpenShiftAPIMonitoringWithNewConnections(ctx context.Context, m *Monit
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m)
+	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
 }
 
 func startOAuthAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
@@ -61,7 +61,7 @@ func startOAuthAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, 
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m)
+	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
 }
 
 func startKubeAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
@@ -69,7 +69,7 @@ func startKubeAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, 
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m)
+	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
 }
 
 func startOpenShiftAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
@@ -77,7 +77,7 @@ func startOpenShiftAPIMonitoringWithConnectionReuse(ctx context.Context, m *Moni
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m)
+	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
 }
 
 func startOAuthAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
@@ -85,7 +85,7 @@ func startOAuthAPIMonitoringWithConnectionReuse(ctx context.Context, m *Monitor,
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m)
+	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
 }
 
 func CreateKubeAPIMonitoringWithNewConnections(clusterConfig *rest.Config) (*BackendSampler, error) {

--- a/pkg/monitor/disruption_locator.go
+++ b/pkg/monitor/disruption_locator.go
@@ -38,14 +38,3 @@ func DisruptionBeganMessage(locator string, connectionType BackendConnectionType
 		return fmt.Sprintf("%s stopped responding to GET requests over %v connections: %v", locator, "Unknown", err)
 	}
 }
-
-func DisruptionContinuingMessage(locator string, connectionType BackendConnectionType, err error) string {
-	switch connectionType {
-	case NewConnectionType:
-		return fmt.Sprintf("%s is not responding to GET requests over new connections: %v", locator, err)
-	case ReusedConnectionType:
-		return fmt.Sprintf("%s is not responding to GET requests over reused connections: %v", locator, err)
-	default:
-		return fmt.Sprintf("%s is not responding to GET requests over %v connections: %v", locator, "Unknown", err)
-	}
-}

--- a/pkg/monitor/disruption_locator.go
+++ b/pkg/monitor/disruption_locator.go
@@ -1,0 +1,51 @@
+package monitor
+
+import (
+	"fmt"
+)
+
+// this entire file should be a separate package with disruption_***, but we are entanged because the sampler lives in monitor
+// and the things being started by the monitor are coupled into .Start.
+// we also got stuck on writing the disruption backends.  We need a way to track which disruption checks we have started,
+// so we can properly write out "zero"
+
+func LocateRouteForDisruptionCheck(ns, name, disruptionBackendName string, connectionType BackendConnectionType) string {
+	return fmt.Sprintf("ns/%s route/%s disruption/%s connection/%s", ns, name, disruptionBackendName, connectionType)
+}
+
+func LocateDisruptionCheck(disruptionBackendName string, connectionType BackendConnectionType) string {
+	return fmt.Sprintf("disruption/%s connection/%s", disruptionBackendName, connectionType)
+}
+
+func DisruptionEndedMessage(locator string, connectionType BackendConnectionType) string {
+	switch connectionType {
+	case NewConnectionType:
+		return fmt.Sprintf("%s started responding to GET requests over new connections", locator)
+	case ReusedConnectionType:
+		return fmt.Sprintf("%s started responding to GET requests over reused connections", locator)
+	default:
+		return fmt.Sprintf("%s started responding to GET requests over %v connections", locator, "Unknown")
+	}
+}
+
+func DisruptionBeganMessage(locator string, connectionType BackendConnectionType, err error) string {
+	switch connectionType {
+	case NewConnectionType:
+		return fmt.Sprintf("%s stopped responding to GET requests over new connections: %v", locator, err)
+	case ReusedConnectionType:
+		return fmt.Sprintf("%s stopped responding to GET requests over reused connections: %v", locator, err)
+	default:
+		return fmt.Sprintf("%s stopped responding to GET requests over %v connections: %v", locator, "Unknown", err)
+	}
+}
+
+func DisruptionContinuingMessage(locator string, connectionType BackendConnectionType, err error) string {
+	switch connectionType {
+	case NewConnectionType:
+		return fmt.Sprintf("%s is not responding to GET requests over new connections: %v", locator, err)
+	case ReusedConnectionType:
+		return fmt.Sprintf("%s is not responding to GET requests over reused connections: %v", locator, err)
+	default:
+		return fmt.Sprintf("%s is not responding to GET requests over %v connections: %v", locator, "Unknown", err)
+	}
+}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -268,7 +268,7 @@ func (m *Monitor) Conditions(from, to time.Time) monitorapi.Intervals {
 	return filterSamples(samples, from, to)
 }
 
-// EventIntervals returns all events that occur between from and to, including
+// Intervals returns all events that occur between from and to, including
 // any sampled conditions that were encountered during that period.
 // Intervals are returned in order of their occurrence. The returned slice
 // is a copy of the monitor's state and is safe to update.

--- a/pkg/monitor/sampler.go
+++ b/pkg/monitor/sampler.go
@@ -8,11 +8,6 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
-type ConditionalSampler interface {
-	ConditionWhenFailing(context.Context, *monitorapi.Condition) SamplerFunc
-	WhenFailing(context.Context, *monitorapi.Condition)
-}
-
 type sampler struct {
 	onFailing *monitorapi.Condition
 	interval  time.Duration
@@ -23,7 +18,7 @@ type sampler struct {
 	available bool
 }
 
-func NewSampler(recorder Recorder, interval time.Duration, sampleFn func(previous bool) (*monitorapi.Condition, bool)) ConditionalSampler {
+func NewSampler(recorder Recorder, interval time.Duration, sampleFn SampleFunc) ConditionalSampler {
 	s := &sampler{
 		available: true,
 		recorder:  recorder,
@@ -38,27 +33,31 @@ func (s *sampler) run(ctx context.Context) {
 	defer ticker.Stop()
 	var lastInterval int = -1
 	for {
-		success := s.isAvailable()
+		previousSampleWasAvailable := s.isAvailable()
 		// the sampleFn may take a significant period of time to run.  In such a case, we want our start interval
 		// for when a failure started to be the time when the request was first made, not the time when the call
 		// returned.  Imagine a timeout set on a DNS lookup of 30s: when the GET finally fails and returns, the outage
 		// was actually 30s before.
 		startTime := time.Now().UTC()
-		condition, ok := s.sampleFn(success)
+		condition, currentSampleIsAvailable := s.sampleFn(previousSampleWasAvailable)
 		if condition != nil {
 			s.recorder.RecordAt(startTime, *condition)
 		}
 		if s.onFailing != nil {
 			switch {
-			case !success && ok:
+			case !previousSampleWasAvailable && currentSampleIsAvailable:
 				if lastInterval != -1 {
 					s.recorder.EndInterval(lastInterval, time.Now().UTC())
 				}
-			case success && !ok:
-				lastInterval = s.recorder.StartInterval(startTime, *s.onFailing)
+			case previousSampleWasAvailable && !currentSampleIsAvailable:
+				if condition != nil { // if an edge condition is provided, use this to load the interval
+					lastInterval = s.recorder.StartInterval(startTime, *condition)
+				} else {
+					lastInterval = s.recorder.StartInterval(startTime, *s.onFailing)
+				}
 			}
 		}
-		s.setAvailable(ok)
+		s.setAvailable(currentSampleIsAvailable)
 
 		select {
 		case <-ticker.C:

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"context"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -31,6 +32,17 @@ type Recorder interface {
 
 	AddSampler(fn SamplerFunc)
 }
+
+type ConditionalSampler interface {
+	ConditionWhenFailing(context.Context, *monitorapi.Condition) SamplerFunc
+	WhenFailing(context.Context, *monitorapi.Condition)
+}
+
+// SampleFunc takes a bool representing "were you failing last time" and returns
+//  1. a nil condition if there is no noteworthy state change
+//  2. a condition if there is a noteworthy state change
+//  3. a bool indicating if it is currently available
+type SampleFunc func(previouslyAvailable bool) (edgeCondition *monitorapi.Condition, currentlyAvailable bool)
 
 type sample struct {
 	at         time.Time

--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -13,9 +13,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
-
 	"github.com/openshift/origin/pkg/monitor"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
 type testStatus struct {

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -1,16 +1,11 @@
 package service
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"net/http"
 	"strconv"
 	"time"
-
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
 
 	"github.com/onsi/ginkgo"
 	configv1 "github.com/openshift/api/config/v1"
@@ -20,32 +15,71 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
 	"k8s.io/kubernetes/test/e2e/framework/service"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
-// UpgradeTest tests that a service is available before, during, and
+// serviceLoadBalancerUpgradeTest tests that a service is available before, during, and
 // after a cluster upgrade.
-type UpgradeTest struct {
-	jig        *service.TestJig
-	tcpService *v1.Service
-
+type serviceLoadBalancerUpgradeTest struct {
+	// filled in by presetup
+	jig                 *service.TestJig
+	tcpService          *v1.Service
 	unsupportedPlatform bool
+
+	backendDisruptionTest disruption.BackendDisruptionUpgradeTest
 }
 
-func (UpgradeTest) Name() string { return "k8s-service-lb-available" }
-func (UpgradeTest) DisplayName() string {
-	return "[sig-network-edge] Application behind service load balancer with PDB is not disrupted"
+func NewServiceLoadBalancerWithNewConnectionsTest() upgrades.Test {
+	serviceLBTest := &serviceLoadBalancerUpgradeTest{}
+	serviceLBTest.backendDisruptionTest =
+		disruption.NewBackendDisruptionTest(
+			"[sig-network-edge] Application behind service load balancer with PDB remains available using new connections",
+			monitor.NewBackend(
+				"service-loadbalancer-with-pdb",
+				"/echo?msg=Hello",
+				monitor.NewConnectionType).
+				WithExpectedBody("Hello"),
+		).WithAllowedDisruption(allowedServiceLBDisruption).
+			WithPreSetup(serviceLBTest.loadBalancerSetup)
+
+	return serviceLBTest
+}
+
+func NewServiceLoadBalancerWithReusedConnectionsTest() upgrades.Test {
+	serviceLBTest := &serviceLoadBalancerUpgradeTest{}
+	serviceLBTest.backendDisruptionTest =
+		disruption.NewBackendDisruptionTest(
+			"[sig-network-edge] Application behind service load balancer with PDB remains available using reused connections",
+			monitor.NewBackend(
+				"service-loadbalancer-with-pdb",
+				"/echo?msg=Hello",
+				monitor.ReusedConnectionType).
+				WithExpectedBody("Hello"),
+		).WithAllowedDisruption(allowedServiceLBDisruption).
+			WithPreSetup(serviceLBTest.loadBalancerSetup)
+
+	return serviceLBTest
+}
+
+func allowedServiceLBDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
+	toleratedDisruption := 0.02
+	allowedDisruptionNanoseconds := int64(float64(totalDuration.Nanoseconds()) * toleratedDisruption)
+	allowedDisruption := time.Duration(allowedDisruptionNanoseconds)
+
+	return &allowedDisruption, nil
+}
+
+func (t *serviceLoadBalancerUpgradeTest) Name() string { return t.backendDisruptionTest.Name() }
+func (t *serviceLoadBalancerUpgradeTest) DisplayName() string {
+	return t.backendDisruptionTest.DisplayName()
 }
 
 func shouldTestPDBs() bool { return true }
 
-// Setup creates a service with a load balancer and makes sure it's reachable.
-func (t *UpgradeTest) Setup(f *framework.Framework) {
+func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framework, backendSampler disruption.BackendSampler) error {
 	configClient, err := configclient.NewForConfig(f.ClientConfig())
 	framework.ExpectNoError(err)
 	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
@@ -59,7 +93,7 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 		t.unsupportedPlatform = true
 	}
 	if t.unsupportedPlatform {
-		return
+		return nil
 	}
 
 	serviceName := "service-test"
@@ -124,45 +158,23 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 	ginkgo.By("hitting pods through the service's LoadBalancer")
 	timeout := 10 * time.Minute
 	// require thirty seconds of passing requests to continue (in case the SLB becomes available and then degrades)
+	// TODO this seems weird to @deads2k, why is status not trustworthy
 	TestReachableHTTPWithMinSuccessCount(tcpIngressIP, svcPort, 30, timeout)
+
+	backendSampler.SetHost(fmt.Sprintf("http://%s", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort))))
 
 	t.jig = jig
 	t.tcpService = tcpService
+	return nil
 }
 
 // Test runs a connectivity check to the service.
-func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+func (t *serviceLoadBalancerUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	if t.unsupportedPlatform {
 		return
 	}
 
-	client, err := framework.LoadClientset()
-	framework.ExpectNoError(err)
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	newBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
-	r := newBroadcaster.NewRecorder(scheme.Scheme, "openshift.io/upgrade-test-service")
-	newBroadcaster.StartRecordingToSink(stopCh)
-
-	ginkgo.By("continuously hitting pods through the service's LoadBalancer")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	m := monitor.NewMonitorWithInterval(1 * time.Second)
-	err = startEndpointMonitoring(ctx, m, t.tcpService, r)
-	framework.ExpectNoError(err, "unable to monitor API")
-
-	start := time.Now()
-	m.StartSampling(ctx)
-
-	// wait to ensure API is still up after the test ends
-	<-done
-	ginkgo.By("waiting for any post disruption failures")
-	time.Sleep(15 * time.Second)
-	cancel()
-	end := time.Now()
-
-	disruption.ExpectNoDisruption(f, 0.02, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Service was unreachable during disruption")
+	t.backendDisruptionTest.Test(f, done, upgrade)
 
 	// verify finalizer behavior
 	defer func() {
@@ -173,115 +185,12 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	service.WaitForServiceUpdatedWithFinalizer(t.jig.Client, t.tcpService.Namespace, t.tcpService.Name, true)
 }
 
-// Teardown cleans up any remaining resources.
-func (t *UpgradeTest) Teardown(f *framework.Framework) {
-	// rely on the namespace deletion to clean up everything
+func (t *serviceLoadBalancerUpgradeTest) Teardown(f *framework.Framework) {
+	t.backendDisruptionTest.Teardown(f)
 }
 
-func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, svc *v1.Service, r events.EventRecorder) error {
-	tcpIngressIP := service.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
-	svcPort := int(svc.Spec.Ports[0].Port)
-	url := fmt.Sprintf("http://%s/echo?msg=Hello", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort)))
-	// this client reuses connections and detects abrupt breaks
-	continuousClient := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout: 15 * time.Second,
-			}).Dial,
-			TLSHandshakeTimeout: 15 * time.Second,
-		},
-	}
-
-	reusedConnectionLocator := monitor.LocateDisruptionCheck("service-loadbalancer-with-pdb", monitor.ReusedConnectionType)
-	newConnectionLocator := monitor.LocateDisruptionCheck("service-loadbalancer-with-pdb", monitor.NewConnectionType)
-	go monitor.NewSampler(m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
-		resp, err := continuousClient.Get(url)
-		if err == nil {
-			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
-			if err == nil && !bytes.Contains(body, []byte("Hello")) {
-				err = fmt.Errorf("service returned success but did not contain the correct body contents: %q", string(body))
-			}
-		}
-		switch {
-		case err == nil && !previous:
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Info,
-				Locator: reusedConnectionLocator,
-				Message: monitor.DisruptionEndedMessage(reusedConnectionLocator, monitor.ReusedConnectionType),
-			}
-		case err != nil && previous:
-			framework.Logf("Service %s is unreachable on reused connections: %v", svc.Name, err)
-			r.Eventf(&v1.ObjectReference{Kind: "Service", Namespace: "kube-system", Name: "service-upgrade-test"}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on reused connections")
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: reusedConnectionLocator,
-				Message: monitor.DisruptionBeganMessage(reusedConnectionLocator, monitor.ReusedConnectionType, err),
-			}
-		case err != nil:
-			framework.Logf("Service %s is unreachable on reused connections: %v", svc.Name, err)
-		}
-		return condition, err == nil
-	}).WhenFailing(ctx, &monitorapi.Condition{
-		Level:   monitorapi.Error,
-		Locator: reusedConnectionLocator,
-		Message: monitor.DisruptionContinuingMessage(reusedConnectionLocator, monitor.ReusedConnectionType, fmt.Errorf("missing error in the code")),
-	})
-
-	// this client creates fresh connections and detects failure to establish connections
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout:   15 * time.Second,
-				KeepAlive: -1,
-			}).Dial,
-			TLSHandshakeTimeout: 15 * time.Second,
-			IdleConnTimeout:     15 * time.Second,
-			DisableKeepAlives:   true,
-		},
-	}
-
-	go monitor.NewSampler(m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
-		resp, err := client.Get(url)
-		if err == nil {
-			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
-			if err == nil && !bytes.Contains(body, []byte("Hello")) {
-				err = fmt.Errorf("service returned success but did not contain the correct body contents: %q", string(body))
-			}
-		}
-		switch {
-		case err == nil && !previous:
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Info,
-				Locator: newConnectionLocator,
-				Message: monitor.DisruptionEndedMessage(newConnectionLocator, monitor.NewConnectionType),
-			}
-		case err != nil && previous:
-			framework.Logf("Service %s is unreachable on new connections: %v", svc.Name, err)
-			r.Eventf(&v1.ObjectReference{Kind: "Service", Namespace: "kube-system", Name: "service-upgrade-test"}, nil, v1.EventTypeWarning, "Unreachable", "detected", "on new connections")
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: newConnectionLocator,
-				Message: monitor.DisruptionBeganMessage(newConnectionLocator, monitor.NewConnectionType, err),
-			}
-		case err != nil:
-			framework.Logf("Service %s is unreachable on new connections: %v", svc.Name, err)
-		}
-		return condition, err == nil
-	}).WhenFailing(ctx, &monitorapi.Condition{
-		Level:   monitorapi.Error,
-		Locator: newConnectionLocator,
-		Message: monitor.DisruptionContinuingMessage(newConnectionLocator, monitor.NewConnectionType, fmt.Errorf("missing error in the code")),
-	})
-
-	return nil
-}
-
-func locateService(svc *v1.Service) string {
-	return fmt.Sprintf("ns/%s svc/%s", svc.Namespace, svc.Name)
+func (t *serviceLoadBalancerUpgradeTest) Setup(f *framework.Framework) {
+	t.backendDisruptionTest.Setup(f)
 }
 
 // TestReachableHTTPWithMinSuccessCount tests that the given host serves HTTP on the given port for a minimum of successCount number of

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -21,47 +22,56 @@ import (
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
-// serviceLoadBalancerUpgradeTest tests that a service is available before, during, and
+// serviceLoadBalancerSetupTeardown tests that a service is available before, during, and
 // after a cluster upgrade.
-type serviceLoadBalancerUpgradeTest struct {
+type serviceLoadBalancerSetupTeardown struct {
 	// filled in by presetup
 	jig                 *service.TestJig
 	tcpService          *v1.Service
 	unsupportedPlatform bool
 
-	backendDisruptionTest disruption.BackendDisruptionUpgradeTest
+	setup         sync.Once
+	teardown      sync.Once
+	testsInFlight sync.WaitGroup
 }
 
-func NewServiceLoadBalancerWithNewConnectionsTest() upgrades.Test {
-	serviceLBTest := &serviceLoadBalancerUpgradeTest{}
-	serviceLBTest.backendDisruptionTest =
-		disruption.NewBackendDisruptionTest(
-			"[sig-network-edge] Application behind service load balancer with PDB remains available using new connections",
-			monitor.NewBackend(
-				"service-loadbalancer-with-pdb",
-				"/echo?msg=Hello",
-				monitor.NewConnectionType).
-				WithExpectedBody("Hello"),
-		).WithAllowedDisruption(allowedServiceLBDisruption).
-			WithPreSetup(serviceLBTest.loadBalancerSetup)
+// returns new and used disruption tests.  They have to share a single service and set of pods and teardown because it's
+// doing something that is exposed on a node, so these are shared so that we can get this finished.
+func NewServiceLoadBalancerDisruptionTests() (upgrades.Test, upgrades.Test) {
+	serviceLBSetup := &serviceLoadBalancerSetupTeardown{
+		setup:         sync.Once{},
+		testsInFlight: sync.WaitGroup{},
+	}
 
-	return serviceLBTest
-}
+	newConnections := disruption.NewBackendDisruptionTest(
+		"[sig-network-edge] Application behind service load balancer with PDB remains available using new connections",
+		monitor.NewBackend(
+			"service-loadbalancer-with-pdb",
+			"/echo?msg=Hello",
+			monitor.NewConnectionType).
+			WithExpectedBody("Hello"),
+	).WithAllowedDisruption(allowedServiceLBDisruption).
+		WithPreSetup(serviceLBSetup.loadBalancerSetup).
+		WithPostTeardown(serviceLBSetup.loadBalancerTeardown)
 
-func NewServiceLoadBalancerWithReusedConnectionsTest() upgrades.Test {
-	serviceLBTest := &serviceLoadBalancerUpgradeTest{}
-	serviceLBTest.backendDisruptionTest =
-		disruption.NewBackendDisruptionTest(
-			"[sig-network-edge] Application behind service load balancer with PDB remains available using reused connections",
-			monitor.NewBackend(
-				"service-loadbalancer-with-pdb",
-				"/echo?msg=Hello",
-				monitor.ReusedConnectionType).
-				WithExpectedBody("Hello"),
-		).WithAllowedDisruption(allowedServiceLBDisruption).
-			WithPreSetup(serviceLBTest.loadBalancerSetup)
+	usedConnections := disruption.NewBackendDisruptionTest(
+		"[sig-network-edge] Application behind service load balancer with PDB remains available using reused connections",
+		monitor.NewBackend(
+			"service-loadbalancer-with-pdb",
+			"/echo?msg=Hello",
+			monitor.ReusedConnectionType).
+			WithExpectedBody("Hello"),
+	).WithAllowedDisruption(allowedServiceLBDisruption).
+		WithPreSetup(serviceLBSetup.loadBalancerSetup).
+		WithPostTeardown(serviceLBSetup.loadBalancerTeardown)
 
-	return serviceLBTest
+	return &serviceLoadBalancerUpdateTest{
+			BackendDisruptionUpgradeTest: newConnections,
+			setupTeardown:                serviceLBSetup,
+		}, &serviceLoadBalancerUpdateTest{
+			BackendDisruptionUpgradeTest: usedConnections,
+			setupTeardown:                serviceLBSetup,
+		}
 }
 
 func allowedServiceLBDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
@@ -72,14 +82,9 @@ func allowedServiceLBDisruption(f *framework.Framework, totalDuration time.Durat
 	return &allowedDisruption, nil
 }
 
-func (t *serviceLoadBalancerUpgradeTest) Name() string { return t.backendDisruptionTest.Name() }
-func (t *serviceLoadBalancerUpgradeTest) DisplayName() string {
-	return t.backendDisruptionTest.DisplayName()
-}
-
 func shouldTestPDBs() bool { return true }
 
-func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framework, backendSampler disruption.BackendSampler) error {
+func (t *serviceLoadBalancerSetupTeardown) loadBalancerSetup(f *framework.Framework, backendSampler disruption.BackendSampler) error {
 	configClient, err := configclient.NewForConfig(f.ClientConfig())
 	framework.ExpectNoError(err)
 	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
@@ -96,63 +101,68 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 		return nil
 	}
 
-	serviceName := "service-test"
-	jig := service.NewTestJig(f.ClientSet, f.Namespace.Name, serviceName)
+	t.setup.Do(
+		func() {
+			serviceName := "service-test"
+			jig := service.NewTestJig(f.ClientSet, f.Namespace.Name, serviceName)
 
-	ns := f.Namespace
-	cs := f.ClientSet
+			ns := f.Namespace
+			cs := f.ClientSet
 
-	ginkgo.By("creating a TCP service " + serviceName + " with type=LoadBalancer in namespace " + ns.Name)
-	tcpService, err := jig.CreateTCPService(func(s *v1.Service) {
-		s.Spec.Type = v1.ServiceTypeLoadBalancer
-		// ServiceExternalTrafficPolicyTypeCluster performs during disruption, Local does not
-		s.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster
-		if s.Annotations == nil {
-			s.Annotations = make(map[string]string)
-		}
-		// We tune the LB checks to match the longest intervals available so that interactions between
-		// upgrading components and the service are more obvious.
-		// - AWS allows configuration, default is 70s (6 failed with 10s interval in 1.17) set to match GCP
-		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"] = "8"
-		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold"] = "3"
-		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold"] = "2"
-		// - Azure is hardcoded to 15s (2 failed with 5s interval in 1.17) and is sufficient
-		// - GCP has a non-configurable interval of 32s (3 failed health checks with 8s interval in 1.17)
-		//   - thus pods need to stay up for > 32s, so pod shutdown period will will be 45s
-	})
-	framework.ExpectNoError(err)
-	tcpService, err = jig.WaitForLoadBalancer(service.GetServiceLoadBalancerCreationTimeout(cs))
-	framework.ExpectNoError(err)
+			ginkgo.By("creating a TCP service " + serviceName + " with type=LoadBalancer in namespace " + ns.Name)
+			tcpService, err := jig.CreateTCPService(func(s *v1.Service) {
+				s.Spec.Type = v1.ServiceTypeLoadBalancer
+				// ServiceExternalTrafficPolicyTypeCluster performs during disruption, Local does not
+				s.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster
+				if s.Annotations == nil {
+					s.Annotations = make(map[string]string)
+				}
+				// We tune the LB checks to match the longest intervals available so that interactions between
+				// upgrading components and the service are more obvious.
+				// - AWS allows configuration, default is 70s (6 failed with 10s interval in 1.17) set to match GCP
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"] = "8"
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold"] = "3"
+				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold"] = "2"
+				// - Azure is hardcoded to 15s (2 failed with 5s interval in 1.17) and is sufficient
+				// - GCP has a non-configurable interval of 32s (3 failed health checks with 8s interval in 1.17)
+				//   - thus pods need to stay up for > 32s, so pod shutdown period will will be 45s
+			})
+			framework.ExpectNoError(err)
+			tcpService, err = jig.WaitForLoadBalancer(service.GetServiceLoadBalancerCreationTimeout(cs))
+			framework.ExpectNoError(err)
 
-	// Get info to hit it with
-	tcpIngressIP := service.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0])
-	svcPort := int(tcpService.Spec.Ports[0].Port)
+			ginkgo.By("creating RC to be part of service " + serviceName)
+			rc, err := jig.Run(func(rc *v1.ReplicationController) {
+				// ensure the pod waits long enough during update for the LB to see the newly ready pod, which
+				// must be longer than the worst load balancer above (GCP at 32s)
+				rc.Spec.MinReadySeconds = 33
+				// ensure the pod waits long enough for most LBs to take it out of rotation, which has to be
+				// longer than the LB failed health check duration + 1 cycle
+				rc.Spec.Template.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
+					PreStop: &v1.Handler{
+						Exec: &v1.ExecAction{Command: []string{"sleep", "45"}},
+					},
+				}
+				// ensure the pod is not forcibly deleted at 30s, but waits longer than the graceful sleep
+				minute := int64(60)
+				rc.Spec.Template.Spec.TerminationGracePeriodSeconds = &minute
 
-	ginkgo.By("creating RC to be part of service " + serviceName)
-	rc, err := jig.Run(func(rc *v1.ReplicationController) {
-		// ensure the pod waits long enough during update for the LB to see the newly ready pod, which
-		// must be longer than the worst load balancer above (GCP at 32s)
-		rc.Spec.MinReadySeconds = 33
-		// ensure the pod waits long enough for most LBs to take it out of rotation, which has to be
-		// longer than the LB failed health check duration + 1 cycle
-		rc.Spec.Template.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
-			PreStop: &v1.Handler{
-				Exec: &v1.ExecAction{Command: []string{"sleep", "45"}},
-			},
-		}
-		// ensure the pod is not forcibly deleted at 30s, but waits longer than the graceful sleep
-		minute := int64(60)
-		rc.Spec.Template.Spec.TerminationGracePeriodSeconds = &minute
+				jig.AddRCAntiAffinity(rc)
+			})
+			framework.ExpectNoError(err)
 
-		jig.AddRCAntiAffinity(rc)
-	})
-	framework.ExpectNoError(err)
+			if shouldTestPDBs() {
+				ginkgo.By("creating a PodDisruptionBudget to cover the ReplicationController")
+				_, err = jig.CreatePDB(rc)
+				framework.ExpectNoError(err)
+			}
 
-	if shouldTestPDBs() {
-		ginkgo.By("creating a PodDisruptionBudget to cover the ReplicationController")
-		_, err = jig.CreatePDB(rc)
-		framework.ExpectNoError(err)
-	}
+			t.jig = jig
+			t.tcpService = tcpService
+		})
+
+	tcpIngressIP := service.GetIngressPoint(&t.tcpService.Status.LoadBalancer.Ingress[0])
+	svcPort := int(t.tcpService.Spec.Ports[0].Port)
 
 	// Hit it once before considering ourselves ready
 	ginkgo.By("hitting pods through the service's LoadBalancer")
@@ -163,34 +173,24 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 
 	backendSampler.SetHost(fmt.Sprintf("http://%s", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort))))
 
-	t.jig = jig
-	t.tcpService = tcpService
 	return nil
 }
 
-// Test runs a connectivity check to the service.
-func (t *serviceLoadBalancerUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
-	if t.unsupportedPlatform {
-		return
-	}
-
-	t.backendDisruptionTest.Test(f, done, upgrade)
+func (t *serviceLoadBalancerSetupTeardown) loadBalancerTeardown(f *framework.Framework) error {
+	t.testsInFlight.Wait()
 
 	// verify finalizer behavior
-	defer func() {
-		ginkgo.By("Check that service can be deleted with finalizer")
-		service.WaitForServiceDeletedWithFinalizer(t.jig.Client, t.tcpService.Namespace, t.tcpService.Name)
-	}()
-	ginkgo.By("Check that finalizer is present on loadBalancer type service")
-	service.WaitForServiceUpdatedWithFinalizer(t.jig.Client, t.tcpService.Namespace, t.tcpService.Name, true)
-}
+	// we can only do this once and only after all the tests are done
+	t.teardown.Do(func() {
+		defer func() {
+			ginkgo.By("Check that service can be deleted with finalizer")
+			service.WaitForServiceDeletedWithFinalizer(t.jig.Client, t.tcpService.Namespace, t.tcpService.Name)
+		}()
+		ginkgo.By("Check that finalizer is present on loadBalancer type service")
+		service.WaitForServiceUpdatedWithFinalizer(t.jig.Client, t.tcpService.Namespace, t.tcpService.Name, true)
+	})
 
-func (t *serviceLoadBalancerUpgradeTest) Teardown(f *framework.Framework) {
-	t.backendDisruptionTest.Teardown(f)
-}
-
-func (t *serviceLoadBalancerUpgradeTest) Setup(f *framework.Framework) {
-	t.backendDisruptionTest.Setup(f)
+	return nil
 }
 
 // TestReachableHTTPWithMinSuccessCount tests that the given host serves HTTP on the given port for a minimum of successCount number of
@@ -211,4 +211,21 @@ func TestReachableHTTPWithMinSuccessCount(host string, port int, successCount in
 		return false, nil // caller can retry
 	})
 	framework.ExpectNoError(err)
+}
+
+type serviceLoadBalancerUpdateTest struct {
+	disruption.BackendDisruptionUpgradeTest
+
+	setupTeardown *serviceLoadBalancerSetupTeardown
+}
+
+// Test runs a connectivity check to the service.
+func (t *serviceLoadBalancerUpdateTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	if t.setupTeardown.unsupportedPlatform {
+		return
+	}
+	t.setupTeardown.testsInFlight.Add(1)
+	defer t.setupTeardown.testsInFlight.Done()
+
+	t.BackendDisruptionUpgradeTest.Test(f, done, upgrade)
 }

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -50,6 +50,8 @@ func NoTests() []upgrades.Test {
 
 // AllTests includes all tests (minimal + disruption)
 func AllTests() []upgrades.Test {
+	serviceLoadBalancerWithNewConnectionsTest, serviceLoadBalancerWithReusedConnectionsTest := service.NewServiceLoadBalancerDisruptionTests()
+
 	return []upgrades.Test{
 		&adminack.UpgradeTest{},
 		controlplane.NewKubeAvailableWithNewConnectionsTest(),
@@ -64,8 +66,8 @@ func AllTests() []upgrades.Test {
 		frontends.NewOAuthRouteAvailableWithConnectionReuseTest(),
 		frontends.NewConsoleRouteAvailableWithNewConnectionsTest(),
 		frontends.NewConsoleRouteAvailableWithConnectionReuseTest(),
-		service.NewServiceLoadBalancerWithNewConnectionsTest(),
-		service.NewServiceLoadBalancerWithReusedConnectionsTest(),
+		serviceLoadBalancerWithNewConnectionsTest,
+		serviceLoadBalancerWithReusedConnectionsTest,
 		&node.SecretUpgradeTest{},
 		&apps.ReplicaSetUpgradeTest{},
 		&apps.StatefulSetUpgradeTest{},

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -71,7 +71,8 @@ func AllTests() []upgrades.Test {
 		&apps.JobUpgradeTest{},
 		&node.ConfigMapUpgradeTest{},
 		&apps.DaemonSetUpgradeTest{},
-		&imageregistry.AvailableTest{},
+		imageregistry.NewImageRegistryAvailableWithNewConnectionsTest(),
+		imageregistry.NewImageRegistryAvailableWithReusedConnectionsTest(),
 		&prometheus.MetricsAvailableAfterUpgradeTest{},
 	}
 }

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/test/e2e/upgrade/service"
+
 	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +35,6 @@ import (
 	"github.com/openshift/origin/test/e2e/upgrade/adminack"
 	"github.com/openshift/origin/test/e2e/upgrade/alert"
 	"github.com/openshift/origin/test/e2e/upgrade/manifestdelete"
-	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/prometheus"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
@@ -63,7 +64,8 @@ func AllTests() []upgrades.Test {
 		frontends.NewOAuthRouteAvailableWithConnectionReuseTest(),
 		frontends.NewConsoleRouteAvailableWithNewConnectionsTest(),
 		frontends.NewConsoleRouteAvailableWithConnectionReuseTest(),
-		&service.UpgradeTest{},
+		service.NewServiceLoadBalancerWithNewConnectionsTest(),
+		service.NewServiceLoadBalancerWithReusedConnectionsTest(),
 		&node.SecretUpgradeTest{},
 		&apps.ReplicaSetUpgradeTest{},
 		&apps.StatefulSetUpgradeTest{},

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53181,6 +53181,9 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function isEndpointConnectivity(eventInterval) {
+        if (!eventInterval.message.includes("stopped responding to GET requests")){
+            return false
+        }
         if (eventInterval.locator.includes("disruption/")) {
             return true
         }
@@ -53191,19 +53194,6 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             return true
         }
 
-        return false
-    }
-
-    function isAPIServerConnectivity(eventInterval) {
-        if (eventInterval.locator == "kube-apiserver-new-connection" || eventInterval.locator == "kube-apiserver-reused-connection") {
-            return true
-        }
-        if (eventInterval.locator == "oauth-apiserver-new-connection" || eventInterval.locator == "oauth-apiserver-reused-connection") {
-            return true
-        }
-        if (eventInterval.locator == "openshift-apiserver-new-connection" || eventInterval.locator == "openshift-apiserver-reused-connection") {
-            return true
-        }
         return false
     }
 
@@ -53351,9 +53341,6 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         }
         return 0
     })
-
-    timelineGroups.push({group: "apiserver-availability", data: []})
-    createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerConnectivity)
 
     timelineGroups.push({group: "endpoint-availability", data: []})
     createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEndpointConnectivity)

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53181,14 +53181,17 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function isEndpointConnectivity(eventInterval) {
+        if (eventInterval.locator.includes("disruption/")) {
+            return true
+        }
         if (eventInterval.locator.startsWith("ns/e2e-k8s-service-lb-available")) {
             return true
         }
         if (eventInterval.locator.includes(" route/")) {
             return true
         }
-        return false
 
+        return false
     }
 
     function isAPIServerConnectivity(eventInterval) {

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -1,0 +1,132 @@
+package disruption
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/openshift/origin/pkg/monitor"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+)
+
+type BackendSampler interface {
+	GetDisruptionBackendName() string
+	GetLocator() string
+	GetURL() (string, error)
+	SetEventRecorder(recorder events.EventRecorder)
+	StartEndpointMonitoring(ctx context.Context, m *monitor.Monitor) error
+}
+
+func NewBackendDisruptionTest(testName string, backend BackendSampler) *backendDisruptionTest {
+	return &backendDisruptionTest{
+		testName:             testName,
+		backend:              backend,
+		getAllowedDisruption: NoDisruption,
+	}
+}
+
+func (t *backendDisruptionTest) WithAllowedDisruption(allowedDisruptionFn AllowedDisruptionFunc) *backendDisruptionTest {
+	t.getAllowedDisruption = allowedDisruptionFn
+	return t
+}
+
+type SetupFunc func(f *framework.Framework) error
+
+func (t *backendDisruptionTest) WithPreSetup(preSetup SetupFunc) *backendDisruptionTest {
+	t.preSetup = preSetup
+	return t
+}
+
+type TearDownFunc func(f *framework.Framework) error
+
+func (t *backendDisruptionTest) WithPostTeardown(postTearDown TearDownFunc) *backendDisruptionTest {
+	t.postTearDown = postTearDown
+	return t
+}
+
+func NoDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
+	zero := 0 * time.Second
+	return &zero, nil
+}
+
+type AllowedDisruptionFunc func(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error)
+
+// availableTest tests that route frontends are available before, during, and
+// after a cluster upgrade.
+type backendDisruptionTest struct {
+	// testName is the name to show in unit.
+	testName string
+	// backend describes a route that should be monitored.
+	backend              BackendSampler
+	getAllowedDisruption AllowedDisruptionFunc
+
+	preSetup     SetupFunc
+	postTearDown TearDownFunc
+}
+
+func (t *backendDisruptionTest) Name() string { return t.backend.GetDisruptionBackendName() }
+func (t *backendDisruptionTest) DisplayName() string {
+	return t.testName
+}
+
+// Setup looks up the host of the route specified by the backendSampler and updates
+// the backendSampler with the route's host.
+func (t *backendDisruptionTest) Setup(f *framework.Framework) {
+	if t.preSetup != nil {
+		framework.ExpectNoError(t.preSetup(f))
+	}
+
+	url, err := t.backend.GetURL()
+	framework.ExpectNoError(err)
+	if len(url) == 0 {
+		framework.Failf("backend has no URL: %v", t.backend.GetLocator())
+	}
+}
+
+// Test runs a connectivity check to a route.
+func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	newBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: f.ClientSet.EventsV1()})
+	t.backend.SetEventRecorder(newBroadcaster.NewRecorder(scheme.Scheme, "openshift.io/"+t.backend.GetDisruptionBackendName()))
+	newBroadcaster.StartRecordingToSink(stopCh)
+
+	ginkgo.By(fmt.Sprintf("continuously hitting backend: %s", t.backend.GetLocator()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m := monitor.NewMonitorWithInterval(1 * time.Second)
+	err := t.backend.StartEndpointMonitoring(ctx, m)
+	framework.ExpectNoError(err, fmt.Sprintf("unable to monitor: %s", t.backend.GetLocator()))
+
+	start := time.Now()
+	m.StartSampling(ctx)
+
+	// Wait to ensure the route is still available after the test ends.
+	<-done
+	ginkgo.By(fmt.Sprintf("waiting for any post disruption failures: %s", t.backend.GetLocator()))
+	time.Sleep(30 * time.Second)
+	cancel()
+	end := time.Now()
+
+	allowedDisruption, err := t.getAllowedDisruption(f, end.Sub(start))
+	framework.ExpectNoError(err)
+
+	ExpectNoDisruptionForDuration(
+		f,
+		*allowedDisruption,
+		end.Sub(start),
+		m.Intervals(time.Time{}, time.Time{}),
+		fmt.Sprintf("%s was unreachable during disruption", t.backend.GetLocator()),
+	)
+}
+
+// Teardown cleans up any remaining resources.
+func (t *backendDisruptionTest) Teardown(f *framework.Framework) {
+	if t.postTearDown != nil {
+		framework.ExpectNoError(t.postTearDown(f))
+	}
+}

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -2,17 +2,15 @@ package controlplane
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"k8s.io/client-go/rest"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 
 	"github.com/blang/semver"
 	apiconfigv1 "github.com/openshift/api/config/v1"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/disruption"
@@ -21,108 +19,79 @@ import (
 
 // NewKubeAvailableWithNewConnectionsTest tests that the Kubernetes control plane remains available during and after a cluster upgrade.
 func NewKubeAvailableWithNewConnectionsTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-api-machinery] Kubernetes APIs remain available for new connections",
-		name:            "kubernetes-api-available-new-connections",
-		startMonitoring: monitor.StartKubeAPIMonitoringWithNewConnections,
-	}
+	restConfig, err := monitor.GetMonitorRESTConfig()
+	utilruntime.Must(err)
+	backendSampler, err := monitor.CreateKubeAPIMonitoringWithNewConnections(restConfig)
+	utilruntime.Must(err)
+	return disruption.NewBackendDisruptionTest(
+		"[sig-api-machinery] Kubernetes APIs remain available for new connections",
+		backendSampler,
+	).WithAllowedDisruption(allowedAPIServerDisruption)
 }
 
 // NewOpenShiftAvailableNewConnectionsTest tests that the OpenShift APIs remains available during and after a cluster upgrade.
 func NewOpenShiftAvailableNewConnectionsTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-api-machinery] OpenShift APIs remain available for new connections",
-		name:            "openshift-api-available-new-connections",
-		startMonitoring: monitor.StartOpenShiftAPIMonitoringWithNewConnections,
-	}
+	restConfig, err := monitor.GetMonitorRESTConfig()
+	utilruntime.Must(err)
+	backendSampler, err := monitor.CreateOpenShiftAPIMonitoringWithNewConnections(restConfig)
+	utilruntime.Must(err)
+	return disruption.NewBackendDisruptionTest(
+		"[sig-api-machinery] OpenShift APIs remain available for new connections",
+		backendSampler,
+	).WithAllowedDisruption(allowedAPIServerDisruption)
 }
 
 // NewOAuthAvailableNewConnectionsTest tests that the OAuth APIs remains available during and after a cluster upgrade.
 func NewOAuthAvailableNewConnectionsTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-api-machinery] OAuth APIs remain available for new connections",
-		name:            "oauth-api-available-new-connections",
-		startMonitoring: monitor.StartOAuthAPIMonitoringWithNewConnections,
-	}
+	restConfig, err := monitor.GetMonitorRESTConfig()
+	utilruntime.Must(err)
+	backendSampler, err := monitor.CreateOAuthAPIMonitoringWithNewConnections(restConfig)
+	utilruntime.Must(err)
+	return disruption.NewBackendDisruptionTest(
+		"[sig-api-machinery] OAuth APIs remain available for new connections",
+		backendSampler,
+	).WithAllowedDisruption(allowedAPIServerDisruption)
 }
 
 // NewKubeAvailableWithConnectionReuseTest tests that the Kubernetes control plane remains available during and after a cluster upgrade.
 func NewKubeAvailableWithConnectionReuseTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-api-machinery] Kubernetes APIs remain available with reused connections",
-		name:            "kubernetes-api-available-reused-connections",
-		startMonitoring: monitor.StartKubeAPIMonitoringWithConnectionReuse,
-	}
+	restConfig, err := monitor.GetMonitorRESTConfig()
+	utilruntime.Must(err)
+	backendSampler, err := monitor.CreateKubeAPIMonitoringWithConnectionReuse(restConfig)
+	utilruntime.Must(err)
+	return disruption.NewBackendDisruptionTest(
+		"[sig-api-machinery] Kubernetes APIs remain available with reused connections",
+		backendSampler,
+	).WithAllowedDisruption(allowedAPIServerDisruption)
 }
 
-// NewOpenShiftAvailableTest tests that the OpenShift APIs remains available during and after a cluster upgrade.
+// NewOpenShiftAvailableWithConnectionReuseTest tests that the OpenShift APIs remains available during and after a cluster upgrade.
 func NewOpenShiftAvailableWithConnectionReuseTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-api-machinery] OpenShift APIs remain available with reused connections",
-		name:            "openshift-api-available-reused-connections",
-		startMonitoring: monitor.StartOpenShiftAPIMonitoringWithConnectionReuse,
-	}
+	restConfig, err := monitor.GetMonitorRESTConfig()
+	utilruntime.Must(err)
+	backendSampler, err := monitor.CreateOpenShiftAPIMonitoringWithConnectionReuse(restConfig)
+	utilruntime.Must(err)
+	return disruption.NewBackendDisruptionTest(
+		"[sig-api-machinery] OpenShift APIs remain available with reused connections",
+		backendSampler,
+	).WithAllowedDisruption(allowedAPIServerDisruption)
 }
 
-// NewOauthAvailableTest tests that the OAuth APIs remains available during and after a cluster upgrade.
+// NewOAuthAvailableWithConnectionReuseTest tests that the OAuth APIs remains available during and after a cluster upgrade.
 func NewOAuthAvailableWithConnectionReuseTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-api-machinery] OAuth APIs remain available with reused connections",
-		name:            "oauth-api-available-reused-connections",
-		startMonitoring: monitor.StartOAuthAPIMonitoringWithConnectionReuse,
-	}
+	restConfig, err := monitor.GetMonitorRESTConfig()
+	utilruntime.Must(err)
+	backendSampler, err := monitor.CreateOAuthAPIMonitoringWithConnectionReuse(restConfig)
+	utilruntime.Must(err)
+	return disruption.NewBackendDisruptionTest(
+		"[sig-api-machinery] OAuth APIs remain available with reused connections",
+		backendSampler,
+	).WithAllowedDisruption(allowedAPIServerDisruption)
 }
 
-func getTopologies(f *framework.Framework) (controlPlaneTopology, infraTopology apiconfigv1.TopologyMode) {
-	oc := util.NewCLIWithFramework(f)
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(),
-		"cluster", metav1.GetOptions{})
-
-	framework.ExpectNoError(err, "unable to determine cluster topology")
-
-	return infra.Status.ControlPlaneTopology, infra.Status.InfrastructureTopology
-}
-
-type availableTest struct {
-	// testName is the name to show in unit
-	testName string
-	// name helps distinguish which API server in particular is unavailable.
-	name            string
-	startMonitoring starter
-}
-
-type starter func(ctx context.Context, m *monitor.Monitor, clusterConfig *rest.Config, timeout time.Duration) error
-
-func (t availableTest) Name() string { return t.name }
-func (t availableTest) DisplayName() string {
-	return t.testName
-}
-
-// Setup does nothing
-func (t *availableTest) Setup(f *framework.Framework) {
-}
-
-// Test runs a connectivity check to the core APIs.
-func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
-	config, err := framework.LoadConfig()
-	framework.ExpectNoError(err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	m := monitor.NewMonitorWithInterval(time.Second)
-	err = t.startMonitoring(ctx, m, config, 15*time.Second)
-	framework.ExpectNoError(err, "unable to monitor API")
-
-	start := time.Now()
-	m.StartSampling(ctx)
-
-	// wait to ensure API is still up after the test ends
-	<-done
-	time.Sleep(15 * time.Second)
-	cancel()
-	end := time.Now()
-
+func allowedAPIServerDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
 	// starting from 4.8, enforce the requirement that control plane remains available
-	hasAllFixes, err := util.AllClusterVersionsAreGTE(semver.Version{Major: 4, Minor: 8}, config)
+	hasAllFixes, err := util.AllClusterVersionsAreGTE(semver.Version{Major: 4, Minor: 8}, f.ClientConfig())
 	if err != nil {
 		framework.Logf("Cannot require full control plane availability, some versions could not be checked: %v", err)
 	}
@@ -143,41 +112,18 @@ func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 			toleratedDisruption = 0
 		}
 	}
-	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption (AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804)", t.name))
+	allowedDisruptionNanoseconds := int64(float64(totalDuration.Nanoseconds()) * toleratedDisruption)
+	allowedDisruption := time.Duration(allowedDisruptionNanoseconds)
+
+	return &allowedDisruption, nil
 }
 
-// Teardown cleans up any remaining resources.
-func (t *availableTest) Teardown(f *framework.Framework) {
-}
+func getTopologies(f *framework.Framework) (controlPlaneTopology, infraTopology apiconfigv1.TopologyMode) {
+	oc := util.NewCLIWithFramework(f)
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(),
+		"cluster", metav1.GetOptions{})
 
-// allClusterVersionsAreGTE returns true if all historical versions on the cluster version are
-// at or newer than the provided semver, ignoring prerelease status. If no versions are found
-// an error is returned.
-func allClusterVersionsAreGTE(version semver.Version, config *rest.Config) (bool, error) {
-	c, err := configv1client.NewForConfig(config)
-	if err != nil {
-		return false, err
-	}
-	cv, err := c.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-	if len(cv.Status.History) == 0 {
-		return false, fmt.Errorf("no versions in cluster version history")
-	}
-	for _, v := range cv.Status.History {
-		ver, err := semver.Parse(v.Version)
-		if err != nil {
-			return false, err
-		}
+	framework.ExpectNoError(err, "unable to determine cluster topology")
 
-		// ignore prerelease version matching here
-		ver.Pre = nil
-		ver.Build = nil
-
-		if ver.LT(version) {
-			return false, nil
-		}
-	}
-	return true, nil
+	return infra.Status.ControlPlaneTopology, infra.Status.InfrastructureTopology
 }

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -1,107 +1,82 @@
 package frontends
 
 import (
-	"bytes"
 	"context"
-	"crypto/tls"
-	"fmt"
-	"net"
-	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/blang/semver"
 	apiconfigv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
-
-	"github.com/onsi/ginkgo"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/events"
-	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/kubernetes/test/e2e/upgrades"
-
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
-	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/disruption"
-)
-
-type Frontend struct {
-	Namespace string
-	Name      string
-	URL       string
-	Path      string
-
-	Expect       string
-	ExpectRegexp *regexp.Regexp
-}
-
-var (
-	oauthRouteFrontend = Frontend{
-		Namespace: "openshift-authentication",
-		Name:      "oauth-openshift",
-		Path:      "/healthz",
-		Expect:    "ok",
-	}
-	consoleRouteFrontend = Frontend{
-		Namespace:    "openshift-console",
-		Name:         "console",
-		ExpectRegexp: regexp.MustCompile(`(Red Hat OpenShift Container Platform|OKD)`),
-	}
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
 // NewOAuthRouteAvailableWithNewConnectionsTest tests that the oauth route
 // remains available during and after a cluster upgrade, using a new connection
 // for each request.
 func NewOAuthRouteAvailableWithNewConnectionsTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-network-edge] OAuth remains available via cluster frontend ingress using new connections",
-		name:            "frontend-ingress-oauth-available-new",
-		frontend:        oauthRouteFrontend,
-		startMonitoring: startEndpointMonitoringWithNewConnections,
-	}
+	return disruption.NewBackendDisruptionTest(
+		"[sig-network-edge] OAuth remains available via cluster backendSampler ingress using new connections",
+		monitor.NewRouteBackend(
+			"openshift-authentication",
+			"oauth-openshift",
+			"ingress-to-oauth-server",
+			"/healthz",
+			monitor.NewConnectionType).
+			WithExpectedBody("ok"),
+	).WithAllowedDisruption(allowedIngressDisruption)
 }
 
 // NewOAuthRouteAvailableWithConnectionReuseTest tests that the oauth route
 // remains available during and after a cluster upgrade, reusing a connection
 // for requests.
 func NewOAuthRouteAvailableWithConnectionReuseTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-network-edge] OAuth remains available via cluster frontend ingress using reused connections",
-		name:            "frontend-ingress-oauth-available-reuse",
-		frontend:        oauthRouteFrontend,
-		startMonitoring: startEndpointMonitoringWithConnectionReuse,
-	}
+	return disruption.NewBackendDisruptionTest(
+		"[sig-network-edge] OAuth remains available via cluster backendSampler ingress using reused connections",
+		monitor.NewRouteBackend(
+			"openshift-authentication",
+			"oauth-openshift",
+			"ingress-to-oauth-server",
+			"/healthz",
+			monitor.ReusedConnectionType).
+			WithExpectedBody("ok"),
+	).WithAllowedDisruption(allowedIngressDisruption)
 }
 
 // NewConsoleRouteAvailableWithNewConnectionsTest tests that the console route
 // remains available during and after a cluster upgrade, using a new connection
 // for each request.
 func NewConsoleRouteAvailableWithNewConnectionsTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-network-edge] Console remains available via cluster frontend ingress using new connections",
-		name:            "frontend-ingress-console-available-new",
-		frontend:        consoleRouteFrontend,
-		startMonitoring: startEndpointMonitoringWithNewConnections,
-	}
+	return disruption.NewBackendDisruptionTest(
+		"[sig-network-edge] Console remains available via cluster backendSampler ingress using new connections",
+		monitor.NewRouteBackend(
+			"openshift-console",
+			"console",
+			"ingress-to-console",
+			"/healthz",
+			monitor.ReusedConnectionType).
+			WithExpectedBodyRegex(`(Red Hat OpenShift Container Platform|OKD)`),
+	).WithAllowedDisruption(allowedIngressDisruption)
 }
 
 // NewConsoleRouteAvailableWithConnectionReuseTest tests that the console route
 // remains available during and after a cluster upgrade, reusing a connection
 // for requests.
 func NewConsoleRouteAvailableWithConnectionReuseTest() upgrades.Test {
-	return &availableTest{
-		testName:        "[sig-network-edge] Console remains available via cluster frontend ingress using reused connections",
-		name:            "frontend-ingress-console-available-reuse",
-		frontend:        consoleRouteFrontend,
-		startMonitoring: startEndpointMonitoringWithConnectionReuse,
-	}
+	return disruption.NewBackendDisruptionTest(
+		"[sig-network-edge] Console remains available via cluster backendSampler ingress using reused connections",
+		monitor.NewRouteBackend(
+			"openshift-console",
+			"console",
+			"ingress-to-console",
+			"/healthz",
+			monitor.ReusedConnectionType).
+			WithExpectedBodyRegex(`(Red Hat OpenShift Container Platform|OKD)`),
+	).WithAllowedDisruption(allowedIngressDisruption)
 }
 
 func getTopologies(f *framework.Framework) (controlPlaneTopology, infraTopology apiconfigv1.TopologyMode) {
@@ -114,94 +89,23 @@ func getTopologies(f *framework.Framework) (controlPlaneTopology, infraTopology 
 	return infra.Status.ControlPlaneTopology, infra.Status.InfrastructureTopology
 }
 
-// availableTest tests that route frontends are available before, during, and
-// after a cluster upgrade.
-type availableTest struct {
-	// testName is the name to show in unit.
-	testName string
-	// name helps distinguish which route is unavailable.
-	name string
-	// frontend describes a route that should be monitored.
-	frontend Frontend
-	// startMonitoring is a function that starts the monitor.
-	startMonitoring starter
-}
-
-type starter func(ctx context.Context, m *monitor.Monitor, frontend Frontend, r events.EventRecorder) error
-
-func (t *availableTest) Name() string { return t.name }
-func (t *availableTest) DisplayName() string {
-	return t.testName
-}
-
-// Setup looks up the host of the route specified by the frontend and updates
-// the frontend with the route's host.
-func (t *availableTest) Setup(f *framework.Framework) {
-	// Setup may have already been called for a different availability test
-	// that uses the same frontend.  In that case, we needn't repeat setup.
-	if len(t.frontend.URL) != 0 {
-		return
-	}
-	config, err := framework.LoadConfig()
-	framework.ExpectNoError(err)
-	client, err := routeclientset.NewForConfig(config)
-	framework.ExpectNoError(err)
-	route, err := client.RouteV1().Routes(t.frontend.Namespace).Get(context.Background(), t.frontend.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
-	for _, ingress := range route.Status.Ingress {
-		if len(ingress.Host) > 0 {
-			t.frontend.URL = fmt.Sprintf("https://%s", ingress.Host)
-
-			break
-		}
-	}
-	if len(t.frontend.URL) == 0 {
-		framework.Failf("route %s/%s has no ingress host: %#v", route.Namespace, route.Name, route.Status.Ingress)
-	}
-}
-
-// Test runs a connectivity check to a route.
-func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
-	config, err := framework.LoadConfig()
-	framework.ExpectNoError(err)
-	client, err := framework.LoadClientset()
-	framework.ExpectNoError(err)
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	newBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
-	r := newBroadcaster.NewRecorder(scheme.Scheme, "openshift.io/"+t.name)
-	newBroadcaster.StartRecordingToSink(stopCh)
-
-	ginkgo.By("continuously hitting infrastructure through the router")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	m := monitor.NewMonitorWithInterval(1 * time.Second)
-	err = t.startMonitoring(ctx, m, t.frontend, r)
-	framework.ExpectNoError(err, "unable to monitor route")
-
-	start := time.Now()
-	m.StartSampling(ctx)
-
-	// Wait to ensure the route is still available after the test ends.
-	<-done
-	ginkgo.By("waiting for any post disruption failures")
-	time.Sleep(15 * time.Second)
-	cancel()
-	end := time.Now()
-
-	// starting from 4.8, enforce the requirement that frontends remains available
-	hasAllFixes, err := util.AllClusterVersionsAreGTE(semver.Version{Major: 4, Minor: 8}, config)
-	if err != nil {
-		framework.Logf("Cannot require full cluster ingress frontend availability; some versions could not be checked: %v", err)
-	}
-
+func allowedIngressDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
 	// Fetch network type for considering whether we allow disruption. For OVN, we currently have to allow disruption
 	// as those tests are failing: BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1983829
-	c, err := configv1client.NewForConfig(config)
-	framework.ExpectNoError(err)
+	c, err := configv1client.NewForConfig(f.ClientConfig())
+	if err != nil {
+		return nil, err
+	}
 	network, err := c.ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	if err != nil {
+		return nil, err
+	}
+
+	// starting from 4.8, enforce the requirement that frontends remains available
+	hasAllFixes, err := util.AllClusterVersionsAreGTE(semver.Version{Major: 4, Minor: 8}, f.ClientConfig())
+	if err != nil {
+		framework.Logf("Cannot require full cluster ingress backendSampler availability; some versions could not be checked: %v", err)
+	}
 
 	toleratedDisruption := 0.20
 	switch controlPlaneTopology, _ := getTopologies(f); {
@@ -217,89 +121,9 @@ func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 			toleratedDisruption = 0
 		}
 	}
-	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Frontend was unreachable during disruption")
-}
 
-// Teardown cleans up any remaining resources.
-func (t *availableTest) Teardown(f *framework.Framework) {
-	// rely on the namespace deletion to clean up everything
-}
+	allowedDisruptionNanoseconds := int64(float64(totalDuration.Nanoseconds()) * toleratedDisruption)
+	allowedDisruption := time.Duration(allowedDisruptionNanoseconds)
 
-// startEndpointMonitoring sets up a client for the given frontend and starts a
-// new sampler for the given monitor that uses the client to monitor
-// connectivity to the frontend and reports any observed disruption.
-//
-// If disableConnectionReuse is false, the client reuses connections and detects
-// abrupt breaks in connectivity.  If disableConnectionReuse is true, the client
-// instead creates fresh connections so that it detects failures to establish
-// connections.
-func startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, frontend Frontend, r events.EventRecorder, disableConnectionReuse bool) error {
-	var keepAlive time.Duration
-	connectionType := monitor.ReusedConnectionType
-	if disableConnectionReuse {
-		keepAlive = -1
-		connectionType = monitor.NewConnectionType
-	}
-	client, err := rest.UnversionedRESTClientFor(&rest.Config{
-		Host:    frontend.URL,
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout:   15 * time.Second,
-				KeepAlive: keepAlive,
-			}).Dial,
-			TLSHandshakeTimeout: 15 * time.Second,
-			IdleConnTimeout:     15 * time.Second,
-			DisableKeepAlives:   disableConnectionReuse,
-			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
-		},
-		ContentConfig: rest.ContentConfig{
-			NegotiatedSerializer: runtime.NewSimpleNegotiatedSerializer(scheme.Codecs.SupportedMediaTypes()[0]),
-		},
-	})
-	if err != nil {
-		return err
-	}
-	locator := monitor.LocateRouteForDisruptionCheck(frontend.Namespace, frontend.Name, connectionType)
-	go monitor.NewSampler(m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
-		data, err := client.Get().AbsPath(frontend.Path).DoRaw(ctx)
-		switch {
-		case err == nil && len(frontend.Expect) != 0 && !bytes.Contains(data, []byte(frontend.Expect)):
-			err = fmt.Errorf("route returned success but did not contain the correct body contents: %q", string(data))
-		case err == nil && frontend.ExpectRegexp != nil && !frontend.ExpectRegexp.MatchString(string(data)):
-			err = fmt.Errorf("route returned success but did not contain the correct body contents: %q", string(data))
-		}
-		switch {
-		case err == nil && !previous:
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Info,
-				Locator: locator,
-				Message: monitor.DisruptionEndedMessage(locator, connectionType),
-			}
-		case err != nil && previous:
-			framework.Logf("Route %s is unreachable on %s connections: %v", frontend.Name, connectionType, err)
-			r.Eventf(&v1.ObjectReference{Kind: "Route", Namespace: frontend.Namespace, Name: frontend.Name}, nil, v1.EventTypeWarning, "Unreachable", "detected", fmt.Sprintf("on %s connections", connectionType))
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: locator,
-				Message: monitor.DisruptionBeganMessage(locator, connectionType, err),
-			}
-		case err != nil:
-			framework.Logf("Route %s is unreachable on %s connections: %v", frontend.Name, connectionType, err)
-		}
-		return condition, err == nil
-	}).WhenFailing(ctx, &monitorapi.Condition{
-		Level:   monitorapi.Error,
-		Locator: locator,
-		Message: monitor.DisruptionContinuingMessage(locator, connectionType, err),
-	})
-	return nil
-}
-
-func startEndpointMonitoringWithNewConnections(ctx context.Context, m *monitor.Monitor, frontend Frontend, r events.EventRecorder) error {
-	return startEndpointMonitoring(ctx, m, frontend, r, true)
-}
-
-func startEndpointMonitoringWithConnectionReuse(ctx context.Context, m *monitor.Monitor, frontend Frontend, r events.EventRecorder) error {
-	return startEndpointMonitoring(ctx, m, frontend, r, false)
+	return &allowedDisruption, nil
 }

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -20,7 +20,7 @@ import (
 // for each request.
 func NewOAuthRouteAvailableWithNewConnectionsTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
-		"[sig-network-edge] OAuth remains available via cluster backendSampler ingress using new connections",
+		"[sig-network-edge] OAuth remains available via cluster ingress using new connections",
 		monitor.NewRouteBackend(
 			"openshift-authentication",
 			"oauth-openshift",
@@ -36,7 +36,7 @@ func NewOAuthRouteAvailableWithNewConnectionsTest() upgrades.Test {
 // for requests.
 func NewOAuthRouteAvailableWithConnectionReuseTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
-		"[sig-network-edge] OAuth remains available via cluster backendSampler ingress using reused connections",
+		"[sig-network-edge] OAuth remains available via cluster ingress using reused connections",
 		monitor.NewRouteBackend(
 			"openshift-authentication",
 			"oauth-openshift",
@@ -52,7 +52,7 @@ func NewOAuthRouteAvailableWithConnectionReuseTest() upgrades.Test {
 // for each request.
 func NewConsoleRouteAvailableWithNewConnectionsTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
-		"[sig-network-edge] Console remains available via cluster backendSampler ingress using new connections",
+		"[sig-network-edge] Console remains available via cluster ingress using new connections",
 		monitor.NewRouteBackend(
 			"openshift-console",
 			"console",
@@ -68,7 +68,7 @@ func NewConsoleRouteAvailableWithNewConnectionsTest() upgrades.Test {
 // for requests.
 func NewConsoleRouteAvailableWithConnectionReuseTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
-		"[sig-network-edge] Console remains available via cluster backendSampler ingress using reused connections",
+		"[sig-network-edge] Console remains available via cluster ingress using reused connections",
 		monitor.NewRouteBackend(
 			"openshift-console",
 			"console",

--- a/test/extended/util/disruption/imageregistry/imageregistry.go
+++ b/test/extended/util/disruption/imageregistry/imageregistry.go
@@ -2,26 +2,8 @@ package imageregistry
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net"
-	"net/http"
 	"time"
-
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
-
-	"github.com/onsi/ginkgo"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/events"
-	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/kubernetes/test/e2e/upgrades"
 
 	apiconfigv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -29,7 +11,44 @@ import (
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/disruption"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
 )
+
+func NewImageRegistryAvailableWithNewConnectionsTest() upgrades.Test {
+	return disruption.NewBackendDisruptionTest(
+		"[sig-imageregistry] Image registry remains available using new connections",
+		monitor.NewRouteBackend(
+			"openshift-image-registry",
+			"test-disruption-new",
+			"image-registry",
+			"/healthz",
+			monitor.NewConnectionType),
+	).
+		WithAllowedDisruption(allowedImageRegistryDisruption).
+		WithPreSetup(setupImageRegistryFor("test-disruption-new")).
+		WithPostTeardown(teardownImageRegistryFor("test-disruption-new"))
+
+}
+
+func NewImageRegistryAvailableWithReusedConnectionsTest() upgrades.Test {
+	return disruption.NewBackendDisruptionTest(
+		"[sig-imageregistry] Image registry remains available using reused connections",
+		monitor.NewRouteBackend(
+			"openshift-image-registry",
+			"test-disruption-reused",
+			"image-registry",
+			"/healthz",
+			monitor.ReusedConnectionType),
+	).
+		WithAllowedDisruption(allowedImageRegistryDisruption).
+		WithPreSetup(setupImageRegistryFor("test-disruption-reused")).
+		WithPostTeardown(teardownImageRegistryFor("test-disruption-reused"))
+
+}
 
 func getTopologies(f *framework.Framework) (controlPlaneTopology, infraTopology apiconfigv1.TopologyMode) {
 	oc := util.NewCLIWithFramework(f)
@@ -41,99 +60,7 @@ func getTopologies(f *framework.Framework) (controlPlaneTopology, infraTopology 
 	return infra.Status.ControlPlaneTopology, infra.Status.InfrastructureTopology
 }
 
-// AvailableTest tests that the image registry is available before, during, and
-// after a cluster upgrade.
-type AvailableTest struct {
-	routeRef *corev1.ObjectReference
-	host     string
-}
-
-func (AvailableTest) Name() string { return "image-registry-available" }
-func (AvailableTest) DisplayName() string {
-	return "[sig-imageregistry] Image registry remain available"
-}
-
-// Setup creates a route that exposes the registry to tests.
-func (t *AvailableTest) Setup(f *framework.Framework) {
-	ctx := context.Background()
-
-	config, err := framework.LoadConfig()
-	framework.ExpectNoError(err)
-	routeClient, err := routeclient.NewForConfig(config)
-	framework.ExpectNoError(err)
-
-	route, err := routeClient.RouteV1().Routes("openshift-image-registry").Create(ctx, &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-disruption",
-		},
-		Spec: routev1.RouteSpec{
-			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: "image-registry",
-			},
-			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromInt(5000),
-			},
-			TLS: &routev1.TLSConfig{
-				Termination:                   routev1.TLSTerminationPassthrough,
-				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-			},
-		},
-	}, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
-
-	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
-		route, err = routeClient.RouteV1().Routes("openshift-image-registry").Get(ctx, "test-disruption", metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		for _, ingress := range route.Status.Ingress {
-			if len(ingress.Host) > 0 {
-				t.host = ingress.Host
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-	framework.ExpectNoError(err, "failed to get route host")
-
-	t.routeRef = &corev1.ObjectReference{
-		Kind:      "Route",
-		Namespace: route.Namespace,
-		Name:      route.Name,
-	}
-}
-
-// Test runs a connectivity check to the service.
-func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
-	client, err := framework.LoadClientset()
-	framework.ExpectNoError(err)
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	newBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
-	r := newBroadcaster.NewRecorder(scheme.Scheme, "openshift.io/image-registry-available-test")
-	newBroadcaster.StartRecordingToSink(stopCh)
-
-	ginkgo.By("continuously hitting image registry")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	m := monitor.NewMonitorWithInterval(1 * time.Second)
-	err = t.startEndpointMonitoring(ctx, m, r)
-	framework.ExpectNoError(err, "unable to monitor route")
-
-	start := time.Now()
-	m.StartSampling(ctx)
-
-	// wait to ensure API is still up after the test ends
-	<-done
-	ginkgo.By("waiting for any post disruption failures")
-	time.Sleep(15 * time.Second)
-	cancel()
-	end := time.Now()
-
+func allowedImageRegistryDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
 	toleratedDisruption := 0.20
 	// BUG: https://bugzilla.redhat.com/show_bug.cgi?id=1972827
 	// starting from 4.x, enforce the requirement that ingress remains available
@@ -158,130 +85,79 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 		toleratedDisruption = 0.30
 	}
 
-	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Image registry was unreachable during disruption (https://bugzilla.redhat.com/show_bug.cgi?id=1972827)")
+	allowedDisruptionNanoseconds := int64(float64(totalDuration.Nanoseconds()) * toleratedDisruption)
+	allowedDisruption := time.Duration(allowedDisruptionNanoseconds)
+
+	return &allowedDisruption, nil
 }
 
-// Teardown cleans up any remaining resources.
-func (t *AvailableTest) Teardown(f *framework.Framework) {
-	ctx := context.Background()
+// Setup creates a route that exposes the registry to tests.
+func setupImageRegistryFor(routeName string) disruption.SetupFunc {
+	return func(f *framework.Framework) error {
+		ctx := context.Background()
 
-	config, err := framework.LoadConfig()
-	framework.ExpectNoError(err)
-	routeClient, err := routeclient.NewForConfig(config)
-	framework.ExpectNoError(err)
-
-	err = routeClient.RouteV1().Routes(t.routeRef.Namespace).Delete(ctx, t.routeRef.Name, metav1.DeleteOptions{})
-	framework.ExpectNoError(err, "failed to delete route")
-}
-
-func (t *AvailableTest) startEndpointMonitoring(ctx context.Context, m *monitor.Monitor, r events.EventRecorder) error {
-	var (
-		url                     = "https://" + t.host
-		path                    = "/healthz"
-		newConnectionLocator    = monitor.LocateRouteForDisruptionCheck("openshift-image-registry", "test-disruption", monitor.NewConnectionType)
-		reusedConnectionLocator = monitor.LocateRouteForDisruptionCheck("openshift-image-registry", "test-disruption", monitor.ReusedConnectionType)
-	)
-
-	// this client reuses connections and detects abrupt breaks
-	continuousClient, err := rest.UnversionedRESTClientFor(&rest.Config{
-		Host:    url,
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout: 15 * time.Second,
-			}).Dial,
-			TLSHandshakeTimeout: 15 * time.Second,
-			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
-		},
-		ContentConfig: rest.ContentConfig{
-			NegotiatedSerializer: runtime.NewSimpleNegotiatedSerializer(scheme.Codecs.SupportedMediaTypes()[0]),
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	go monitor.NewSampler(m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
-		_, err := continuousClient.Get().AbsPath(path).DoRaw(ctx)
-		// TODO this looks bugged.  If we get a non 200 or 300 series status, it seems like we ought to be failing.
-		switch {
-		case err == nil && !previous:
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Info,
-				Locator: reusedConnectionLocator,
-				Message: monitor.DisruptionEndedMessage(reusedConnectionLocator, monitor.ReusedConnectionType),
-			}
-		case err != nil && previous:
-			framework.Logf("Route for image-registry is unreachable on reused connections: %v", err)
-			r.Eventf(t.routeRef, nil, corev1.EventTypeWarning, "Unreachable", "detected", "on reused connections")
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: reusedConnectionLocator,
-				Message: monitor.DisruptionBeganMessage(reusedConnectionLocator, monitor.ReusedConnectionType, err),
-			}
-		case err != nil:
-			framework.Logf("Route for image-registry is unreachable on reused connections: %v", err)
+		routeClient, err := routeclient.NewForConfig(f.ClientConfig())
+		if err != nil {
+			return err
 		}
-		return condition, err == nil
-	}).WhenFailing(ctx, &monitorapi.Condition{
-		Level:   monitorapi.Error,
-		Locator: reusedConnectionLocator,
-		Message: monitor.DisruptionContinuingMessage(reusedConnectionLocator, monitor.ReusedConnectionType, err),
-	})
 
-	// this client creates fresh connections and detects failure to establish connections
-	client, err := rest.UnversionedRESTClientFor(&rest.Config{
-		Host:    url,
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout:   15 * time.Second,
-				KeepAlive: -1,
-			}).Dial,
-			TLSHandshakeTimeout: 15 * time.Second,
-			IdleConnTimeout:     15 * time.Second,
-			DisableKeepAlives:   true,
-			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
-		},
-		ContentConfig: rest.ContentConfig{
-			NegotiatedSerializer: runtime.NewSimpleNegotiatedSerializer(scheme.Codecs.SupportedMediaTypes()[0]),
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	go monitor.NewSampler(m, time.Second, func(previous bool) (condition *monitorapi.Condition, next bool) {
-		_, err := client.Get().AbsPath(path).DoRaw(ctx)
-		// TODO this looks bugged.  If we get a non 200 or 300 series status, it seems like we ought to be failing.
-		switch {
-		case err == nil && !previous:
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Info,
-				Locator: newConnectionLocator,
-				Message: monitor.DisruptionEndedMessage(newConnectionLocator, monitor.NewConnectionType),
-			}
-		case err != nil && previous:
-			framework.Logf("Route for image-registry is unreachable on new connections: %v", err)
-			r.Eventf(t.routeRef, nil, corev1.EventTypeWarning, "Unreachable", "detected", "on new connections")
-			condition = &monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: newConnectionLocator,
-				Message: monitor.DisruptionBeganMessage(newConnectionLocator, monitor.NewConnectionType, err),
-			}
-		case err != nil:
-			framework.Logf("Route for image-registry is unreachable on new connections: %v", err)
+		route, err := routeClient.RouteV1().Routes("openshift-image-registry").Create(ctx, &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: routeName,
+			},
+			Spec: routev1.RouteSpec{
+				To: routev1.RouteTargetReference{
+					Kind: "Service",
+					Name: "image-registry",
+				},
+				Port: &routev1.RoutePort{
+					TargetPort: intstr.FromInt(5000),
+				},
+				TLS: &routev1.TLSConfig{
+					Termination:                   routev1.TLSTerminationPassthrough,
+					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+				},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return err
 		}
-		return condition, err == nil
-	}).WhenFailing(ctx, &monitorapi.Condition{
-		Level:   monitorapi.Error,
-		Locator: newConnectionLocator,
-		Message: monitor.DisruptionContinuingMessage(newConnectionLocator, monitor.NewConnectionType, err),
-	})
 
-	return nil
+		err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+			route, err = routeClient.RouteV1().Routes("openshift-image-registry").Get(ctx, routeName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			for _, ingress := range route.Status.Ingress {
+				if len(ingress.Host) > 0 {
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get route host: %w", err)
+		}
+
+		return nil
+	}
 }
 
-func locateRoute(ns, name string) string {
-	return fmt.Sprintf("ns/%s route/%s", ns, name)
+func teardownImageRegistryFor(routeName string) disruption.TearDownFunc {
+	return func(f *framework.Framework) error {
+		ctx := context.Background()
+
+		routeClient, err := routeclient.NewForConfig(f.ClientConfig())
+		if err != nil {
+			return err
+		}
+		framework.ExpectNoError(err)
+
+		err = routeClient.RouteV1().Routes("openshift-image-registry").Delete(ctx, routeName, metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to delete route: %w", err)
+		}
+		return nil
+	}
 }

--- a/test/extended/util/disruption/imageregistry/imageregistry.go
+++ b/test/extended/util/disruption/imageregistry/imageregistry.go
@@ -93,7 +93,7 @@ func allowedImageRegistryDisruption(f *framework.Framework, totalDuration time.D
 
 // Setup creates a route that exposes the registry to tests.
 func setupImageRegistryFor(routeName string) disruption.SetupFunc {
-	return func(f *framework.Framework) error {
+	return func(f *framework.Framework, _ disruption.BackendSampler) error {
 		ctx := context.Background()
 
 		routeClient, err := routeclient.NewForConfig(f.ClientConfig())


### PR DESCRIPTION
the existing monitor sampler is odd.  On the one hand, it appears to be trying to provide even samples with direct recording to the monitor.  But it also attempts to have the monitor itself poll.  It seems that we actually used *both* of these techniques at the same time.

In addition, it doesn't provide even sampling over time (the sample func can skew the disruption calculation). 

The simplest thing to do was simply divorce the disruption from the sampler.  I think there are now zero uses of sampler now and ultimately it's likely easier to have the in-memory sampler forever work as a push model.  Which also obviates the need for an actual sampler.  So perhaps we simply delete it in a followup.

/assign @dgoodwin 