### PR TITLE
Break out test for OSUpdateStaged event with no OSUpdateStarted.

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -32,6 +32,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testErrImagePullGeneric(events)...)
 	tests = append(tests, testAlerts(events, kubeClientConfig)...)
 	tests = append(tests, testOperatorOSUpdateStaged(events, kubeClientConfig)...)
+	tests = append(tests, testOperatorOSUpdateStartedEventRecorded(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 
 	return tests
@@ -57,6 +58,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testErrImagePullGeneric(events)...)
 	tests = append(tests, testAlerts(events, kubeClientConfig)...)
 	tests = append(tests, testOperatorOSUpdateStaged(events, kubeClientConfig)...)
+	tests = append(tests, testOperatorOSUpdateStartedEventRecorded(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 
 	return tests


### PR DESCRIPTION
This is confirmed to be happening and we can see that we're missing
events in the disruption monitor watch when apiservers are upgrading.

Move this scenario out to it's own test, which will only ever flake,
while we work on a fix.

Original test will now ignore this scenario.
