### PR TITLE
Bug 2045590: Adding new cloud provider e2e for alibabacloud

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -84,7 +84,7 @@ func decodeProvider(provider string, dryRun, discover bool, clusterState *exutil
 		}
 		fallthrough
 
-	case "azure", "aws", "baremetal", "gce", "vsphere":
+	case "azure", "aws", "baremetal", "gce", "vsphere", "alibabacloud":
 		if clusterState == nil {
 			clientConfig, err := e2e.LoadConfig(true)
 			if err != nil {

--- a/cmd/openshift-tests/provider_test.go
+++ b/cmd/openshift-tests/provider_test.go
@@ -32,6 +32,13 @@ var vspherePlatform = &configv1.PlatformStatus{
 	Type: configv1.VSpherePlatformType,
 }
 
+var alibabaPlatform = &configv1.PlatformStatus{
+	Type: configv1.AlibabaCloudPlatformType,
+	AlibabaCloud: &configv1.AlibabaCloudPlatformStatus{
+		Region: "us-east-1",
+	},
+}
+
 var noPlatform = &configv1.PlatformStatus{
 	Type: configv1.NonePlatformType,
 }
@@ -194,6 +201,15 @@ func TestDecodeProvider(t *testing.T) {
 			// NB: It does not actually use the passed-in Provider value
 			expectedConfig: `{"type":"skeleton","ProjectID":"","Region":"","Zone":"","NumNodes":3,"MultiMaster":true,"MultiZone":false,"Zones":[],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"OpenShiftSDN","HasIPv4":true,"HasIPv6":false,"HasSCTP":false}`,
 			runTests:       sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online", "ipv4"),
+		},
+		{
+			name:               "simple AlibabaCloud",
+			provider:           "alibabacloud",
+			discoveredPlatform: alibabaPlatform,
+			discoveredMasters:  simpleMasters,
+			discoveredNetwork:  sdnConfig,
+			expectedConfig:     `{"type":"skeleton","ProjectID":"","Region":"us-east-1","Zone":"us-east-1a","NumNodes":3,"MultiMaster":true,"MultiZone":true,"Zones":["us-east-1a", "us-east-1b"],"ConfigFile":"","Disconnected":false,"NetworkPlugin":"OpenShiftSDN","HasIPv4":true,"HasIPv6":false,"HasSCTP":false}`,
+			runTests:           sets.NewString("everyone", "not-gce", "not-aws", "not-multitenant", "online", "ipv4"),
 		},
 		{
 			name:               "json simple override",

--- a/test/extended/util/alibabacloud/provider.go
+++ b/test/extended/util/alibabacloud/provider.go
@@ -1,0 +1,18 @@
+package alibabacloud
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func init() {
+	framework.RegisterProvider("alibabacloud", newProvider)
+}
+
+func newProvider() (framework.ProviderInterface, error) {
+	return &Provider{}, nil
+}
+
+// Provider is a structure to handle alibabacloud for e2e testing
+type Provider struct {
+	framework.NullProvider
+}


### PR DESCRIPTION
Adding AlibabaCloud as a new cloud provider so that I can perform e2e tests.

Calling e2e is failing due to `alibabacloud` missing as a cloud provider.
```
E0124 22:54:06.535535     281 test_context.go:503] Unknown provider "alibabacloud". The following providers are known: aws azure baremetal gce gke ibmcloud kubemark kubevirt local openstack ovirt skeleton vsphere
```
https://github.com/openshift/release/pull/20841