### PR TITLE
add more frequently failing loki alerts to the allow-list

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -113,6 +113,14 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
 			Text:     "Loki is nice to have, but we can allow it to be down",
 		},
+		{
+			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
 	}
 
 	pendingAlertsWithBugs := helper.MetricConditions{

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -331,6 +331,14 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 				Text:     "Loki is nice to have, but we can allow it to be down",
 			},
 			{
+				Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-e2e-loki"},
+				Text:     "Loki is nice to have, but we can allow it to be down",
+			},
+			{
+				Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
+				Text:     "Loki is nice to have, but we can allow it to be down",
+			},
+			{
 				Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
 				Text:     "high CPU utilization during e2e runs is normal",
 			},


### PR DESCRIPTION
These fail about 1% of the time in the general population of failures.  While loki is important, it's not important enough to fail the job over.  Once we have more than a single volunteer keeping loki working, trying to improve this is a valid thing to attempt.  With only one volunteer maintaining it, trying to press and determine expected vs unexpected and how to improve isn't viable.