### PR TITLE
baremetal: add test for preprovisioning images

### DIFF
--- a/test/extended/baremetal/common.go
+++ b/test/extended/baremetal/common.go
@@ -86,6 +86,11 @@ func hostfirmwaresettingsClient(dc dynamic.Interface) dynamic.ResourceInterface 
 	return hfsClient.Namespace("openshift-machine-api")
 }
 
+func preprovisioningImagesClient(dc dynamic.Interface) dynamic.ResourceInterface {
+	ppiClient := dc.Resource(schema.GroupVersionResource{Group: "metal3.io", Resource: "preprovisioningimages", Version: "v1alpha1"})
+	return ppiClient.Namespace("openshift-machine-api")
+}
+
 type FieldGetterFunc func(obj map[string]interface{}, fields ...string) (interface{}, bool, error)
 
 func expectField(object unstructured.Unstructured, resource string, nestedField string, fieldGetter FieldGetterFunc) o.Assertion {

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1861,6 +1861,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-installer][Feature:baremetal] Baremetal platform should have hostfirmwaresetting resources": "have hostfirmwaresetting resources [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-installer][Feature:baremetal] Baremetal platform should have preprovisioning images for workers": "have preprovisioning images for workers [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-installer][Feature:baremetal] Baremetal platform should not allow updating BootMacAddress": "not allow updating BootMacAddress [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-installer][Feature:baremetal] Baremetal/OpenStack/vSphere/None platforms  have a metal3 deployment": "have a metal3 deployment [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This patch adds a new simple test to verify that for every worker deployed there is a related preprovisioning image resource