### PR TITLE
Allow a single test to override suite timeout

### DIFF
--- a/pkg/test/ginkgo/ginkgo.go
+++ b/pkg/test/ginkgo/ginkgo.go
@@ -21,7 +21,11 @@ func testsForSuite(cfg config.GinkgoConfigType) ([]*testCase, error) {
 			}
 			return nil, err
 		}
-		tests = append(tests, newTestCase(spec))
+		tc, err := newTestCase(spec)
+		if err != nil {
+			return nil, err
+		}
+		tests = append(tests, tc)
 	}
 	return tests, nil
 }

--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -151,7 +151,13 @@ func (s *testStatus) Run(ctx context.Context, test *testCase) {
 	c := exec.Command(os.Args[0], "run-test", test.name)
 	c.Env = append(os.Environ(), s.env...)
 	s.fprintf(fmt.Sprintf("started: (%s) %q\n\n", "%d/%d/%d", test.name))
-	out, err := runWithTimeout(ctx, c, s.timeout)
+
+	timeout := s.timeout
+	if test.testTimeout != 0 {
+		timeout = test.testTimeout
+	}
+
+	out, err := runWithTimeout(ctx, c, timeout)
 	test.end = time.Now()
 
 	duration := test.end.Sub(test.start).Round(time.Second / 10)


### PR DESCRIPTION
This patch adds the possibility to override the current timeout defined at the suite level for a specif test. This is required since in some specific cases a single test may require some extra time to successfully complete its execution, and it's not desirable to modify the global suite timeout since it will affect also other tests in the same suite.

The timeout is specified as part of the name using the special tag `[Timeout:<duration>]` with the required duration string, for example:

```
...
g.It("skip inspection when disabled by annotation [Timeout:300s]", func() {
...
```
In case of a malformed/incorrect duration string an error will be reported immediatly.
