### PR TITLE
Bug 2034285: test/extended: re-enable API data in etcd test

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -298,33 +298,7 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, kubeConfig *restclient.Config, e
 		gvr("flowcontrol.apiserver.k8s.io", "v1alpha1", "prioritylevelconfigurations"),
 		gvr("internal.apiserver.k8s.io", "v1alpha1", "storageversions"),
 		gvr("node.k8s.io", "v1alpha1", "runtimeclasses"),
-		gvr("rbac.authorization.k8s.io", "v1alpha1", "clusterrolebindings"),
-		gvr("rbac.authorization.k8s.io", "v1alpha1", "clusterroles"),
-		gvr("rbac.authorization.k8s.io", "v1alpha1", "rolebindings"),
-		gvr("rbac.authorization.k8s.io", "v1alpha1", "roles"),
-		gvr("scheduling.k8s.io", "v1alpha1", "priorityclasses"),
 		gvr("storage.k8s.io", "v1alpha1", "csistoragecapacities"),
-		gvr("storage.k8s.io", "v1alpha1", "volumeattachments"),
-
-		// disabled beta versions
-		gvr("apiextensions.k8s.io", "v1beta1", "customresourcedefinitions"),
-		gvr("apiregistration.k8s.io", "v1beta1", "apiservices"),
-		gvr("admissionregistration.k8s.io", "v1beta1", "validatingwebhookconfigurations"),
-		gvr("admissionregistration.k8s.io", "v1beta1", "mutatingwebhookconfigurations"),
-		gvr("certificates.k8s.io", "v1beta1", "certificatesigningrequests"),
-		gvr("coordination.k8s.io", "v1beta1", "leases"),
-		gvr("extensions", "v1beta1", "ingresses"),
-		gvr("networking.k8s.io", "v1beta1", "ingressclasses"),
-		gvr("networking.k8s.io", "v1beta1", "ingresses"),
-		gvr("rbac.authorization.k8s.io", "v1beta1", "clusterrolebindings"),
-		gvr("rbac.authorization.k8s.io", "v1beta1", "clusterroles"),
-		gvr("rbac.authorization.k8s.io", "v1beta1", "rolebindings"),
-		gvr("rbac.authorization.k8s.io", "v1beta1", "roles"),
-		gvr("scheduling.k8s.io", "v1beta1", "priorityclasses"),
-		gvr("storage.k8s.io", "v1beta1", "csidrivers"),
-		gvr("storage.k8s.io", "v1beta1", "csinodes"),
-		gvr("storage.k8s.io", "v1beta1", "storageclasses"),
-		gvr("storage.k8s.io", "v1beta1", "volumeattachments"),
 	)
 
 	// Apply output of git diff origin/release-1.22 origin/release-1.23 test/integration/etcd/data.go. This is needed

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -45,7 +45,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [Serial][sig-node][Feature:TopologyManager] Configured cluster with gu workload should guarantee NUMA-aligned cpu cores in gu pods with single pod, single container requesting 4 cores, 1 device": "with single pod, single container requesting 4 cores, 1 device [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial]": "should be stored at the correct location and version for all resources [Serial] [Disabled:Broken]",
+	"[Top Level] [sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial]": "should be stored at the correct location and version for all resources [Serial] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-api-machinery] API priority and fairness should ensure that requests can be classified by adding FlowSchema and PriorityLevelConfiguration": "should ensure that requests can be classified by adding FlowSchema and PriorityLevelConfiguration [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -66,8 +66,6 @@ var (
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=2004074
 			`\[sig-network-edge\]\[Feature:Idling\] Unidling should work with TCP \(while idling\)`,
-
-			`\[sig-api-machinery\] API data in etcd`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
Etcd data from upstream has been updated with the rebase and the APIs that the test was previously complaining about have been added: https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/test/integration/etcd/data.go