### PR TITLE
Debug missing OSUpdateStarted events

### DIFF
--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -123,8 +123,9 @@ func testOperatorOSUpdateStaged(events monitorapi.Intervals, clientConfig *rest.
 	var failTest bool // set true if we see anything over 10 minutes, our failure threshold
 	for node, ss := range nodeOSUpdateTimes {
 		if ss.OSUpdateStarted.IsZero() {
-			// Watch for an edge case we're not sure can/will occur:
-			slowStageMessages = append(slowStageMessages, fmt.Sprintf("%s OSUpdateStarted at %s, did not make it to OSUpdateStaged", node, ss.OSUpdateStarted.Format(time.RFC3339)))
+			// We've seen this on metal where we've got no start time, the event is in the gather-extra/events.json but
+			// not in the junit/e2e-events.json the test framework writes afterwards, unclear how it's getting missed.
+			slowStageMessages = append(slowStageMessages, fmt.Sprintf("%s OSUpdateStaged at %s, but no OSUpdateStarted event was recorded", node, ss.OSUpdateStaged.Format(time.RFC3339)))
 			failTest = true // considering this a failure for now
 		} else if ss.OSUpdateStaged.IsZero() || ss.OSUpdateStarted.After(ss.OSUpdateStaged) {
 			// Watch that we don't do multiple started->staged transitions, if we see started > staged, we must have


### PR DESCRIPTION
- Improve edge cases error message for OSUpdateStaged test.
- Debugging hack for missing event intervals.

An edge case we didn't really think was possible is occurring in about 0.07% of jobs. 

When this happens it appears we record an OSUpdateStaged event, but are missing an OSUpdateStarted, which logically should be there. Gather-extra sees it after the job when we oc get events, but for some reason the monitor is not recording it. Affects just one host in the job run, the others are fine.

Attempt to debug by ruling out whether or not we're getting the event at all in our watch.
