### PR TITLE
localResourceAccessReviewTest: allow event explorer

### DIFF
--- a/test/extended/authorization/authorization.go
+++ b/test/extended/authorization/authorization.go
@@ -352,6 +352,10 @@ func (test localResourceAccessReviewTest) run() {
 				if strings.HasPrefix(curr, "system:serviceaccount:openshift-") {
 					continue
 				}
+				// Allow event-explorer from loki namespace
+				if strings.HasPrefix(curr, "system:serviceaccount:loki:") {
+					continue
+				}
 				// Managed ibmcloud openshift has an IAM user that needs to be ignored
 				if strings.HasPrefix(curr, "IAM#") {
 					if *controlPlaneTopology == configv1.ExternalTopologyMode && e2e.TestContext.Provider == ibmcloud.ProviderName {


### PR DESCRIPTION
Skip event-explorer SA from loki namespace - it records events from all namespaces. This was introduced in https://github.com/openshift/release/pull/25344.

The alternative to this PR is https://github.com/openshift/release/pull/25376