### PR TITLE
Bug 2037075: builds: fix filename in csi build volumes within Tech Preview test

### DIFF
--- a/test/extended/builds/volumes.go
+++ b/test/extended/builds/volumes.go
@@ -218,7 +218,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 		dockerDeploymentConfig = filepath.Join(baseDir, "docker-deploymentconfig.yaml")
 		dockerImageStream      = filepath.Join(baseDir, "docker-imagestream.yaml")
 		// csi enabled volume specifics
-		csiSharedSecret                            = filepath.Join(baseDir, "csi-shared-secret.yaml")
+		csiSharedSecret                            = filepath.Join(baseDir, "csi-sharedsecret.yaml")
 		csiSharedRole                              = filepath.Join(baseDir, "csi-sharedresourcerole.yaml")
 		csiSharedRoleBinding                       = filepath.Join(baseDir, "csi-sharedresourcerolebinding.yaml")
 		csiS2iBuildConfig                          = filepath.Join(baseDir, "csi-s2i-buildconfig.yaml")


### PR DESCRIPTION
"[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster" tests are causing techpreview e2e jobs to fail since #26646 merged, e.g.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-aws-techpreview/1485804740204826624
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-azure-techpreview/1485804741903519744
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-techpreview/1485804752787738624

/cc @jkhelil @deepsm007
/assign @adambkaplan﻿
