### PR TITLE
Bug 2034688: allow Prometheus/Thanos to return 401 or 403 when the request isn't authenticated

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -580,8 +580,8 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 				return false, nil
 			})).NotTo(o.HaveOccurred(), fmt.Sprintf("Did not find tsdb_samples_appended_total, tsdb_head_samples_appended_total, or prometheus_tsdb_head_samples_appended_total"))
 
-			g.By("verifying the oauth-proxy reports a 403 on the root URL")
-			err := helper.ExpectURLStatusCodeExec(ns, execPod.Name, url, 403)
+			g.By("verifying the Thanos querier service requires authentication")
+			err := helper.ExpectURLStatusCodeExec(ns, execPod.Name, url, 401, 403)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("verifying a service account token is able to authenticate")


### PR DESCRIPTION
Both tests are querying prometheus/thanos endpoints without any authentication information, the response HTTP status code should be [401 unauthorized](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) (the user is not yet authenticated) instead of [403 forbidden](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) (an authenticated user has no access to the requested resource.

Do not merge yet. This can block tests of Cluster Monitoring Operator which is returning the code 403 from Oauth-proxy at the moment.