### PR TITLE
Increase scale test timeout to 30 minutes

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -216,7 +216,12 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 		helper.DeleteAllExtraWorkers()
 	})
 
-	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:20m]", func() {
+	// The 30m timeout is essentially required by the baremetal platform environment,
+	// since an extra worker is created during the test setup: it takes approx 10 minutes for
+	// provisioning the new host, while it could take approx another 10 minutes for deprovisioning
+	// and deleting it. The extra timeout amount should be enough to cover future slower execution
+	// environments.
+	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m]", func() {
 		// expect new nodes to come up for machineSet
 		verifyNodeScalingFunc := func(c *kubernetes.Clientset, dc dynamic.Interface, expectedScaleOut int, machineSet objx.Map) bool {
 			nodes, err := getNodesFromMachineSet(c, dc, machineName(machineSet))

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1581,7 +1581,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should have same number of Machines and Nodes": "have same number of Machines and Nodes [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:20m]": "grow and decrease when scaling different machineSets simultaneously [Timeout:20m] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:30m]": "grow and decrease when scaling different machineSets simultaneously [Timeout:30m] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-coreos] [Conformance] CoreOS bootimages TestBootimagesPresent": "TestBootimagesPresent [Suite:openshift/conformance/parallel/minimal]",
 


### PR DESCRIPTION
For some jobs we noticed that the current 20 minutes timeout doesn't seem to be sufficient (ie `e2e-metal-ipi-serial-ovn-ipv6`), thus increasing it a little bit