### PR TITLE
Bug 2039539: Allow apiserver burn rate alert to fire in CI

### DIFF
--- a/pkg/synthetictests/allowedalerts/all.go
+++ b/pkg/synthetictests/allowedalerts/all.go
@@ -24,7 +24,7 @@ func AllAlertTests() []AlertTest {
 		newAlert("etcd", "etcdHighNumberOfLeaderChanges").firing(),
 
 		newAlert("kube-apiserver", "KubeAPIErrorBudgetBurn").pending().neverFail(),
-		newAlert("kube-apiserver", "KubeAPIErrorBudgetBurn").firing().neverFail(), // https://bugzilla.redhat.com/show_bug.cgi?id=2039539
+		newAlert("kube-apiserver", "KubeAPIErrorBudgetBurn").firing(),
 		newAlert("kube-apiserver", "KubeClientErrors").pending().neverFail(),
 		newAlert("kube-apiserver", "KubeClientErrors").firing(),
 


### PR DESCRIPTION
Allow the apiserver burn rate to fire since it is a great umbrella alert
to notice anything going wrong in the cluster. With the new thresholds
coming from upstream, it will only fire when a big enough disruption
impacting our SLO is happening.

Holding until https://github.com/openshift/cluster-kube-apiserver-operator/pull/1284 is merged.

/hold
/cc @deads2k @tkashem 