### PR TITLE
test/extended/util/annotate/generated: Delegate to team leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,3 +11,43 @@ aliases:
   - jottofar
   - vrutkovs
   - wking
+  team-leads:
+  - JAORMX # Infrastructure Security and Compliance
+  - JoelSpeed # Cluster Infrastructure
+  - LalatenduMohanty # Over the Air Updates
+  - Miciah # Network Edge
+  - adambkaplan # Build + Jenkins
+  - ashishkamra # Performance and Latency Sensitive Application Platform
+  - beekhof # Machine Lifecycle
+  - brenton # Technical Release Team
+  - bthurber # Partner Accelerators
+  - c3d # OpenShift Sandboxed Containers
+  - celebdor # Ecosystem Edge
+  - dmage # Image Registry
+  - dulek # Kuryr Networking
+  - hexfusion # etcd
+  - jaypoulz # Multi Arch
+  - jcantrill # Cluster Logging
+  - jmrodri # Operator SDK
+  - joelddiaz # Hive
+  - jparrill # Portfolio Integration
+  - jsafrane # Storage
+  - jwmatthews # App Migration
+  - kevinrizza # Operator Lifecycle Manager
+  - mandre # Shift on Stack
+  - miabbott # CoreOS
+  - pedjak # App Services
+  - petr-muller # Test Platform
+  - romfreiman # Single Node OpenShift
+  - rphillips # Node
+  - s-urbaniak # Authentication
+  - sadasu # Metal Platform
+  - selansen # Windows Containers
+  - simonpasquier # Monitoring - In Cluster
+  - sinnykumari # MCO
+  - soltysh # Workloads
+  - sosiouxme # Automated Release Tooling
+  - staebler # OpenShift Installer
+  - sttts # API Server
+  - trozet # Networking
+  - umohnani8 # Container Engine Tools

--- a/test/extended/util/annotate/generated/OWNERS
+++ b/test/extended/util/annotate/generated/OWNERS
@@ -1,4 +1,4 @@
 reviewers:
-  - dmage
+  - team-leads
 approvers:
-  - dmage
+  - team-leads


### PR DESCRIPTION
Expand on the scaffolding set up with e6f298436d (#26652) to empower all OpenShift team leads to manage skips and such for test-cases covering their own components.

Alias content based on `misc/tools/bin/leads.py` from the internal `li` repo (sorry external folks) as of 4c5bc167f9 (2021-12-17), with subsequent manual pruning for teams that had missing data or didn't seem like they'd care about origin content.
