### PR TITLE
Alter junit test suite names for jobs with multiple junit xmls.

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -306,7 +306,7 @@ func newRunCommand() *cobra.Command {
 				if !opt.DryRun {
 					fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 				}
-				err = opt.Run(&suite.TestSuite)
+				err = opt.Run(&suite.TestSuite, "openshift-tests")
 				if suite.PostSuite != nil {
 					suite.PostSuite(opt)
 				}
@@ -369,7 +369,7 @@ func newRunUpgradeCommand() *cobra.Command {
 				if !opt.DryRun {
 					fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 				}
-				err = opt.Run(&suite.TestSuite)
+				err = opt.Run(&suite.TestSuite, "openshift-tests-upgrade")
 				if suite.PostSuite != nil {
 					suite.PostSuite(opt)
 				}

--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
-// upgradeSuites are all known upgade test suites this binary should run
+// upgradeSuites are all known upgrade test suites this binary should run
 var upgradeSuites = testSuites{
 	{
 		TestSuite: ginkgo.TestSuite{

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -134,7 +134,7 @@ func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite,
 	return suite, nil
 }
 
-func (opt *Options) Run(suite *TestSuite) error {
+func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 	if len(opt.Regex) > 0 {
 		if err := filterWithRegex(suite, opt.Regex); err != nil {
 			return err
@@ -484,7 +484,7 @@ func (opt *Options) Run(suite *TestSuite) error {
 	}
 
 	if len(opt.JUnitDir) > 0 {
-		if err := writeJUnitReport("junit_e2e", "openshift-tests", tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
+		if err := writeJUnitReport("junit_e2e", junitSuiteName, tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
 			fmt.Fprintf(opt.Out, "error: Unable to write e2e JUnit results: %v", err)
 		}
 	}


### PR DESCRIPTION
Reverts [26686](https://github.com/openshift/origin/pull/26686)