### PR TITLE
test: avoid double slash in path

### DIFF
--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -51,7 +51,7 @@ const (
 	oauthConfigPath  = "/var/config/system/configmaps/oauth-config"
 	serviceCADirPath = "/var/config/system/configmaps/service-ca"
 
-	configObjectsDir = "/var/oauth/configobjects/"
+	configObjectsDir = "/var/oauth/configobjects"
 
 	RouteName = "test-oauth-route"
 	SAName    = "e2e-oauth"


### PR DESCRIPTION
every user of configObjectsDir already appends a slash after
configObjectsDir.  Avoid generating a path that has a double slash
as `var/oauth/configobjects//htpasswd`.

The reason for such fix is that the crun version currently used in the
CI has a bug when dealing with paths with multiple slashes.  The issue
has already been addressed upstream.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>