### PR TITLE
Bug 2055193: Reenable wait on worker deletion and increase serial tes…

### DIFF
--- a/test/extended/baremetal/helper.go
+++ b/test/extended/baremetal/helper.go
@@ -138,6 +138,8 @@ func (b *BaremetalTestHelper) DeleteAllExtraWorkers() {
 	for _, worker := range b.extraWorkers {
 		err := b.bmcClient.Delete(context.Background(), worker.GetName(), metav1.DeleteOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
+
+		b.waitForDeletion(worker)
 	}
 }
 

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -216,7 +216,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 		helper.DeleteAllExtraWorkers()
 	})
 
-	g.It("grow and decrease when scaling different machineSets simultaneously", func() {
+	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:20m]", func() {
 		// expect new nodes to come up for machineSet
 		verifyNodeScalingFunc := func(c *kubernetes.Clientset, dc dynamic.Interface, expectedScaleOut int, machineSet objx.Map) bool {
 			nodes, err := getNodesFromMachineSet(c, dc, machineName(machineSet))

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1565,7 +1565,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should have same number of Machines and Nodes": "have same number of Machines and Nodes [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously": "grow and decrease when scaling different machineSets simultaneously [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:20m]": "grow and decrease when scaling different machineSets simultaneously [Timeout:20m] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-coreos] [Conformance] CoreOS bootimages TestBootimagesPresent": "TestBootimagesPresent [Suite:openshift/conformance/parallel/minimal]",
 


### PR DESCRIPTION
…t timeout

With the fix to remove the extra worker deletion (https://github.com/openshift/origin/pull/26774)
there have been occasional test failures when the time to delete the extra worker
has exceeded the 15 minute test time. This adds back in the wait after the extra worker
is deleted and increases the test time to allow the deletion to complete.

(cherry picked from commit bdaf1db8c17caa67bdbb50338e9b4ea3f3ad36f8)