### PR TITLE
WIP: operators: add test that verify cluster operators reconciling conditions

### DIFF
--- a/test/extended/operators/clusteroperators.go
+++ b/test/extended/operators/clusteroperators.go
@@ -2,6 +2,13 @@ package operators
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/synthetictests"
+
+	"k8s.io/client-go/util/retry"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -20,6 +27,8 @@ var _ = g.Describe("[sig-arch] ClusterOperators", func() {
 	defer g.GinkgoRecover()
 
 	var clusterOperators []config.ClusterOperator
+	var clusterOperatorsClient configclient.ClusterOperatorInterface
+
 	whitelistNoNamespace := sets.NewString(
 		"cloud-credential",
 		"image-registry",
@@ -45,11 +54,89 @@ var _ = g.Describe("[sig-arch] ClusterOperators", func() {
 	g.BeforeEach(func() {
 		kubeConfig, err := e2e.LoadConfig()
 		o.Expect(err).ToNot(o.HaveOccurred())
-		configClient, err := configclient.NewForConfig(kubeConfig)
+		client, err := configclient.NewForConfig(kubeConfig)
 		o.Expect(err).ToNot(o.HaveOccurred())
-		clusterOperatorsList, err := configClient.ClusterOperators().List(context.Background(), metav1.ListOptions{})
+		clusterOperatorsClient = client.ClusterOperators()
+		clusterOperatorsList, err := clusterOperatorsClient.List(context.Background(), metav1.ListOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
 		clusterOperators = clusterOperatorsList.Items
+	})
+
+	g.It("should reconcile the messages and update last transition time", func() {
+		operatorOriginalConditions := map[string][]config.ClusterOperatorStatusCondition{}
+		operatorsToReconcileMessage := sets.NewString()
+		interestingConditionTypes := sets.NewString("Available", "Degraded", "Progressing", "Upgradeable")
+
+		messageToReconcile := "operator is expected to reconcile this message"
+		for _, clusterOperator := range clusterOperators {
+			updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				newClusterOperator, err := clusterOperatorsClient.Get(context.TODO(), clusterOperator.Name, metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				if err != nil {
+					return err
+				}
+				clusterOperatorCopy := newClusterOperator.DeepCopy()
+				for i := range clusterOperatorCopy.Status.Conditions {
+					newCondition := clusterOperatorCopy.Status.Conditions[i]
+					if !interestingConditionTypes.Has(string(newCondition.Type)) {
+						continue
+					}
+					operatorOriginalConditions[newClusterOperator.Name] = append(operatorOriginalConditions[clusterOperator.Name], clusterOperatorCopy.Status.Conditions[i])
+					newCondition.Message = messageToReconcile
+					clusterOperatorCopy.Status.Conditions[i] = newCondition
+				}
+				_, err = clusterOperatorsClient.UpdateStatus(context.TODO(), clusterOperatorCopy, metav1.UpdateOptions{})
+				return err
+			})
+			// if we failed to update single cluster operator, this test failed
+			if updateErr != nil {
+				o.Expect(updateErr).ToNot(o.HaveOccurred())
+				return
+			}
+			operatorsToReconcileMessage.Insert(clusterOperator.Name)
+		}
+
+		for {
+			time.Sleep(300 * time.Millisecond) // prevent hot-looping
+
+			for _, clusterOperator := range clusterOperators {
+				reconciledClusterOperator, err := clusterOperatorsClient.Get(context.TODO(), clusterOperator.Name, metav1.GetOptions{})
+				if err != nil {
+					e2e.Logf("failed to get %q operator: %w", clusterOperator.Name, err)
+				}
+
+				hasMessageToReconcile := false
+				for _, c := range reconciledClusterOperator.Status.Conditions {
+					if !interestingConditionTypes.Has(string(c.Type)) {
+						continue
+					}
+					// check if the condition message has changed, if not go to next operator and return to this one in next iteration
+					if c.Message == messageToReconcile {
+						e2e.Logf("operator %s condition %s has not reconciled ...", clusterOperator.Name, c.Type)
+						hasMessageToReconcile = true
+					}
+				}
+				if !hasMessageToReconcile {
+					operatorsToReconcileMessage.Delete(clusterOperator.Name)
+				}
+			}
+
+			select {
+			case <-time.After(60 * time.Second):
+				messages := []string{}
+				for _, operatorName := range operatorsToReconcileMessage.List() {
+					component := synthetictests.GetBugzillaComponentForOperator(operatorName)
+					messages = append(messages, fmt.Sprintf("[bz-%s] cluster operator %s failed to reconcile condition message after it changed", component, operatorName))
+				}
+				o.Expect(fmt.Errorf(strings.Join(messages, "\n"))).ToNot(o.HaveOccurred())
+				return
+			default:
+				// all operators reconciled their messages
+				if operatorsToReconcileMessage.Len() == 0 {
+					return
+				}
+			}
+		}
 	})
 
 	g.Context("should define", func() {

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -589,6 +589,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] ClusterOperators should define at least one related object that is not a namespace": "at least one related object that is not a namespace [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-arch] ClusterOperators should reconcile the messages and update last transition time": "should reconcile the messages and update last transition time [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-arch] Managed cluster should ensure control plane operators do not make themselves unevictable": "ensure control plane operators do not make themselves unevictable [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch] Managed cluster should ensure control plane pods do not run in best-effort QoS": "ensure control plane pods do not run in best-effort QoS [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This test checks if all cluster operators properly reconcile their messages and update lastTransitionTime when the message is changed from external (the test does it here).
This test fail if one or more operators fail to change the message for condition back (or to something else) in 2 minutes.

xref: https://github.com/openshift/enhancements/pull/1025