### PR TITLE
Bug 2038389: Fix vsphere testing workarounds

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -78,7 +78,7 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 	// currently UPI install defaults to HW 13 which causes events in 4.10 CI
 	// since 4.10 still supports vSphere 6.5, we can't default to HW 15 in RHCOS image but such clusters are unupgradable to 4.11 and hence
 	// events are still valid.
-	regexp.MustCompile(`ns/openshift-cluster-storage-operator\s+deployment/vsphere-problem-detector-operator - reason/VSphereOlderVersionDetected.+vmx-13`),
+	regexp.MustCompile(`ns/openshift-cluster-csi-drivers\s+deployment/vmware-vsphere-csi-driver-operator - reason/check_deprecated_hw_version.+vmx-13`),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{

--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -75,10 +75,6 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 	// If image pulls in e2e namespaces fail catastrophically we'd expect them to lead to test failures
 	// We are deliberately not ignoring image pull failures for core component namespaces
 	regexp.MustCompile(`ns/e2e-.* reason/BackOff Back-off pulling image`),
-	// currently UPI install defaults to HW 13 which causes events in 4.10 CI
-	// since 4.10 still supports vSphere 6.5, we can't default to HW 15 in RHCOS image but such clusters are unupgradable to 4.11 and hence
-	// events are still valid.
-	regexp.MustCompile(`ns/openshift-cluster-csi-drivers\s+deployment/vmware-vsphere-csi-driver-operator - reason/check_deprecated_hw_version.+vmx-13`),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -84,10 +84,6 @@ func TestEventRegexExcluder(t *testing.T) {
 			name:    "local-volume-failed-scheduling",
 			message: `ns/e2e-persistent-local-volumes-test-7012 pod/pod-940713ce-7645-4d8c-bba0-5705350a5655 reason/FailedScheduling 0/6 nodes are available: 1 node(s) had volume node affinity conflict, 2 node(s) didn't match Pod's node affinity/selector, 3 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate. (2 times)`,
 		},
-		{
-			name:    "vsphere-hw-13-default-upi-install",
-			message: `ns/openshift-cluster-csi-drivers deployment/vmware-vsphere-csi-driver-operator - reason/check_deprecated_hw_version Marking cluster un-upgradeable because node control-plane-1 has hardware version vmx-13, which is below the minimum required version 15`,
-		},
 	}
 
 	for _, test := range tests {

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -86,7 +86,7 @@ func TestEventRegexExcluder(t *testing.T) {
 		},
 		{
 			name:    "vsphere-hw-13-default-upi-install",
-			message: `ns/openshift-cluster-storage-operator deployment/vsphere-problem-detector-operator - reason/VSphereOlderVersionDetected Marking cluster un-upgradeable because one or more VMs are on hardware version vmx-13`,
+			message: `ns/openshift-cluster-csi-drivers deployment/vmware-vsphere-csi-driver-operator - reason/check_deprecated_hw_version Marking cluster un-upgradeable because node control-plane-1 has hardware version vmx-13, which is below the minimum required version 15`,
 		},
 	}
 

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	vmxPattern = regexp.MustCompile(`VSphereProblemDetectorControllerUpgradeable.+vmx-13`)
+	vmxPattern = regexp.MustCompile(`VMwareVSphereControllerUpgradeable.+vmx-13`)
 )
 
 var _ = g.Describe("[sig-arch][Early] Managed cluster should", func() {


### PR DESCRIPTION
We changed the operator that is responsible for marking cluster as un-upgradeable. so update the e2e workarounds accordingly for UPI installs.

xref https://bugzilla.redhat.com/show_bug.cgi?id=2038389

