### PR TITLE
Bug 2043042: Additional checks for requestheaders.go

### DIFF
--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -62,6 +62,13 @@ var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [I
 	var oc = exutil.NewCLI("request-headers")
 
 	g.It("test RequestHeaders IdP", func() {
+
+		// In some rare cases, CAO might be damaged when entering this test. If it is - the results
+		// of this test might flaky. This check ensures that we capture such situation early and
+		// investigate why it wasn't ready before this test.
+		e2e.Logf("Ensuring CAO is available==True, progressing==False, degraded==False")
+		waitForAuthenticationProgressing(oc, configv1.ConditionFalse)
+
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -461,7 +468,7 @@ func waitForAuthenticationProgressing(oc *exutil.CLI, expectedProgressing config
 		}
 
 		if expectedProgressing == configv1.ConditionFalse {
-			// make additional checkes on availability and degraded status
+			// make additional checks on availability and degraded status
 			if clusteroperatorhelpers.IsStatusConditionFalse(authn.Status.Conditions, configv1.OperatorAvailable) ||
 				clusteroperatorhelpers.IsStatusConditionTrue(authn.Status.Conditions, configv1.OperatorDegraded) {
 				e2e.Logf("Waiting for available==True, progressing==False, degraded==False: %s", spew.Sdump(authn.Status.Conditions))

--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -379,6 +379,9 @@ func oauthHTTPRequest(caCerts *x509.CertPool, oauthBaseURL, endpoint, token stri
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 
+	// Adding the token prevents the server from logging a misleading warning (which is oftentimes interpreted as
+	// a root cause of a failure). It doesn't need to be anything specific for this test.
+	req.Header.Set("X-CSRF-Token", "1")
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs: caCerts,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2043042

This Pull Request adds a generation check and a missing `X-CSRF-Token` header to the `[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP]`. This should help stabilizing the test or at least, make failure investigation easier in the future.

It also adds additional check to make explicitly sure the CAO is stable before executing the test.
