### PR TITLE
Add test for OS updates being staged within 5-10m.

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -31,6 +31,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testErrImagePullGenericOpenShiftNamespaces(events)...)
 	tests = append(tests, testErrImagePullGeneric(events)...)
 	tests = append(tests, testAlerts(events, kubeClientConfig)...)
+	tests = append(tests, testOperatorOSUpdateStaged(events)...)
 
 	return tests
 }
@@ -54,6 +55,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testErrImagePullGenericOpenShiftNamespaces(events)...)
 	tests = append(tests, testErrImagePullGeneric(events)...)
 	tests = append(tests, testAlerts(events, kubeClientConfig)...)
+	tests = append(tests, testOperatorOSUpdateStaged(events)...)
 	return tests
 }
 


### PR DESCRIPTION
Recent test failure investigation led to a possibility of slow disk
speeds doing OS content extraction. Add a test to ensure that we move
from OSUpdateStarted to OSUpdateStaged within 5-10 minutes, which
primarily just encompasses extraction of the content.

If any node is over 10 minutes we will fail the test, if some are over 5
we'll flake instead.
