### PR TITLE
find disruption backends from the event intervals instead of a hardcoded list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	k8s.io/kubernetes v1.22.1
 	k8s.io/legacy-cloud-providers v0.22.1
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
+	sigs.k8s.io/kustomize/kyaml v0.11.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/pkg/monitor/backenddisruption/disruption_locator.go
+++ b/pkg/monitor/backenddisruption/disruption_locator.go
@@ -38,14 +38,3 @@ func DisruptionBeganMessage(locator string, connectionType BackendConnectionType
 		return fmt.Sprintf("%s stopped responding to GET requests over %v connections: %v", locator, "Unknown", err)
 	}
 }
-
-func DisruptionContinuingMessage(locator string, connectionType BackendConnectionType, err error) string {
-	switch connectionType {
-	case NewConnectionType:
-		return fmt.Sprintf("%s is not responding to GET requests over new connections: %v", locator, err)
-	case ReusedConnectionType:
-		return fmt.Sprintf("%s is not responding to GET requests over reused connections: %v", locator, err)
-	default:
-		return fmt.Sprintf("%s is not responding to GET requests over %v connections: %v", locator, "Unknown", err)
-	}
-}

--- a/pkg/monitor/disruption_known_backends.go
+++ b/pkg/monitor/disruption_known_backends.go
@@ -13,34 +13,6 @@ import (
 // we also got stuck on writing the disruption backends.  We need a way to track which disruption checks we have started,
 // so we can properly write out "zero"
 
-var (
-	LocatorKubeAPIServerNewConnection         = backenddisruption.LocateDisruptionCheck("kube-api", backenddisruption.NewConnectionType)
-	LocatorKubeAPIServerReusedConnection      = backenddisruption.LocateDisruptionCheck("kube-api", backenddisruption.ReusedConnectionType)
-	LocatorOpenshiftAPIServerNewConnection    = backenddisruption.LocateDisruptionCheck("openshift-api", backenddisruption.NewConnectionType)
-	LocatorOpenshiftAPIServerReusedConnection = backenddisruption.LocateDisruptionCheck("openshift-api", backenddisruption.ReusedConnectionType)
-	LocatorOAuthAPIServerNewConnection        = backenddisruption.LocateDisruptionCheck("oauth-api", backenddisruption.NewConnectionType)
-	LocatorOAuthAPIServerReusedConnection     = backenddisruption.LocateDisruptionCheck("oauth-api", backenddisruption.ReusedConnectionType)
-)
-
-// BackendDisruptionLocatorsToName maps from the locator name used to track disruption to the name used to recognize it in
-// the job aggregator.
-var BackendDisruptionLocatorsToName = map[string]string{
-	LocatorKubeAPIServerNewConnection:         "kube-api-new-connections",
-	LocatorOpenshiftAPIServerNewConnection:    "openshift-api-new-connections",
-	LocatorOAuthAPIServerNewConnection:        "oauth-api-new-connections",
-	LocatorKubeAPIServerReusedConnection:      "kube-api-reused-connections",
-	LocatorOpenshiftAPIServerReusedConnection: "openshift-api-reused-connections",
-	LocatorOAuthAPIServerReusedConnection:     "oauth-api-reused-connections",
-	backenddisruption.LocateRouteForDisruptionCheck("openshift-authentication", "oauth-openshift", "ingress-to-oauth-server", backenddisruption.NewConnectionType):    "ingress-to-oauth-server-new-connections",
-	backenddisruption.LocateRouteForDisruptionCheck("openshift-authentication", "oauth-openshift", "ingress-to-oauth-server", backenddisruption.ReusedConnectionType): "ingress-to-oauth-server-used-connections",
-	backenddisruption.LocateRouteForDisruptionCheck("openshift-console", "console", "ingress-to-console", backenddisruption.NewConnectionType):                        "ingress-to-console-new-connections",
-	backenddisruption.LocateRouteForDisruptionCheck("openshift-console", "console", "ingress-to-console", backenddisruption.ReusedConnectionType):                     "ingress-to-console-used-connections",
-	backenddisruption.LocateRouteForDisruptionCheck("openshift-image-registry", "test-disruption", "image-registry", backenddisruption.NewConnectionType):             "image-registry-new-connections",
-	backenddisruption.LocateRouteForDisruptionCheck("openshift-image-registry", "test-disruption", "image-registry", backenddisruption.ReusedConnectionType):          "image-registry-reused-connections",
-	backenddisruption.LocateDisruptionCheck("service-loadbalancer-with-pdb", backenddisruption.NewConnectionType):                                                     "service-load-balancer-with-pdb-new-connections",
-	backenddisruption.LocateDisruptionCheck("service-loadbalancer-with-pdb", backenddisruption.ReusedConnectionType):                                                  "service-load-balancer-with-pdb-reused-connections",
-}
-
 func startKubeAPIMonitoringWithNewConnections(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
 	backendSampler, err := CreateKubeAPIMonitoringWithNewConnections(clusterConfig)
 	if err != nil {

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -91,3 +91,20 @@ func NamespaceFrom(locatorParts map[string]string) string {
 func AlertFrom(locatorParts map[string]string) string {
 	return locatorParts["alert"]
 }
+
+func DisruptionFrom(locatorParts map[string]string) string {
+	return locatorParts["disruption"]
+}
+
+func DisruptionConnectionTypeFrom(locatorParts map[string]string) string {
+	return locatorParts["connection"]
+}
+
+func IsEventForLocator(locator string) EventIntervalMatchesFunc {
+	return func(eventInterval EventInterval) bool {
+		if eventInterval.Locator == locator {
+			return true
+		}
+		return false
+	}
+}

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -175,6 +175,17 @@ func IsErrorEvent(eventInterval EventInterval) bool {
 	return false
 }
 
+func And(filters ...EventIntervalMatchesFunc) EventIntervalMatchesFunc {
+	return func(eventInterval EventInterval) bool {
+		for _, filter := range filters {
+			if !filter(eventInterval) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 // Filter returns a copy of intervals with only intervals that match the provided
 // function.
 func (intervals Intervals) Filter(eventFilterMatches EventIntervalMatchesFunc) Intervals {

--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -6,36 +6,69 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/test/ginkgo"
 )
 
-const (
-	// Max. duration of API server unreachability, in fraction of total test duration.
-	tolerateDisruptionPercent = 0.01
-)
-
-func testServerAvailability(locator string, events monitorapi.Intervals, duration time.Duration) []*ginkgo.JUnitTestCase {
+func testServerAvailability(owner, locator string, events monitorapi.Intervals, jobRunDuration time.Duration) []*ginkgo.JUnitTestCase {
 	errDuration, errMessages, _ := monitorapi.BackendDisruptionSeconds(locator, events)
 
-	testName := fmt.Sprintf("[sig-api-machinery] %s should be available", locator)
+	testName := fmt.Sprintf("[%s] %s should be available throughout the test", owner, locator)
 	successTest := &ginkgo.JUnitTestCase{
 		Name:     testName,
-		Duration: duration.Seconds(),
+		Duration: jobRunDuration.Seconds(),
 	}
-	if percent := float64(errDuration) / float64(duration); percent > tolerateDisruptionPercent {
+	if errDuration > 0 {
 		test := &ginkgo.JUnitTestCase{
 			Name:     testName,
-			Duration: duration.Seconds(),
+			Duration: jobRunDuration.Seconds(),
 			FailureOutput: &ginkgo.FailureOutput{
-				Output: fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Round(time.Second), 100*percent),
+				Output: fmt.Sprintf("%s was failing for %s seconds (test duration: %s)", locator, errDuration.Round(time.Second), jobRunDuration.Round(time.Second)),
 			},
 			SystemOut: strings.Join(errMessages, "\n"),
 		}
 		// Return *two* tests results to pretend this is a flake not to fail whole testsuite.
 		return []*ginkgo.JUnitTestCase{test, successTest}
+
 	} else {
-		successTest.SystemOut = fmt.Sprintf("%s was failing for %s seconds (%0.0f%% of the test duration)", locator, errDuration.Round(time.Second), 100*percent)
+		successTest.SystemOut = fmt.Sprintf("%s was failing for %s seconds (test duration: %s)", locator, errDuration.Round(time.Second), jobRunDuration.Round(time.Second))
 		return []*ginkgo.JUnitTestCase{successTest}
 	}
+}
+
+func testAllAPIAvailability(events monitorapi.Intervals, jobRunDuration time.Duration) []*ginkgo.JUnitTestCase {
+	allAPIServerLocators := sets.String{}
+	allDisruptionEventsIntervals := events.Filter(monitorapi.IsDisruptionEvent)
+	for _, eventInterval := range allDisruptionEventsIntervals {
+		backend := monitorapi.DisruptionFrom(monitorapi.LocatorParts(eventInterval.Locator))
+		if strings.HasSuffix(backend, "-api") {
+			allAPIServerLocators.Insert(eventInterval.Locator)
+		}
+	}
+
+	ret := []*ginkgo.JUnitTestCase{}
+	for _, apiServerLocator := range allAPIServerLocators.List() {
+		ret = append(ret, testServerAvailability("sig-api-machinery", apiServerLocator, allDisruptionEventsIntervals, jobRunDuration)...)
+	}
+
+	return ret
+}
+
+func testAllIngressAvailability(events monitorapi.Intervals, jobRunDuration time.Duration) []*ginkgo.JUnitTestCase {
+	allAPIServerLocators := sets.String{}
+	allDisruptionEventsIntervals := events.Filter(monitorapi.IsDisruptionEvent)
+	for _, eventInterval := range allDisruptionEventsIntervals {
+		backend := monitorapi.DisruptionFrom(monitorapi.LocatorParts(eventInterval.Locator))
+		if strings.HasPrefix(backend, "ingress-") {
+			allAPIServerLocators.Insert(eventInterval.Locator)
+		}
+	}
+
+	ret := []*ginkgo.JUnitTestCase{}
+	for _, apiServerLocator := range allAPIServerLocators.List() {
+		ret = append(ret, testServerAvailability("sig-network-edge", apiServerLocator, allDisruptionEventsIntervals, jobRunDuration)...)
+	}
+
+	return ret
 }

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -3,12 +3,9 @@ package synthetictests
 import (
 	"time"
 
-	"k8s.io/client-go/rest"
-
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
-
-	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/test/ginkgo"
+	"k8s.io/client-go/rest"
 )
 
 // StableSystemEventInvariants are invariants that should hold true when a cluster is in
@@ -24,12 +21,8 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testKubeletToAPIServerGracefulTermination(events)...)
 	tests = append(tests, testPodTransitions(events)...)
 	tests = append(tests, testPodSandboxCreation(events)...)
-	tests = append(tests, testServerAvailability(monitor.LocatorKubeAPIServerNewConnection, events, duration)...)
-	tests = append(tests, testServerAvailability(monitor.LocatorOpenshiftAPIServerNewConnection, events, duration)...)
-	tests = append(tests, testServerAvailability(monitor.LocatorOAuthAPIServerNewConnection, events, duration)...)
-	tests = append(tests, testServerAvailability(monitor.LocatorKubeAPIServerReusedConnection, events, duration)...)
-	tests = append(tests, testServerAvailability(monitor.LocatorOpenshiftAPIServerReusedConnection, events, duration)...)
-	tests = append(tests, testServerAvailability(monitor.LocatorOAuthAPIServerReusedConnection, events, duration)...)
+	tests = append(tests, testAllAPIAvailability(events, duration)...)
+	tests = append(tests, testAllIngressAvailability(events, duration)...)
 	tests = append(tests, testStableSystemOperatorStateTransitions(events)...)
 	tests = append(tests, testDuplicatedEventForStableSystem(events, kubeClientConfig)...)
 

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -40,7 +40,7 @@ func NewServiceLoadBalancerWithNewConnectionsTest() upgrades.Test {
 			"[sig-network-edge] Application behind service load balancer with PDB remains available using new connections",
 			backenddisruption.NewSimpleBackend(
 				"", // late binding host
-				"service-loadbalancer-with-pdb",
+				"service-load-balancer-with-pdb",
 				"/echo?msg=Hello",
 				backenddisruption.NewConnectionType).
 				WithExpectedBody("Hello"),
@@ -57,7 +57,7 @@ func NewServiceLoadBalancerWithReusedConnectionsTest() upgrades.Test {
 			"[sig-network-edge] Application behind service load balancer with PDB remains available using reused connections",
 			backenddisruption.NewSimpleBackend(
 				"", // late binding host
-				"service-loadbalancer-with-pdb",
+				"service-load-balancer-with-pdb",
 				"/echo?msg=Hello",
 				backenddisruption.ReusedConnectionType).
 				WithExpectedBody("Hello"),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3117,6 +3117,7 @@ sigs.k8s.io/kustomize/api/resmap
 sigs.k8s.io/kustomize/api/resource
 sigs.k8s.io/kustomize/api/types
 # sigs.k8s.io/kustomize/kyaml v0.11.0
+## explicit
 sigs.k8s.io/kustomize/kyaml/comments
 sigs.k8s.io/kustomize/kyaml/errors
 sigs.k8s.io/kustomize/kyaml/ext


### PR DESCRIPTION
builds on https://github.com/openshift/origin/pull/26703 and should give us a complete backend .json