### PR TITLE
Increase cluster-monitor-operator watch count threshold on single-node clusters

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -296,7 +296,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"cluster-autoscaler-operator":            44,
 				"cluster-baremetal-operator":             31,
 				"cluster-image-registry-operator":        119,
-				"cluster-monitoring-operator":            39,
+				"cluster-monitoring-operator":            48,
 				"cluster-node-tuning-operator":           39,
 				"cluster-samples-operator":               23,
 				"cluster-storage-operator":               202,


### PR DESCRIPTION
Observed it reaching 95 watch requests [prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial/1466885201148776448](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial/1466885201148776448)

[bugzilla.redhat.com/show_bug.cgi?id=2056450](https://bugzilla.redhat.com/show_bug.cgi?id=2056450) has been created to
follow up on this issue of increased watches

This PR can be reverted once the issue with increased watch is fixed