### PR TITLE
allow loki target to be down

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -108,7 +108,12 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			},
 		},
 	}
-	allowedFiringAlerts := helper.MetricConditions{}
+	allowedFiringAlerts := helper.MetricConditions{
+		{
+			Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
+	}
 
 	pendingAlertsWithBugs := helper.MetricConditions{
 		{

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -327,6 +327,10 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		}
 		allowedFiringAlerts := helper.MetricConditions{
 			{
+				Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
+				Text:     "Loki is nice to have, but we can allow it to be down",
+			},
+			{
 				Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
 				Text:     "high CPU utilization during e2e runs is normal",
 			},


### PR DESCRIPTION
prevent failures like https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-aws-ovn-upgrade/1484205905842016256