### PR TITLE
add job type key to the error we track for statistical jobs

### DIFF
--- a/pkg/synthetictests/allowedalerts/basic_alert.go
+++ b/pkg/synthetictests/allowedalerts/basic_alert.go
@@ -187,12 +187,12 @@ func (a *basicAlertTest) failOrFlake(ctx context.Context, restConfig *rest.Confi
 	flakeAfter := a.allowanceCalculator.FlakeAfter(a.alertName, *jobType)
 	switch {
 	case durationAtOrAboveLevel > failAfter:
-		return fail, fmt.Sprintf("%s was at or above %s for at least %s (maxAllowed=%s): pending for %s, firing for %s:\n\n%s",
-			a.AlertName(), a.AlertState(), durationAtOrAboveLevel, failAfter, pendingDuration, firingDuration, strings.Join(describe, "\n"))
+		return fail, fmt.Sprintf("%s was at or above %s for at least %s on %#v (maxAllowed=%s): pending for %s, firing for %s:\n\n%s",
+			a.AlertName(), a.AlertState(), durationAtOrAboveLevel, *jobType, failAfter, pendingDuration, firingDuration, strings.Join(describe, "\n"))
 
 	case durationAtOrAboveLevel > flakeAfter:
-		return flake, fmt.Sprintf("%s was at or above %s for at least %s (maxAllowed=%s): pending for %s, firing for %s:\n\n%s",
-			a.AlertName(), a.AlertState(), durationAtOrAboveLevel, flakeAfter, pendingDuration, firingDuration, strings.Join(describe, "\n"))
+		return flake, fmt.Sprintf("%s was at or above %s for at least %s on %#v (maxAllowed=%s): pending for %s, firing for %s:\n\n%s",
+			a.AlertName(), a.AlertState(), durationAtOrAboveLevel, *jobType, flakeAfter, pendingDuration, firingDuration, strings.Join(describe, "\n"))
 	}
 
 	return pass, ""

--- a/pkg/synthetictests/allowedalerts/matches.go
+++ b/pkg/synthetictests/allowedalerts/matches.go
@@ -54,12 +54,8 @@ func (d *percentileAllowances) FlakeAfter(alertName string, jobType platformiden
 // We enforce "don't get worse" for disruption by watching the aggregate data in CI over many runs.
 func getClosestPercentilesValues(alertName string, jobType platformidentification.JobType) *percentileDuration {
 	exactMatchKey := LastWeekPercentileKey{
-		AlertName:   alertName,
-		Release:     jobType.Release,
-		FromRelease: jobType.FromRelease,
-		Platform:    jobType.Platform,
-		Network:     jobType.Network,
-		Topology:    jobType.Topology,
+		AlertName: alertName,
+		JobType:   jobType,
 	}
 	_, percentileAsMap := getCurrentResults()
 

--- a/pkg/synthetictests/allowedalerts/types.go
+++ b/pkg/synthetictests/allowedalerts/types.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"strconv"
 	"sync"
+
+	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
 )
 
 const (
@@ -61,12 +63,8 @@ type Percentiles struct {
 }
 
 type LastWeekPercentileKey struct {
-	AlertName   string
-	Release     string
-	FromRelease string
-	Platform    string
-	Network     string
-	Topology    string
+	AlertName                      string
+	platformidentification.JobType `json:",inline"`
 }
 
 func getCurrentResults() ([]LastWeekPercentiles, map[LastWeekPercentileKey]LastWeekPercentiles) {

--- a/pkg/synthetictests/allowedbackenddisruption/matches.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches.go
@@ -11,23 +11,21 @@ import (
 
 // GetAllowedDisruption uses the backend and information about the cluster to choose the best historical p95 to operate against.
 // We enforce "don't get worse" for disruption by watching the aggregate data in CI over many runs.
-func GetAllowedDisruption(ctx context.Context, backendName string, clientConfig *rest.Config) (*time.Duration, error) {
+func GetAllowedDisruption(ctx context.Context, backendName string, clientConfig *rest.Config) (*time.Duration, string, error) {
 	jobType, err := platformidentification.GetJobType(ctx, clientConfig)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return GetClosestP99Value(backendName, jobType.Release, jobType.FromRelease, jobType.Platform, jobType.Network, jobType.Topology), nil
+	return GetClosestP99Value(backendName, *jobType),
+		fmt.Sprintf("jobType=%#v", jobType),
+		nil
 }
 
-func GetClosestP99Value(backendName, release, fromRelease, platform, networkType, topology string) *time.Duration {
+func GetClosestP99Value(backendName string, jobType platformidentification.JobType) *time.Duration {
 	exactMatchKey := LastWeekPercentileKey{
 		BackendName: backendName,
-		Release:     release,
-		FromRelease: fromRelease,
-		Platform:    platform,
-		Network:     networkType,
-		Topology:    topology,
+		JobType:     jobType,
 	}
 	_, percentileAsMap := getCurrentResults()
 

--- a/pkg/synthetictests/allowedbackenddisruption/matches_test.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
 )
 
 func TestGetClosestP95Value(t *testing.T) {
@@ -17,11 +19,7 @@ func TestGetClosestP95Value(t *testing.T) {
 	}
 	type args struct {
 		backendName string
-		release     string
-		fromRelease string
-		platform    string
-		networkType string
-		topology    string
+		jobType     platformidentification.JobType
 	}
 	tests := []struct {
 		name string
@@ -32,11 +30,13 @@ func TestGetClosestP95Value(t *testing.T) {
 			name: "test-that-failed-in-ci",
 			args: args{
 				backendName: "ingress-to-oauth-server-reused-connections",
-				release:     "4.10",
-				fromRelease: "4.10",
-				platform:    "gcp",
-				networkType: "sdn",
-				topology:    "ha",
+				jobType: platformidentification.JobType{
+					Release:     "4.10",
+					FromRelease: "4.10",
+					Platform:    "gcp",
+					Network:     "sdn",
+					Topology:    "ha",
+				},
 			},
 			want: mustDuration("4s"),
 		},
@@ -44,17 +44,19 @@ func TestGetClosestP95Value(t *testing.T) {
 			name: "missing",
 			args: args{
 				backendName: "kube-api-reused-connections",
-				release:     "4.10",
-				fromRelease: "4.10",
-				platform:    "azure",
-				topology:    "missing",
+				jobType: platformidentification.JobType{
+					Release:     "4.10",
+					FromRelease: "4.10",
+					Platform:    "azure",
+					Topology:    "missing",
+				},
 			},
 			want: mustDuration("2.718s"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetClosestP99Value(tt.args.backendName, tt.args.release, tt.args.fromRelease, tt.args.platform, tt.args.networkType, tt.args.topology); !reflect.DeepEqual(got, tt.want) {
+			if got := GetClosestP99Value(tt.args.backendName, tt.args.jobType); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetClosestP99Value() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/synthetictests/allowedbackenddisruption/types.go
+++ b/pkg/synthetictests/allowedbackenddisruption/types.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"strconv"
 	"sync"
+
+	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
 )
 
 const (
@@ -65,12 +67,8 @@ type LastWeekPercentiles struct {
 }
 
 type LastWeekPercentileKey struct {
-	BackendName string
-	Release     string
-	FromRelease string
-	Platform    string
-	Network     string
-	Topology    string
+	BackendName                    string
+	platformidentification.JobType `json:",inline"`
 }
 
 func getCurrentResults() ([]LastWeekPercentiles, map[LastWeekPercentileKey]LastWeekPercentiles) {


### PR DESCRIPTION
This will show us which combination of configuration we're missing for a particular disruption check.

Shows up like `jobType=&platformidentification.JobType{Release:"4.11", FromRelease:"4.11", Platform:"gcp", Network:"sdn", Topology:"ha"}`