### PR TITLE
baremetal: add test helper

### DIFF
--- a/test/extended/baremetal/commons.go
+++ b/test/extended/baremetal/commons.go
@@ -1,0 +1,109 @@
+package baremetal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+)
+
+func skipIfNotBaremetal(oc *exutil.CLI) {
+	g.By("checking platform type")
+
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
+		e2eskipper.Skipf("No baremetal platform detected")
+	}
+}
+
+func baremetalClient(dc dynamic.Interface) dynamic.ResourceInterface {
+	baremetalClient := dc.Resource(schema.GroupVersionResource{Group: "metal3.io", Resource: "baremetalhosts", Version: "v1alpha1"})
+	return baremetalClient.Namespace("openshift-machine-api")
+}
+
+func hostfirmwaresettingsClient(dc dynamic.Interface) dynamic.ResourceInterface {
+	hfsClient := dc.Resource(schema.GroupVersionResource{Group: "metal3.io", Resource: "hostfirmwaresettings", Version: "v1alpha1"})
+	return hfsClient.Namespace("openshift-machine-api")
+}
+
+type FieldGetterFunc func(obj map[string]interface{}, fields ...string) (interface{}, bool, error)
+
+func expectField(host unstructured.Unstructured, resource string, nestedField string, fieldGetter FieldGetterFunc) o.Assertion {
+	fields := strings.Split(nestedField, ".")
+
+	value, found, err := fieldGetter(host.Object, fields...)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(found).To(o.BeTrue(), fmt.Sprintf("`%s` field `%s` not found", resource, nestedField))
+	return o.Expect(value)
+}
+
+func expectStringField(host unstructured.Unstructured, resource string, nestedField string) o.Assertion {
+	return expectField(host, resource, nestedField, func(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
+		return unstructured.NestedString(host.Object, fields...)
+	})
+}
+
+func expectBoolField(host unstructured.Unstructured, resource string, nestedField string) o.Assertion {
+	return expectField(host, resource, nestedField, func(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
+		return unstructured.NestedBool(host.Object, fields...)
+	})
+}
+
+func expectStringMapField(host unstructured.Unstructured, resource string, nestedField string) o.Assertion {
+	return expectField(host, resource, nestedField, func(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
+		return unstructured.NestedStringMap(host.Object, fields...)
+	})
+}
+
+func expectSliceField(host unstructured.Unstructured, resource string, nestedField string) o.Assertion {
+	return expectField(host, resource, nestedField, func(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
+		return unstructured.NestedSlice(host.Object, fields...)
+	})
+}
+
+// Conditions are stored as a slice of maps, check that the type has the correct status
+func checkConditionStatus(hfs unstructured.Unstructured, condType string, condStatus string) {
+
+	conditions, _, err := unstructured.NestedSlice(hfs.Object, "status", "conditions")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(conditions).ToNot(o.BeEmpty())
+
+	for _, c := range conditions {
+		condition, ok := c.(map[string]interface{})
+		o.Expect(ok).To(o.BeTrue())
+
+		t, ok := condition["type"]
+		o.Expect(ok).To(o.BeTrue())
+		if t == condType {
+			s, ok := condition["status"]
+			o.Expect(ok).To(o.BeTrue())
+			o.Expect(s).To(o.Equal(condStatus))
+		}
+	}
+}
+
+func getField(host unstructured.Unstructured, resource string, nestedField string, fieldGetter FieldGetterFunc) string {
+	fields := strings.Split(nestedField, ".")
+
+	value, found, err := fieldGetter(host.Object, fields...)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(found).To(o.BeTrue(), fmt.Sprintf("`%s` field `%s` not found", resource, nestedField))
+	return value.(string)
+}
+
+func getStringField(host unstructured.Unstructured, resource string, nestedField string) string {
+	return getField(host, resource, nestedField, func(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
+		return unstructured.NestedFieldNoCopy(host.Object, fields...)
+	})
+}

--- a/test/extended/baremetal/helper.go
+++ b/test/extended/baremetal/helper.go
@@ -1,0 +1,163 @@
+package baremetal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/yaml"
+)
+
+// BaremetalTestHelper is an helper class for the baremetal tests,
+// providing support for the most common operations perfomed by
+// the tests. It will also help in reducing the noise in the test
+// definition by hiding technical details
+type BaremetalTestHelper struct {
+	clientSet *kubernetes.Clientset
+	bmcClient dynamic.ResourceInterface
+
+	hostsCreated []*unstructured.Unstructured
+}
+
+// NewBaremetalTestHelper creates a new test helper instance. It is
+// meant to be used in the BeforeEach method
+func NewBaremetalTestHelper(oc *exutil.CLI) *BaremetalTestHelper {
+	clientSet, err := e2e.LoadClientset()
+	o.Expect(err).ToNot(o.HaveOccurred())
+
+	return &BaremetalTestHelper{
+		clientSet: clientSet,
+		bmcClient: baremetalClient(oc.AdminDynamicClient()),
+	}
+}
+
+// extraWorkersRetrieveData fetches the information stored in the `extraworkers-secret` previously
+// created via dev-scripts. The secret contains baremetal host and secret definition for every
+// extra worker allocated by dev-scripts
+func (b *BaremetalTestHelper) extraWorkersRetrieveData() (*v1.Secret, error) {
+	ew, err := b.clientSet.CoreV1().Secrets("openshift-machine-api").Get(context.TODO(), "extraworkers-secret", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return ew, nil
+}
+
+func (b *BaremetalTestHelper) extraWorkersSecretKey(index int) string {
+	return fmt.Sprintf("extraworker-%d-secret", index)
+}
+
+func (b *BaremetalTestHelper) extraWorkerKey(index int) string {
+	return fmt.Sprintf("extraworker-%d-bmh", index)
+}
+
+// getExtraWorkerSecretData gets and decodes the secret associated for the
+// specified extra worker. If not found, the test will fail
+func (b *BaremetalTestHelper) getExtraWorkerSecretData(index int) *v1.Secret {
+	ew, err := b.extraWorkersRetrieveData()
+	o.Expect(err).ToNot(o.HaveOccurred())
+
+	yamlData, ok := ew.Data[b.extraWorkersSecretKey(index)]
+	o.Expect(ok).To(o.BeTrue(), fmt.Sprintf("unable to find data for extra worker %d", index))
+
+	var secret v1.Secret
+	err = yaml.Unmarshal(yamlData, &secret)
+	o.Expect(err).ToNot(o.HaveOccurred())
+	return &secret
+}
+
+// getExtraWorkerSecretData gets and decodes the baremetal host associated for the
+// specified extra worker. If not found, the test will fail
+func (b *BaremetalTestHelper) getExtraWorkerData(index int) *unstructured.Unstructured {
+	ew, err := b.extraWorkersRetrieveData()
+	o.Expect(err).ToNot(o.HaveOccurred())
+
+	yamlData, ok := ew.Data[b.extraWorkerKey(index)]
+	o.Expect(ok).To(o.BeTrue(), fmt.Sprintf("unable to find data for extra worker %d", index))
+
+	jsonData, err := yaml.YAMLToJSON(yamlData)
+	o.Expect(err).ToNot(o.HaveOccurred())
+
+	var host unstructured.Unstructured
+	err = host.UnmarshalJSON(jsonData)
+	o.Expect(err).ToNot(o.HaveOccurred())
+
+	return &host
+}
+
+// GetExtraWorkerData gets baremetal host and secret for the specified extra worker.
+// If not found, the test will fail
+func (b *BaremetalTestHelper) GetExtraWorkerData(index int) (*unstructured.Unstructured, *v1.Secret) {
+	return b.getExtraWorkerData(index), b.getExtraWorkerSecretData(index)
+}
+
+// CreateExtraWorker creates a new BaremetalHost (and associated Secret).
+// If successfull, returns the newly created host and secret resources
+func (b *BaremetalTestHelper) CreateExtraWorker(host *unstructured.Unstructured, secret *v1.Secret) (*unstructured.Unstructured, *v1.Secret) {
+
+	secret, err := b.clientSet.CoreV1().Secrets("openshift-machine-api").Create(context.Background(), secret, metav1.CreateOptions{})
+	o.Expect(err).ToNot(o.HaveOccurred())
+
+	host, err = b.bmcClient.Create(context.Background(), host, metav1.CreateOptions{})
+	o.Expect(err).ToNot(o.HaveOccurred())
+
+	b.hostsCreated = append(b.hostsCreated, host)
+
+	return host, secret
+}
+
+func (b *BaremetalTestHelper) getHostName(host *unstructured.Unstructured) string {
+	return getStringField(*host, "baremetalhost", "metadata.name")
+}
+
+// DeleteAllExtraWorkers deletes all the extra workers created in the current session
+func (b *BaremetalTestHelper) DeleteAllExtraWorkers() {
+	for _, host := range b.hostsCreated {
+		hostName := b.getHostName(host)
+
+		err := b.bmcClient.Delete(context.Background(), hostName, metav1.DeleteOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+	}
+}
+
+// WaitForProvisioningState waits for the given baremetal host to reach the specified provisioning state.
+// If successfull, returns the updated host resource, otherwise the test will fail
+func (b *BaremetalTestHelper) WaitForProvisioningState(host *unstructured.Unstructured, expectedProvisioningState string) *unstructured.Unstructured {
+
+	hostName := b.getHostName(host)
+	var newHost *unstructured.Unstructured
+
+	g.By(fmt.Sprintf("wait until %s becomes %s", hostName, expectedProvisioningState))
+	err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (done bool, err error) {
+		newHost, err = b.bmcClient.Get(context.TODO(), hostName, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		actual, found, err := unstructured.NestedString(newHost.Object, "status", "provisioning", "state")
+		if err != nil {
+			return false, err
+		}
+		if found {
+			return expectedProvisioningState == actual, nil
+		}
+		return false, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return newHost
+}


### PR DESCRIPTION
This patch adds the BaremetalTestHelper type (and also refactors a little bit the code) to start using the feature introduced in https://github.com/openshift-metal3/dev-scripts/pull/1315