### PR TITLE
separate prometheus watch alerts

### DIFF
--- a/pkg/synthetictests/allowedalerts/all.go
+++ b/pkg/synthetictests/allowedalerts/all.go
@@ -33,5 +33,8 @@ func AllAlertTests() []AlertTest {
 
 		newAlert("machine config operator", "MCDDrainError").pending().neverFail(),
 		newAlert("machine config operator", "MCDDrainError").firing(),
+
+		newAlert("monitoring", "PrometheusOperatorWatchErrors").pending().neverFail(),
+		newAlert("monitoring", "PrometheusOperatorWatchErrors").firing(),
 	}
 }

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -667,6 +667,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch][bz-machine config operator][Late] Alerts alert/MCDDrainError should not be at or above pending": "alert/MCDDrainError should not be at or above pending [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-arch][bz-monitoring][Late] Alerts alert/PrometheusOperatorWatchErrors should not be at or above info": "alert/PrometheusOperatorWatchErrors should not be at or above info [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch][bz-monitoring][Late] Alerts alert/PrometheusOperatorWatchErrors should not be at or above pending": "alert/PrometheusOperatorWatchErrors should not be at or above pending [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-arch][bz-monitoring][Late] Alerts alert/Watchdog must have no gaps or changes": "alert/Watchdog must have no gaps or changes [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][bz-storage][Late] Alerts alert/KubePersistentVolumeErrors should not be at or above info": "alert/KubePersistentVolumeErrors should not be at or above info [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
https://search.ci.openshift.org/?search=alert+PrometheusOperatorWatchErrors+fired&maxAge=48h&context=1&type=bug%2Bjunit&name=4.10.*upgrade&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job shows that 1% of upgrades are hitting this alert.

The value seems small, but fixing enough 1% problems have real impact.  This doesn't fix it, but it does prevent it from failing the "we don't recognize this alert" test and will give is us a good bit of frequency data for different platforms.