### PR TITLE
bug 2053143:allow inexact matches for disruption data

### DIFF
--- a/pkg/synthetictests/allowedalerts/matches.go
+++ b/pkg/synthetictests/allowedalerts/matches.go
@@ -1,8 +1,9 @@
 package allowedalerts
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/openshift/origin/pkg/synthetictests/historicaldata"
 
 	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
 )
@@ -41,53 +42,17 @@ type percentileAllowances struct {
 var defaultAllowances = &percentileAllowances{}
 
 func (d *percentileAllowances) FailAfter(alertName string, jobType platformidentification.JobType) time.Duration {
-	allowed := getClosestPercentilesValues(alertName, jobType)
+	allowed, _, _ := getClosestPercentilesValues(alertName, jobType)
 	return allowed.P99
 }
 
 func (d *percentileAllowances) FlakeAfter(alertName string, jobType platformidentification.JobType) time.Duration {
-	allowed := getClosestPercentilesValues(alertName, jobType)
+	allowed, _, _ := getClosestPercentilesValues(alertName, jobType)
 	return allowed.P95
 }
 
-// getClosestPercentilesValues uses the backend and information about the cluster to choose the best historical p95 to operate against.
+// getClosestPercentilesValues uses the backend and information about the cluster to choose the best historical p99 to operate against.
 // We enforce "don't get worse" for disruption by watching the aggregate data in CI over many runs.
-func getClosestPercentilesValues(alertName string, jobType platformidentification.JobType) *percentileDuration {
-	exactMatchKey := LastWeekPercentileKey{
-		AlertName: alertName,
-		JobType:   jobType,
-	}
-	_, percentileAsMap := getCurrentResults()
-
-	// chose so we can find them easily in the log
-	defaultSeconds, err := time.ParseDuration("3.141s")
-	if err != nil {
-		panic(err)
-	}
-	defaultPercentiles := &percentileDuration{
-		P95: defaultSeconds,
-		P99: defaultSeconds,
-	}
-
-	if percentiles, ok := percentileAsMap[exactMatchKey]; ok {
-		p99, err := time.ParseDuration(fmt.Sprintf("%2fs", percentiles.P99))
-		if err != nil {
-			panic(err)
-		}
-		p95, err := time.ParseDuration(fmt.Sprintf("%2fs", percentiles.P95))
-		if err != nil {
-			panic(err)
-		}
-		return &percentileDuration{
-			P95: p95,
-			P99: p99,
-		}
-	}
-
-	return defaultPercentiles
-}
-
-type percentileDuration struct {
-	P95 time.Duration
-	P99 time.Duration
+func getClosestPercentilesValues(alertName string, jobType platformidentification.JobType) (historicaldata.StatisticalDuration, string, error) {
+	return getCurrentResults().BestMatchDuration(alertName, jobType)
 }

--- a/pkg/synthetictests/allowedalerts/matches_test.go
+++ b/pkg/synthetictests/allowedalerts/matches_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/origin/pkg/synthetictests/historicaldata"
+
 	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
 )
 
@@ -21,7 +23,7 @@ func TestGetClosestP95Value(t *testing.T) {
 		name      string
 		alertName string
 		jobType   platformidentification.JobType
-		want      *percentileDuration
+		want      historicaldata.StatisticalDuration
 	}{
 		{
 			name:      "test-that-failed-in-ci",
@@ -33,7 +35,18 @@ func TestGetClosestP95Value(t *testing.T) {
 				Network:     "sdn",
 				Topology:    "ha",
 			},
-			want: &percentileDuration{
+			want: historicaldata.StatisticalDuration{
+				DataKey: historicaldata.DataKey{
+					Name: "etcdGRPCRequestsSlow",
+					JobType: platformidentification.JobType{
+						Release:     "4.10",
+						FromRelease: "4.10",
+						Platform:    "gcp",
+						Network:     "sdn",
+						Topology:    "ha",
+					},
+				},
+
 				P95: mustDuration("2s"),
 				P99: mustDuration("3s"),
 			},
@@ -47,7 +60,17 @@ func TestGetClosestP95Value(t *testing.T) {
 				Platform:    "azure",
 				Topology:    "missing",
 			},
-			want: &percentileDuration{
+			want: historicaldata.StatisticalDuration{
+				DataKey: historicaldata.DataKey{
+					Name: "ingress-to-oauth-server-reused-connections",
+					JobType: platformidentification.JobType{
+						Release:     "4.10",
+						FromRelease: "4.10",
+						Platform:    "azure",
+						Topology:    "missing",
+					},
+				},
+
 				P95: mustDuration("3.141s"),
 				P99: mustDuration("3.141s"),
 			},
@@ -55,7 +78,7 @@ func TestGetClosestP95Value(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getClosestPercentilesValues(tt.alertName, tt.jobType); !reflect.DeepEqual(got, tt.want) {
+			if got, _, _ := getClosestPercentilesValues(tt.alertName, tt.jobType); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetClosestP99Value() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/synthetictests/allowedalerts/types.go
+++ b/pkg/synthetictests/allowedalerts/types.go
@@ -49,12 +49,16 @@ var (
 	historicalData historicaldata.BestMatcher
 )
 
+// if data is missing for a particular jobtype combination, this is the value returned.  Choose a unique value that will
+// be easily searchable across large numbers of job runs.  I like pi.
+const defaultReturn = 3.141
+
 func getCurrentResults() historicaldata.BestMatcher {
 	readResults.Do(
 		func() {
 			var err error
 			genericBytes := bytes.ReplaceAll(queryResults, []byte(`    "AlertName": "`), []byte(`    "Name": "`))
-			historicalData, err = historicaldata.NewMatcher(genericBytes, 3.141)
+			historicalData, err = historicaldata.NewMatcher(genericBytes, defaultReturn)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/synthetictests/allowedbackenddisruption/matches.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches.go
@@ -1,47 +1,13 @@
 package allowedbackenddisruption
 
 import (
-	"context"
-	"fmt"
 	"time"
 
 	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
-	"k8s.io/client-go/rest"
 )
 
 // GetAllowedDisruption uses the backend and information about the cluster to choose the best historical p95 to operate against.
 // We enforce "don't get worse" for disruption by watching the aggregate data in CI over many runs.
-func GetAllowedDisruption(ctx context.Context, backendName string, clientConfig *rest.Config) (*time.Duration, string, error) {
-	jobType, err := platformidentification.GetJobType(ctx, clientConfig)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return GetClosestP99Value(backendName, *jobType),
-		fmt.Sprintf("jobType=%#v", jobType),
-		nil
-}
-
-func GetClosestP99Value(backendName string, jobType platformidentification.JobType) *time.Duration {
-	exactMatchKey := LastWeekPercentileKey{
-		BackendName: backendName,
-		JobType:     jobType,
-	}
-	_, percentileAsMap := getCurrentResults()
-
-	// chose so we can find them easily in the log
-	defaultSeconds, err := time.ParseDuration("2.718s")
-	if err != nil {
-		panic(err)
-	}
-
-	if percentiles, ok := percentileAsMap[exactMatchKey]; ok {
-		ret, err := time.ParseDuration(fmt.Sprintf("%2fs", percentiles.P99))
-		if err != nil {
-			return &defaultSeconds
-		}
-		return &ret
-	}
-
-	return &defaultSeconds
+func GetAllowedDisruption(backendName string, jobType platformidentification.JobType) (*time.Duration, string, error) {
+	return getCurrentResults().BestMatchP99(backendName, jobType)
 }

--- a/pkg/synthetictests/allowedbackenddisruption/matches_test.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches_test.go
@@ -43,6 +43,21 @@ func TestGetClosestP95Value(t *testing.T) {
 			expectedDuration: mustDuration("4s"),
 		},
 		{
+			name: "fuzzy-match",
+			args: args{
+				backendName: "ingress-to-oauth-server-reused-connections",
+				jobType: platformidentification.JobType{
+					Release:     "4.11",
+					FromRelease: "4.11",
+					Platform:    "azure",
+					Network:     "sdn",
+					Topology:    "ha",
+				},
+			},
+			expectedDuration: mustDuration("12.87s"),
+			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"ingress-to-oauth-server-reused-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.11", Platform:"azure", Network:"sdn", Topology:"ha"}}, fell back to historicaldata.DataKey{Name:"ingress-to-oauth-server-reused-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.10", Platform:"azure", Network:"sdn", Topology:"ha"}})`,
+		},
+		{
 			name: "missing",
 			args: args{
 				backendName: "kube-api-reused-connections",
@@ -54,7 +69,7 @@ func TestGetClosestP95Value(t *testing.T) {
 				},
 			},
 			expectedDuration: mustDuration("2.718s"),
-			expectedDetails:  `jobType=platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"azure", Network:"", Topology:"missing"}`,
+			expectedDetails:  `(no exact or fuzzy match for jobType=platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"azure", Network:"", Topology:"missing"})`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/synthetictests/allowedbackenddisruption/matches_test.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches_test.go
@@ -22,9 +22,11 @@ func TestGetClosestP95Value(t *testing.T) {
 		jobType     platformidentification.JobType
 	}
 	tests := []struct {
-		name string
-		args args
-		want *time.Duration
+		name             string
+		args             args
+		expectedDuration *time.Duration
+		expectedDetails  string
+		expectedErr      error
 	}{
 		{
 			name: "test-that-failed-in-ci",
@@ -38,7 +40,7 @@ func TestGetClosestP95Value(t *testing.T) {
 					Topology:    "ha",
 				},
 			},
-			want: mustDuration("4s"),
+			expectedDuration: mustDuration("4s"),
 		},
 		{
 			name: "missing",
@@ -51,13 +53,21 @@ func TestGetClosestP95Value(t *testing.T) {
 					Topology:    "missing",
 				},
 			},
-			want: mustDuration("2.718s"),
+			expectedDuration: mustDuration("2.718s"),
+			expectedDetails:  `jobType=platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"azure", Network:"", Topology:"missing"}`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetClosestP99Value(tt.args.backendName, tt.args.jobType); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetClosestP99Value() = %v, want %v", got, tt.want)
+			actualDuration, actualDetails, actualErr := GetAllowedDisruption(tt.args.backendName, tt.args.jobType)
+			if got, want := actualDuration, tt.expectedDuration; !reflect.DeepEqual(got, want) {
+				t.Errorf("GetClosestP99Value() = %v, want %v", got, want)
+			}
+			if got, want := actualDetails, tt.expectedDetails; !reflect.DeepEqual(got, want) {
+				t.Errorf("GetClosestP99Value() = %v, want %v", got, want)
+			}
+			if got, want := actualErr, tt.expectedErr; !reflect.DeepEqual(got, want) {
+				t.Errorf("GetClosestP99Value() = %v, want %v", got, want)
 			}
 		})
 	}

--- a/pkg/synthetictests/allowedbackenddisruption/types.go
+++ b/pkg/synthetictests/allowedbackenddisruption/types.go
@@ -57,12 +57,16 @@ var (
 	historicalData historicaldata.BestMatcher
 )
 
+// if data is missing for a particular jobtype combination, this is the value returned.  Choose a unique value that will
+// be easily searchable across large numbers of job runs.  I like e.
+const defaultReturn = 2.718
+
 func getCurrentResults() historicaldata.BestMatcher {
 	readResults.Do(
 		func() {
 			var err error
 			genericBytes := bytes.ReplaceAll(queryResults, []byte(`    "BackendName": "`), []byte(`    "Name": "`))
-			historicalData, err = historicaldata.NewMatcher(genericBytes, 2.718)
+			historicalData, err = historicaldata.NewMatcher(genericBytes, defaultReturn)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/synthetictests/allowedbackenddisruption/types.go
+++ b/pkg/synthetictests/allowedbackenddisruption/types.go
@@ -3,11 +3,9 @@ package allowedbackenddisruption
 import (
 	"bytes"
 	_ "embed"
-	"encoding/json"
-	"strconv"
 	"sync"
 
-	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
+	"github.com/openshift/origin/pkg/synthetictests/historicaldata"
 )
 
 const (
@@ -55,57 +53,20 @@ order by
 var queryResults []byte
 
 var (
-	readResults       sync.Once
-	percentilesAsList []LastWeekPercentiles
-	percentilesAsMap  = map[LastWeekPercentileKey]LastWeekPercentiles{}
+	readResults    sync.Once
+	historicalData historicaldata.BestMatcher
 )
 
-type LastWeekPercentiles struct {
-	LastWeekPercentileKey `json:",inline"`
-	P95                   float64
-	P99                   float64
-}
-
-type LastWeekPercentileKey struct {
-	BackendName                    string
-	platformidentification.JobType `json:",inline"`
-}
-
-func getCurrentResults() ([]LastWeekPercentiles, map[LastWeekPercentileKey]LastWeekPercentiles) {
+func getCurrentResults() historicaldata.BestMatcher {
 	readResults.Do(
 		func() {
-			inFile := bytes.NewBuffer(queryResults)
-			jsonDecoder := json.NewDecoder(inFile)
-
-			type DecodingLastWeekPercentile struct {
-				LastWeekPercentileKey `json:",inline"`
-				P95                   string
-				P99                   string
-			}
-			decodingPercentilesList := []DecodingLastWeekPercentile{}
-
-			if err := jsonDecoder.Decode(&decodingPercentilesList); err != nil {
+			var err error
+			genericBytes := bytes.ReplaceAll(queryResults, []byte(`    "BackendName": "`), []byte(`    "Name": "`))
+			historicalData, err = historicaldata.NewMatcher(genericBytes, 2.718)
+			if err != nil {
 				panic(err)
-			}
-
-			for _, currDecoded := range decodingPercentilesList {
-				p95, err := strconv.ParseFloat(currDecoded.P95, 64)
-				if err != nil {
-					panic(err)
-				}
-				p99, err := strconv.ParseFloat(currDecoded.P99, 64)
-				if err != nil {
-					panic(err)
-				}
-				curr := LastWeekPercentiles{
-					LastWeekPercentileKey: currDecoded.LastWeekPercentileKey,
-					P95:                   p95,
-					P99:                   p99,
-				}
-				percentilesAsList = append(percentilesAsList, curr)
-				percentilesAsMap[curr.LastWeekPercentileKey] = curr
 			}
 		})
 
-	return percentilesAsList, percentilesAsMap
+	return historicalData
 }

--- a/pkg/synthetictests/historicaldata/next_best_guess.go
+++ b/pkg/synthetictests/historicaldata/next_best_guess.go
@@ -1,0 +1,133 @@
+package historicaldata
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
+)
+
+// nextBestGuessers is the order in which to attempt to lookup other alternative matches that are close to this job type.
+var nextBestGuessers = []NextBestKey{
+	MicroReleaseUpgrade,
+	MinorReleaseUpgrade,
+	PreviousReleaseUpgrade,
+	combine(PreviousReleaseUpgrade, MicroReleaseUpgrade),
+	combine(PreviousReleaseUpgrade, MinorReleaseUpgrade),
+}
+
+// NextBestKey returns the next best key in the query_results.json generated from BigQuery and a bool indicating whether this guesser has an opinion.
+// If the bool is false, the key should not be used.
+// Returning true doesn't mean the key exists, it just means that the key is worth trying.
+type NextBestKey func(in platformidentification.JobType) (platformidentification.JobType, bool)
+
+// MinorReleaseUpgrade if we don't have data for the current fromRelease and it's a micro upgrade, perhaps we have data
+// for a minor upgrade.  A 4.11 to 4.11 upgrade will attempt a 4.10 to 4.11 upgrade.
+func MinorReleaseUpgrade(in platformidentification.JobType) (platformidentification.JobType, bool) {
+	if len(in.FromRelease) == 0 {
+		return platformidentification.JobType{}, false
+	}
+
+	fromReleaseMinor := getMinor(in.FromRelease)
+	toReleaseMajor := getMajor(in.Release)
+	toReleaseMinor := getMinor(in.Release)
+	// if we're already a minor upgrade, this doesn't apply
+	if fromReleaseMinor == (toReleaseMinor - 1) {
+		return platformidentification.JobType{}, false
+	}
+
+	ret := platformidentification.CloneJobType(in)
+	ret.FromRelease = fmt.Sprintf("%d.%d", toReleaseMajor, toReleaseMinor-1)
+	return ret, true
+}
+
+// MicroReleaseUpgrade if we don't have data for the current fromRelease and it's a minor upgrade, perhaps we have data
+// for a micro upgrade.  A 4.10 to 4.11 upgrade will attempt a 4.11 to 4.11 upgrade.
+func MicroReleaseUpgrade(in platformidentification.JobType) (platformidentification.JobType, bool) {
+	if len(in.FromRelease) == 0 {
+		return platformidentification.JobType{}, false
+	}
+
+	fromReleaseMinor := getMinor(in.FromRelease)
+	toReleaseMajor := getMajor(in.Release)
+	toReleaseMinor := getMinor(in.Release)
+	// if we're already a micro upgrade, this doesn't apply
+	if fromReleaseMinor == toReleaseMinor {
+		return platformidentification.JobType{}, false
+	}
+
+	ret := platformidentification.CloneJobType(in)
+	ret.FromRelease = fmt.Sprintf("%d.%d", toReleaseMajor, toReleaseMinor)
+	return ret, true
+}
+
+// PreviousReleaseUpgrade if we don't have data for the current toRelease, perhaps we have data for the congruent test
+// on the prior release.   A 4.11 to 4.11 upgrade will attempt a 4.10 to 4.10 upgrade.  A 4.11 no upgrade, will attempt a 4.10 no upgrade.
+func PreviousReleaseUpgrade(in platformidentification.JobType) (platformidentification.JobType, bool) {
+	toReleaseMajor := getMajor(in.Release)
+	toReleaseMinor := getMinor(in.Release)
+
+	ret := platformidentification.CloneJobType(in)
+	ret.Release = fmt.Sprintf("%d.%d", toReleaseMajor, toReleaseMinor-1)
+	if len(in.FromRelease) > 0 {
+		fromReleaseMinor := getMinor(in.FromRelease)
+		ret.FromRelease = fmt.Sprintf("%d.%d", toReleaseMajor, fromReleaseMinor-1)
+	}
+	return ret, true
+}
+
+func getMajor(in string) int {
+	major, err := strconv.ParseInt(strings.Split(in, ".")[0], 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	return int(major)
+}
+
+func getMinor(in string) int {
+	minor, err := strconv.ParseInt(strings.Split(in, ".")[1], 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	return int(minor)
+}
+
+// OnOVN maybe we have data on OVN
+func OnOVN(in platformidentification.JobType) (platformidentification.JobType, bool) {
+	if in.Network == "ovn" {
+		return platformidentification.JobType{}, false
+	}
+
+	ret := platformidentification.CloneJobType(in)
+	ret.Network = "ovn"
+	return ret, true
+}
+
+// OnSDN maybe we have data on SDN
+func OnSDN(in platformidentification.JobType) (platformidentification.JobType, bool) {
+	if in.Network == "sdn" {
+		return platformidentification.JobType{}, false
+	}
+
+	ret := platformidentification.CloneJobType(in)
+	ret.Network = "sdn"
+	return ret, true
+}
+
+// combine will start with the input and call each guess in order.  It uses the output of the previous NextBestKeyFn
+// as the input to the next.  This allows combinations like "previous release upgrade micro" without writing custom
+// functions for each.
+func combine(nextBestKeys ...NextBestKey) NextBestKey {
+	return func(in platformidentification.JobType) (platformidentification.JobType, bool) {
+		curr := in
+		for _, nextBestKey := range nextBestKeys {
+			var ok bool
+			curr, ok = nextBestKey(curr)
+			if !ok {
+				return curr, false
+			}
+		}
+		return curr, true
+	}
+}

--- a/pkg/synthetictests/historicaldata/types.go
+++ b/pkg/synthetictests/historicaldata/types.go
@@ -1,0 +1,132 @@
+package historicaldata
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
+)
+
+type BestMatcher interface {
+	// BestMatch returns the best possible match for this historical data.  It attempts a full match first, then
+	// it attempts to match on the most important keys in order, before giving up and returning a default.
+	BestMatch(name string, jopType platformidentification.JobType) (StatisticalData, string, error)
+	// BestMatchDuration returns the best possible match for this historical data.  It attempts a full match first, then
+	// it attempts to match on the most important keys in order, before giving up and returning a default.
+	BestMatchDuration(name string, jopType platformidentification.JobType) (StatisticalDuration, string, error)
+
+	BestMatchP99(name string, jobType platformidentification.JobType) (*time.Duration, string, error)
+}
+
+type StatisticalDuration struct {
+	DataKey `json:",inline"`
+	P95     time.Duration
+	P99     time.Duration
+}
+
+type StatisticalData struct {
+	DataKey `json:",inline"`
+	P95     float64
+	P99     float64
+}
+
+type DataKey struct {
+	// Name is the identifier for the particular bit of data.  It's like BackendName or AlertName
+	Name string
+
+	platformidentification.JobType `json:",inline"`
+}
+
+type bestMatcher struct {
+	historicalData map[DataKey]StatisticalData
+	defaultReturn  float64
+}
+
+func NewMatcher(historicalJSON []byte, defaultReturn float64) (BestMatcher, error) {
+	historicalData := map[DataKey]StatisticalData{}
+
+	inFile := bytes.NewBuffer(historicalJSON)
+	jsonDecoder := json.NewDecoder(inFile)
+
+	type DecodingPercentile struct {
+		DataKey `json:",inline"`
+		P95     string
+		P99     string
+	}
+	decodingPercentilesList := []DecodingPercentile{}
+
+	if err := jsonDecoder.Decode(&decodingPercentilesList); err != nil {
+		return nil, err
+	}
+
+	for _, currDecoded := range decodingPercentilesList {
+		p95, err := strconv.ParseFloat(currDecoded.P95, 64)
+		if err != nil {
+			return nil, err
+		}
+		p99, err := strconv.ParseFloat(currDecoded.P99, 64)
+		if err != nil {
+			return nil, err
+		}
+		curr := StatisticalData{
+			DataKey: currDecoded.DataKey,
+			P95:     p95,
+			P99:     p99,
+		}
+		historicalData[curr.DataKey] = curr
+	}
+
+	return &bestMatcher{
+		historicalData: historicalData,
+		defaultReturn:  defaultReturn,
+	}, nil
+}
+
+func (b *bestMatcher) BestMatch(name string, jobType platformidentification.JobType) (StatisticalData, string, error) {
+	exactMatchKey := DataKey{
+		Name:    name,
+		JobType: jobType,
+	}
+
+	if percentiles, ok := b.historicalData[exactMatchKey]; ok {
+		return percentiles, "", nil
+	}
+
+	defaultReturn := StatisticalData{
+		DataKey: exactMatchKey,
+		P95:     b.defaultReturn,
+		P99:     b.defaultReturn,
+	}
+	return defaultReturn,
+		fmt.Sprintf("jobType=%#v", jobType),
+		nil
+}
+
+func (b *bestMatcher) BestMatchDuration(name string, jobType platformidentification.JobType) (StatisticalDuration, string, error) {
+	rawData, details, err := b.BestMatch(name, jobType)
+	return toStatisticalDuration(rawData), details, err
+}
+
+func (b *bestMatcher) BestMatchP99(name string, jobType platformidentification.JobType) (*time.Duration, string, error) {
+	rawData, details, err := b.BestMatchDuration(name, jobType)
+	return &rawData.P99, details, err
+}
+
+func toStatisticalDuration(in StatisticalData) StatisticalDuration {
+	return StatisticalDuration{
+		DataKey: in.DataKey,
+		P95:     durationOrDie(in.P95),
+		P99:     durationOrDie(in.P99),
+	}
+}
+
+func durationOrDie(seconds float64) time.Duration {
+	ret, err := time.ParseDuration(fmt.Sprintf("%.3fs", seconds))
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}

--- a/pkg/synthetictests/platformidentification/types.go
+++ b/pkg/synthetictests/platformidentification/types.go
@@ -18,6 +18,16 @@ type JobType struct {
 	Topology    string
 }
 
+func CloneJobType(in JobType) JobType {
+	return JobType{
+		Release:     in.Release,
+		FromRelease: in.FromRelease,
+		Platform:    in.Platform,
+		Network:     in.Network,
+		Topology:    in.Topology,
+	}
+}
+
 // GetJobType returns information that can be used to identify a job
 func GetJobType(ctx context.Context, clientConfig *rest.Config) (*JobType, error) {
 	configClient, err := configclient.NewForConfig(clientConfig)

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
+
 	"github.com/onsi/ginkgo"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
@@ -59,7 +61,12 @@ func (t *backendDisruptionTest) WithPostTeardown(postTearDown TearDownFunc) *bac
 
 func (t *backendDisruptionTest) historicalP95Disruption(f *framework.Framework, totalDuration time.Duration) (*time.Duration, string, error) {
 	backendName := t.backend.GetDisruptionBackendName() + "-" + string(t.backend.GetConnectionType()) + "-connections"
-	return allowedbackenddisruption.GetAllowedDisruption(context.Background(), backendName, f.ClientConfig())
+	jobType, err := platformidentification.GetJobType(context.TODO(), f.ClientConfig())
+	if err != nil {
+		return nil, "", err
+	}
+
+	return allowedbackenddisruption.GetAllowedDisruption(backendName, *jobType)
 }
 
 // returns allowedDuration, detailsString(for display), error


### PR DESCRIPTION
This will help alleviate problems like https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-network-operator/1302/pull-ci-openshift-cluster-network-operator-master-e2e-agnostic-upgrade/1491351105987153920  where we don't have exact data matches.