### PR TITLE
ip reconciler ignore

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -108,8 +108,15 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			},
 		},
 		{
-			Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"}, // not sure how to do a job_name prefix
+			Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"},
 			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2054426",
+			Matches: func(sample *model.Sample) bool {
+				// Only match if the job_name label starts with ip-reconciler:
+				if strings.HasPrefix(string(sample.Metric[model.LabelName("job_name")]), "ip-reconciler-") {
+					return true
+				}
+				return false
+			},
 		},
 	}
 	allowedFiringAlerts := helper.MetricConditions{

--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -107,6 +107,10 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 				return framework.ProviderIs("gce")
 			},
 		},
+		{
+			Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"}, // not sure how to do a job_name prefix
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2054426",
+		},
 	}
 	allowedFiringAlerts := helper.MetricConditions{
 		{

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -324,6 +324,10 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
 				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
 			},
+			{
+				Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"}, // not sure how to do a job_name prefix
+				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2054426",
+			},
 		}
 		allowedFiringAlerts := helper.MetricConditions{
 			{
@@ -748,6 +752,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 				"Watchdog",
 				"AlertmanagerReceiversNotConfigured",
 				"PrometheusRemoteWriteDesiredShards",
+				"KubeJobFailed", // this is a result of bug https://bugzilla.redhat.com/show_bug.cgi?id=2054426 .  We should catch these in the late test above.
 			}
 
 			// we exclude alerts that have their own separate tests.


### PR DESCRIPTION
- ignore ip-reconciler failures in CI for now
- Improve ignore for ip-reconciler KubeJobFailed alert.
