### PR TITLE
Fix broken console disruption test.

### DIFF
--- a/test/extended/util/disruption/frontends/known_backends.go
+++ b/test/extended/util/disruption/frontends/known_backends.go
@@ -62,7 +62,7 @@ func createConsoleRouteAvailableWithNewConnections() *backenddisruption.BackendS
 		"ingress-to-console",
 		"/healthz",
 		backenddisruption.NewConnectionType).
-		WithExpectedBodyRegex(`(Red Hat OpenShift Container Platform|OKD)`)
+		WithExpectedBodyRegex(`(Red Hat OpenShift|OKD)`)
 }
 
 func createConsoleRouteAvailableWithConnectionReuse() *backenddisruption.BackendSampler {
@@ -75,5 +75,5 @@ func createConsoleRouteAvailableWithConnectionReuse() *backenddisruption.Backend
 		"ingress-to-console",
 		"/healthz",
 		backenddisruption.ReusedConnectionType).
-		WithExpectedBodyRegex(`(Red Hat OpenShift Container Platform|OKD)`)
+		WithExpectedBodyRegex(`(Red Hat OpenShift|OKD)`)
 }


### PR DESCRIPTION
This test is currently blocking the required e2e-gcp-upgrade job on all
origin PRs. It looks to have broken sometime in the last few days when
the following tests began failing:

disruption_tests: [sig-network-edge] Console remains available via cluster ingress using new connections
disruption_tests: [sig-network-edge] Console remains available via cluster ingress using reused connections

The disruption shown is massive, one hour, the entire duration of the
upgrade.

This is because we are getting a response from the UI that does not
contain the expected text. Previously we expected to see "Red Hat
OpenShift Container Platform" (or OKD).

The actual request body is essentially to inform us that:

<noscript>JavaScript must be enabled.</noscript>

Presumably this is not new.

We no longer see "Red Hat OpenShift Container Platform", but we do see:

<title>Red Hat OpenShift</title>

As such I've changed the expected text on the assumption that it
has changed in 4.11.
