### PR TITLE
split watchdog test into its own test

### DIFF
--- a/pkg/synthetictests/allowedalerts/all.go
+++ b/pkg/synthetictests/allowedalerts/all.go
@@ -2,6 +2,8 @@ package allowedalerts
 
 func AllAlertTests() []AlertTest {
 	return []AlertTest{
+		newWatchdogAlert(),
+
 		newAlert("etcd", "etcdMembersDown").pending().neverFail(),
 		newAlert("etcd", "etcdMembersDown").firing(),
 		newAlert("etcd", "etcdGRPCRequestsSlow").pending().neverFail(),

--- a/pkg/synthetictests/allowedalerts/basic_alert.go
+++ b/pkg/synthetictests/allowedalerts/basic_alert.go
@@ -33,11 +33,6 @@ type AlertTest interface {
 
 	TestAlert(ctx context.Context, prometheusClient prometheusv1.API, restConfig *rest.Config) error
 	InvariantCheck(ctx context.Context, restConfig *rest.Config, intervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error)
-
-	// FailAfter is the amount of time that an alert can be at or above the current state before failing a test
-	FailAfter(jobType platformidentification.JobType) time.Duration
-	// FlakeAfter is the amount of time that an alert can be at or above the current state before flaking a test
-	FlakeAfter(jobType platformidentification.JobType) time.Duration
 }
 
 // AlertState is the state of the alert. They are logically ordered, so if a test says it limits on "pending", then

--- a/pkg/synthetictests/allowedalerts/watchdog.go
+++ b/pkg/synthetictests/allowedalerts/watchdog.go
@@ -1,0 +1,109 @@
+package allowedalerts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	o "github.com/onsi/gomega"
+	helper "github.com/openshift/origin/test/extended/util/prometheus"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+type watchdogAlertTest struct {
+}
+
+func newWatchdogAlert() *watchdogAlertTest {
+	return &watchdogAlertTest{}
+}
+
+func (a *watchdogAlertTest) toTest() AlertTest {
+	return a
+}
+
+func (a *watchdogAlertTest) TestNamePrefix() string {
+	return "[bz-monitoring][Late] Alerts"
+}
+
+func (a *watchdogAlertTest) LateTestNameSuffix() string {
+	return "alert/Watchdog must have no gaps or changes"
+}
+
+func (a *watchdogAlertTest) InvariantTestName() string {
+	return "[bz-monitoring][invariant] alert/Watchdog must have no gaps or changes"
+}
+
+func (a *watchdogAlertTest) AlertName() string {
+	return "Watchdog"
+}
+
+func (a *watchdogAlertTest) AlertState() AlertState {
+	return AlertInfo
+}
+
+func (a *watchdogAlertTest) TestAlert(ctx context.Context, prometheusClient prometheusv1.API, restConfig *rest.Config) error {
+	testDuration := exutil.DurationSinceStartInSeconds().String()
+
+	// Invariant: The watchdog alert should be firing continuously during the whole upgrade via the thanos
+	// querier (which should have no gaps when it queries the individual stores). Allow zero or one changes
+	// to the presence of this series (zero if data is preserved over upgrade, one if data is lost on upgrade).
+	// This would not catch the alert stopping firing, but we catch that in other places and tests.
+	watchdogQuery := fmt.Sprintf(`changes((max((ALERTS{alertstate="firing",alertname="Watchdog",severity="none"}) or (absent(ALERTS{alertstate="firing",alertname="Watchdog",severity="none"})*0)))[%s:1s]) > 1`, testDuration)
+	result, err := helper.RunQuery(ctx, prometheusClient, watchdogQuery)
+	if err != nil {
+		return fmt.Errorf("unable to check watchdog alert over the window: %v", err)
+	}
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if len(result.Data.Result) > 0 {
+		framework.Failf("Watchdog alert had %s changes during the run, which may be a sign of a Prometheus outage in violation of the prometheus query SLO of 100%% uptime", result.Data.Result[0].Value)
+	}
+
+	return nil
+}
+
+func IsWatchdogAlert(eventInterval monitorapi.EventInterval) bool {
+	return eventInterval.Locator == "alert/Watchdog ns/openshift-monitoring"
+}
+
+func (a *watchdogAlertTest) InvariantCheck(ctx context.Context, restConfig *rest.Config, alertIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	watchdogIntervals := alertIntervals.Filter(IsWatchdogAlert)
+	describe := watchdogIntervals.Strings()
+
+	switch len(watchdogIntervals) {
+	case 1:
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: a.InvariantTestName(),
+			},
+		}, nil
+	case 0:
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: a.InvariantTestName(),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: "Watchdog alert not found",
+				},
+				SystemOut: "Watchdog alert not found",
+			},
+		}, nil
+	default:
+		message := fmt.Sprintf("Watchdog alert had %v changes during the run, which may be a sign of a Prometheus outage in violation of the prometheus query SLO of 100%% uptime\n\n%s", len(alertIntervals), strings.Join(describe, "\n"))
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: a.InvariantTestName(),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: message,
+				},
+				SystemOut: message,
+			},
+		}, nil
+
+	}
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -667,6 +667,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch][bz-machine config operator][Late] Alerts alert/MCDDrainError should not be at or above pending": "alert/MCDDrainError should not be at or above pending [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-arch][bz-monitoring][Late] Alerts alert/Watchdog must have no gaps or changes": "alert/Watchdog must have no gaps or changes [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-arch][bz-storage][Late] Alerts alert/KubePersistentVolumeErrors should not be at or above info": "alert/KubePersistentVolumeErrors should not be at or above info [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][bz-storage][Late] Alerts alert/KubePersistentVolumeErrors should not be at or above pending": "alert/KubePersistentVolumeErrors should not be at or above pending [Suite:openshift/conformance/parallel]",
@@ -1847,7 +1849,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't exceed the 500 series limit of total series sent via telemetry from each cluster": "shouldn't exceed the 500 series limit of total series sent via telemetry from each cluster [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any alerts in firing or pending state apart from Watchdog and AlertmanagerReceiversNotConfigured and have no gaps in Watchdog firing": "shouldn't report any alerts in firing or pending state apart from Watchdog and AlertmanagerReceiversNotConfigured and have no gaps in Watchdog firing [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any unexpected alerts in firing or pending state": "shouldn't report any unexpected alerts in firing or pending state [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules should have a runbook_url annotation if the alert is critical": "should have a runbook_url annotation if the alert is critical [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
This separates the "no gaps in watchdog" into a separate test so we can track success/failure for it distinct from other alerts failing and avoid noise in the signal without losing the test coverage.

This also adds it as an invariant check at the end of runs to cover all those cases that aren't running [Late] tests.