### PR TITLE
Flake instead of fail the timely OSUpdateStaged test on metal and ovirt.

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -31,7 +31,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testErrImagePullGenericOpenShiftNamespaces(events)...)
 	tests = append(tests, testErrImagePullGeneric(events)...)
 	tests = append(tests, testAlerts(events, kubeClientConfig)...)
-	tests = append(tests, testOperatorOSUpdateStaged(events)...)
+	tests = append(tests, testOperatorOSUpdateStaged(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 
 	return tests
@@ -56,7 +56,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testErrImagePullGenericOpenShiftNamespaces(events)...)
 	tests = append(tests, testErrImagePullGeneric(events)...)
 	tests = append(tests, testAlerts(events, kubeClientConfig)...)
-	tests = append(tests, testOperatorOSUpdateStaged(events)...)
+	tests = append(tests, testOperatorOSUpdateStaged(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 
 	return tests


### PR DESCRIPTION
This new test seems to fail a fair bit on those platforms causing
unecessary failed jobs on platforms that can't yet meet this guideline.
Make sure we only flake on these platforms for now.
