### PR TITLE
Bug 201551: Use Local instead of Cluster for ext traf policy

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -132,7 +132,7 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 	tcpService, err := jig.CreateTCPService(func(s *v1.Service) {
 		s.Spec.Type = v1.ServiceTypeLoadBalancer
 		// ServiceExternalTrafficPolicyTypeCluster performs during disruption, Local does not
-		s.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster
+		s.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 		if s.Annotations == nil {
 			s.Annotations = make(map[string]string)
 		}


### PR DESCRIPTION
With OVN on GCP there there is an LB disruption when
a node is rebooted. Each node in the cluster handles
LB requests when the policy is Cluster and there is
a bug that requests will still be given to the rebooting
node as they are LB'd to each node. When that happens
the request will hang and this shows up as a disruption.
the bug still needs to be resolved as this is not a
problem in other environments (openshift-sdn, other
clouds like aws)

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>