### PR TITLE
Bug 2035128: disruption: use proxy from environment when measuring disruption

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -260,6 +260,7 @@ func (b *BackendSampler) GetHTTPClient() (*http.Client, error) {
 				IdleConnTimeout:       timeoutForPartOfRequest,
 				ResponseHeaderTimeout: timeoutForPartOfRequest,
 				ExpectContinueTimeout: timeoutForPartOfRequest,
+				Proxy:                 http.ProxyFromEnvironment,
 			}
 
 		case ReusedConnectionType:
@@ -272,6 +273,7 @@ func (b *BackendSampler) GetHTTPClient() (*http.Client, error) {
 				IdleConnTimeout:       timeoutForPartOfRequest,
 				ResponseHeaderTimeout: timeoutForPartOfRequest,
 				ExpectContinueTimeout: timeoutForPartOfRequest,
+				Proxy:                 http.ProxyFromEnvironment,
 			}
 
 		default:


### PR DESCRIPTION
In CI, metal clusters are accessed using a proxy, so the new sampler doesn't
work on metal.