### PR TITLE
Bug 2033720: Drop usage of old imagestreams

### DIFF
--- a/examples/jenkins/pipeline/bluegreen-pipeline.yaml
+++ b/examples/jenkins/pipeline/bluegreen-pipeline.yaml
@@ -158,7 +158,7 @@ objects:
           value: ${NPM_MIRROR}
         from:
           kind: ImageStreamTag
-          name: nodejs:12
+          name: nodejs:${NODEJS_VERSION}
           namespace: ${NAMESPACE}
       type: Source
     triggers:
@@ -405,6 +405,21 @@ parameters:
   name: NAME
   required: true
   value: nodejs-postgresql-example
+- description: The OpenShift Namespace where the NodeJS and postgresql ImageStreams reside.
+  displayName: Namespace
+  name: NAMESPACE
+  required: true
+  value: openshift
+- description: Version of NodeJS image to be used (14-ubi8, or latest).
+  displayName: Version of NodeJS Image
+  name: NODEJS_VERSION
+  required: true
+  value: 14-ubi8
+- description: Version of PostgreSQL image to be used (12-el8, or latest).
+  displayName: Version of PostgreSQL Image
+  name: POSTGRESQL_VERSION
+  required: true
+  value: 12-el8
 - description: The exposed hostname that will route to the Node.js service, if left
     blank a value will be defaulted.
   displayName: Application Hostname
@@ -474,11 +489,6 @@ parameters:
 - description: The custom NPM mirror URL
   displayName: Custom NPM Mirror URL
   name: NPM_MIRROR
-- description: The OpenShift Namespace where the NodeJS and postgresql ImageStreams reside.
-  displayName: Namespace
-  name: NAMESPACE
-  required: true
-  value: openshift
 - description: Whether to enable verbose logging of Jenkinsfile steps in pipeline
   displayName: Verbose
   name: VERBOSE

--- a/examples/jenkins/pipeline/samplepipeline.yaml
+++ b/examples/jenkins/pipeline/samplepipeline.yaml
@@ -307,11 +307,11 @@ parameters:
     name: NAMESPACE
     required: true
     value: openshift
-  - description: Version of NodeJS image to be used (10-ubi8, 12-ubi8, or latest).
+  - description: Version of NodeJS image to be used (14-ubi8, or latest).
     displayName: Version of NodeJS Image
     name: NODEJS_VERSION
     required: true
-    value: 12-ubi8
+    value: 14-ubi8
   - description: Version of PostgreSQL image to be used (12-el8, or latest).
     displayName: Version of PostgreSQL Image
     name: POSTGRESQL_VERSION

--- a/test/extended/image_ecosystem/s2i_images.go
+++ b/test/extended/image_ecosystem/s2i_images.go
@@ -102,13 +102,6 @@ var s2iImages = map[string][]tc{
 	},
 	"nodejs": {
 		{
-			Version:  "12",
-			Cmd:      "node --version",
-			Expected: "v12",
-			Tag:      "12-ubi8",
-			Arches:   []string{"amd64", "arm64", "ppc64le", "s390x"},
-		},
-		{
 			Version:  "14",
 			Cmd:      "node --version",
 			Expected: "v14",

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -14481,7 +14481,7 @@ objects:
           value: ${NPM_MIRROR}
         from:
           kind: ImageStreamTag
-          name: nodejs:12
+          name: nodejs:${NODEJS_VERSION}
           namespace: ${NAMESPACE}
       type: Source
     triggers:
@@ -14728,6 +14728,21 @@ parameters:
   name: NAME
   required: true
   value: nodejs-postgresql-example
+- description: The OpenShift Namespace where the NodeJS and postgresql ImageStreams reside.
+  displayName: Namespace
+  name: NAMESPACE
+  required: true
+  value: openshift
+- description: Version of NodeJS image to be used (14-ubi8, or latest).
+  displayName: Version of NodeJS Image
+  name: NODEJS_VERSION
+  required: true
+  value: 14-ubi8
+- description: Version of PostgreSQL image to be used (12-el8, or latest).
+  displayName: Version of PostgreSQL Image
+  name: POSTGRESQL_VERSION
+  required: true
+  value: 12-el8
 - description: The exposed hostname that will route to the Node.js service, if left
     blank a value will be defaulted.
   displayName: Application Hostname
@@ -14797,11 +14812,6 @@ parameters:
 - description: The custom NPM mirror URL
   displayName: Custom NPM Mirror URL
   name: NPM_MIRROR
-- description: The OpenShift Namespace where the NodeJS and postgresql ImageStreams reside.
-  displayName: Namespace
-  name: NAMESPACE
-  required: true
-  value: openshift
 - description: Whether to enable verbose logging of Jenkinsfile steps in pipeline
   displayName: Verbose
   name: VERBOSE
@@ -15602,11 +15612,11 @@ parameters:
     name: NAMESPACE
     required: true
     value: openshift
-  - description: Version of NodeJS image to be used (10-ubi8, 12-ubi8, or latest).
+  - description: Version of NodeJS image to be used (14-ubi8, or latest).
     displayName: Version of NodeJS Image
     name: NODEJS_VERSION
     required: true
-    value: 12-ubi8
+    value: 14-ubi8
   - description: Version of PostgreSQL image to be used (12-el8, or latest).
     displayName: Version of PostgreSQL Image
     name: POSTGRESQL_VERSION

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -23958,8 +23958,8 @@ var _testExtendedTestdataClusterQuickstartsCakephpMysqlJson = []byte(`{
 		{
 			"name": "PHP_VERSION",
 			"displayName": "PHP Version",
-			"description": "Version of PHP image to be used (7.3-ubi7, 7.3-ubi8, or latest).",
-			"value": "7.3-ubi8",
+			"description": "Version of PHP image to be used (7.4-ubi7, 7.4-ubi8, or latest).",
+			"value": "7.4-ubi8",
 			"required": true
 		},
 		{
@@ -24079,7 +24079,8 @@ var _testExtendedTestdataClusterQuickstartsCakephpMysqlJson = []byte(`{
 		"app": "cakephp-mysql-example",
 		"template": "cakephp-mysql-example"
 	}
-}`)
+}
+`)
 
 func testExtendedTestdataClusterQuickstartsCakephpMysqlJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataClusterQuickstartsCakephpMysqlJson, nil
@@ -25242,7 +25243,7 @@ var _testExtendedTestdataClusterQuickstartsNodejsPostgresqlJson = []byte(`{
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
 				"name": "${NAME}"
@@ -25256,7 +25257,7 @@ var _testExtendedTestdataClusterQuickstartsNodejsPostgresqlJson = []byte(`{
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"annotations": {
@@ -25266,7 +25267,7 @@ var _testExtendedTestdataClusterQuickstartsNodejsPostgresqlJson = []byte(`{
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"annotations": {
@@ -25330,7 +25331,7 @@ var _testExtendedTestdataClusterQuickstartsNodejsPostgresqlJson = []byte(`{
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -25473,7 +25474,7 @@ var _testExtendedTestdataClusterQuickstartsNodejsPostgresqlJson = []byte(`{
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -25610,8 +25611,8 @@ var _testExtendedTestdataClusterQuickstartsNodejsPostgresqlJson = []byte(`{
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (10-ubi8, 12-ubi8, or latest).",
-			"value": "12-ubi8",
+			"description": "Version of NodeJS image to be used (14-ubi8, or latest).",
+			"value": "14-ubi8",
 			"required": true
 		},
 		{
@@ -25714,7 +25715,8 @@ var _testExtendedTestdataClusterQuickstartsNodejsPostgresqlJson = []byte(`{
 		"app": "nodejs-postgresql-example",
 		"template": "nodejs-postgresql-example"
 	}
-}`)
+}
+`)
 
 func testExtendedTestdataClusterQuickstartsNodejsPostgresqlJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataClusterQuickstartsNodejsPostgresqlJson, nil
@@ -25850,7 +25852,7 @@ var _testExtendedTestdataClusterQuickstartsRailsPostgresqlJson = []byte(`{
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:2.6-ubi8",
+							"name": "ruby:2.7-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -26315,7 +26317,8 @@ var _testExtendedTestdataClusterQuickstartsRailsPostgresqlJson = []byte(`{
 		"app": "rails-postgresql-example",
 		"template": "rails-postgresql-example"
 	}
-}`)
+}
+`)
 
 func testExtendedTestdataClusterQuickstartsRailsPostgresqlJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataClusterQuickstartsRailsPostgresqlJson, nil

--- a/test/extended/testdata/cluster/quickstarts/cakephp-mysql.json
+++ b/test/extended/testdata/cluster/quickstarts/cakephp-mysql.json
@@ -450,8 +450,8 @@
 		{
 			"name": "PHP_VERSION",
 			"displayName": "PHP Version",
-			"description": "Version of PHP image to be used (7.3-ubi7, 7.3-ubi8, or latest).",
-			"value": "7.3-ubi8",
+			"description": "Version of PHP image to be used (7.4-ubi7, 7.4-ubi8, or latest).",
+			"value": "7.4-ubi8",
 			"required": true
 		},
 		{

--- a/test/extended/testdata/cluster/quickstarts/nodejs-postgresql.json
+++ b/test/extended/testdata/cluster/quickstarts/nodejs-postgresql.json
@@ -54,7 +54,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "route.openshift.io/v1",
 			"kind": "Route",
 			"metadata": {
 				"name": "${NAME}"
@@ -68,7 +68,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "image.openshift.io/v1",
 			"kind": "ImageStream",
 			"metadata": {
 				"annotations": {
@@ -78,7 +78,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "build.openshift.io/v1",
 			"kind": "BuildConfig",
 			"metadata": {
 				"annotations": {
@@ -142,7 +142,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -285,7 +285,7 @@
 			}
 		},
 		{
-			"apiVersion": "v1",
+			"apiVersion": "apps.openshift.io/v1",
 			"kind": "DeploymentConfig",
 			"metadata": {
 				"annotations": {
@@ -422,8 +422,8 @@
 		{
 			"name": "NODEJS_VERSION",
 			"displayName": "Version of NodeJS Image",
-			"description": "Version of NodeJS image to be used (10-ubi8, 12-ubi8, or latest).",
-			"value": "12-ubi8",
+			"description": "Version of NodeJS image to be used (14-ubi8, or latest).",
+			"value": "14-ubi8",
 			"required": true
 		},
 		{

--- a/test/extended/testdata/cluster/quickstarts/rails-postgresql.json
+++ b/test/extended/testdata/cluster/quickstarts/rails-postgresql.json
@@ -117,7 +117,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:2.6-ubi8",
+							"name": "ruby:2.7-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1503,8 +1503,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.18-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.18-ubi8\" should print the usage",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:12-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:12-ubi8\" should print the usage",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:14-ubi7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:14-ubi7\" should print the usage",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:14-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:14-ubi8\" should print the usage",
@@ -1546,8 +1544,6 @@ var annotations = map[string]string{
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.18-ubi7\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.18-ubi7\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.18-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.18-ubi8\" should be SCL enabled",
-
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:12-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:12-ubi8\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:14-ubi7\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/nodejs:14-ubi7\" should be SCL enabled",
 


### PR DESCRIPTION
The SCL team dropped this from imagestreams earlier than expected.

﻿- cluster: update nodejs-postgresql quickstart to nodejs:14-ubi8
- image_ecosystem: remove nodejs:12-ubi8
- jenkins: update templates for nodejs:14-ubi8
