### PR TITLE
Bug 2033810: pkg: Buffer signals for abortCh

### DIFF
--- a/pkg/monitor/cmd.go
+++ b/pkg/monitor/cmd.go
@@ -22,7 +22,7 @@ type Options struct {
 func (opt *Options) Run() error {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
-	abortCh := make(chan os.Signal)
+	abortCh := make(chan os.Signal, 2)
 	go func() {
 		<-abortCh
 		fmt.Fprintf(opt.ErrOut, "Interrupted, terminating\n")

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -205,7 +205,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
-	abortCh := make(chan os.Signal)
+	abortCh := make(chan os.Signal, 2)
 	go func() {
 		<-abortCh
 		fmt.Fprintf(opt.ErrOut, "Interrupted, terminating tests\n")


### PR DESCRIPTION
[Avoid][1]:

```
INFO[2021-12-17T19:07:56Z] Tagging openshift/release:rhel-8-release-golang-1.17-openshift-4.10 into pipeline:root.
...
go vet  ./...
# github.com/openshift/origin/pkg/monitor
pkg/monitor/cmd.go:39:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
# github.com/openshift/origin/pkg/test/ginkgo
pkg/test/ginkgo/cmd_runsuite.go:222:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
```

which is [new for Go 1.17][2].  I'm not all that clear why the handler wants the buffering, because it seems like you could fill the buffer just as easily as you could fill an unbuffered channel.  But whatever, it's easy enough to give each of these channels two slots, so `Notify` can catch and queue enough to get us to quickly exit without needing to block on a channel write.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26712/pull-ci-openshift-origin-master-verify/1471919425958449152
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2033810