### PR TITLE
allow slow kubelet updates for static pods, but still fail if they never succeed

### DIFF
--- a/pkg/synthetictests/static_pod.go
+++ b/pkg/synthetictests/static_pod.go
@@ -3,6 +3,7 @@ package synthetictests
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -11,6 +12,31 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+// staticPodFailureRegex trying to pull out information from messages like
+// `static pod lifecycle failure - static pod: "etcd" in namespace: "openshift-etcd" for revision: 6 on node: "ovirt10-gh8t5-master-2" didn't show up, waited: 2m30s`
+var staticPodFailureRegex = regexp.MustCompile(
+	`static pod lifecycle failure - static pod: ".*" in namespace: "(.*)" for revision: (\d) on node: "(.*)" didn't show up, waited: .*`)
+
+type staticPodFailure struct {
+	namespace      string
+	node           string
+	revision       string
+	failureMessage string
+}
+
+func staticPodFailureFromMessage(message string) (*staticPodFailure, error) {
+	matches := staticPodFailureRegex.FindStringSubmatch(message)
+	if len(matches) != 4 {
+		return nil, fmt.Errorf("wrong number of matches: %v", matches)
+	}
+	return &staticPodFailure{
+		namespace:      matches[1],
+		node:           matches[3],
+		revision:       matches[2],
+		failureMessage: message,
+	}, nil
+}
 
 func testStaticPodLifecycleFailure(events monitorapi.Intervals, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
 	ctx := context.TODO()
@@ -36,6 +62,7 @@ func testStaticPodLifecycleFailure(events monitorapi.Intervals, kubeClientConfig
 		"openshift-kube-controller-manager-operator",
 		"openshift-kube-scheduler-operator",
 	}
+	staticPodFailures := []staticPodFailure{}
 	for _, ns := range staticPodNamespaces {
 		// we need to get all the events from the cluster, so we cannot use the monitor events.
 		events, err := kubeClient.EventsV1().Events(ns).List(ctx, metav1.ListOptions{})
@@ -45,11 +72,43 @@ func testStaticPodLifecycleFailure(events monitorapi.Intervals, kubeClientConfig
 		}
 
 		for _, event := range events.Items {
+			if event.Reason == "OperatorStatusChanged" { // skip the clusteroperator status change event.
+				continue
+			}
 			if !strings.Contains(event.Note, "static pod lifecycle failure") {
 				continue
 			}
-			failures = append(failures, fmt.Sprintf("%#v", event))
+
+			staticPodFailure, err := staticPodFailureFromMessage(event.Note)
+			if err != nil {
+				failures = append(failures, fmt.Sprintf("%v", err))
+				continue
+			}
+			staticPodFailures = append(staticPodFailures, *staticPodFailure)
 		}
+	}
+
+	// now check each failure to see if we eventually reached the level.  If we eventually reached the level, then don't flag it
+	for _, staticPodFailure := range staticPodFailures {
+		events, err := kubeClient.EventsV1().Events(staticPodFailure.namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			failures = append(failures, err.Error())
+			continue
+		}
+
+		for _, event := range events.Items {
+			isRevisionUpdate := event.Reason == "NodeCurrentRevisionChanged"
+			isForNode := strings.Contains(event.Note, staticPodFailure.node)
+			reachedRevision := strings.Contains(event.Note, " to "+staticPodFailure.revision+" because static pod is ready")
+			if isRevisionUpdate && isForNode && reachedRevision {
+				// if we reach the level eventually, don't fail the test. We might choose to add an "it's slow" test, but
+				// it hasn't failed.
+				continue
+			}
+
+			failures = append(failures, staticPodFailure.failureMessage)
+		}
+
 	}
 
 	if len(failures) > 0 {

--- a/pkg/synthetictests/static_pod_test.go
+++ b/pkg/synthetictests/static_pod_test.go
@@ -1,0 +1,41 @@
+package synthetictests
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_staticPodFailureFromMessage(t *testing.T) {
+	type args struct {
+		message string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *staticPodFailure
+		wantErr bool
+	}{
+		{
+			name: "parser",
+			args: args{message: `static pod lifecycle failure - static pod: "etcd" in namespace: "openshift-etcd" for revision: 6 on node: "ovirt10-gh8t5-master-2" didn't show up, waited: 2m30s`},
+			want: &staticPodFailure{
+				namespace:      "openshift-etcd",
+				node:           "ovirt10-gh8t5-master-2",
+				revision:       "6",
+				failureMessage: `static pod lifecycle failure - static pod: "etcd" in namespace: "openshift-etcd" for revision: 6 on node: "ovirt10-gh8t5-master-2" didn't show up, waited: 2m30s`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := staticPodFailureFromMessage(tt.args.message)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("staticPodFailureFromMessage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("staticPodFailureFromMessage() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
in https://docs.google.com/document/d/1NCqpSzIcUVsIcRnsR0dLcB-ja1L20ePVWKKZM5sKw-U/edit, we found failures where the kubelet was slow in creating the new revision.  This lets it be late.