### PR TITLE
test/extended/pods/priorityclasses: Don't complain about known bugs that have been fixed

### DIFF
--- a/test/extended/pods/priorityclasses.go
+++ b/test/extended/pods/priorityclasses.go
@@ -68,11 +68,11 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 			} else if _, ok := labels["job-name"]; ok { // or for job, we have a image-pruner running as job.
 				knownBugKey = knownBugKey[:strings.LastIndex(knownBugKey, "-")]
 			}
-			if bz, ok := knownBugs[knownBugKey]; ok {
-				knownBugList.Insert(fmt.Sprintf("Component %v has a bug associated already: %v", knownBugKey, bz))
-				continue
-			}
 			if !strings.HasPrefix(pod.Spec.PriorityClassName, "system-") && !strings.EqualFold(pod.Spec.PriorityClassName, "openshift-user-critical") {
+				if bz, ok := knownBugs[knownBugKey]; ok {
+					knownBugList.Insert(fmt.Sprintf("Component %v (%s/%s, currently %q) has a bug associated already: %v", knownBugKey, pod.Namespace, pod.Name, pod.Spec.PriorityClassName, bz))
+					continue
+				}
 				invalidPodPriority.Insert(fmt.Sprintf("%s/%s (currently %q)", pod.Namespace, pod.Name, pod.Spec.PriorityClassName))
 			}
 		}


### PR DESCRIPTION
For [example][1]:

```
  : [sig-arch] Managed cluster should ensure platform components have system-* priority class associated [Suite:openshift/conformance/parallel]
    Run #0: Failed	1s
    flake: Workloads with outstanding bugs:
    Component downloads has a bug associated already: https://bugzilla.redhat.com/show_bug.cgi?id=1954866
    Component ingress-canary has a bug associated already: https://bugzilla.redhat.com/show_bug.cgi?id=1954892
    ...
```

But [rhbz#1954866][2] was fixed in 4.8.0, and these 4.10 pods are great:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws/1474040369288056832/artifacts/e2e-aws/gather-extra/artifacts/pods.json | jq -r '.items[] | select(.metadata.name | startswith("downloads-")).spec.priorityClassName' | uniq
system-cluster-critical
```

We can't drop the exception just yet, because we still run [4.7 -> ... -> 4.10 jobs][3], and we don't want an overly strict 4.10 origin suite complaining about the lack of a priority class name when watching the initial 4.7 cluster.

But with this change, we'll no longer have a distracting flake entry complaining when there's nothing to complain about, and when we stop seeing the flakes altogether, we can drop all of the known-exception entries.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws/1474040369288056832
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1954866
[3]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.10-informing#release-openshift-origin-installer-e2e-aws-upgrade-4.7-to-4.8-to-4.9-to-4.10-ci