### PR TITLE
Verify Builds with CSI Volume Sources 

### DIFF
--- a/test/extended/builds/volumes.go
+++ b/test/extended/builds/volumes.go
@@ -1,11 +1,19 @@
 package builds
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
 	"time"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	buildv1 "github.com/openshift/api/build/v1"
+	configv1 "github.com/openshift/api/config/v1"
 
 	deploymentutil "github.com/openshift/origin/test/extended/deployments"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -126,3 +134,283 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func()
 		})
 	})
 })
+
+var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview disabled clusters", func() {
+	var (
+		oc                   = exutil.NewCLI("build-volumes")
+		baseDir              = exutil.FixturePath("testdata", "builds", "volumes")
+		s2iImageStream       = filepath.Join(baseDir, "s2i-imagestream.yaml")
+		dockerImageStream    = filepath.Join(baseDir, "docker-imagestream.yaml")
+		csiS2iBuildConfig    = filepath.Join(baseDir, "csi-s2i-buildconfig.yaml")
+		csiDockerBuildConfig = filepath.Join(baseDir, "csi-docker-buildconfig.yaml")
+	)
+
+	g.Context("", func() {
+		g.BeforeEach(func() {
+			exutil.PreTestDump()
+		})
+
+		g.JustBeforeEach(func() {
+			if isTechPreviewNoUpgrade(oc) {
+				g.Skip("the test is not expected to work within Tech Preview enabled clusters")
+			}
+		})
+
+		g.AfterEach(func() {
+			if g.CurrentGinkgoTestDescription().Failed {
+				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
+				exutil.DumpPodLogsStartingWith("", oc)
+			}
+		})
+
+		g.It("should fail mounting given csi shared resource secret into the build pod for source strategy builds", func() {
+			g.By("creating an imagestream")
+			err := oc.Run("create").Args("-f", s2iImageStream).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating a build config")
+			err = oc.Run("create").Args("-f", csiS2iBuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting a build and waiting for it to complete")
+			br, err := exutil.StartBuildAndWait(oc, "mys2itest")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			br.DumpLogs()
+
+			build, err := oc.BuildClient().BuildV1().Builds(oc.Namespace()).Get(context.Background(), br.Build.Name, metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(build.Status.Phase).To(o.Equal(buildv1.BuildPhaseNew))
+			o.Expect(build.Status.Reason).To(o.BeEquivalentTo("CannotCreateBuildPodSpec"))
+			o.Expect(build.Status.Message).To(o.BeEquivalentTo("Failed to create pod spec."))
+
+		})
+		g.It("should fail mounting given csi shared resource secret into the build pod for docker strategy builds", func() {
+			g.By("creating an imagestream")
+			err := oc.Run("create").Args("-f", dockerImageStream).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating a build config")
+			err = oc.Run("create").Args("-f", csiDockerBuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting a build and waiting for it to complete")
+			br, err := exutil.StartBuildAndWait(oc, "mydockertest")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			br.DumpLogs()
+
+			build, err := oc.BuildClient().BuildV1().Builds(oc.Namespace()).Get(context.Background(), br.Build.Name, metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(build.Status.Phase).To(o.Equal(buildv1.BuildPhaseNew))
+			o.Expect(build.Status.Reason).To(o.BeEquivalentTo("CannotCreateBuildPodSpec"))
+			o.Expect(build.Status.Message).To(o.BeEquivalentTo("Failed to create pod spec."))
+		})
+	})
+})
+
+var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc                     = exutil.NewCLI("build-volumes-csi")
+		baseDir                = exutil.FixturePath("testdata", "builds", "volumes")
+		secret                 = filepath.Join(baseDir, "secret.yaml")
+		s2iDeploymentConfig    = filepath.Join(baseDir, "s2i-deploymentconfig.yaml")
+		s2iImageStream         = filepath.Join(baseDir, "s2i-imagestream.yaml")
+		dockerDeploymentConfig = filepath.Join(baseDir, "docker-deploymentconfig.yaml")
+		dockerImageStream      = filepath.Join(baseDir, "docker-imagestream.yaml")
+		// csi enabled volume specifics
+		csiSharedSecret                            = filepath.Join(baseDir, "csi-sharedsecret.yaml")
+		csiSharedRole                              = filepath.Join(baseDir, "csi-sharedresourcerole.yaml")
+		csiSharedRoleBinding                       = filepath.Join(baseDir, "csi-sharedresourcerolebinding.yaml")
+		csiS2iBuildConfig                          = filepath.Join(baseDir, "csi-s2i-buildconfig.yaml")
+		csiDockerBuildConfig                       = filepath.Join(baseDir, "csi-docker-buildconfig.yaml")
+		csiWihthoutResourceRefreshS2iBuildConfig   = filepath.Join(baseDir, "csi-without-rr-s2i-buildconfig.yaml")
+		csiWithoutResourceRefreshDockerBuildConfig = filepath.Join(baseDir, "csi-without-rr-docker-buildconfig.yaml")
+	)
+
+	g.Context("", func() {
+		g.BeforeEach(func() {
+			exutil.PreTestDump()
+		})
+
+		g.JustBeforeEach(func() {
+			if !isTechPreviewNoUpgrade(oc) {
+				g.Skip("the test is not expected to work within Tech Preview disabled clusters")
+			}
+			// create the secret to share in a new namespace
+			g.By("creating a secret")
+			err := oc.AsAdmin().Run("--namespace=default", "apply").Args("-f", secret).Execute()
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			// create the csi shared secret object
+			g.By("creating a csi shared secret resource")
+			err = oc.AsAdmin().Run("apply").Args("-f", csiSharedSecret).Execute()
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			// process the role to grant use of the share
+			g.By("creating a csi shared role resource")
+			err = oc.AsAdmin().Run("create").Args("-f", csiSharedRole).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// process the rolebinding to grant use of the share
+			g.By("creating a csi shared role binding resource")
+			rolebinding, _, err := oc.AsAdmin().Run("process").Args("-f", csiSharedRoleBinding, "-p", fmt.Sprintf("NAMESPACE=%s", oc.Namespace())).Outputs()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = oc.AsAdmin().Run("create").Args("-f", "-").InputString(rolebinding).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
+		g.AfterEach(func() {
+			if g.CurrentGinkgoTestDescription().Failed {
+				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
+				exutil.DumpPodLogsStartingWith("", oc)
+			}
+		})
+
+		g.It("should mount given csi shared resource secret into the build pod for source strategy builds", func() {
+			g.By("creating an imagestream")
+			err := oc.Run("create").Args("-f", s2iImageStream).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating a build config")
+			err = oc.Run("create").Args("-f", csiS2iBuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting a build and waiting for it to complete")
+			br, _ := exutil.StartBuildAndWait(oc, "mys2itest")
+			br.AssertSuccess()
+
+			g.By("ensuring that the build pod logs contain the provided shared secret")
+			buildPodLogs, err := br.Logs()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(buildPodLogs).To(o.ContainSubstring("my-secret-value"))
+
+			g.By("creating a deployment config")
+			err = oc.Run("create").Args("-f", s2iDeploymentConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for the deployment to complete")
+			_, err = deploymentutil.WaitForDeployerToComplete(oc, "mys2itest-1", 5*time.Minute)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("ensuring that the shared secret does not exist in the build image")
+			out, err := oc.Run("rsh").Args("dc/mys2itest", "cat", "/var/run/secrets/some-secret/key").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("cat: /var/run/secrets/some-secret/key: No such file or directory"))
+		})
+
+		g.It("should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds", func() {
+			g.By("creating an imagestream")
+			err := oc.Run("create").Args("-f", s2iImageStream).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating a build config")
+			err = oc.Run("create").Args("-f", csiWihthoutResourceRefreshS2iBuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting a build and waiting for it to complete")
+			br, _ := exutil.StartBuildAndWait(oc, "mys2itest")
+			br.AssertSuccess()
+
+			g.By("ensuring that the build pod logs contain the provided shared secret")
+			buildPodLogs, err := br.Logs()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(buildPodLogs).To(o.ContainSubstring("my-secret-value"))
+
+			g.By("creating a deployment config")
+			err = oc.Run("create").Args("-f", s2iDeploymentConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for the deployment to complete")
+			_, err = deploymentutil.WaitForDeployerToComplete(oc, "mys2itest-1", 5*time.Minute)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("ensuring that the shared secret does not exist in the build image")
+			out, err := oc.Run("rsh").Args("dc/mys2itest", "cat", "/var/run/secrets/some-secret/key").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("cat: /var/run/secrets/some-secret/key: No such file or directory"))
+		})
+
+		g.It("should mount given csi shared resource secret into the build pod for docker strategy builds", func() {
+			g.By("creating an imagestream")
+			err := oc.Run("create").Args("-f", dockerImageStream).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating a build config")
+			err = oc.Run("create").Args("-f", csiDockerBuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting a build and waiting for it to complete")
+			br, _ := exutil.StartBuildAndWait(oc, "mydockertest")
+			br.AssertSuccess()
+
+			g.By("ensuring that the build pod logs contain the provided shared")
+			buildPodLogs, err := br.Logs()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(buildPodLogs).To(o.ContainSubstring("my-secret-value"))
+
+			g.By("creating a deployment config")
+			err = oc.Run("create").Args("-f", dockerDeploymentConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for the deployment to complete")
+			_, err = deploymentutil.WaitForDeployerToComplete(oc, "mydockertest-1", 5*time.Minute)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("ensuring that the shared secret does not exist in the build image")
+			out, err := oc.Run("rsh").Args("dc/mydockertest", "cat", "/var/run/secrets/some-secret/key").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("cat: /var/run/secrets/some-secret/key: No such file or directory"))
+		})
+
+		g.It("should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds", func() {
+			g.By("creating an imagestream")
+			err := oc.Run("create").Args("-f", dockerImageStream).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating a build config")
+			err = oc.Run("create").Args("-f", csiWithoutResourceRefreshDockerBuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting a build and waiting for it to complete")
+			br, _ := exutil.StartBuildAndWait(oc, "mydockertest")
+			br.AssertSuccess()
+
+			g.By("ensuring that the build pod logs contain the provided shared")
+			buildPodLogs, err := br.Logs()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(buildPodLogs).To(o.ContainSubstring("my-secret-value"))
+
+			g.By("creating a deployment config")
+			err = oc.Run("create").Args("-f", dockerDeploymentConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for the deployment to complete")
+			_, err = deploymentutil.WaitForDeployerToComplete(oc, "mydockertest-1", 5*time.Minute)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("ensuring that the shared secret does not exist in the build image")
+			out, err := oc.Run("rsh").Args("dc/mydockertest", "cat", "/var/run/secrets/some-secret/key").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("cat: /var/run/secrets/some-secret/key: No such file or directory"))
+		})
+	})
+})
+
+// isTechPreviewNoUpgrade checks if a cluster is a TechPreviewNoUpgrade cluster
+func isTechPreviewNoUpgrade(oc *exutil.CLI) bool {
+	featureGate, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		e2e.Failf("could not retrieve feature-gate: %v", err)
+	}
+
+	return featureGate.Spec.FeatureSet == configv1.TechPreviewNoUpgrade
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -146,6 +146,13 @@
 // test/extended/testdata/builds/valuefrom/test-is.json
 // test/extended/testdata/builds/valuefrom/test-secret.yaml
 // test/extended/testdata/builds/volumes/configmap.yaml
+// test/extended/testdata/builds/volumes/csi-docker-buildconfig.yaml
+// test/extended/testdata/builds/volumes/csi-s2i-buildconfig.yaml
+// test/extended/testdata/builds/volumes/csi-sharedresourcerole.yaml
+// test/extended/testdata/builds/volumes/csi-sharedresourcerolebinding.yaml
+// test/extended/testdata/builds/volumes/csi-sharedsecret.yaml
+// test/extended/testdata/builds/volumes/csi-without-rr-docker-buildconfig.yaml
+// test/extended/testdata/builds/volumes/csi-without-rr-s2i-buildconfig.yaml
 // test/extended/testdata/builds/volumes/docker-buildconfig.yaml
 // test/extended/testdata/builds/volumes/docker-deploymentconfig.yaml
 // test/extended/testdata/builds/volumes/docker-imagestream.yaml
@@ -21768,6 +21775,320 @@ func testExtendedTestdataBuildsVolumesConfigmapYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/builds/volumes/configmap.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsVolumesCsiDockerBuildconfigYaml = []byte(`apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: mydockertest
+  labels:
+    name: test
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mydockerstream:latest
+  postCommit:
+    script: cat /var/run/secrets/some-secret/key
+  triggers: []
+  runPolicy: Serial
+  source:
+    dockerfile:
+      'FROM quay.io/redhat-developer/test-build-simples2i:1.2'
+  strategy:
+    type: Docker
+    dockerStrategy:
+      env:
+        - name: BUILD_LOGLEVEL
+          value: "5"
+      volumes:
+      - mounts:
+        - destinationPath: "/var/run/secrets/some-secret"
+        name: my-csi-shared-secret
+        source:
+          csi:
+            driver: csi.sharedresource.openshift.io
+            readOnly: true
+            volumeAttributes:
+              sharedSecret: my-share
+          type: CSI
+  resources: {}
+  nodeSelector: null
+status: {}`)
+
+func testExtendedTestdataBuildsVolumesCsiDockerBuildconfigYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsVolumesCsiDockerBuildconfigYaml, nil
+}
+
+func testExtendedTestdataBuildsVolumesCsiDockerBuildconfigYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsVolumesCsiDockerBuildconfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/volumes/csi-docker-buildconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsVolumesCsiS2iBuildconfigYaml = []byte(`apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: mys2itest
+  labels:
+    name: test
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mys2istream:latest
+  postCommit:
+    script: cat /var/run/secrets/some-secret/key
+  triggers: []
+  runPolicy: Serial
+  source:
+    type: Binary
+    binary: {}
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: quay.io/redhat-developer/test-build-simples2i:1.2
+      volumes:
+      - mounts:
+        - destinationPath: "/var/run/secrets/some-secret"
+        name: my-csi-shared-secret
+        source:
+          csi:
+            driver: csi.sharedresource.openshift.io
+            readOnly: true
+            volumeAttributes:
+              sharedSecret: my-share
+          type: CSI
+  resources: {}
+  nodeSelector: null
+status: {}`)
+
+func testExtendedTestdataBuildsVolumesCsiS2iBuildconfigYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsVolumesCsiS2iBuildconfigYaml, nil
+}
+
+func testExtendedTestdataBuildsVolumesCsiS2iBuildconfigYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsVolumesCsiS2iBuildconfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/volumes/csi-s2i-buildconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsVolumesCsiSharedresourceroleYaml = []byte(`apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: shared-resource-my-share
+rules:
+- apiGroups:
+    - sharedresource.openshift.io
+  resources:
+    - sharedsecrets
+  resourceNames:
+    - my-share
+  verbs:
+    - use
+  `)
+
+func testExtendedTestdataBuildsVolumesCsiSharedresourceroleYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsVolumesCsiSharedresourceroleYaml, nil
+}
+
+func testExtendedTestdataBuildsVolumesCsiSharedresourceroleYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsVolumesCsiSharedresourceroleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/volumes/csi-sharedresourcerole.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsVolumesCsiSharedresourcerolebindingYaml = []byte(`kind: Template
+apiVersion: v1
+metadata:
+  name: "build-volume-csi-roles-template"
+labels:
+  createdBy: "build-volume-csi-roles-template"
+parameters:
+  - description: "The namespace to create roles in."
+    name: NAMESPACE
+    required: true
+objects:
+  - apiVersion: authorization.openshift.io/v1
+    kind: RoleBinding
+    metadata:
+      name: shared-resource-my-share
+      namespace: ${NAMESPACE}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: shared-resource-my-share
+      namespace: ${NAMESPACE} 
+    subjects:
+    - kind: ServiceAccount
+      name: builder
+      namespace: ${NAMESPACE}`)
+
+func testExtendedTestdataBuildsVolumesCsiSharedresourcerolebindingYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsVolumesCsiSharedresourcerolebindingYaml, nil
+}
+
+func testExtendedTestdataBuildsVolumesCsiSharedresourcerolebindingYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsVolumesCsiSharedresourcerolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/volumes/csi-sharedresourcerolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsVolumesCsiSharedsecretYaml = []byte(`apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: my-share
+spec:
+  secretRef:
+    name: my-secret
+    namespace: default
+`)
+
+func testExtendedTestdataBuildsVolumesCsiSharedsecretYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsVolumesCsiSharedsecretYaml, nil
+}
+
+func testExtendedTestdataBuildsVolumesCsiSharedsecretYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsVolumesCsiSharedsecretYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/volumes/csi-sharedsecret.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsVolumesCsiWithoutRrDockerBuildconfigYaml = []byte(`apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: mydockertest
+  labels:
+    name: test
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mydockerstream:latest
+  postCommit:
+    script: cat /var/run/secrets/some-secret/key
+  triggers: []
+  runPolicy: Serial
+  source:
+    dockerfile:
+      'FROM quay.io/redhat-developer/test-build-simples2i:1.2'
+  strategy:
+    type: Docker
+    dockerStrategy:
+      env:
+        - name: BUILD_LOGLEVEL
+          value: "5"
+      volumes:
+      - mounts:
+        - destinationPath: "/var/run/secrets/some-secret"
+        name: my-csi-shared-secret
+        source:
+          csi:
+            driver: csi.sharedresource.openshift.io
+            readOnly: true
+            volumeAttributes:
+              sharedSecret: my-share
+              refreshResource: "false"
+          type: CSI
+  resources: {}
+  nodeSelector: null
+status: {}`)
+
+func testExtendedTestdataBuildsVolumesCsiWithoutRrDockerBuildconfigYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsVolumesCsiWithoutRrDockerBuildconfigYaml, nil
+}
+
+func testExtendedTestdataBuildsVolumesCsiWithoutRrDockerBuildconfigYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsVolumesCsiWithoutRrDockerBuildconfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/volumes/csi-without-rr-docker-buildconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsVolumesCsiWithoutRrS2iBuildconfigYaml = []byte(`apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: mys2itest
+  labels:
+    name: test
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mys2istream:latest
+  postCommit:
+    script: cat /var/run/secrets/some-secret/key
+  triggers: []
+  runPolicy: Serial
+  source:
+    type: Binary
+    binary: {}
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: quay.io/redhat-developer/test-build-simples2i:1.2
+      volumes:
+      - mounts:
+        - destinationPath: "/var/run/secrets/some-secret"
+        name: my-csi-shared-secret
+        source:
+          csi:
+            driver: csi.sharedresource.openshift.io
+            readOnly: true
+            volumeAttributes:
+              sharedSecret: my-share
+              refreshResource: "false"
+          type: CSI
+  resources: {}
+  nodeSelector: null
+status: {}`)
+
+func testExtendedTestdataBuildsVolumesCsiWithoutRrS2iBuildconfigYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsVolumesCsiWithoutRrS2iBuildconfigYaml, nil
+}
+
+func testExtendedTestdataBuildsVolumesCsiWithoutRrS2iBuildconfigYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsVolumesCsiWithoutRrS2iBuildconfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/volumes/csi-without-rr-s2i-buildconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -53700,6 +54021,13 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/builds/valuefrom/test-is.json":                                                   testExtendedTestdataBuildsValuefromTestIsJson,
 	"test/extended/testdata/builds/valuefrom/test-secret.yaml":                                               testExtendedTestdataBuildsValuefromTestSecretYaml,
 	"test/extended/testdata/builds/volumes/configmap.yaml":                                                   testExtendedTestdataBuildsVolumesConfigmapYaml,
+	"test/extended/testdata/builds/volumes/csi-docker-buildconfig.yaml":                                      testExtendedTestdataBuildsVolumesCsiDockerBuildconfigYaml,
+	"test/extended/testdata/builds/volumes/csi-s2i-buildconfig.yaml":                                         testExtendedTestdataBuildsVolumesCsiS2iBuildconfigYaml,
+	"test/extended/testdata/builds/volumes/csi-sharedresourcerole.yaml":                                      testExtendedTestdataBuildsVolumesCsiSharedresourceroleYaml,
+	"test/extended/testdata/builds/volumes/csi-sharedresourcerolebinding.yaml":                               testExtendedTestdataBuildsVolumesCsiSharedresourcerolebindingYaml,
+	"test/extended/testdata/builds/volumes/csi-sharedsecret.yaml":                                            testExtendedTestdataBuildsVolumesCsiSharedsecretYaml,
+	"test/extended/testdata/builds/volumes/csi-without-rr-docker-buildconfig.yaml":                           testExtendedTestdataBuildsVolumesCsiWithoutRrDockerBuildconfigYaml,
+	"test/extended/testdata/builds/volumes/csi-without-rr-s2i-buildconfig.yaml":                              testExtendedTestdataBuildsVolumesCsiWithoutRrS2iBuildconfigYaml,
 	"test/extended/testdata/builds/volumes/docker-buildconfig.yaml":                                          testExtendedTestdataBuildsVolumesDockerBuildconfigYaml,
 	"test/extended/testdata/builds/volumes/docker-deploymentconfig.yaml":                                     testExtendedTestdataBuildsVolumesDockerDeploymentconfigYaml,
 	"test/extended/testdata/builds/volumes/docker-imagestream.yaml":                                          testExtendedTestdataBuildsVolumesDockerImagestreamYaml,
@@ -54320,14 +54648,21 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"test-secret.yaml":                               {testExtendedTestdataBuildsValuefromTestSecretYaml, map[string]*bintree{}},
 					}},
 					"volumes": {nil, map[string]*bintree{
-						"configmap.yaml":               {testExtendedTestdataBuildsVolumesConfigmapYaml, map[string]*bintree{}},
-						"docker-buildconfig.yaml":      {testExtendedTestdataBuildsVolumesDockerBuildconfigYaml, map[string]*bintree{}},
-						"docker-deploymentconfig.yaml": {testExtendedTestdataBuildsVolumesDockerDeploymentconfigYaml, map[string]*bintree{}},
-						"docker-imagestream.yaml":      {testExtendedTestdataBuildsVolumesDockerImagestreamYaml, map[string]*bintree{}},
-						"s2i-buildconfig.yaml":         {testExtendedTestdataBuildsVolumesS2iBuildconfigYaml, map[string]*bintree{}},
-						"s2i-deploymentconfig.yaml":    {testExtendedTestdataBuildsVolumesS2iDeploymentconfigYaml, map[string]*bintree{}},
-						"s2i-imagestream.yaml":         {testExtendedTestdataBuildsVolumesS2iImagestreamYaml, map[string]*bintree{}},
-						"secret.yaml":                  {testExtendedTestdataBuildsVolumesSecretYaml, map[string]*bintree{}},
+						"configmap.yaml":                         {testExtendedTestdataBuildsVolumesConfigmapYaml, map[string]*bintree{}},
+						"csi-docker-buildconfig.yaml":            {testExtendedTestdataBuildsVolumesCsiDockerBuildconfigYaml, map[string]*bintree{}},
+						"csi-s2i-buildconfig.yaml":               {testExtendedTestdataBuildsVolumesCsiS2iBuildconfigYaml, map[string]*bintree{}},
+						"csi-sharedresourcerole.yaml":            {testExtendedTestdataBuildsVolumesCsiSharedresourceroleYaml, map[string]*bintree{}},
+						"csi-sharedresourcerolebinding.yaml":     {testExtendedTestdataBuildsVolumesCsiSharedresourcerolebindingYaml, map[string]*bintree{}},
+						"csi-sharedsecret.yaml":                  {testExtendedTestdataBuildsVolumesCsiSharedsecretYaml, map[string]*bintree{}},
+						"csi-without-rr-docker-buildconfig.yaml": {testExtendedTestdataBuildsVolumesCsiWithoutRrDockerBuildconfigYaml, map[string]*bintree{}},
+						"csi-without-rr-s2i-buildconfig.yaml":    {testExtendedTestdataBuildsVolumesCsiWithoutRrS2iBuildconfigYaml, map[string]*bintree{}},
+						"docker-buildconfig.yaml":                {testExtendedTestdataBuildsVolumesDockerBuildconfigYaml, map[string]*bintree{}},
+						"docker-deploymentconfig.yaml":           {testExtendedTestdataBuildsVolumesDockerDeploymentconfigYaml, map[string]*bintree{}},
+						"docker-imagestream.yaml":                {testExtendedTestdataBuildsVolumesDockerImagestreamYaml, map[string]*bintree{}},
+						"s2i-buildconfig.yaml":                   {testExtendedTestdataBuildsVolumesS2iBuildconfigYaml, map[string]*bintree{}},
+						"s2i-deploymentconfig.yaml":              {testExtendedTestdataBuildsVolumesS2iDeploymentconfigYaml, map[string]*bintree{}},
+						"s2i-imagestream.yaml":                   {testExtendedTestdataBuildsVolumesS2iImagestreamYaml, map[string]*bintree{}},
+						"secret.yaml":                            {testExtendedTestdataBuildsVolumesSecretYaml, map[string]*bintree{}},
 					}},
 					"webhook": {nil, map[string]*bintree{
 						"bitbucket": {nil, map[string]*bintree{

--- a/test/extended/testdata/builds/volumes/csi-docker-buildconfig.yaml
+++ b/test/extended/testdata/builds/volumes/csi-docker-buildconfig.yaml
@@ -1,0 +1,38 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: mydockertest
+  labels:
+    name: test
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mydockerstream:latest
+  postCommit:
+    script: cat /var/run/secrets/some-secret/key
+  triggers: []
+  runPolicy: Serial
+  source:
+    dockerfile:
+      'FROM quay.io/redhat-developer/test-build-simples2i:1.2'
+  strategy:
+    type: Docker
+    dockerStrategy:
+      env:
+        - name: BUILD_LOGLEVEL
+          value: "5"
+      volumes:
+      - mounts:
+        - destinationPath: "/var/run/secrets/some-secret"
+        name: my-csi-shared-secret
+        source:
+          csi:
+            driver: csi.sharedresource.openshift.io
+            readOnly: true
+            volumeAttributes:
+              sharedSecret: my-share
+          type: CSI
+  resources: {}
+  nodeSelector: null
+status: {}

--- a/test/extended/testdata/builds/volumes/csi-s2i-buildconfig.yaml
+++ b/test/extended/testdata/builds/volumes/csi-s2i-buildconfig.yaml
@@ -1,0 +1,38 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: mys2itest
+  labels:
+    name: test
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mys2istream:latest
+  postCommit:
+    script: cat /var/run/secrets/some-secret/key
+  triggers: []
+  runPolicy: Serial
+  source:
+    type: Binary
+    binary: {}
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: quay.io/redhat-developer/test-build-simples2i:1.2
+      volumes:
+      - mounts:
+        - destinationPath: "/var/run/secrets/some-secret"
+        name: my-csi-shared-secret
+        source:
+          csi:
+            driver: csi.sharedresource.openshift.io
+            readOnly: true
+            volumeAttributes:
+              sharedSecret: my-share
+          type: CSI
+  resources: {}
+  nodeSelector: null
+status: {}

--- a/test/extended/testdata/builds/volumes/csi-sharedresourcerole.yaml
+++ b/test/extended/testdata/builds/volumes/csi-sharedresourcerole.yaml
@@ -1,0 +1,14 @@
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: shared-resource-my-share
+rules:
+- apiGroups:
+    - sharedresource.openshift.io
+  resources:
+    - sharedsecrets
+  resourceNames:
+    - my-share
+  verbs:
+    - use
+  

--- a/test/extended/testdata/builds/volumes/csi-sharedresourcerolebinding.yaml
+++ b/test/extended/testdata/builds/volumes/csi-sharedresourcerolebinding.yaml
@@ -1,0 +1,25 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: "build-volume-csi-roles-template"
+labels:
+  createdBy: "build-volume-csi-roles-template"
+parameters:
+  - description: "The namespace to create roles in."
+    name: NAMESPACE
+    required: true
+objects:
+  - apiVersion: authorization.openshift.io/v1
+    kind: RoleBinding
+    metadata:
+      name: shared-resource-my-share
+      namespace: ${NAMESPACE}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: shared-resource-my-share
+      namespace: ${NAMESPACE} 
+    subjects:
+    - kind: ServiceAccount
+      name: builder
+      namespace: ${NAMESPACE}

--- a/test/extended/testdata/builds/volumes/csi-sharedsecret.yaml
+++ b/test/extended/testdata/builds/volumes/csi-sharedsecret.yaml
@@ -1,0 +1,8 @@
+apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: my-share
+spec:
+  secretRef:
+    name: my-secret
+    namespace: default

--- a/test/extended/testdata/builds/volumes/csi-without-rr-docker-buildconfig.yaml
+++ b/test/extended/testdata/builds/volumes/csi-without-rr-docker-buildconfig.yaml
@@ -1,0 +1,39 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: mydockertest
+  labels:
+    name: test
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mydockerstream:latest
+  postCommit:
+    script: cat /var/run/secrets/some-secret/key
+  triggers: []
+  runPolicy: Serial
+  source:
+    dockerfile:
+      'FROM quay.io/redhat-developer/test-build-simples2i:1.2'
+  strategy:
+    type: Docker
+    dockerStrategy:
+      env:
+        - name: BUILD_LOGLEVEL
+          value: "5"
+      volumes:
+      - mounts:
+        - destinationPath: "/var/run/secrets/some-secret"
+        name: my-csi-shared-secret
+        source:
+          csi:
+            driver: csi.sharedresource.openshift.io
+            readOnly: true
+            volumeAttributes:
+              sharedSecret: my-share
+              refreshResource: "false"
+          type: CSI
+  resources: {}
+  nodeSelector: null
+status: {}

--- a/test/extended/testdata/builds/volumes/csi-without-rr-s2i-buildconfig.yaml
+++ b/test/extended/testdata/builds/volumes/csi-without-rr-s2i-buildconfig.yaml
@@ -1,0 +1,39 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: mys2itest
+  labels:
+    name: test
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: mys2istream:latest
+  postCommit:
+    script: cat /var/run/secrets/some-secret/key
+  triggers: []
+  runPolicy: Serial
+  source:
+    type: Binary
+    binary: {}
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: quay.io/redhat-developer/test-build-simples2i:1.2
+      volumes:
+      - mounts:
+        - destinationPath: "/var/run/secrets/some-secret"
+        name: my-csi-shared-secret
+        source:
+          csi:
+            driver: csi.sharedresource.openshift.io
+            readOnly: true
+            volumeAttributes:
+              sharedSecret: my-share
+              refreshResource: "false"
+          type: CSI
+  resources: {}
+  nodeSelector: null
+status: {}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1231,6 +1231,18 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-builds][Feature:Builds][volumes] build volumes  should mount given secrets and configmaps into the build pod for source strategy builds": "should mount given secrets and configmaps into the build pod for source strategy builds [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview disabled clusters  should fail mounting given csi shared resource secret into the build pod for docker strategy builds": "should fail mounting given csi shared resource secret into the build pod for docker strategy builds [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview disabled clusters  should fail mounting given csi shared resource secret into the build pod for source strategy builds": "should fail mounting given csi shared resource secret into the build pod for source strategy builds [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster  should mount given csi shared resource secret into the build pod for docker strategy builds": "should mount given csi shared resource secret into the build pod for docker strategy builds [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster  should mount given csi shared resource secret into the build pod for source strategy builds": "should mount given csi shared resource secret into the build pod for source strategy builds [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster  should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds": "should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster  should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds": "should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhook": "TestWebhook [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhookGitHubPing": "TestWebhookGitHubPing [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
- Adds e2e tests for builds with csi volume in a techpreview clusters. e2e should be successful
- Adds e2e tests for builds with csi volume in non techpreview clusters. e2e should fail in this case

https://issues.redhat.com/browse/BUILD-275