### PR TITLE
allow skipping a backend test

### DIFF
--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -91,12 +91,6 @@ func (t *backendDisruptionTest) Setup(f *framework.Framework) {
 	if t.preSetup != nil {
 		framework.ExpectNoError(t.preSetup(f, t.backend))
 	}
-
-	url, err := t.backend.GetURL()
-	framework.ExpectNoError(err)
-	if len(url) == 0 {
-		framework.Failf("backend has no URL: %v", t.backend.GetLocator())
-	}
 }
 
 // Test runs a connectivity check to a route.


### PR DESCRIPTION
I think this will solve our immediate problem, but we should add a better skip for the disruption test at some future point.  I don't know that we'll need to mess with it in 4.10, but it would be a good improvement if we end up back in the disruption calculations again for some reason.

/assign @stbenjam 

adding valid BZ to allow merging 

see existing skip logic here: https://github.com/openshift/origin/blob/master/test/e2e/upgrade/service/service.go#L112-L124