### PR TITLE
set allowed disruption based on historical p95 data

### DIFF
--- a/pkg/synthetictests/allowedbackenddisruption/matches.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches.go
@@ -1,0 +1,101 @@
+package allowedbackenddisruption
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+// GetAllowedDisruption uses the backend and information about the cluster to choose the best historical p95 to operate against.
+// We enforce "don't get worse" for disruption by watching the aggregate data in CI over many runs.
+func GetAllowedDisruption(ctx context.Context, backendName string, clientConfig *rest.Config) (*time.Duration, error) {
+	configClient, err := configclient.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	infrastructure, err := configClient.Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	network, err := configClient.Networks().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	release := versionFromHistory(clusterVersion.Status.History[0])
+
+	fromRelease := ""
+	if len(clusterVersion.Status.History) > 1 {
+		fromRelease = versionFromHistory(clusterVersion.Status.History[1])
+	}
+
+	platform := ""
+	switch infrastructure.Status.PlatformStatus.Type {
+	case configv1.AWSPlatformType:
+		platform = "aws"
+	case configv1.GCPPlatformType:
+		platform = "gcp"
+	case configv1.AzurePlatformType:
+		platform = "azure"
+	case configv1.VSpherePlatformType:
+		platform = "vsphere"
+	case configv1.BareMetalPlatformType:
+		platform = "metal"
+	}
+
+	networkType := ""
+	switch network.Status.NetworkType {
+	case "OpenShiftSDN":
+		networkType = "sdn"
+	case "OVNKubernetes":
+		networkType = "ovn"
+	}
+
+	return GetClosestP95Value(backendName, release, fromRelease, platform, networkType), nil
+}
+
+func versionFromHistory(history configv1.UpdateHistory) string {
+	versionParts := strings.Split(history.Version, ".")
+	if len(versionParts) < 2 {
+		return ""
+	}
+
+	version := versionParts[0] + "." + versionParts[1]
+	if strings.HasPrefix(version, "v") {
+		version = version[1:]
+	}
+	return version
+}
+
+func GetClosestP95Value(backendName, release, fromRelease, platform, networkType string) *time.Duration {
+	exactMatchKey := LastWeekP95Key{
+		BackendName: backendName,
+		Release:     release,
+		FromRelease: fromRelease,
+		Platform:    platform,
+		Network:     networkType,
+	}
+	_, p95AsMap := getCurrentResults()
+
+	zeroSeconds := 0 * time.Second
+
+	if p95, ok := p95AsMap[exactMatchKey]; ok {
+		ret, err := time.ParseDuration(fmt.Sprintf("%2fs", p95.P95))
+		if err != nil {
+			return &zeroSeconds
+		}
+		return &ret
+	}
+
+	return &zeroSeconds
+}

--- a/pkg/synthetictests/allowedbackenddisruption/matches_test.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches_test.go
@@ -1,0 +1,49 @@
+package allowedbackenddisruption
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGetClosestP95Value(t *testing.T) {
+
+	mustDuration := func(durationString string) *time.Duration {
+		ret, err := time.ParseDuration(durationString)
+		if err != nil {
+			panic(err)
+		}
+		return &ret
+	}
+	type args struct {
+		backendName string
+		release     string
+		fromRelease string
+		platform    string
+		networkType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *time.Duration
+	}{
+		{
+			name: "test-that-failed-in-ci",
+			args: args{
+				backendName: "ingress-to-oauth-server-reused-connections",
+				release:     "4.10",
+				fromRelease: "4.10",
+				platform:    "gcp",
+				networkType: "sdn",
+			},
+			want: mustDuration("10.4s"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetClosestP95Value(tt.args.backendName, tt.args.release, tt.args.fromRelease, tt.args.platform, tt.args.networkType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetClosestP95Value() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/synthetictests/allowedbackenddisruption/query_results.json
+++ b/pkg/synthetictests/allowedbackenddisruption/query_results.json
@@ -1,0 +1,2386 @@
+[
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "63.89999999999997"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "60.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "64.199999999999974"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "2368.1999999999994"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "57.54999999999999"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "72.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "104.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "3443.9"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "10.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "5.099999999999989"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "20.799999999999965"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "2368.1999999999994"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "19.54999999999999"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "14.699999999999967"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "8.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "3443.9"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "40.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "30.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "66.05"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "2926.2"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "64.299999999999983"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "70.799999999999983"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "81.34999999999998"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "103.49999999999999"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "3443.2"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "18.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "52.05"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "39.1999999999996"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "2926.2"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "61.299999999999983"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "58.399999999999878"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "41.049999999999947"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "66.749999999999972"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "3443.9"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "61.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "2926.2"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "71.19999999999996"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "73.34999999999998"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "103.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "3443.9"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "14.849999999999957"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "22.499999999999709"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "53.05"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "10.399999999999983"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "2926.2"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "10.299999999999983"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "37.999999999999943"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "23.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "13.249999999999984"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "3443.9"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "6.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.69999999999999885"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "4.79999999999999"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "3.39999999999998"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "2.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "15.399999999999983"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "8340.5999999999985"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "2.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "2.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "26.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "12.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "10633.8"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "6.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.69999999999999885"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "3.7999999999999936"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "2.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "2.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "21.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "8340.1999999999989"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "1.2999999999999834"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "1.8499999999999972"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "24.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "13.749999999999995"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "10633.8"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "6.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.69999999999999885"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "5.399999999999995"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "2.3499999999999952"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "3.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "15.399999999999983"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "8340.1999999999989"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "3.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "21.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "48.049999999999947"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "14.749999999999995"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "10633.8"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.39999999999999769"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.34999999999999942"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "6.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "1.0499999999999983"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "4.79999999999999"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "2.3499999999999952"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "3.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "15.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "8340.5999999999985"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "2.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "16.849999999999998"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "45.34999999999998"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "138.75"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "10633.8"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "6.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "6.7999999999999829"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "3.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "3.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "12.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "8340.1999999999989"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "2.2999999999999834"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "21.849999999999998"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "42.049999999999947"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "16.499999999999989"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "10633.8"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "6.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.34999999999999942"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "6.7999999999999829"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "1.349999999999995"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "3.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "15.399999999999983"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "8340.1999999999989"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "3.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "17.849999999999998"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "40.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "134.49999999999991"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "10633.8"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "62.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "23.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "10.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "24.049999999999994"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "10.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "25.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "15.399999999999988"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "26.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "233.49999999999989"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "21.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "20.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "azure",
+    "Network": "ovn",
+    "P95": "30.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "30.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.10",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "21.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "30.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "azure",
+    "Network": "sdn",
+    "P95": "50.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "ovn",
+    "P95": "135.49999999999997"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.10",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "ovn",
+    "P95": "60.349999999999994"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "24.79999999999999"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.8",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "aws",
+    "Network": "sdn",
+    "P95": "11.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "gcp",
+    "Network": "sdn",
+    "P95": "33.999999999999979"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.9",
+    "FromRelease": "4.9",
+    "Platform": "metal",
+    "Network": "sdn",
+    "P95": "0.0"
+  }
+]

--- a/pkg/synthetictests/allowedbackenddisruption/types.go
+++ b/pkg/synthetictests/allowedbackenddisruption/types.go
@@ -1,0 +1,102 @@
+package allowedbackenddisruption
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"strconv"
+	"sync"
+)
+
+const (
+	p95ViewQuery = `
+SELECT
+	BackendName,
+	Release,
+	FromRelease,
+	Platform,
+	Network,
+	ANY_VALUE(P95) AS P95,
+FROM (
+	SELECT
+		Jobs.Release,
+		Jobs.FromRelease,
+		Jobs.Platform,
+		Jobs.Network,
+		BackendName,
+		PERCENTILE_CONT(BackendDisruption.DisruptionSeconds, 0.95) OVER(PARTITION BY BackendDisruption.BackendName, Jobs.Network, Jobs.Platform, Jobs.Release, Jobs.FromRelease) AS P95,
+	FROM
+		openshift-ci-data-analysis.ci_data.BackendDisruption as BackendDisruption
+	INNER JOIN
+		openshift-ci-data-analysis.ci_data.BackendDisruption_JobRuns as JobRuns on JobRuns.Name = BackendDisruption.JobRunName
+	INNER JOIN
+		openshift-ci-data-analysis.ci_data.Jobs as Jobs on Jobs.JobName = JobRuns.JobName
+	WHERE
+		JobRuns.StartTime BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 10 DAY)
+	AND
+		TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
+)
+GROUP BY
+	BackendName, Release, FromRelease, Platform, Network
+`
+
+	p95Query = `
+SELECT * FROM openshift-ci-data-analysis.ci_data.BackendDisruption_Unified_LastWeek_P95 
+order by 
+ BackendName, Release, FromRelease, Platform, Network`
+)
+
+//go:embed query_results.json
+var queryResults []byte
+
+var (
+	readResults sync.Once
+	p95AsList   []LastWeekP95
+	p95AsMap    = map[LastWeekP95Key]LastWeekP95{}
+)
+
+type LastWeekP95 struct {
+	LastWeekP95Key `json:",inline"`
+	P95            float64
+}
+
+type LastWeekP95Key struct {
+	BackendName string
+	Release     string
+	FromRelease string
+	Platform    string
+	Network     string
+}
+
+func getCurrentResults() ([]LastWeekP95, map[LastWeekP95Key]LastWeekP95) {
+	readResults.Do(
+		func() {
+			inFile := bytes.NewBuffer(queryResults)
+			jsonDecoder := json.NewDecoder(inFile)
+
+			type DecodingLastWeekP95 struct {
+				LastWeekP95Key `json:",inline"`
+				P95            string
+			}
+			decodingP95AsList := []DecodingLastWeekP95{}
+
+			if err := jsonDecoder.Decode(&decodingP95AsList); err != nil {
+				panic(err)
+			}
+
+			for _, currDecoded := range decodingP95AsList {
+				p95, err := strconv.ParseFloat(currDecoded.P95, 64)
+				if err != nil {
+					panic(err)
+				}
+				curr := LastWeekP95{
+					LastWeekP95Key: currDecoded.LastWeekP95Key,
+					P95:            p95,
+				}
+				p95AsList = append(p95AsList, curr)
+				p95AsMap[curr.LastWeekP95Key] = curr
+			}
+		})
+
+	return p95AsList, p95AsMap
+}

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -47,7 +47,7 @@ func NewServiceLoadBalancerWithNewConnectionsTest() upgrades.Test {
 				"/echo?msg=Hello",
 				backenddisruption.NewConnectionType).
 				WithExpectedBody("Hello"),
-		).WithAllowedDisruption(allowedServiceLBDisruption).
+		).
 			WithPreSetup(serviceLBTest.loadBalancerSetup)
 
 	return serviceLBTest
@@ -66,18 +66,10 @@ func NewServiceLoadBalancerWithReusedConnectionsTest() upgrades.Test {
 				"/echo?msg=Hello",
 				backenddisruption.ReusedConnectionType).
 				WithExpectedBody("Hello"),
-		).WithAllowedDisruption(allowedServiceLBDisruption).
+		).
 			WithPreSetup(serviceLBTest.loadBalancerSetup)
 
 	return serviceLBTest
-}
-
-func allowedServiceLBDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
-	toleratedDisruption := 0.02
-	allowedDisruptionNanoseconds := int64(float64(totalDuration.Nanoseconds()) * toleratedDisruption)
-	allowedDisruption := time.Duration(allowedDisruptionNanoseconds)
-
-	return &allowedDisruption, nil
 }
 
 func (t *serviceLoadBalancerUpgradeTest) Name() string { return t.backendDisruptionTest.Name() }

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/origin/pkg/synthetictests/allowedbackenddisruption"
+
 	"github.com/onsi/ginkgo"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
@@ -29,11 +31,12 @@ type BackendDisruptionUpgradeTest interface {
 }
 
 func NewBackendDisruptionTest(testName string, backend BackendSampler) *backendDisruptionTest {
-	return &backendDisruptionTest{
-		testName:             testName,
-		backend:              backend,
-		getAllowedDisruption: NoDisruption,
+	ret := &backendDisruptionTest{
+		testName: testName,
+		backend:  backend,
 	}
+	ret.getAllowedDisruption = ret.historicalP95Disruption
+	return ret
 }
 
 func (t *backendDisruptionTest) WithAllowedDisruption(allowedDisruptionFn AllowedDisruptionFunc) *backendDisruptionTest {
@@ -55,9 +58,9 @@ func (t *backendDisruptionTest) WithPostTeardown(postTearDown TearDownFunc) *bac
 	return t
 }
 
-func NoDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
-	zero := 0 * time.Second
-	return &zero, nil
+func (t *backendDisruptionTest) historicalP95Disruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
+	backendName := t.backend.GetDisruptionBackendName() + "-" + string(t.backend.GetConnectionType()) + "-connections"
+	return allowedbackenddisruption.GetAllowedDisruption(context.Background(), backendName, f.ClientConfig())
 }
 
 type AllowedDisruptionFunc func(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error)

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -1,20 +1,12 @@
 package controlplane
 
 import (
-	"context"
-	"time"
-
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 
-	"github.com/blang/semver"
-	apiconfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/pkg/monitor"
-	"github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/disruption"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NewKubeAvailableWithNewConnectionsTest tests that the Kubernetes control plane remains available during and after a cluster upgrade.
@@ -26,7 +18,7 @@ func NewKubeAvailableWithNewConnectionsTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
 		"[sig-api-machinery] Kubernetes APIs remain available for new connections",
 		backendSampler,
-	).WithAllowedDisruption(allowedAPIServerDisruption)
+	)
 }
 
 // NewOpenShiftAvailableNewConnectionsTest tests that the OpenShift APIs remains available during and after a cluster upgrade.
@@ -38,7 +30,7 @@ func NewOpenShiftAvailableNewConnectionsTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
 		"[sig-api-machinery] OpenShift APIs remain available for new connections",
 		backendSampler,
-	).WithAllowedDisruption(allowedAPIServerDisruption)
+	)
 }
 
 // NewOAuthAvailableNewConnectionsTest tests that the OAuth APIs remains available during and after a cluster upgrade.
@@ -50,7 +42,7 @@ func NewOAuthAvailableNewConnectionsTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
 		"[sig-api-machinery] OAuth APIs remain available for new connections",
 		backendSampler,
-	).WithAllowedDisruption(allowedAPIServerDisruption)
+	)
 }
 
 // NewKubeAvailableWithConnectionReuseTest tests that the Kubernetes control plane remains available during and after a cluster upgrade.
@@ -62,7 +54,7 @@ func NewKubeAvailableWithConnectionReuseTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
 		"[sig-api-machinery] Kubernetes APIs remain available with reused connections",
 		backendSampler,
-	).WithAllowedDisruption(allowedAPIServerDisruption)
+	)
 }
 
 // NewOpenShiftAvailableWithConnectionReuseTest tests that the OpenShift APIs remains available during and after a cluster upgrade.
@@ -74,7 +66,7 @@ func NewOpenShiftAvailableWithConnectionReuseTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
 		"[sig-api-machinery] OpenShift APIs remain available with reused connections",
 		backendSampler,
-	).WithAllowedDisruption(allowedAPIServerDisruption)
+	)
 }
 
 // NewOAuthAvailableWithConnectionReuseTest tests that the OAuth APIs remains available during and after a cluster upgrade.
@@ -86,49 +78,5 @@ func NewOAuthAvailableWithConnectionReuseTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
 		"[sig-api-machinery] OAuth APIs remain available with reused connections",
 		backendSampler,
-	).WithAllowedDisruption(allowedAPIServerDisruption)
-}
-
-func allowedAPIServerDisruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, error) {
-	// starting from 4.8, enforce the requirement that control plane remains available
-	hasAllFixes, err := util.AllClusterVersionsAreGTE(semver.Version{Major: 4, Minor: 8}, f.ClientConfig())
-	if err != nil {
-		framework.Logf("Cannot require full control plane availability, some versions could not be checked: %v", err)
-	}
-
-	toleratedDisruption := 0.08
-	switch controlPlaneTopology, _ := getTopologies(f); {
-	case controlPlaneTopology == apiconfigv1.SingleReplicaTopologyMode:
-		// we cannot avoid API downtime during upgrades on single-node control plane topologies (we observe around ~10% disruption)
-		toleratedDisruption = 0.15
-
-		// We observe even higher disruption on Azure single-node upgrades
-		if framework.ProviderIs("azure") {
-			toleratedDisruption = 0.23
-		}
-	case framework.ProviderIs("azure"), framework.ProviderIs("aws"), framework.ProviderIs("gce"):
-		if hasAllFixes {
-			framework.Logf("Cluster contains no versions older than 4.8, tolerating no disruption")
-			toleratedDisruption = 0
-		}
-	}
-	allowedDisruptionNanoseconds := int64(float64(totalDuration.Nanoseconds()) * toleratedDisruption)
-	allowedDisruption := time.Duration(allowedDisruptionNanoseconds)
-
-	// TODO this should be removed early in 1/2022, but the new sampler is more responsive than the old so we cannot be tight and merge
-	if allowedDisruption < 15*time.Second {
-		allowedDisruption = 15 * time.Second
-	}
-
-	return &allowedDisruption, nil
-}
-
-func getTopologies(f *framework.Framework) (controlPlaneTopology, infraTopology apiconfigv1.TopologyMode) {
-	oc := util.NewCLIWithFramework(f)
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(),
-		"cluster", metav1.GetOptions{})
-
-	framework.ExpectNoError(err, "unable to determine cluster topology")
-
-	return infra.Status.ControlPlaneTopology, infra.Status.InfrastructureTopology
+	)
 }

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -312,25 +312,6 @@ func createTestFrameworks(tests []upgrades.Test) map[string]*framework.Framework
 	return testFrameworks
 }
 
-// ExpectNoDisruption fails if the sum of the duration of all events exceeds tolerate as a fraction ([0-1]) of total, reports a
-// disruption flake if any disruption occurs, and uses reason to prefix the message. I.e. tolerate 0.1 of 10m total will fail
-// if the sum of the intervals is greater than 1m, or report a flake if any interval is found.
-func ExpectNoDisruption(f *framework.Framework, tolerate float64, total time.Duration, events monitorapi.Intervals, reason string) {
-	FrameworkEventIntervals(f, events)
-	describe := events.Strings()
-
-	errorEvents := events.Filter(monitorapi.IsErrorEvent)
-	duration := errorEvents.Duration(1 * time.Second)
-	if percent := float64(duration) / float64(total); percent > tolerate {
-		framework.Failf("%s for at least %s of %s (%0.0f%%, but only %0.0f%% is tolerated):\n\n%s", reason, duration.Round(time.Second), total.Round(time.Second), percent*100, tolerate*100, strings.Join(describe, "\n"))
-	} else if duration > 0 {
-		FrameworkFlakef(f, "%s for at least %s of %s (%0.0f%%), this is currently sufficient to pass the"+
-			" test/job but not considered completely correct.\nTolerating up to %0.0f%% disruption:\n\n%s",
-			reason, duration.Round(time.Second), total.Round(time.Second), percent*100, tolerate*100,
-			strings.Join(describe, "\n"))
-	}
-}
-
 // ExpectNoDisruptionForDuration fails if the sum of the duration of all events exceeds allowedDisruption, reports a
 // disruption flake if any disruption occurs, and uses reason to prefix the message.
 func ExpectNoDisruptionForDuration(f *framework.Framework, allowedDisruption time.Duration, total time.Duration, events monitorapi.Intervals, reason string) {


### PR DESCRIPTION
built on https://github.com/openshift/origin/pull/26707

The last commit adds the historical data and the calculation