### PR TITLE
Display ErrImagePull messages.

### DIFF
--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -428,18 +428,18 @@ func buildTestsFailIfRegexMatch(testName string, matchRE, dontMatchRE *regexp.Re
 		return []*ginkgo.JUnitTestCase{success}
 	}
 
-	locators := make([]string, 0, len(matchedIntervals))
+	matchedIntervalMsgs := make([]string, 0, len(matchedIntervals))
 	for _, ei := range matchedIntervals {
-		locators = append(locators, ei.Locator)
+		matchedIntervalMsgs = append(matchedIntervalMsgs, fmt.Sprintf("%s: %s", ei.Locator, ei.Message))
 	}
-	sort.Strings(locators)
+	sort.Strings(matchedIntervalMsgs)
 
 	failure := &ginkgo.JUnitTestCase{
 		Name:      testName,
 		SystemOut: strings.Join(matchedIntervals.Strings(), "\n"),
 		FailureOutput: &ginkgo.FailureOutput{
 			Output: fmt.Sprintf("Found %d ErrImagePull intervals for: \n\n%s",
-				len(locators), strings.Join(locators, "\n")),
+				len(matchedIntervalMsgs), strings.Join(matchedIntervalMsgs, "\n")),
 		},
 	}
 


### PR DESCRIPTION
Previously when listing the image pull problems we only showed the
location of the problem pod, but we do not see the actual message. As
such it's not possible to tell where we're pulling from.

Modified to include the interval message on each line which should
indicate where the pull problem was from.
