### PR TITLE
Bug 2026488: Skip Duplicate openshift-controller-manager Events

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -211,7 +211,7 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 
 	// any image not in the allowed prefixes is considered a failure, as the user
 	// may have added a new test image without calling the appropriate helpers
-	return func(events monitorapi.Intervals, _ time.Duration, cfg *rest.Config) []*ginkgo.JUnitTestCase {
+	return func(events monitorapi.Intervals, _ time.Duration, cfg *rest.Config, testSuite string) []*ginkgo.JUnitTestCase {
 		imageStreamPrefixes, err := imagePrefixesFromNamespaceImageStreams("openshift")
 		if err != nil {
 			klog.Errorf("Unable to identify image prefixes from the openshift namespace: %v", err)

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -12,8 +12,8 @@ import (
 // steady state (not being changed externally). Use these with suites that assume the
 // cluster is under no adversarial change (config changes, induced disruption to nodes,
 // etcd, or apis).
-func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config) (tests []*ginkgo.JUnitTestCase) {
-	tests = SystemEventInvariants(events, duration, kubeClientConfig)
+func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*ginkgo.JUnitTestCase) {
+	tests = SystemEventInvariants(events, duration, kubeClientConfig, testSuite)
 	tests = append(tests, testContainerFailures(events)...)
 	tests = append(tests, testDeleteGracePeriodZero(events)...)
 	tests = append(tests, testKubeApiserverProcessOverlap(events)...)
@@ -24,15 +24,15 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testAllAPIAvailability(events, duration)...)
 	tests = append(tests, testAllIngressAvailability(events, duration)...)
 	tests = append(tests, testStableSystemOperatorStateTransitions(events)...)
-	tests = append(tests, testDuplicatedEventForStableSystem(events, kubeClientConfig)...)
+	tests = append(tests, testDuplicatedEventForStableSystem(events, kubeClientConfig, testSuite)...)
 
 	return tests
 }
 
 // SystemUpgradeEventInvariants are invariants tested against events that should hold true in a cluster
 // that is being upgraded without induced disruption
-func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config) (tests []*ginkgo.JUnitTestCase) {
-	tests = SystemEventInvariants(events, duration, kubeClientConfig)
+func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*ginkgo.JUnitTestCase) {
+	tests = SystemEventInvariants(events, duration, kubeClientConfig, testSuite)
 	tests = append(tests, testContainerFailures(events)...)
 	tests = append(tests, testDeleteGracePeriodZero(events)...)
 	tests = append(tests, testKubeApiserverProcessOverlap(events)...)
@@ -42,14 +42,14 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testPodSandboxCreation(events)...)
 	tests = append(tests, testNodeUpgradeTransitions(events)...)
 	tests = append(tests, testUpgradeOperatorStateTransitions(events)...)
-	tests = append(tests, testDuplicatedEventForUpgrade(events, kubeClientConfig)...)
+	tests = append(tests, testDuplicatedEventForUpgrade(events, kubeClientConfig, testSuite)...)
 	return tests
 }
 
 // SystemEventInvariants are invariants tested against events that should hold true in any cluster,
 // even one undergoing disruption. These are usually focused on things that must be true on a single
 // machine, even if the machine crashes.
-func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config) (tests []*ginkgo.JUnitTestCase) {
+func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*ginkgo.JUnitTestCase) {
 	tests = append(tests, testSystemDTimeout(events)...)
 	return tests
 }

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -392,7 +392,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 	if len(events) > 0 {
 		var buf *bytes.Buffer
 		syntheticTestResults, buf, _ = createSyntheticTestsFromMonitor(events, duration)
-		testCases := syntheticEventTests.JUnitsForEvents(events, duration, restConfig)
+		testCases := syntheticEventTests.JUnitsForEvents(events, duration, restConfig, suite.Name)
 		syntheticTestResults = append(syntheticTestResults, testCases...)
 
 		if len(syntheticTestResults) > 0 {

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -16,29 +16,29 @@ type JUnitsForEvents interface {
 	// JUnitsForEvents returns a set of additional test passes or failures implied by the
 	// events sent during the test suite run. If passed is false, the entire suite is failed.
 	// To set a test as flaky, return a passing and failing JUnitTestCase with the same name.
-	JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config) []*JUnitTestCase
+	JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*JUnitTestCase
 }
 
 // JUnitForEventsFunc converts a function into the JUnitForEvents interface.
 // kubeClientConfig may or may not be present.  The JUnit evaluation needs to tolerate a missing *rest.Config
 // and an unavailable cluster without crashing.
-type JUnitForEventsFunc func(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config) []*JUnitTestCase
+type JUnitForEventsFunc func(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*JUnitTestCase
 
-func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config) []*JUnitTestCase {
-	return fn(events, duration, kubeClientConfig)
+func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*JUnitTestCase {
+	return fn(events, duration, kubeClientConfig, testSuite)
 }
 
 // JUnitsForAllEvents aggregates multiple JUnitsForEvent interfaces and returns
 // the result of all invocations. It ignores nil interfaces.
 type JUnitsForAllEvents []JUnitsForEvents
 
-func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config) []*JUnitTestCase {
+func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*JUnitTestCase {
 	var all []*JUnitTestCase
 	for _, obj := range a {
 		if obj == nil {
 			continue
 		}
-		results := obj.JUnitsForEvents(events, duration, kubeClientConfig)
+		results := obj.JUnitsForEvents(events, duration, kubeClientConfig, testSuite)
 		all = append(all, results...)
 	}
 	return all


### PR DESCRIPTION
The full build suite includes several tests that force rollouts of
openshift-controller-manager. This causes duplicate
"reason/SuccessfulDelete" events to be detected, even though these
events are being triggered by separate rollouts. To fully address this
issue, openshift-controller-manager should be installed as a Deployment
rather than a DameonSet. This has better performance semantics with
respect to rollouts, which may benefit the install and upgrade
experience and reduce these "SuccessfulDelete" events.

This change provides a mechanism for known duplicate events to be
linked to a specific test suite, in addition to a specific platform or
topology. The known problem here is limited to the openshift/build test
suite, which can flake on this check and generally fails when the suite
is run on a cluster that enables tech preview features.

This skip should be removed when Bug 2034984 is fixed.

See also:
- https://bugzilla.redhat.com/show_bug.cgi?id=2026488
- https://bugzilla.redhat.com/show_bug.cgi?id=2034984