### PR TITLE
Bug 1961233: Add DNS availability upgrade test

### DIFF
--- a/test/e2e/upgrade/dns/dns.go
+++ b/test/e2e/upgrade/dns/dns.go
@@ -1,0 +1,133 @@
+package dns
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+
+	kappsv1 "k8s.io/api/apps/v1"
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+type UpgradeTest struct{}
+
+var appName string
+
+func (t *UpgradeTest) Name() string { return "check-for-dns-availability" }
+func (UpgradeTest) DisplayName() string {
+	return "[sig-network-edge] Verify DNS availability during and after upgrade success"
+}
+
+// Setup creates a DaemonSet to verify DNS availability during and after upgrade
+func (t *UpgradeTest) Setup(f *framework.Framework) {
+	ginkgo.By("Setting up upgrade DNS availability test")
+
+	ginkgo.By("Getting DNS Service Cluster IP")
+	dnsServiceIP := t.getServiceIP(f)
+
+	ginkgo.By("Creating a DaemonSet to verify DNS availability")
+	appName = fmt.Sprintf("dns-test-%s", string(uuid.NewUUID()))
+	t.createDNSTestDaemonSet(f, dnsServiceIP)
+}
+
+// Test checks for logs from DNS availability test a minute after upgrade finishes
+// to cover during and after upgrade phase, and verifies the results.
+func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, _ upgrades.UpgradeType) {
+	ginkgo.By("Validating DNS results during upgrade")
+	t.validateDNSResults(f)
+
+	// Block until upgrade is done
+	<-done
+
+	ginkgo.By("Sleeping for a minute to give it time for verifying DNS after upgrade")
+	time.Sleep(1 * time.Minute)
+
+	ginkgo.By("Validating DNS results after upgrade")
+	t.validateDNSResults(f)
+}
+
+// getServiceIP gets Cluster IP from DNS Service
+func (t *UpgradeTest) getServiceIP(f *framework.Framework) string {
+	dnsService, err := f.ClientSet.CoreV1().Services("openshift-dns").Get(context.Background(), "dns-default", metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	return dnsService.Spec.ClusterIP
+}
+
+// createDNSTestDaemonSet creates a DaemonSet to test DNS availability
+func (t *UpgradeTest) createDNSTestDaemonSet(f *framework.Framework, dnsServiceIP string) {
+	cmd := fmt.Sprintf("while true; do dig +short @%s google.com || echo $(date) fail && sleep 1; done", dnsServiceIP)
+	_, err := f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).Create(context.Background(), &kappsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: appName},
+		Spec: kappsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": appName},
+			},
+			Template: kapiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": appName},
+				},
+				Spec: kapiv1.PodSpec{
+					Containers: []kapiv1.Container{
+						{
+							Name:    "querier",
+							Image:   imageutils.GetE2EImage(imageutils.JessieDnsutils),
+							Command: []string{"sh", "-c", cmd},
+						},
+					},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+}
+
+// validateDNSResults retrieves the Pod logs and validates the results
+func (t *UpgradeTest) validateDNSResults(f *framework.Framework) {
+	ginkgo.By(fmt.Sprintf("Listing Pods with label app=%s", appName))
+	podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
+	selector, _ := labels.Parse(fmt.Sprintf("app=%s", appName))
+	pods, err := podClient.List(context.Background(), metav1.ListOptions{LabelSelector: selector.String()})
+	framework.ExpectNoError(err)
+
+	ginkgo.By("Retrieving logs from all the Pods belonging to the DaemonSet and asserting no failure")
+	for _, pod := range pods.Items {
+		r, err := podClient.GetLogs(pod.Name, &kapiv1.PodLogOptions{Container: "querier"}).Stream(context.Background())
+		framework.ExpectNoError(err)
+
+		failureCount := 0.0
+		successCount := 0.0
+		scan := bufio.NewScanner(r)
+		for scan.Scan() {
+			line := scan.Text()
+			if strings.Contains(line, "fail") {
+				failureCount++
+			} else if ip := net.ParseIP(line); ip != nil {
+				successCount++
+			}
+		}
+
+		if successRate := (successCount / (successCount + failureCount)) * 100; successRate < 99 {
+			err = fmt.Errorf("success rate is less than 99%% on the node %s: [%0.2f]", pod.Spec.NodeName, successRate)
+		} else {
+			err = nil
+		}
+		framework.ExpectNoError(err)
+	}
+}
+
+// Teardown cleans up any objects that are created that
+// aren't already cleaned up by the framework.
+func (t *UpgradeTest) Teardown(_ *framework.Framework) {
+	// rely on the namespace deletion to clean up everything
+}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/origin/test/e2e/upgrade/service"
-
 	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +32,9 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/test/e2e/upgrade/adminack"
 	"github.com/openshift/origin/test/e2e/upgrade/alert"
+	"github.com/openshift/origin/test/e2e/upgrade/dns"
 	"github.com/openshift/origin/test/e2e/upgrade/manifestdelete"
+	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/prometheus"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
@@ -76,6 +76,7 @@ func AllTests() []upgrades.Test {
 		imageregistry.NewImageRegistryAvailableWithNewConnectionsTest(),
 		imageregistry.NewImageRegistryAvailableWithReusedConnectionsTest(),
 		&prometheus.MetricsAvailableAfterUpgradeTest{},
+		&dns.UpgradeTest{},
 	}
 }
 


### PR DESCRIPTION
Add a new test to the upgrade test suite to validate DNS availability during and after an upgrade. The new test implements the simple [UpgradeTest interface](https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/test/e2e/upgrades/upgrade.go#L46). 
- `test/e2e/upgrade/dns/dns.go`: 
(`Name()`) and (`DisplayName()`) provides a name for the test to be used by the framework (e.g. for namespace creation, printing in the logs). 
(`Setup()`) performs the intial setup before the upgrade starts. It retrieves DNS Service Cluster IP and creates a DaemonSet (`createDNSTestDaemonSet()`) which performs a simple dig command (`while true; do dig +short @CLUSTER_IP google.com || echo $(date) fail && sleep 1; done`) to check DNS availability using the obtained Cluster IP.
(`Test()`) is called during upgrade and the `done` channel is closed when the upgrade is finished. `validateDNSResults()` is the function called within `Test()` to test the availability during and after upgrade (i.e. after `done` is closed). It retrieves logs from DaemonSet Pods, counts number of sucessful and failed DNS queries, and calculates the success rate. It fails the test if the success rate is less than 99%. 
(`Teardown()`) is an empty function created only to implement the interface. Framework deletes the namespace created for this test after the test suit finishes. That's why there is no any other clean up need for this test.
- `test/e2e/upgrade/upgrade.go`: Add the new DNS upgrade test to the list of `AllTests` so that it gets executed as a part of ClusterUpgrade tests.