### PR TITLE
Revert "Alter junit test suite names for jobs with multiple junit xmls."

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -296,7 +296,7 @@ func newRunCommand() *cobra.Command {
 				if !opt.DryRun {
 					fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 				}
-				err = opt.Run(&suite.TestSuite, "openshift-tests")
+				err = opt.Run(&suite.TestSuite)
 				if suite.PostSuite != nil {
 					suite.PostSuite(opt)
 				}
@@ -361,7 +361,7 @@ func newRunUpgradeCommand() *cobra.Command {
 				if !opt.DryRun {
 					fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 				}
-				err = opt.Run(&suite.TestSuite, "openshift-tests-upgrade")
+				err = opt.Run(&suite.TestSuite)
 				if suite.PostSuite != nil {
 					suite.PostSuite(opt)
 				}

--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
-// upgradeSuites are all known upgrade test suites this binary should run
+// upgradeSuites are all known upgade test suites this binary should run
 var upgradeSuites = testSuites{
 	{
 		TestSuite: ginkgo.TestSuite{

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -111,7 +111,7 @@ func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite,
 	return suite, nil
 }
 
-func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
+func (opt *Options) Run(suite *TestSuite) error {
 	if len(opt.Regex) > 0 {
 		if err := filterWithRegex(suite, opt.Regex); err != nil {
 			return err
@@ -456,7 +456,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 	}
 
 	if len(opt.JUnitDir) > 0 {
-		if err := writeJUnitReport("junit_e2e", junitSuiteName, tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
+		if err := writeJUnitReport("junit_e2e", "openshift-tests", tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
 			fmt.Fprintf(opt.Out, "error: Unable to write e2e JUnit results: %v", err)
 		}
 	}


### PR DESCRIPTION
Reverts openshift/origin#26667

This is blocking payloads because on Azure, we now correctly report the sandbox test as a failure, whereas previously the pass+fail tests were incorrectly put together and considered a flake. Aggregation code and bigquery thinks the historical pass rate is 97%, and that is not the case at all on azure. With deads out and required to push any changes to fix the image manually, I don't think I can code a way to skip the test. 

For now I will revert this fix, until we can figure out how to keep payloads flowing and get the test data updated.