### PR TITLE
Bug 2055193: Allow a single test to override suite timeout

### DIFF
--- a/pkg/test/ginkgo/ginkgo.go
+++ b/pkg/test/ginkgo/ginkgo.go
@@ -21,7 +21,11 @@ func testsForSuite(cfg config.GinkgoConfigType) ([]*testCase, error) {
 			}
 			return nil, err
 		}
-		tests = append(tests, newTestCase(spec))
+		tc, err := newTestCase(spec)
+		if err != nil {
+			return nil, err
+		}
+		tests = append(tests, tc)
 	}
 	return tests, nil
 }

--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -151,7 +151,13 @@ func (s *testStatus) Run(ctx context.Context, test *testCase) {
 	c := exec.Command(os.Args[0], "run-test", test.name)
 	c.Env = append(os.Environ(), s.env...)
 	s.fprintf(fmt.Sprintf("started: (%s) %q\n\n", "%d/%d/%d", test.name))
-	out, err := runWithTimeout(ctx, c, s.timeout)
+
+	timeout := s.timeout
+	if test.testTimeout != 0 {
+		timeout = test.testTimeout
+	}
+
+	out, err := runWithTimeout(ctx, c, timeout)
 	test.end = time.Now()
 
 	duration := test.end.Sub(test.start).Round(time.Second / 10)


### PR DESCRIPTION
(cherry picked from commit 01d5fca41604c6e01bdfc440a5d30bab494b0145)