### PR TITLE
adds a synthetic test for checking if the pod.spec.nodeName field is immutable

### DIFF
--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -72,3 +72,25 @@ func testAllIngressAvailability(events monitorapi.Intervals, jobRunDuration time
 
 	return ret
 }
+
+func testPodNodeNameIsImmutable(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-api-machinery] the pod.spec.nodeName field is immutable, once set cannot be changed"
+
+	failures := []string{}
+	for _, event := range events {
+		if strings.Contains(event.Message, "pod once assigned to a node must stay on it") {
+			failures = append(failures, fmt.Sprintf("%v %v", event.Locator, event.Message))
+		}
+	}
+	if len(failures) == 0 {
+		return []*junitapi.JUnitTestCase{{Name: testName}}
+	}
+
+	return []*junitapi.JUnitTestCase{{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &junitapi.FailureOutput{
+			Output: fmt.Sprintf("Please report in https://bugzilla.redhat.com/show_bug.cgi?id=2042657\n\n%d pods had their immutable field (spec.nodeName) changed\n\n%v", len(failures), strings.Join(failures, "\n")),
+		},
+	}}
+}

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -32,6 +32,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testErrImagePullGeneric(events)...)
 	tests = append(tests, testAlerts(events, kubeClientConfig)...)
 	tests = append(tests, testOperatorOSUpdateStaged(events)...)
+	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 
 	return tests
 }
@@ -56,6 +57,8 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testErrImagePullGeneric(events)...)
 	tests = append(tests, testAlerts(events, kubeClientConfig)...)
 	tests = append(tests, testOperatorOSUpdateStaged(events)...)
+	tests = append(tests, testPodNodeNameIsImmutable(events)...)
+
 	return tests
 }
 


### PR DESCRIPTION
a simple monitor test for checking immutability of `pod.spec.nodeName` field. 
The field is not allowed to change once set i.e. a pod assigned to a node must stay on it.

It will help gather more data (if any) for https://bugzilla.redhat.com/show_bug.cgi?id=2042657