### PR TITLE
use route to access prometheus instead of exec pods.

### DIFF
--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -64,8 +64,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed clu
 var _ = g.Describe("[sig-node] Managed cluster", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc               = exutil.NewCLIWithoutNamespace("managed-cluster-node")
-		prometheusClient = oc.NewPrometheusClient(context.TODO())
+		oc = exutil.NewCLIWithoutNamespace("managed-cluster-node")
 	)
 
 	g.It("should report ready nodes the entire duration of the test run [Late]", func() {
@@ -80,7 +79,7 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 			// 1m30s and we can live with ith
 			fmt.Sprintf(`(min_over_time((max by (node) (kube_node_status_condition{condition="Ready",status="true"} offset 1m) and (((max by (node) (kube_node_status_condition offset 1m))) and (0*max by (node) (kube_node_status_condition offset 7m)) and (0*max by (node) (kube_node_status_condition))))[%s:1s])) < 1`, testDuration): false,
 		}
-		err := prometheus.RunQueries(context.TODO(), prometheusClient, tests, oc)
+		err := prometheus.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), tests, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 })

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -64,25 +64,11 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed clu
 var _ = g.Describe("[sig-node] Managed cluster", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithoutNamespace("managed-cluster-node")
-
-		url, bearerToken string
+		oc               = exutil.NewCLIWithoutNamespace("managed-cluster-node")
+		prometheusClient = oc.NewPrometheusClient(context.TODO())
 	)
-	g.BeforeEach(func() {
-		var ok bool
-		url, _, bearerToken, ok = prometheus.LocatePrometheus(oc)
-		if !ok {
-			e2e.Failf("Prometheus could not be located on this cluster, failing prometheus test")
-		}
-	})
 
 	g.It("should report ready nodes the entire duration of the test run [Late]", func() {
-		ns := oc.SetupNamespace()
-		execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
-		defer func() {
-			oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
-		}()
-
 		// we only consider samples since the beginning of the test
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
@@ -94,7 +80,7 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 			// 1m30s and we can live with ith
 			fmt.Sprintf(`(min_over_time((max by (node) (kube_node_status_condition{condition="Ready",status="true"} offset 1m) and (((max by (node) (kube_node_status_condition offset 1m))) and (0*max by (node) (kube_node_status_condition offset 7m)) and (0*max by (node) (kube_node_status_condition))))[%s:1s])) < 1`, testDuration): false,
 		}
-		err := prometheus.RunQueries(tests, oc, ns, execPod.Name, url, bearerToken)
+		err := prometheus.RunQueries(context.TODO(), prometheusClient, tests, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 })

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -18,18 +18,8 @@ import (
 var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc               = exutil.NewCLIWithoutNamespace("prometheus")
-		prometheusClient = oc.NewPrometheusClient(context.TODO())
-
-		url, bearerToken string
+		oc = exutil.NewCLIWithoutNamespace("prometheus")
 	)
-	g.BeforeEach(func() {
-		var ok bool
-		url, _, bearerToken, ok = helper.LocatePrometheus(oc)
-		if !ok {
-			e2eskipper.Skipf("Prometheus could not be located on this cluster, skipping prometheus test")
-		}
-	})
 
 	g.AfterEach(func() {
 		if g.CurrentGinkgoTestDescription().Failed {
@@ -66,7 +56,7 @@ var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus
 			terminalTests := map[string]bool{
 				buildCountMetricName: true,
 			}
-			err = helper.RunQueries(context.TODO(), prometheusClient, terminalTests, oc)
+			err = helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), terminalTests, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// NOTE:  in manual testing on a laptop, starting several serial builds in succession was sufficient for catching

--- a/test/extended/prometheus/storage.go
+++ b/test/extended/prometheus/storage.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/origin/pkg/test/ginkgo/result"
 	exutil "github.com/openshift/origin/test/extended/util"
 	helper "github.com/openshift/origin/test/extended/util/prometheus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -44,11 +43,6 @@ var _ = g.Describe("[sig-storage][Late] Metrics", func() {
 
 func checkOperation(oc *exutil.CLI, url string, bearerToken string, component string, name string, threshold int) {
 	plugins := []string{"kubernetes.io/azure-disk", "kubernetes.io/aws-ebs", "kubernetes.io/gce-pd", "kubernetes.io/cinder", "kubernetes.io/vsphere-volume"}
-	ns := oc.SetupNamespace()
-	execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
-	defer func() {
-		oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
-	}()
 
 	// we only consider series sent since the beginning of the test
 	testDuration := exutil.DurationSinceStartInSeconds().String()
@@ -69,7 +63,7 @@ func checkOperation(oc *exutil.CLI, url string, bearerToken string, component st
 		tests[query] = false
 	}
 
-	err := helper.RunQueries(tests, oc, ns, execPod.Name, url, bearerToken)
+	err := helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), tests, oc)
 	if err != nil {
 		result.Flakef("Operation %s of plugin %s took more than %d seconds: %s", name, plugins, threshold, err)
 	}

--- a/test/extended/prometheus/upgrade.go
+++ b/test/extended/prometheus/upgrade.go
@@ -2,11 +2,12 @@ package prometheus
 
 import (
 	"context"
+	"time"
+
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
 	helper "github.com/openshift/origin/test/extended/util/prometheus"
-	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +19,7 @@ import (
 // MetricsAvailableAfterUpgradeTest tests that metrics from before an upgrade
 // are also available after the upgrade.
 type MetricsAvailableAfterUpgradeTest struct {
-	executionTimestamp      model.Time
+	executionTimestamp      time.Time
 	persistentVolumeEnabled bool
 }
 
@@ -31,47 +32,27 @@ func (t *MetricsAvailableAfterUpgradeTest) DisplayName() string {
 }
 
 func (t *MetricsAvailableAfterUpgradeTest) Setup(f *e2e.Framework) {
+	ctx := context.Background()
 	oc := exutil.NewCLIWithFramework(f)
-	queryUrl, _, bearerToken, ok := helper.LocatePrometheus(oc)
-	if !ok {
-		e2e.Failf("Prometheus could not be located on this cluster, failing test %s", t.Name())
-	}
-
-	ns := oc.SetupNamespace()
-	execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
-
-	defer func() {
-		oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
-	}()
 
 	g.By("getting the prometheus_build_info metric before the upgrade")
 	preUpgradeQuery := `prometheus_build_info{pod="prometheus-k8s-0"}`
-	preUpgradeResponse, err := helper.RunQuery(preUpgradeQuery, ns, execPod.Name, queryUrl, bearerToken)
+	preUpgradeResponse, err := helper.RunQuery(ctx, oc.NewPrometheusClient(ctx), preUpgradeQuery)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(preUpgradeResponse.Data.Result).NotTo(o.BeEmpty())
 
-	t.executionTimestamp = preUpgradeResponse.Data.Result[0].Timestamp
+	t.executionTimestamp = preUpgradeResponse.Data.Result[0].Timestamp.Time()
 }
 
 func (t *MetricsAvailableAfterUpgradeTest) Test(f *e2e.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	ctx := context.Background()
 	<-done
 
 	oc := exutil.NewCLIWithFramework(f)
-	queryUrl, _, bearerToken, ok := helper.LocatePrometheus(oc)
-	if !ok {
-		e2e.Failf("Prometheus could not be located on this cluster, failing test %s", t.Name())
-	}
-
-	ns := oc.SetupNamespace()
-	execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
-
-	defer func() {
-		oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
-	}()
 
 	g.By("verifying that the timeseries is queryable at the same timestamp after the upgrade")
 	postUpgradeQuery := `prometheus_build_info{pod="prometheus-k8s-0"}`
-	postUpgradeResponse, err := helper.RunQueryAtTime(postUpgradeQuery, ns, execPod.Name, queryUrl, bearerToken, t.executionTimestamp)
+	postUpgradeResponse, err := helper.RunQueryAtTime(ctx, oc.NewPrometheusClient(ctx), postUpgradeQuery, t.executionTimestamp)
 
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(postUpgradeResponse.Data.Result).NotTo(o.BeEmpty())


### PR DESCRIPTION
This reduces the dependency chain and eliminates a source of error.  Just use the route directly.