### PR TITLE
Record zero for known alerts

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	"github.com/openshift/library-go/pkg/image/reference"
@@ -211,7 +213,7 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 
 	// any image not in the allowed prefixes is considered a failure, as the user
 	// may have added a new test image without calling the appropriate helpers
-	return func(events monitorapi.Intervals, _ time.Duration, cfg *rest.Config, testSuite string) []*ginkgo.JUnitTestCase {
+	return func(events monitorapi.Intervals, _ time.Duration, cfg *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
 		imageStreamPrefixes, err := imagePrefixesFromNamespaceImageStreams("openshift")
 		if err != nil {
 			klog.Errorf("Unable to identify image prefixes from the openshift namespace: %v", err)
@@ -227,7 +229,7 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 
 		allowedPrefixes := allowedPrefixes.List()
 
-		var tests []*ginkgo.JUnitTestCase
+		var tests []*junitapi.JUnitTestCase
 
 		pulls := make(map[string]sets.String)
 		for _, event := range events {
@@ -269,17 +271,17 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 					fmt.Fprintf(buf, "  %s\n", locator)
 				}
 			}
-			tests = append(tests, &ginkgo.JUnitTestCase{
+			tests = append(tests, &junitapi.JUnitTestCase{
 				Name:      "[sig-arch] Only known images used by tests",
 				SystemOut: buf.String(),
-				FailureOutput: &ginkgo.FailureOutput{
+				FailureOutput: &junitapi.FailureOutput{
 					Output: fmt.Sprintf("Cluster accessed images that were not mirrored to the testing repository or already part of the cluster, see test/extended/util/image/README.md in the openshift/origin repo:\n\n%s", buf.String()),
 				},
 			})
 
 		} else {
 			// if the test passed, indicate that too.
-			tests = append(tests, &ginkgo.JUnitTestCase{
+			tests = append(tests, &junitapi.JUnitTestCase{
 				Name: "[sig-arch] Only known images used by tests",
 			})
 		}

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -211,6 +211,14 @@ type runOptions struct {
 	config *cluster.ClusterConfiguration
 }
 
+func NewRunOptions(fromRepository string) *runOptions {
+	return &runOptions{
+		Options: *testginkgo.NewOptions(),
+
+		FromRepository: fromRepository,
+	}
+}
+
 func (opt *runOptions) AsEnv() []string {
 	var args []string
 	args = append(args, "KUBE_TEST_REPO_LIST=") // explicitly prevent selective override
@@ -258,9 +266,7 @@ func (opt *runOptions) SelectSuite(suites testSuites, args []string) (*testSuite
 }
 
 func newRunCommand() *cobra.Command {
-	opt := &runOptions{
-		FromRepository: defaultTestImageMirrorLocation,
-	}
+	opt := NewRunOptions(defaultTestImageMirrorLocation)
 
 	cmd := &cobra.Command{
 		Use:   "run SUITE",
@@ -313,9 +319,7 @@ func newRunCommand() *cobra.Command {
 }
 
 func newRunUpgradeCommand() *cobra.Command {
-	opt := &runOptions{
-		FromRepository: defaultTestImageMirrorLocation,
-	}
+	opt := NewRunOptions(defaultTestImageMirrorLocation)
 
 	cmd := &cobra.Command{
 		Use:   "run-upgrade SUITE",
@@ -439,12 +443,6 @@ func newRunTestCommand() *cobra.Command {
 // any error returned from fn. The function returns fn() or any error encountered while
 // attempting to open the file.
 func mirrorToFile(opt *testginkgo.Options, fn func() error) error {
-	if opt.Out == nil {
-		opt.Out = os.Stdout
-	}
-	if opt.ErrOut == nil {
-		opt.ErrOut = os.Stderr
-	}
 	if len(opt.OutFile) == 0 {
 		return fn()
 	}

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -169,26 +169,17 @@ type EventIntervalMatchesFunc func(eventInterval EventInterval) bool
 
 // IsErrorEvent returns true if the eventInterval is an Error
 func IsErrorEvent(eventInterval EventInterval) bool {
-	if eventInterval.Level == Error {
-		return true
-	}
-	return false
+	return eventInterval.Level == Error
 }
 
 // IsWarningEvent returns true if the eventInterval is an Warning
 func IsWarningEvent(eventInterval EventInterval) bool {
-	if eventInterval.Level == Warning {
-		return true
-	}
-	return false
+	return eventInterval.Level == Warning
 }
 
 // IsInfoEvent returns true if the eventInterval is an Info
 func IsInfoEvent(eventInterval EventInterval) bool {
-	if eventInterval.Level == Info {
-		return true
-	}
-	return false
+	return eventInterval.Level == Info
 }
 
 func And(filters ...EventIntervalMatchesFunc) EventIntervalMatchesFunc {

--- a/pkg/monitor/write_job_run_data.go
+++ b/pkg/monitor/write_job_run_data.go
@@ -6,38 +6,38 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"sort"
 	"strings"
-
-	"sigs.k8s.io/kustomize/kyaml/sets"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 	"github.com/openshift/origin/test/extended/testdata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/kustomize/kyaml/sets"
 )
 
-// WriteRunDataToArtifactsDir attempts to write useful run data to the specified directory.
-func WriteRunDataToArtifactsDir(artifactDir string, monitor *Monitor, events monitorapi.Intervals, timeSuffix string) error {
+func WriteEventsForJobRun(artifactDir string, monitor *Monitor, events monitorapi.Intervals, timeSuffix string) error {
+	return monitorserialization.EventsToFile(filepath.Join(artifactDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)), events)
+}
+
+func WriteEventsIntervalsForJobRun(artifactDir string, monitor *Monitor, events monitorapi.Intervals, timeSuffix string) error {
+	return monitorserialization.EventsIntervalsToFile(filepath.Join(artifactDir, fmt.Sprintf("e2e-intervals%s.json", timeSuffix)), events)
+}
+
+func WriteEventsIntervalsHTMLForJobRun(artifactDir string, monitor *Monitor, events monitorapi.Intervals, timeSuffix string) error {
+	eventIntervalsJSON, err := monitorserialization.EventsIntervalsToJSON(events)
+	if err != nil {
+		return err
+	}
+	e2eChartTemplate := testdata.MustAsset("e2echart/e2e-chart-template.html")
+	e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)
+	e2eChartHTMLPath := filepath.Join(artifactDir, fmt.Sprintf("e2e-intervals%s.html", timeSuffix))
+
+	return ioutil.WriteFile(e2eChartHTMLPath, e2eChartHTML, 0644)
+}
+
+func WriteTrackedResourcesForJobRun(artifactDir string, monitor *Monitor, events monitorapi.Intervals, timeSuffix string) error {
 	errors := []error{}
-	if err := monitorserialization.EventsToFile(filepath.Join(artifactDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)), events); err != nil {
-		errors = append(errors, err)
-	} else {
-	}
-	if err := monitorserialization.EventsIntervalsToFile(filepath.Join(artifactDir, fmt.Sprintf("e2e-intervals%s.json", timeSuffix)), events); err != nil {
-		errors = append(errors, err)
-	}
-	if eventIntervalsJSON, err := monitorserialization.EventsIntervalsToJSON(events); err == nil {
-		e2eChartTemplate := testdata.MustAsset("e2echart/e2e-chart-template.html")
-		e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)
-		e2eChartHTMLPath := filepath.Join(artifactDir, fmt.Sprintf("e2e-intervals%s.html", timeSuffix))
-		if err := ioutil.WriteFile(e2eChartHTMLPath, e2eChartHTML, 0644); err != nil {
-			errors = append(errors, err)
-		}
-	} else {
-		errors = append(errors, err)
-	}
 
 	// write out the current state of resources that we explicitly tracked.
 	resourcesMap := monitor.CurrentResourceState()
@@ -48,17 +48,12 @@ func WriteRunDataToArtifactsDir(artifactDir string, monitor *Monitor, events mon
 		}
 	}
 
-	backendDisruption := computeDisruptionData(events)
-	if err := writeDisruptionData(filepath.Join(artifactDir, fmt.Sprintf("backend-disruption%s.json", timeSuffix)), backendDisruption); err != nil {
-		errors = append(errors, err)
-	}
-
-	alertData := computeAlertData(events)
-	if err := writeAlertData(filepath.Join(artifactDir, fmt.Sprintf("alerts%s.json", timeSuffix)), alertData); err != nil {
-		errors = append(errors, err)
-	}
-
 	return utilerrors.NewAggregate(errors)
+}
+
+func WriteBackendDisruptionForJobRun(artifactDir string, monitor *Monitor, events monitorapi.Intervals, timeSuffix string) error {
+	backendDisruption := computeDisruptionData(events)
+	return writeDisruptionData(filepath.Join(artifactDir, fmt.Sprintf("backend-disruption%s.json", timeSuffix)), backendDisruption)
 }
 
 type BackendDisruptionList struct {
@@ -113,132 +108,4 @@ func computeDisruptionData(eventIntervals monitorapi.Intervals) *BackendDisrupti
 	}
 
 	return ret
-}
-
-type AlertList struct {
-	// Alerts is keyed by name to make the consumption easier
-	Alerts []Alert
-}
-
-// name and namespace are consistent (usually) for every CI run
-type AlertKey struct {
-	Name      string
-	Namespace string
-	Level     AlertLevel
-}
-
-type AlertKeyByAlert []AlertKey
-
-func (a AlertKeyByAlert) Len() int      { return len(a) }
-func (a AlertKeyByAlert) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a AlertKeyByAlert) Less(i, j int) bool {
-	if strings.Compare(a[i].Name, a[j].Name) < 0 {
-		return true
-	}
-	if strings.Compare(a[i].Namespace, a[j].Namespace) < 0 {
-		return true
-	}
-	if strings.Compare(string(a[i].Level), string(a[j].Level)) < 0 {
-		return true
-	}
-
-	return false
-}
-
-type AlertLevel string
-
-var (
-	UnknownAlertLevel  AlertLevel = "Unknown"
-	WarningAlertLevel  AlertLevel = "Warning"
-	CriticalAlertLevel AlertLevel = "Critical"
-)
-
-type Alert struct {
-	AlertKey `json:",inline"`
-	Duration metav1.Duration
-}
-
-type AlertByKey []Alert
-
-func (a AlertByKey) Len() int      { return len(a) }
-func (a AlertByKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a AlertByKey) Less(i, j int) bool {
-	if strings.Compare(a[i].Name, a[j].Name) < 0 {
-		return true
-	}
-	if strings.Compare(a[i].Namespace, a[j].Namespace) < 0 {
-		return true
-	}
-	if strings.Compare(string(a[i].Level), string(a[j].Level)) < 0 {
-		return true
-	}
-
-	return false
-}
-
-func writeAlertData(filename string, alertData *AlertList) error {
-	jsonContent, err := json.MarshalIndent(alertData, "", "    ")
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(filename, jsonContent, 0644)
-}
-
-func getAlertLevelFromEvent(event monitorapi.EventInterval) AlertLevel {
-	if event.Level == monitorapi.Error {
-		return CriticalAlertLevel
-	}
-	if event.Level == monitorapi.Warning {
-		return WarningAlertLevel
-	}
-	return UnknownAlertLevel
-}
-
-func computeAlertData(events monitorapi.Intervals) *AlertList {
-	alertEvents := events.Filter(
-		func(eventInterval monitorapi.EventInterval) bool {
-			locator := monitorapi.LocatorParts(eventInterval.Locator)
-			alertName := monitorapi.AlertFrom(locator)
-			if len(alertName) == 0 {
-				return false
-			}
-			if alertName == "Watchdog" {
-				return false
-			}
-			// skip everything but warning and critical
-			if getAlertLevelFromEvent(eventInterval) == UnknownAlertLevel {
-				return false
-			}
-			return true
-		},
-	)
-
-	alertMap := map[AlertKey]*Alert{}
-	for _, alertInterval := range alertEvents {
-		alertLocator := monitorapi.LocatorParts(alertInterval.Locator)
-		alertKey := AlertKey{
-			Name:      monitorapi.AlertFrom(alertLocator),
-			Namespace: monitorapi.NamespaceFrom(alertLocator),
-			Level:     getAlertLevelFromEvent(alertInterval),
-		}
-		alert, ok := alertMap[alertKey]
-		if !ok {
-			alert = &Alert{
-				AlertKey: alertKey,
-			}
-		}
-		//the same alert can fire multiple times, so we add all the durations together
-		alert.Duration = metav1.Duration{Duration: alert.Duration.Duration + alertInterval.To.Sub(alertInterval.From)}
-		alertMap[alertKey] = alert
-	}
-
-	alertList := []Alert{}
-	for _, alert := range alertMap {
-		alertList = append(alertList, *alert)
-	}
-	sort.Stable(AlertByKey(alertList))
-
-	return &AlertList{
-		Alerts: alertList,
-	}
 }

--- a/pkg/synthetictests/alerts.go
+++ b/pkg/synthetictests/alerts.go
@@ -3,16 +3,16 @@ package synthetictests
 import (
 	"context"
 
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
 	"k8s.io/client-go/rest"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
-	"github.com/openshift/origin/pkg/test/ginkgo"
-
 	"github.com/openshift/origin/pkg/synthetictests/allowedalerts"
 )
 
-func testAlerts(events monitorapi.Intervals, restConfig *rest.Config) []*ginkgo.JUnitTestCase {
-	ret := []*ginkgo.JUnitTestCase{}
+func testAlerts(events monitorapi.Intervals, restConfig *rest.Config) []*junitapi.JUnitTestCase {
+	ret := []*junitapi.JUnitTestCase{}
 
 	alertTests := allowedalerts.AllAlertTests()
 	for i := range alertTests {
@@ -20,9 +20,9 @@ func testAlerts(events monitorapi.Intervals, restConfig *rest.Config) []*ginkgo.
 
 		junit, err := alertTest.InvariantCheck(context.TODO(), restConfig, events)
 		if err != nil {
-			ret = append(ret, &ginkgo.JUnitTestCase{
+			ret = append(ret, &junitapi.JUnitTestCase{
 				Name: alertTest.InvariantTestName(),
-				FailureOutput: &ginkgo.FailureOutput{
+				FailureOutput: &junitapi.FailureOutput{
 					Output: err.Error(),
 				},
 				SystemOut: err.Error(),

--- a/pkg/synthetictests/allowedalerts/all.go
+++ b/pkg/synthetictests/allowedalerts/all.go
@@ -2,7 +2,34 @@ package allowedalerts
 
 func AllAlertTests() []AlertTest {
 	return []AlertTest{
+		newAlert("etcd", "etcdMembersDown").pending().neverFail(),
+		newAlert("etcd", "etcdMembersDown").firing(),
+		newAlert("etcd", "etcdGRPCRequestsSlow").pending().neverFail(),
+		newAlert("etcd", "etcdGRPCRequestsSlow").firing(),
+		newAlert("etcd", "etcdHighNumberOfFailedGRPCRequests").pending().neverFail(),
+		newAlert("etcd", "etcdHighNumberOfFailedGRPCRequests").firing(),
+		newAlert("etcd", "etcdMemberCommunicationSlow").pending().neverFail(),
+		newAlert("etcd", "etcdMemberCommunicationSlow").firing(),
+		newAlert("etcd", "etcdNoLeader").pending().neverFail(),
+		newAlert("etcd", "etcdNoLeader").firing(),
+		newAlert("etcd", "etcdHighFsyncDurations").pending().neverFail(),
+		newAlert("etcd", "etcdHighFsyncDurations").firing(),
+		newAlert("etcd", "etcdHighCommitDurations").pending().neverFail(),
+		newAlert("etcd", "etcdHighCommitDurations").firing(),
+		newAlert("etcd", "etcdInsufficientMembers").pending().neverFail(),
+		newAlert("etcd", "etcdInsufficientMembers").firing(),
+		newAlert("etcd", "etcdHighNumberOfLeaderChanges").pending().neverFail(),
+		newAlert("etcd", "etcdHighNumberOfLeaderChanges").firing(),
+
 		newAlert("kube-apiserver", "KubeAPIErrorBudgetBurn").pending().neverFail(),
 		newAlert("kube-apiserver", "KubeAPIErrorBudgetBurn").firing(),
+		newAlert("kube-apiserver", "KubeClientErrors").pending().neverFail(),
+		newAlert("kube-apiserver", "KubeClientErrors").firing(),
+
+		newAlert("storage", "KubePersistentVolumeErrors").pending().neverFail(),
+		newAlert("storage", "KubePersistentVolumeErrors").firing(),
+
+		newAlert("machine config operator", "MCDDrainError").pending().neverFail(),
+		newAlert("machine config operator", "MCDDrainError").firing(),
 	}
 }

--- a/pkg/synthetictests/allowedalerts/basic_alert.go
+++ b/pkg/synthetictests/allowedalerts/basic_alert.go
@@ -111,11 +111,11 @@ func (a *basicAlertTest) TestNamePrefix() string {
 }
 
 func (a *basicAlertTest) LateTestNameSuffix() string {
-	return fmt.Sprintf("alert/%s should not at or above %s", a.alertName, a.alertState)
+	return fmt.Sprintf("alert/%s should not be at or above %s", a.alertName, a.alertState)
 }
 
 func (a *basicAlertTest) InvariantTestName() string {
-	return fmt.Sprintf("[bz-%v][invariant] alert/%s should not at or above %s", a.bugzillaComponent, a.alertName, a.alertState)
+	return fmt.Sprintf("[bz-%v][invariant] alert/%s should not be at or above %s", a.bugzillaComponent, a.alertName, a.alertState)
 }
 
 func (a *basicAlertTest) AlertName() string {

--- a/pkg/synthetictests/allowedalerts/job_run_data.go
+++ b/pkg/synthetictests/allowedalerts/job_run_data.go
@@ -1,0 +1,174 @@
+package allowedalerts
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func WriteAlertDataForJobRun(artifactDir string, monitor *monitor.Monitor, events monitorapi.Intervals, timeSuffix string) error {
+	alertData := computeAlertData(events)
+	addMissingAlertsForLevel(alertData, WarningAlertLevel)
+	addMissingAlertsForLevel(alertData, CriticalAlertLevel)
+
+	return writeAlertData(filepath.Join(artifactDir, fmt.Sprintf("alerts%s.json", timeSuffix)), alertData)
+}
+
+func addMissingAlertsForLevel(alertList *AlertList, level AlertLevel) {
+	wellKnownAlerts := sets.NewString()
+	for _, alertTest := range AllAlertTests() {
+		wellKnownAlerts.Insert(alertTest.AlertName())
+	}
+	alertsFound := sets.NewString()
+	for _, alert := range alertList.Alerts {
+		if alert.Level == level {
+			alertsFound.Insert(alert.Name)
+		}
+	}
+	for _, missingAlert := range wellKnownAlerts.Difference(alertsFound).List() {
+		alertList.Alerts = append(alertList.Alerts, Alert{
+			AlertKey: AlertKey{
+				Name:  missingAlert,
+				Level: level,
+			},
+			Duration: metav1.Duration{Duration: 0 * time.Second},
+		})
+	}
+}
+
+type AlertList struct {
+	// Alerts is keyed by name to make the consumption easier
+	Alerts []Alert
+}
+
+// name and namespace are consistent (usually) for every CI run
+type AlertKey struct {
+	Name      string
+	Namespace string
+	Level     AlertLevel
+}
+
+type AlertKeyByAlert []AlertKey
+
+func (a AlertKeyByAlert) Len() int      { return len(a) }
+func (a AlertKeyByAlert) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a AlertKeyByAlert) Less(i, j int) bool {
+	if strings.Compare(a[i].Name, a[j].Name) < 0 {
+		return true
+	}
+	if strings.Compare(a[i].Namespace, a[j].Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(string(a[i].Level), string(a[j].Level)) < 0 {
+		return true
+	}
+
+	return false
+}
+
+type AlertLevel string
+
+var (
+	UnknownAlertLevel  AlertLevel = "Unknown"
+	WarningAlertLevel  AlertLevel = "Warning"
+	CriticalAlertLevel AlertLevel = "Critical"
+)
+
+type Alert struct {
+	AlertKey `json:",inline"`
+	Duration metav1.Duration
+}
+
+type AlertByKey []Alert
+
+func (a AlertByKey) Len() int      { return len(a) }
+func (a AlertByKey) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a AlertByKey) Less(i, j int) bool {
+	if strings.Compare(a[i].Name, a[j].Name) < 0 {
+		return true
+	}
+	if strings.Compare(a[i].Namespace, a[j].Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(string(a[i].Level), string(a[j].Level)) < 0 {
+		return true
+	}
+
+	return false
+}
+
+func writeAlertData(filename string, alertData *AlertList) error {
+	jsonContent, err := json.MarshalIndent(alertData, "", "    ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filename, jsonContent, 0644)
+}
+
+func getAlertLevelFromEvent(event monitorapi.EventInterval) AlertLevel {
+	if event.Level == monitorapi.Error {
+		return CriticalAlertLevel
+	}
+	if event.Level == monitorapi.Warning {
+		return WarningAlertLevel
+	}
+	return UnknownAlertLevel
+}
+
+func computeAlertData(events monitorapi.Intervals) *AlertList {
+	alertEvents := events.Filter(
+		func(eventInterval monitorapi.EventInterval) bool {
+			locator := monitorapi.LocatorParts(eventInterval.Locator)
+			alertName := monitorapi.AlertFrom(locator)
+			if len(alertName) == 0 {
+				return false
+			}
+			if alertName == "Watchdog" {
+				return false
+			}
+			// skip everything but warning and critical
+			if getAlertLevelFromEvent(eventInterval) == UnknownAlertLevel {
+				return false
+			}
+			return true
+		},
+	)
+
+	alertMap := map[AlertKey]*Alert{}
+	for _, alertInterval := range alertEvents {
+		alertLocator := monitorapi.LocatorParts(alertInterval.Locator)
+		alertKey := AlertKey{
+			Name:      monitorapi.AlertFrom(alertLocator),
+			Namespace: monitorapi.NamespaceFrom(alertLocator),
+			Level:     getAlertLevelFromEvent(alertInterval),
+		}
+		alert, ok := alertMap[alertKey]
+		if !ok {
+			alert = &Alert{
+				AlertKey: alertKey,
+			}
+		}
+		//the same alert can fire multiple times, so we add all the durations together
+		alert.Duration = metav1.Duration{Duration: alert.Duration.Duration + alertInterval.To.Sub(alertInterval.From)}
+		alertMap[alertKey] = alert
+	}
+
+	alertList := []Alert{}
+	for _, alert := range alertMap {
+		alertList = append(alertList, *alert)
+	}
+	sort.Stable(AlertByKey(alertList))
+
+	return &AlertList{
+		Alerts: alertList,
+	}
+}

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -3,8 +3,9 @@ package synthetictests
 import (
 	"time"
 
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
-	"github.com/openshift/origin/pkg/test/ginkgo"
 	"k8s.io/client-go/rest"
 )
 
@@ -12,7 +13,7 @@ import (
 // steady state (not being changed externally). Use these with suites that assume the
 // cluster is under no adversarial change (config changes, induced disruption to nodes,
 // etcd, or apis).
-func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*ginkgo.JUnitTestCase) {
+func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*junitapi.JUnitTestCase) {
 	tests = SystemEventInvariants(events, duration, kubeClientConfig, testSuite)
 	tests = append(tests, testContainerFailures(events)...)
 	tests = append(tests, testDeleteGracePeriodZero(events)...)
@@ -36,7 +37,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 
 // SystemUpgradeEventInvariants are invariants tested against events that should hold true in a cluster
 // that is being upgraded without induced disruption
-func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*ginkgo.JUnitTestCase) {
+func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*junitapi.JUnitTestCase) {
 	tests = SystemEventInvariants(events, duration, kubeClientConfig, testSuite)
 	tests = append(tests, testContainerFailures(events)...)
 	tests = append(tests, testDeleteGracePeriodZero(events)...)
@@ -59,7 +60,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 // SystemEventInvariants are invariants tested against events that should hold true in any cluster,
 // even one undergoing disruption. These are usually focused on things that must be true on a single
 // machine, even if the machine crashes.
-func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*ginkgo.JUnitTestCase) {
+func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*junitapi.JUnitTestCase) {
 	tests = append(tests, testSystemDTimeout(events)...)
 	return tests
 }

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -5,23 +5,24 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/pkg/monitor"
-	"github.com/openshift/origin/pkg/test/ginkgo"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func testStableSystemOperatorStateTransitions(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
+func testStableSystemOperatorStateTransitions(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded})
 }
 
-func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*ginkgo.JUnitTestCase {
+func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded})
 }
-func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []configv1.ClusterStatusConditionType) []*ginkgo.JUnitTestCase {
-	ret := []*ginkgo.JUnitTestCase{}
+func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []configv1.ClusterStatusConditionType) []*junitapi.JUnitTestCase {
+	ret := []*junitapi.JUnitTestCase{}
 
 	var start, stop time.Time
 	for _, event := range events {
@@ -46,7 +47,7 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 			testName := fmt.Sprintf("[bz-%v] clusteroperator/%v should not change condition/%v", bzComponent, operatorName, condition)
 			operatorEvents := eventsByOperator[operatorName]
 			if len(operatorEvents) == 0 {
-				ret = append(ret, &ginkgo.JUnitTestCase{
+				ret = append(ret, &junitapi.JUnitTestCase{
 					Name:     testName,
 					Duration: duration,
 				})
@@ -55,17 +56,17 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 
 			failures := testOperatorState(condition, operatorEvents, e2eEventIntervals)
 			if len(failures) > 0 {
-				ret = append(ret, &ginkgo.JUnitTestCase{
+				ret = append(ret, &junitapi.JUnitTestCase{
 					Name:      testName,
 					Duration:  duration,
 					SystemOut: strings.Join(failures, "\n"),
-					FailureOutput: &ginkgo.FailureOutput{
+					FailureOutput: &junitapi.FailureOutput{
 						Output: fmt.Sprintf("%d unexpected clusteroperator state transitions during e2e test run \n\n%v", len(failures), strings.Join(failures, "\n")),
 					},
 				})
 			}
 			// always add a success so we flake and not fail
-			ret = append(ret, &ginkgo.JUnitTestCase{Name: testName})
+			ret = append(ret, &junitapi.JUnitTestCase{Name: testName})
 		}
 	}
 

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
 	"github.com/openshift/origin/pkg/synthetictests/allowedalerts"
 
 	"github.com/onsi/ginkgo/config"
@@ -365,7 +367,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 	pass, fail, skip, failing := summarizeTests(tests)
 
 	// monitor the cluster while the tests are running and report any detected anomalies
-	var syntheticTestResults []*JUnitTestCase
+	var syntheticTestResults []*junitapi.JUnitTestCase
 	var syntheticFailure bool
 	timeSuffix := fmt.Sprintf("_%s", start.UTC().Format("20060102-150405"))
 	events := m.Intervals(time.Time{}, time.Time{})

--- a/pkg/test/ginkgo/junit.go
+++ b/pkg/test/ginkgo/junit.go
@@ -9,119 +9,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
 	"github.com/openshift/origin/pkg/version"
 )
 
-// The below types are directly marshalled into XML. The types correspond to jUnit
-// XML schema, but do not contain all valid fields. For instance, the class name
-// field for test cases is omitted, as this concept does not directly apply to Go.
-// For XML specifications see http://help.catchsoftware.com/display/ET/JUnit+Format
-// or view the XSD included in this package as 'junit.xsd'
-
-// TestSuites represents a flat collection of jUnit test suites.
-type JUnitTestSuites struct {
-	XMLName xml.Name `xml:"testsuites"`
-
-	// Suites are the jUnit test suites held in this collection
-	Suites []*JUnitTestSuite `xml:"testsuite"`
-}
-
-// TestSuite represents a single jUnit test suite, potentially holding child suites.
-type JUnitTestSuite struct {
-	XMLName xml.Name `xml:"testsuite"`
-
-	// Name is the name of the test suite
-	Name string `xml:"name,attr"`
-
-	// NumTests records the number of tests in the TestSuite
-	NumTests uint `xml:"tests,attr"`
-
-	// NumSkipped records the number of skipped tests in the suite
-	NumSkipped uint `xml:"skipped,attr"`
-
-	// NumFailed records the number of failed tests in the suite
-	NumFailed uint `xml:"failures,attr"`
-
-	// Duration is the time taken in seconds to run all tests in the suite
-	Duration float64 `xml:"time,attr"`
-
-	// Properties holds other properties of the test suite as a mapping of name to value
-	Properties []*TestSuiteProperty `xml:"properties,omitempty"`
-
-	// TestCases are the test cases contained in the test suite
-	TestCases []*JUnitTestCase `xml:"testcase"`
-
-	// Children holds nested test suites
-	Children []*JUnitTestSuite `xml:"testsuite"`
-}
-
-// TestSuiteProperty contains a mapping of a property name to a value
-type TestSuiteProperty struct {
-	XMLName xml.Name `xml:"property"`
-
-	Name  string `xml:"name,attr"`
-	Value string `xml:"value,attr"`
-}
-
-// JUnitTestCase represents a jUnit test case
-type JUnitTestCase struct {
-	XMLName xml.Name `xml:"testcase"`
-
-	// Name is the name of the test case
-	Name string `xml:"name,attr"`
-
-	// Classname is an attribute set by the package type and is required
-	Classname string `xml:"classname,attr,omitempty"`
-
-	// Duration is the time taken in seconds to run the test
-	Duration float64 `xml:"time,attr"`
-
-	// SkipMessage holds the reason why the test was skipped
-	SkipMessage *SkipMessage `xml:"skipped"`
-
-	// FailureOutput holds the output from a failing test
-	FailureOutput *FailureOutput `xml:"failure"`
-
-	// SystemOut is output written to stdout during the execution of this test case
-	SystemOut string `xml:"system-out,omitempty"`
-
-	// SystemErr is output written to stderr during the execution of this test case
-	SystemErr string `xml:"system-err,omitempty"`
-}
-
-// SkipMessage holds a message explaining why a test was skipped
-type SkipMessage struct {
-	XMLName xml.Name `xml:"skipped"`
-
-	// Message explains why the test was skipped
-	Message string `xml:"message,attr,omitempty"`
-}
-
-// FailureOutput holds the output from a failing test
-type FailureOutput struct {
-	XMLName xml.Name `xml:"failure"`
-
-	// Message holds the failure message from the test
-	Message string `xml:"message,attr"`
-
-	// Output holds verbose failure output from the test
-	Output string `xml:",chardata"`
-}
-
-// TestResult is the result of a test case
-type TestResult string
-
-const (
-	TestResultPass TestResult = "pass"
-	TestResultSkip TestResult = "skip"
-	TestResultFail TestResult = "fail"
-)
-
-func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, duration time.Duration, errOut io.Writer, additionalResults ...*JUnitTestCase) error {
-	s := &JUnitTestSuite{
+func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, duration time.Duration, errOut io.Writer, additionalResults ...*junitapi.JUnitTestCase) error {
+	s := &junitapi.JUnitTestSuite{
 		Name:     name,
 		Duration: duration.Seconds(),
-		Properties: []*TestSuiteProperty{
+		Properties: []*junitapi.TestSuiteProperty{
 			{
 				Name:  "TestVersion",
 				Value: version.Get().String(),
@@ -133,22 +30,22 @@ func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, du
 		case test.skipped:
 			s.NumTests++
 			s.NumSkipped++
-			s.TestCases = append(s.TestCases, &JUnitTestCase{
+			s.TestCases = append(s.TestCases, &junitapi.JUnitTestCase{
 				Name:      test.name,
 				SystemOut: string(test.out),
 				Duration:  test.duration.Seconds(),
-				SkipMessage: &SkipMessage{
+				SkipMessage: &junitapi.SkipMessage{
 					Message: lastLinesUntil(string(test.out), 100, "skip ["),
 				},
 			})
 		case test.failed:
 			s.NumTests++
 			s.NumFailed++
-			s.TestCases = append(s.TestCases, &JUnitTestCase{
+			s.TestCases = append(s.TestCases, &junitapi.JUnitTestCase{
 				Name:      test.name,
 				SystemOut: string(test.out),
 				Duration:  test.duration.Seconds(),
-				FailureOutput: &FailureOutput{
+				FailureOutput: &junitapi.FailureOutput{
 					Output: lastLinesUntil(string(test.out), 100, "fail ["),
 				},
 			})
@@ -156,17 +53,17 @@ func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, du
 			if test.flake {
 				s.NumTests++
 				s.NumFailed++
-				s.TestCases = append(s.TestCases, &JUnitTestCase{
+				s.TestCases = append(s.TestCases, &junitapi.JUnitTestCase{
 					Name:      test.name,
 					SystemOut: string(test.out),
 					Duration:  test.duration.Seconds(),
-					FailureOutput: &FailureOutput{
+					FailureOutput: &junitapi.FailureOutput{
 						Output: lastLinesUntil(string(test.out), 100, "flake:"),
 					},
 				})
 			}
 			s.NumTests++
-			s.TestCases = append(s.TestCases, &JUnitTestCase{
+			s.TestCases = append(s.TestCases, &junitapi.JUnitTestCase{
 				Name:     test.name,
 				Duration: test.duration.Seconds(),
 			})

--- a/pkg/test/ginkgo/junitapi/types.go
+++ b/pkg/test/ginkgo/junitapi/types.go
@@ -1,0 +1,99 @@
+package junitapi
+
+import "encoding/xml"
+
+// The below types are directly marshalled into XML. The types correspond to jUnit
+// XML schema, but do not contain all valid fields. For instance, the class name
+// field for test cases is omitted, as this concept does not directly apply to Go.
+// For XML specifications see http://help.catchsoftware.com/display/ET/JUnit+Format
+// or view the XSD included in this package as 'junit.xsd'
+
+// TestSuites represents a flat collection of jUnit test suites.
+type JUnitTestSuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	// Suites are the jUnit test suites held in this collection
+	Suites []*JUnitTestSuite `xml:"testsuite"`
+}
+
+// TestSuite represents a single jUnit test suite, potentially holding child suites.
+type JUnitTestSuite struct {
+	XMLName xml.Name `xml:"testsuite"`
+
+	// Name is the name of the test suite
+	Name string `xml:"name,attr"`
+
+	// NumTests records the number of tests in the TestSuite
+	NumTests uint `xml:"tests,attr"`
+
+	// NumSkipped records the number of skipped tests in the suite
+	NumSkipped uint `xml:"skipped,attr"`
+
+	// NumFailed records the number of failed tests in the suite
+	NumFailed uint `xml:"failures,attr"`
+
+	// Duration is the time taken in seconds to run all tests in the suite
+	Duration float64 `xml:"time,attr"`
+
+	// Properties holds other properties of the test suite as a mapping of name to value
+	Properties []*TestSuiteProperty `xml:"properties,omitempty"`
+
+	// TestCases are the test cases contained in the test suite
+	TestCases []*JUnitTestCase `xml:"testcase"`
+
+	// Children holds nested test suites
+	Children []*JUnitTestSuite `xml:"testsuite"`
+}
+
+// TestSuiteProperty contains a mapping of a property name to a value
+type TestSuiteProperty struct {
+	XMLName xml.Name `xml:"property"`
+
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// JUnitTestCase represents a jUnit test case
+type JUnitTestCase struct {
+	XMLName xml.Name `xml:"testcase"`
+
+	// Name is the name of the test case
+	Name string `xml:"name,attr"`
+
+	// Classname is an attribute set by the package type and is required
+	Classname string `xml:"classname,attr,omitempty"`
+
+	// Duration is the time taken in seconds to run the test
+	Duration float64 `xml:"time,attr"`
+
+	// SkipMessage holds the reason why the test was skipped
+	SkipMessage *SkipMessage `xml:"skipped"`
+
+	// FailureOutput holds the output from a failing test
+	FailureOutput *FailureOutput `xml:"failure"`
+
+	// SystemOut is output written to stdout during the execution of this test case
+	SystemOut string `xml:"system-out,omitempty"`
+
+	// SystemErr is output written to stderr during the execution of this test case
+	SystemErr string `xml:"system-err,omitempty"`
+}
+
+// SkipMessage holds a message explaining why a test was skipped
+type SkipMessage struct {
+	XMLName xml.Name `xml:"skipped"`
+
+	// Message explains why the test was skipped
+	Message string `xml:"message,attr,omitempty"`
+}
+
+// FailureOutput holds the output from a failing test
+type FailureOutput struct {
+	XMLName xml.Name `xml:"failure"`
+
+	// Message holds the failure message from the test
+	Message string `xml:"message,attr"`
+
+	// Output holds verbose failure output from the test
+	Output string `xml:",chardata"`
+}

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
 	"k8s.io/client-go/rest"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -16,15 +18,15 @@ type JUnitsForEvents interface {
 	// JUnitsForEvents returns a set of additional test passes or failures implied by the
 	// events sent during the test suite run. If passed is false, the entire suite is failed.
 	// To set a test as flaky, return a passing and failing JUnitTestCase with the same name.
-	JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*JUnitTestCase
+	JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase
 }
 
 // JUnitForEventsFunc converts a function into the JUnitForEvents interface.
 // kubeClientConfig may or may not be present.  The JUnit evaluation needs to tolerate a missing *rest.Config
 // and an unavailable cluster without crashing.
-type JUnitForEventsFunc func(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*JUnitTestCase
+type JUnitForEventsFunc func(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase
 
-func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*JUnitTestCase {
+func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
 	return fn(events, duration, kubeClientConfig, testSuite)
 }
 
@@ -32,8 +34,8 @@ func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.Intervals, durati
 // the result of all invocations. It ignores nil interfaces.
 type JUnitsForAllEvents []JUnitsForEvents
 
-func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*JUnitTestCase {
-	var all []*JUnitTestCase
+func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
+	var all []*junitapi.JUnitTestCase
 	for _, obj := range a {
 		if obj == nil {
 			continue
@@ -44,8 +46,8 @@ func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.Intervals, duratio
 	return all
 }
 
-func createSyntheticTestsFromMonitor(events monitorapi.Intervals, monitorDuration time.Duration) ([]*JUnitTestCase, *bytes.Buffer, *bytes.Buffer) {
-	var syntheticTestResults []*JUnitTestCase
+func createSyntheticTestsFromMonitor(events monitorapi.Intervals, monitorDuration time.Duration) ([]*junitapi.JUnitTestCase, *bytes.Buffer, *bytes.Buffer) {
+	var syntheticTestResults []*junitapi.JUnitTestCase
 
 	buf, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
 	fmt.Fprintf(buf, "\nTimeline:\n\n")
@@ -63,17 +65,17 @@ func createSyntheticTestsFromMonitor(events monitorapi.Intervals, monitorDuratio
 	if errorCount > 0 {
 		syntheticTestResults = append(
 			syntheticTestResults,
-			&JUnitTestCase{
+			&junitapi.JUnitTestCase{
 				Name:      monitorTestName,
 				SystemOut: buf.String(),
 				Duration:  monitorDuration.Seconds(),
-				FailureOutput: &FailureOutput{
+				FailureOutput: &junitapi.FailureOutput{
 					Output: fmt.Sprintf("%d error level events were detected during this test run:\n\n%s", errorCount, errBuf.String()),
 				},
 			},
 			// write a passing test to trigger detection of this issue as a flake, indicating we have no idea whether
 			// these are actual failures or not
-			&JUnitTestCase{
+			&junitapi.JUnitTestCase{
 				Name:     monitorTestName,
 				Duration: monitorDuration.Seconds(),
 			},
@@ -82,7 +84,7 @@ func createSyntheticTestsFromMonitor(events monitorapi.Intervals, monitorDuratio
 		// even if no error events, add a passed test including the output so we can scan with search.ci:
 		syntheticTestResults = append(
 			syntheticTestResults,
-			&JUnitTestCase{
+			&junitapi.JUnitTestCase{
 				Name:      monitorTestName,
 				Duration:  monitorDuration.Seconds(),
 				SystemOut: buf.String(),

--- a/pkg/test/ginkgo/write_job_run_data.go
+++ b/pkg/test/ginkgo/write_job_run_data.go
@@ -1,0 +1,30 @@
+package ginkgo
+
+import (
+	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type RunDataWriter interface {
+	WriteRunData(artifactDir string, monitor *monitor.Monitor, events monitorapi.Intervals, timeSuffix string) error
+}
+
+type RunDataWriterFunc func(artifactDir string, monitor *monitor.Monitor, events monitorapi.Intervals, timeSuffix string) error
+
+func (fn RunDataWriterFunc) WriteRunData(artifactDir string, monitor *monitor.Monitor, events monitorapi.Intervals, timeSuffix string) error {
+	return fn(artifactDir, monitor, events, timeSuffix)
+}
+
+// WriteRunDataToArtifactsDir attempts to write useful run data to the specified directory.
+func (opt *Options) WriteRunDataToArtifactsDir(artifactDir string, monitor *monitor.Monitor, events monitorapi.Intervals, timeSuffix string) error {
+	errs := []error{}
+
+	for _, writer := range opt.RunDataWriters {
+		currErr := writer.WriteRunData(artifactDir, monitor, events, timeSuffix)
+		if currErr != nil {
+			errs = append(errs, currErr)
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -619,9 +619,57 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch][Late] operators should not create watch channels very often": "operators should not create watch channels very often [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch][bz-kube-apiserver][Late] Alerts alert/KubeAPIErrorBudgetBurn should not at or above info": "alert/KubeAPIErrorBudgetBurn should not at or above info [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdGRPCRequestsSlow should not be at or above info": "alert/etcdGRPCRequestsSlow should not be at or above info [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch][bz-kube-apiserver][Late] Alerts alert/KubeAPIErrorBudgetBurn should not at or above pending": "alert/KubeAPIErrorBudgetBurn should not at or above pending [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdGRPCRequestsSlow should not be at or above pending": "alert/etcdGRPCRequestsSlow should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdHighCommitDurations should not be at or above info": "alert/etcdHighCommitDurations should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdHighCommitDurations should not be at or above pending": "alert/etcdHighCommitDurations should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdHighFsyncDurations should not be at or above info": "alert/etcdHighFsyncDurations should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdHighFsyncDurations should not be at or above pending": "alert/etcdHighFsyncDurations should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdHighNumberOfFailedGRPCRequests should not be at or above info": "alert/etcdHighNumberOfFailedGRPCRequests should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdHighNumberOfFailedGRPCRequests should not be at or above pending": "alert/etcdHighNumberOfFailedGRPCRequests should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdHighNumberOfLeaderChanges should not be at or above info": "alert/etcdHighNumberOfLeaderChanges should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdHighNumberOfLeaderChanges should not be at or above pending": "alert/etcdHighNumberOfLeaderChanges should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdInsufficientMembers should not be at or above info": "alert/etcdInsufficientMembers should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdInsufficientMembers should not be at or above pending": "alert/etcdInsufficientMembers should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdMemberCommunicationSlow should not be at or above info": "alert/etcdMemberCommunicationSlow should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdMemberCommunicationSlow should not be at or above pending": "alert/etcdMemberCommunicationSlow should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdMembersDown should not be at or above info": "alert/etcdMembersDown should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdMembersDown should not be at or above pending": "alert/etcdMembersDown should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdNoLeader should not be at or above info": "alert/etcdNoLeader should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-etcd][Late] Alerts alert/etcdNoLeader should not be at or above pending": "alert/etcdNoLeader should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-kube-apiserver][Late] Alerts alert/KubeAPIErrorBudgetBurn should not be at or above info": "alert/KubeAPIErrorBudgetBurn should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-kube-apiserver][Late] Alerts alert/KubeAPIErrorBudgetBurn should not be at or above pending": "alert/KubeAPIErrorBudgetBurn should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-kube-apiserver][Late] Alerts alert/KubeClientErrors should not be at or above info": "alert/KubeClientErrors should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-kube-apiserver][Late] Alerts alert/KubeClientErrors should not be at or above pending": "alert/KubeClientErrors should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-machine config operator][Late] Alerts alert/MCDDrainError should not be at or above info": "alert/MCDDrainError should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-machine config operator][Late] Alerts alert/MCDDrainError should not be at or above pending": "alert/MCDDrainError should not be at or above pending [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-storage][Late] Alerts alert/KubePersistentVolumeErrors should not be at or above info": "alert/KubePersistentVolumeErrors should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-storage][Late] Alerts alert/KubePersistentVolumeErrors should not be at or above pending": "alert/KubePersistentVolumeErrors should not be at or above pending [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth] Certificates API [Privileged:ClusterAdmin] should support CSR API operations [Conformance]": "should support CSR API operations [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift/origin/pkg/synthetictests/allowedbackenddisruption"
-
 	"github.com/onsi/ginkgo"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/synthetictests/allowedbackenddisruption"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/kubernetes/test/e2e/framework"


### PR DESCRIPTION
We have a list of known alerts now that is fairly easy to add to.  This is useful to allow us to indicate those runs where this alert did not fire.  This will allow us to find proper percentile values.

/assign @dgoodwin 