### PR TITLE
Bug 2033740: Implement e2e-images-update label

### DIFF
--- a/test/extended/util/image/OWNERS
+++ b/test/extended/util/image/OWNERS
@@ -7,3 +7,5 @@ approvers:
 - smarterclayton
 - soltysh
 - sttts
+labels:
+- "e2e-images-update"


### PR DESCRIPTION
This will allow origin PRs which touch test/extended/util/image, which require special handling, to be labelled for better tracking.

This is the follow-up to https://github.com/openshift/release/pull/24398

/cc @smarterclayton @soltysh @sttts
who currently manage such PRs.﻿
