### PR TITLE
Bug 2047911: IBMCloud: Stop creating CRB for IBM Cloud clusters

### DIFF
--- a/test/extended/util/ibmcloud/provider.go
+++ b/test/extended/util/ibmcloud/provider.go
@@ -1,13 +1,6 @@
 package ibmcloud
 
 import (
-	"context"
-
-	o "github.com/onsi/gomega"
-
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -24,32 +17,4 @@ func newProvider() (framework.ProviderInterface, error) {
 // Provider is a structure to handle IBMCloud for e2e testing
 type Provider struct {
 	framework.NullProvider
-}
-
-// TODO: Determine if this can be avoided by running worker kubelets without
-// --enable-controller-attach-detach=false
-// e2e: https://bugzilla.redhat.com/show_bug.cgi?id=1825034 - Mock CSI tests fail on IBM ROKS clusters
-func (p *Provider) FrameworkBeforeEach(f *framework.Framework) {
-	_, err := f.ClientSet.RbacV1().ClusterRoleBindings().Get(context.Background(), "e2e-node-attacher", metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		rb := &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "e2e-node-attacher",
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					APIGroup: rbacv1.SchemeGroupVersion.Group,
-					Kind:     "Group",
-					Name:     "system:nodes",
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.SchemeGroupVersion.Group,
-				Kind:     "ClusterRole",
-				Name:     "system:controller:attachdetach-controller",
-			},
-		}
-		_, err = f.ClientSet.RbacV1().ClusterRoleBindings().Create(context.Background(), rb, metav1.CreateOptions{})
-	}
-	o.Expect(err).NotTo(o.HaveOccurred())
 }


### PR DESCRIPTION
Update the IBM Cloud provider framework to no longer create a
ClusterRoleBinding for IBM Cloud clusters, as unmanaged clusters
should not need this CRB and managed clusters will need to account
for this as needed.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1825034