### PR TITLE
Bug 1919453: [release-4.6] configure tests to pull images from mirror

### DIFF
--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -2,6 +2,8 @@ package images
 
 import (
 	"context"
+	imageutil "github.com/openshift/origin/test/extended/util/image"
+	"os"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -18,6 +20,14 @@ import (
 
 var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", func() {
 	defer g.GinkgoRecover()
+
+	mirrorRegistryDefined := os.Getenv("TEST_IMAGE_MIRROR_REGISTRY") != ""
+	busyboxImage := "busybox:latest"
+	mysqlImage := "mysql:latest"
+	if mirrorRegistryDefined {
+		busyboxImage, _ = imageutil.GetE2eImageMappedToRegistry(busyboxImage, "library")
+		mysqlImage, _ = imageutil.GetE2eImageMappedToRegistry(mysqlImage, "library")
+	}
 
 	var oc *exutil.CLI
 	var ns string
@@ -48,11 +58,11 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 				Import: true,
 				Images: []imageapi.ImageImportSpec{
 					{
-						From: kapi.ObjectReference{Kind: "DockerImage", Name: "busybox:latest"},
+						From: kapi.ObjectReference{Kind: "DockerImage", Name: busyboxImage},
 						To:   &kapi.LocalObjectReference{Name: "busybox"},
 					},
 					{
-						From: kapi.ObjectReference{Kind: "DockerImage", Name: "mysql:latest"},
+						From: kapi.ObjectReference{Kind: "DockerImage", Name: mysqlImage},
 						To:   &kapi.LocalObjectReference{Name: "mysql"},
 					},
 				},

--- a/test/extended/images/info.go
+++ b/test/extended/images/info.go
@@ -3,12 +3,20 @@ package images
 import (
 	"github.com/MakeNowJust/heredoc"
 	g "github.com/onsi/ginkgo"
+	imageutil "github.com/openshift/origin/test/extended/util/image"
+	"os"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-imageregistry][Feature:ImageInfo] Image info", func() {
 	defer g.GinkgoRecover()
+
+	mirrorRegistryDefined := os.Getenv("TEST_IMAGE_MIRROR_REGISTRY") != ""
+	mysqlImage := "docker.io/library/mysql:latest"
+	if mirrorRegistryDefined {
+		mysqlImage, _ = imageutil.GetE2eImageMappedToRegistry(mysqlImage, "library")
+	}
 
 	var oc *exutil.CLI
 	var ns string
@@ -31,11 +39,11 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageInfo] Image info", func() {
 			oc image info quay.io/coreos/etcd:latest
 
 			# display info about an image on quay.io
-			oc image info docker.io/library/mysql:latest
+			oc image info %[1]s
 
 			# display info about an image in json format
 			oc image info quay.io/coreos/etcd:latest -o json
-		`)))
+		`, mysqlImage)))
 		cli.WaitForSuccess(pod.Name, podStartupTimeout)
 	})
 })

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -3,6 +3,8 @@ package images
 import (
 	"context"
 	"fmt"
+	imageutil "github.com/openshift/origin/test/extended/util/image"
+	"os"
 	"time"
 
 	g "github.com/onsi/ginkgo"
@@ -26,6 +28,14 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 	var oc *exutil.CLI
 	var ns []string
 	ctx := context.Background()
+
+	mirrorRegistryDefined := os.Getenv("TEST_IMAGE_MIRROR_REGISTRY") != ""
+	busyboxImage := "busybox:latest"
+	mysqlImage := "mysql:latest"
+	if mirrorRegistryDefined {
+		busyboxImage, _ = imageutil.GetE2eImageMappedToRegistry(busyboxImage, "library")
+		mysqlImage, _ = imageutil.GetE2eImageMappedToRegistry(mysqlImage, "library")
+	}
 
 	g.AfterEach(func() {
 		if g.CurrentGinkgoTestDescription().Failed {
@@ -85,11 +95,11 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 				Import: true,
 				Images: []imagev1.ImageImportSpec{
 					{
-						From: corev1.ObjectReference{Kind: "DockerImage", Name: "busybox:latest"},
+						From: corev1.ObjectReference{Kind: "DockerImage", Name: busyboxImage},
 						To:   &corev1.LocalObjectReference{Name: "busybox"},
 					},
 					{
-						From: corev1.ObjectReference{Kind: "DockerImage", Name: "mysql:latest"},
+						From: corev1.ObjectReference{Kind: "DockerImage", Name: mysqlImage},
 						To:   &corev1.LocalObjectReference{Name: "mysql"},
 					},
 				},

--- a/test/extended/images/trigger/annotation.go
+++ b/test/extended/images/trigger/annotation.go
@@ -2,6 +2,9 @@ package trigger
 
 import (
 	"context"
+	"fmt"
+	imageutil "github.com/openshift/origin/test/extended/util/image"
+	"os"
 	"time"
 
 	g "github.com/onsi/ginkgo"
@@ -22,6 +25,12 @@ var (
 var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers] Annotation trigger", func() {
 	defer g.GinkgoRecover()
 
+	mirrorRegistryDefined := os.Getenv("TEST_IMAGE_MIRROR_REGISTRY") != ""
+	centosImage := "docker.io/library/centos:latest"
+	if mirrorRegistryDefined {
+		centosImage, _ = imageutil.GetE2eImageMappedToRegistry(centosImage, "library")
+	}
+
 	oc := exutil.NewCLI("cli-deployment")
 
 	var (
@@ -41,8 +50,8 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers] Annotation trigge
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(o.Equal(" "))
 
-		g.By("tagging the docker.io/library/centos:latest as test:v1 image to create ImageStream")
-		out, err := oc.Run("tag").Args("docker.io/library/centos:latest", "test:v1").Output()
+		g.By(fmt.Sprintf("tagging the %s as test:v1 image to create ImageStream", centosImage))
+		out, err := oc.Run("tag").Args(centosImage, "test:v1").Output()
 		framework.Logf("%s", out)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/util/image/util.go
+++ b/test/extended/util/image/util.go
@@ -1,0 +1,30 @@
+package image
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// GetE2eImageMappedToRegistry for some CLI tests in 4.6 either no registry is provided for the image
+// and/or docker.io is hard coded.
+// returns the fully qualified path, the base image name/tag, or error
+func GetE2eImageMappedToRegistry(image string, path string) (string, error) {
+	registry, defined := os.LookupEnv("TEST_IMAGE_MIRROR_REGISTRY")
+	if !defined {
+		return "", errors.New("TEST_IMAGE_MIRROR_REGISTRY not defined")
+	}
+	baseName := ""
+	parts := strings.Split(image, "/")
+	if len(parts) < 2 {
+		baseName = image
+	} else {
+		baseName = parts[len(parts)-1]
+	}
+	if len(parts) == 3 && path == "" {
+		path = parts[1]
+	}
+
+	return fmt.Sprintf("%s/%s/%s", registry, path, baseName), nil
+}


### PR DESCRIPTION
The intention of this PR is to enable some tests in the `openshift/conformance/parallel` suite which are not subject to the mirror configuration in `/etc/containers/registries.conf` to use a mirror as the source of their required images.  

Note: The pattern in this PR could be applied to other suites as well.

This is needed due to docker.io rate limiting causing CI on some platforms on 4.6 to be in permafail.  To use the feature in this PR:
- Prior to running `openshift-tests`, `export TEST_IMAGE_MIRROR_REGISTRY=<pull-through-cache-host>:<port>`
- Configure a pull-through cache for docker.io with a certificate signed by a well-known CA on a bastion that is only reachable by the nodes executing e2e tests. For example:
~~~
podman run -d -p 5000:5000 -v /home/admin/registry_storage:/var/lib/registry:Z -v /home/admin/registry_certs:/certs:Z --restart always --name registry-docker.io -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key -e REGISTRY_PROXY_REMOTEURL="https://registry-1.docker.io" -e REGISTRY_PROXY_USERNAME=<optional user name> -e REGISTRY_PROXY_PASSWORD=<optional password> registry:2
~~~

To enable resources which can take advantage of the mirror registry, apply a [machine-config](https://github.com/openshift/release/blob/master/ci-operator/step-registry/ipi/install/vsphere/registry/ipi-install-vsphere-registry-commands.sh#L34-L52) which configures the pull-through cache as a docker.io registry mirror.  This will allow, over the course of a day or so(based on pull-rate exhaustion), for all required images to be pulled and cached.

This PR is an alternate to solution to that proposed in #26256 
