### PR TITLE
stop flaking on disruption because we always produce data for analysis

### DIFF
--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -324,11 +324,6 @@ func ExpectNoDisruptionForDuration(f *framework.Framework, allowedDisruption tim
 	roundedDisruptionDuration := disruptionDuration.Round(time.Second)
 	if roundedDisruptionDuration > roundedAllowedDisruption {
 		framework.Failf("%s for at least %s of %s (maxAllowed=%s):\n\n%s", reason, roundedDisruptionDuration, total.Round(time.Second), roundedAllowedDisruption, strings.Join(describe, "\n"))
-	} else if roundedDisruptionDuration > 0 {
-		FrameworkFlakef(f, "%s for at least %s of %s (maxAllowed=%s), this is currently sufficient to pass the"+
-			" test/job but not considered completely correct.\nTolerating up to %s disruption:\n\n%s",
-			reason, roundedDisruptionDuration, total.Round(time.Second), roundedAllowedDisruption, roundedAllowedDisruption,
-			strings.Join(describe, "\n"))
 	}
 }
 


### PR DESCRIPTION
we produce backend-disruption_20220107-223048.json, so no longer need to have the flake noise on every CI run.