### PR TITLE
Delete extra workers before running metal high availability test

### DIFF
--- a/test/extended/baremetal/helper.go
+++ b/test/extended/baremetal/helper.go
@@ -135,6 +135,10 @@ func (b *BaremetalTestHelper) CreateExtraWorker(host *unstructured.Unstructured,
 
 // DeleteAllExtraWorkers deletes all the extra workers created in the current session
 func (b *BaremetalTestHelper) DeleteAllExtraWorkers() {
+	if b.extraWorkers == nil {
+		return
+	}
+
 	for _, worker := range b.extraWorkers {
 		err := b.bmcClient.Delete(context.Background(), worker.GetName(), metav1.DeleteOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())

--- a/test/extended/baremetal/high_availability.go
+++ b/test/extended/baremetal/high_availability.go
@@ -32,7 +32,19 @@ const (
 var _ = g.Describe("[sig-installer][Feature:baremetal][Serial] Baremetal platform should ensure", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLI("baremetal")
+	var (
+		oc     = exutil.NewCLI("baremetal")
+		helper *BaremetalTestHelper
+	)
+
+	g.BeforeEach(func() {
+		helper = NewBaremetalTestHelper(oc.AdminDynamicClient())
+		helper.Setup()
+	})
+
+	g.AfterEach(func() {
+		helper.DeleteAllExtraWorkers()
+	})
 
 	g.It("cluster baremetal operator and metal3 deployment return back healthy after they are deleted", func() {
 		skipIfNotBaremetal(oc)


### PR DESCRIPTION
This PR adds before step to run metal high availability test.
Thanks to that, test will ensure there is no other extra workers which
statuses can be set variably.