### PR TITLE
storage operator can go upgradeable=unknown if vsphere is unreachable

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -242,6 +242,7 @@ func surprisingConditions(co objx.Map) ([]configv1.ClusterOperatorStatusConditio
 			if cond.Get("status").String() != string(expected) {
 				reason := cond.Get("reason").String()
 				message := cond.Get("message").String()
+				status := cond.Get("status").String()
 				if conditionType == configv1.OperatorUpgradeable && (name == "kube-storage-version-migrator" || // https://bugzilla.redhat.com/show_bug.cgi?id=1928141 , currently fixed for 4.10, but no backports at the moment.  We currently have ...-upgrade-4.y-to-4.(y+1)-to-4.(y+2)-to-4.(y+3)-ci jobs, so as long as we don't extend that +3 skew for those jobs, we should be able to drop this code once 4.13 forks off of the development branch.
 					name == "openshift-controller-manager" || // https://bugzilla.redhat.com/show_bug.cgi?id=1948011 , currently fixed for 4.8, but no backports at the moment.  We currently have ...-upgrade-4.y-to-4.(y+1)-to-4.(y+2)-to-4.(y+3)-ci jobs, so as long as we don't extend that +3 skew for those jobs, we should be able to drop this code once 4.10 forks off the development branch.
 					name == "service-ca" || // https://bugzilla.redhat.com/show_bug.cgi?id=1948012 , currently fixed for 4.8, but no backports at the moment.  We currently have ...-upgrade-4.y-to-4.(y+1)-to-4.(y+2)-to-4.(y+3)-ci jobs, so as long as we don't extend that +3 skew for those jobs, we should be able to drop this code once 4.10 forks off the development branch.
@@ -263,7 +264,10 @@ func surprisingConditions(co objx.Map) ([]configv1.ClusterOperatorStatusConditio
 					// [3]: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1199
 					(name == "kube-apiserver" && reason == "KubeletMinorVersion_KubeletMinorVersionUnsupportedNextUpgrade") ||
 					// https://bugzilla.redhat.com/show_bug.cgi?id=2015187
-					(name == "storage" && vmxPattern.MatchString(message))) {
+					(name == "storage" && vmxPattern.MatchString(message)) ||
+					// storage attempts to contact vsphere to determine if it can be ugpraded.  If the storage operator cannot reach vsphere to determine
+					// whether the upgrade is safe or not, it is appropriate to be upgradeable=Unknown
+					(name == "storage" && status == "Unknown" && strings.Contains(message, "Failed to connect to vSphere"))) {
 					continue
 				}
 				badConditions = append(badConditions, configv1.ClusterOperatorStatusCondition{


### PR DESCRIPTION
cleans up failures like https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi-serial/1484206475835346944

/assign @wking @gnufied 