### PR TITLE
Make a test to specifically look for image pull backoff for registry.redhat.io

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -97,6 +97,9 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 
 	// we have a separate test for this
 	regexp.MustCompile(ovnReadinessRegExpStr),
+
+	// Separated out in testBackoffPullingRegistryRedhatImage
+	regexp.MustCompile(imagePullRedhatRegEx),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -36,6 +36,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testOperatorOSUpdateStaged(events, kubeClientConfig)...)
 	tests = append(tests, testOperatorOSUpdateStartedEventRecorded(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
+	tests = append(tests, testBackoffPullingRegistryRedhatImage(events)...)
 
 	return tests
 }
@@ -64,6 +65,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testOperatorOSUpdateStaged(events, kubeClientConfig)...)
 	tests = append(tests, testOperatorOSUpdateStartedEventRecorded(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
+	tests = append(tests, testBackoffPullingRegistryRedhatImage(events)...)
 
 	return tests
 }

--- a/pkg/synthetictests/image_pulls.go
+++ b/pkg/synthetictests/image_pulls.go
@@ -1,0 +1,99 @@
+package synthetictests
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+const (
+	imagePullRedhatRegEx          = `reason/[a-zA-Z]+ .*Back-off pulling image .*registry.redhat.io`
+	imagePullRedhatFailThreshold  = 8
+	imagePullRedhatFlakeThreshold = 5
+)
+
+type eventRecognizerFunc func(event monitorapi.EventInterval) bool
+
+func matchEventForRegexOrDie(regex string) eventRecognizerFunc {
+	regExp := regexp.MustCompile(regex)
+	return func(e monitorapi.EventInterval) bool {
+		return regExp.MatchString(e.Message)
+	}
+}
+
+type singleEventCheckRegex struct {
+	testName       string
+	recognizer     eventRecognizerFunc
+	failThreshold  int
+	flakeThreshold int
+}
+
+// test goes through the events, looks for a match using the s.recognizer function,
+// if a match is found, and occurs more than s.failThreshold times, we mark it as a
+// flake (this allows us to see how often this symptom is happening).
+//
+func (s *singleEventCheckRegex) test(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	success := &junitapi.JUnitTestCase{Name: s.testName}
+	var failureOutput, flakeOutput []string
+	for _, e := range events {
+		if s.recognizer(e) {
+
+			msg := fmt.Sprintf("%s - %s", e.Locator, e.Message)
+			eventDisplayMessage, times := getTimesAnEventHappened(msg)
+			switch {
+			case times > s.failThreshold:
+				failureOutput = append(failureOutput, fmt.Sprintf("event [%s] happened %d times", eventDisplayMessage, times))
+			case times > s.flakeThreshold:
+				flakeOutput = append(flakeOutput, fmt.Sprintf("event [%s] happened %d times", eventDisplayMessage, times))
+			}
+		}
+	}
+	if len(failureOutput) > 0 {
+		totalOutput := failureOutput
+		if len(flakeOutput) >= 0 {
+			totalOutput = append(totalOutput, flakeOutput...)
+		}
+		failure := &junitapi.JUnitTestCase{
+			Name:      s.testName,
+			SystemOut: strings.Join(totalOutput, "\n"),
+			FailureOutput: &junitapi.FailureOutput{
+				Output: strings.Join(totalOutput, "\n"),
+			},
+		}
+		return []*junitapi.JUnitTestCase{failure}
+	}
+	if len(flakeOutput) > 0 {
+		failure := &junitapi.JUnitTestCase{
+			Name:      s.testName,
+			SystemOut: strings.Join(flakeOutput, "\n"),
+			FailureOutput: &junitapi.FailureOutput{
+				Output: strings.Join(flakeOutput, "\n"),
+			},
+		}
+		return []*junitapi.JUnitTestCase{failure, success}
+	}
+
+	return []*junitapi.JUnitTestCase{success}
+}
+
+func newSingleEventCheckRegex(testName, regex string) *singleEventCheckRegex {
+	return &singleEventCheckRegex{
+		testName:       testName,
+		recognizer:     matchEventForRegexOrDie(regex),
+		failThreshold:  imagePullRedhatFailThreshold,
+		flakeThreshold: imagePullRedhatFlakeThreshold,
+	}
+}
+
+// testBackoffPullingRegistryRedhatImage looks for this symptom:
+//   reason/ContainerWait ... Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
+//   reason/BackOff Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
+// to happen over a certain threshold and marks it as a failure or flake accordingly.
+//
+func testBackoffPullingRegistryRedhatImage(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	testName := "[sig-arch] should not see excessive pull back-off on registry.redhat.io"
+	return newSingleEventCheckRegex(testName, imagePullRedhatRegEx).test(events)
+}

--- a/pkg/synthetictests/image_pulls_test.go
+++ b/pkg/synthetictests/image_pulls_test.go
@@ -1,0 +1,69 @@
+package synthetictests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+func Test_testBackoffPullingRegistryRedhatImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   string
+		num_tests int
+		kind      string
+	}{
+		{
+			name:    "Test flake",
+			message: `ns/openshift-e2e-loki pod/loki-promtail-ww2rx node/ip-10-0-157-209.us-east-2.compute.internal reason/BackOff Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest" (6 times)`,
+			kind:    "flake",
+		},
+		{
+			name:    "Test fail",
+			message: `ns/openshift-e2e-loki pod/loki-promtail-ww2rx node/ip-10-0-157-209.us-east-2.compute.internal reason/BackOff Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest" (9 times)`,
+			kind:    "fail",
+		},
+		{
+			name:    "Test pass",
+			message: `ns/openshift-e2e-loki pod/loki-promtail-qrpkm node/ip-10-0-240-197.us-east-2.compute.internal reason/BackOff Back-off pulling image "registry.not-redhat.io/openshift4/ose-oauth-proxy:latest" (1 times)`,
+			kind:    "pass",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := monitorapi.Intervals{
+				{
+					Condition: monitorapi.Condition{
+						Message: tt.message,
+					},
+					From: time.Unix(1, 0),
+					To:   time.Unix(1, 0),
+				},
+			}
+			junit_tests := testBackoffPullingRegistryRedhatImage(e)
+			switch tt.kind {
+			case "pass":
+				if len(junit_tests) != 1 {
+					t.Errorf("This should've been a single passing test, but got %d tests", len(junit_tests))
+				}
+				if len(junit_tests[0].SystemOut) != 0 {
+					t.Errorf("This should've been a pass, but got %s", junit_tests[0].SystemErr)
+				}
+			case "fail":
+				if len(junit_tests) != 1 {
+					t.Errorf("This should've been a single failing test, but got %d tests", len(junit_tests))
+				}
+				if len(junit_tests[0].SystemOut) == 0 {
+					t.Error("This should've been a failure but got no output")
+				}
+			case "flake":
+				if len(junit_tests) != 2 {
+					t.Errorf("This should've been a two tests as flake, but got %d tests", len(junit_tests))
+				}
+			default:
+				t.Errorf("Unknown test kind")
+			}
+		})
+	}
+}


### PR DESCRIPTION
We'd like to track cases like [this](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26854/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1496240296596344832):

```
event happened 45 times, something is wrong: ns/openshift-e2e-loki pod/loki-promtail-r6cbn node/ci-op-ipx1i5kt-db044-hw8hj-worker-b-p276c - reason/BackOff Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
event happened 324 times, something is wrong: ns/openshift-e2e-loki pod/loki-promtail-h2zmg node/ci-op-ipx1i5kt-db044-hw8hj-master-2 - reason/BackOff Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
```

and

```
ns/openshift-e2e-loki pod/loki-promtail-77rnl node/ip-10-0-182-230.ec2.internal container/oauth-proxy - reason/ContainerWait cause/ImagePullBackOff duration/696.91s Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
ns/openshift-e2e-loki pod/loki-promtail-7tpsj node/ip-10-0-148-202.ec2.internal container/oauth-proxy - reason/ContainerWait cause/ErrImagePull duration/671.53s rpc error: code = Unknown desc = loading manifest for target platform: reading manifest sha256:8e77bd9d4e81b4031620f32f0b5774aad843ee77fca56b555ca0a71f9ff64cd5 in registry.redhat.io/openshift4/ose-oauth-proxy: StatusCode: 404, Not found
```