### PR TITLE
bug 2005901: Allow KA guard probe to fail as designed

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -79,6 +79,11 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 
 	// promtail crashlooping as its being started by sideloading manifests.  per @vrutkovs
 	regexp.MustCompile("ns/loki pod/loki-promtail.*Readiness probe failed"),
+
+	// kube-apiserver guard probe failing due to kube-apiserver operands getting rolled out
+	// multiple times during the bootstrapping phase of a cluster installation
+	regexp.MustCompile("ns/openshift-kube-apiserver pod/kube-apiserver-guard.*ProbeError Readiness probe error"),
+	regexp.MustCompile("ns/openshift-kube-apiserver pod/kube-apiserver-guard.*Unhealthy Readiness probe failed"),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{


### PR DESCRIPTION
To address
```
event happened 47 times, something is wrong: ns/openshift-kube-apiserver pod/kube-apiserver-guard-ci-op-h9q0w0xg-14a78-7gf8z-master-0 node/ci-op-h9q0w0xg-14a78-7gf8z-master-0 - reason/ProbeError Readiness probe error: Get "https://10.0.0.8:6443/healthz": dial tcp 10.0.0.8:6443: connect: connection refused
body:
event happened 47 times, something is wrong: ns/openshift-kube-apiserver pod/kube-apiserver-guard-ci-op-h9q0w0xg-14a78-7gf8z-master-0 node/ci-op-h9q0w0xg-14a78-7gf8z-master-0 - reason/Unhealthy Readiness probe failed: Get "https://10.0.0.8:6443/healthz": dial tcp 10.0.0.8:6443: connect: connection refused
```

E.g. https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn-upgrade/1482186672689909760

The KA guard pod probe is expected to fail as its readiness depends on KA operand to be ready. Which may not always hold during the bootstrapping phase.