### PR TITLE
operators: test Prometheus UI is inaccessible

### DIFF
--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -63,6 +63,7 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 			expect []int
 		}{
 			{ns: "openshift-console", name: "console", scheme: "https", path: "", expect: []int{200}},
+			{ns: "openshift-monitoring", name: "prometheus-k8s", scheme: "https", path: "", expect: []int{503}},
 			{ns: "openshift-monitoring", name: "prometheus-k8s", scheme: "https", path: "api/v1/targets", expect: []int{403, 401}},
 		}
 		for _, r := range routes {


### PR DESCRIPTION
The Prometheus UI removal has landed in CMO (https://github.com/openshift/cluster-monitoring-operator/pull/1532). This adds a test to check that the UI is indeed inaccessible via the route.