### PR TITLE
Fix ovnkube-node readiness test to include successes.

### DIFF
--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -205,14 +205,12 @@ func testOvnNodeReadinessProbe(events monitorapi.Intervals) []*junitapi.JUnitTes
 			}
 		}
 	}
+	test := &junitapi.JUnitTestCase{Name: testName}
 	if len(failureOutput) > 0 {
-		tests = append(tests, &junitapi.JUnitTestCase{
-			Name: testName,
-			FailureOutput: &junitapi.FailureOutput{
-				Output: failureOutput,
-			},
-		})
-
+		test.FailureOutput = &junitapi.FailureOutput{
+			Output: failureOutput,
+		}
 	}
+	tests = append(tests, test)
 	return tests
 }


### PR DESCRIPTION
Test was skipping a junit on success, which appears to break aggregation
because it requires at least 3 results, and we're only getting 1 (a
failure) fairly commonly.
