### PR TITLE
Attempted fix for missing monitor events.

### DIFF
--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -9,189 +9,168 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Interface) {
 	reMatchFirstQuote := regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`)
 
-	go func() {
-		// Track our last observed resource version from each event, used to re-establish the watch
-		// when it's requested rv gets too old for the server. (which may happen when apiservers cycle)
-		var rv string
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
+	// filter out events written "now" but with significantly older start times (events
+	// created in test jobs are the most common)
+	significantlyBeforeNow := time.Now().UTC().Add(-15 * time.Minute)
 
-			// filter out events written "now" but with significantly older start times (events
-			// created in test jobs are the most common)
-			significantlyBeforeNow := time.Now().UTC().Add(-15 * time.Minute)
+	// map event UIDs to the last resource version we observed, used to skip recording resources
+	// we've already recorded.
+	processedEventUIDs := map[types.UID]string{}
 
-			// Doing our own List + Watch here, cannot use an Informer as it will group similar events, when we need
-			// each individual.
-
-			if rv == "" {
-				events, err := client.CoreV1().Events("").List(ctx, metav1.ListOptions{Limit: 1})
-				if err != nil {
+	listWatch := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), "events", "", fields.Everything())
+	customStore := &cache.FakeCustomStore{
+		// ReplaceFunc called when we do our initial list on starting the reflector. With no resync period,
+		// it should not get called again.
+		ReplaceFunc: func(items []interface{}, rv string) error {
+			for _, obj := range items {
+				event, ok := obj.(*corev1.Event)
+				if !ok {
 					continue
 				}
-				rv = events.ResourceVersion
-				fmt.Printf("Using initial resource version from event list: %s\n", rv)
-				for i := range events.Items {
-					m.RecordResource("events", &events.Items[i])
+				if processedEventUIDs[event.UID] != event.ResourceVersion {
+					m.RecordResource("events", event)
+					processedEventUIDs[event.UID] = event.ResourceVersion
 				}
-			} else {
-				// Re-use the last resource version we observed.
-				fmt.Printf("Using last observed resource version: %s\n", rv)
 			}
+			return nil
+		},
+		AddFunc: func(obj interface{}) error {
+			event, ok := obj.(*corev1.Event)
+			if !ok {
+				return nil
+			}
+			if processedEventUIDs[event.UID] != event.ResourceVersion {
+				recordAddOrUpdateEvent(ctx, m, client, reMatchFirstQuote, significantlyBeforeNow, event)
+				processedEventUIDs[event.UID] = event.ResourceVersion
+			}
+			return nil
+		},
+		UpdateFunc: func(obj interface{}) error {
+			event, ok := obj.(*corev1.Event)
+			if !ok {
+				return nil
+			}
+			if processedEventUIDs[event.UID] != event.ResourceVersion {
+				recordAddOrUpdateEvent(ctx, m, client, reMatchFirstQuote, significantlyBeforeNow, event)
+				processedEventUIDs[event.UID] = event.ResourceVersion
+			}
+			return nil
+		},
+	}
+	reflector := cache.NewReflector(listWatch, &corev1.Event{}, customStore, 0)
+	go reflector.Run(ctx.Done())
+}
 
-			for expired := false; !expired; {
-				w, err := client.CoreV1().Events("").Watch(ctx, metav1.ListOptions{ResourceVersion: rv})
-				if err != nil {
-					if errors.IsResourceExpired(err) {
-						break
-					}
-					continue
+func recordAddOrUpdateEvent(
+	ctx context.Context,
+	m Recorder,
+	client kubernetes.Interface,
+	reMatchFirstQuote *regexp.Regexp,
+	significantlyBeforeNow time.Time,
+	obj *corev1.Event) {
+
+	m.RecordResource("events", obj)
+
+	// Temporary hack by dgoodwin, we're missing events here that show up later in
+	// gather-extra/events.json. Adding some output to see if we can isolate what we saw
+	// and where it might have been filtered out.
+	// TODO: monitor for occurrences of this string, may no longer be needed given the
+	// new rv handling logic added above.
+	osEvent := false
+	if obj.Reason == "OSUpdateStaged" || obj.Reason == "OSUpdateStarted" {
+		osEvent = true
+		fmt.Printf("Watch received OS update event: %s - %s - %s\n",
+			obj.Reason, obj.InvolvedObject.Name, obj.LastTimestamp.Format(time.RFC3339))
+
+	}
+	t := obj.LastTimestamp.Time
+	if t.IsZero() {
+		t = obj.EventTime.Time
+	}
+	if t.IsZero() {
+		t = obj.CreationTimestamp.Time
+	}
+	if t.Before(significantlyBeforeNow) {
+		if osEvent {
+			fmt.Printf("OS update event filtered for being too old: %s - %s - %s (now: %s)\n",
+				obj.Reason, obj.InvolvedObject.Name, obj.LastTimestamp.Format(time.RFC3339),
+				time.Now().Format(time.RFC3339))
+		}
+		return
+	}
+
+	message := obj.Message
+	if obj.Count > 1 {
+		message += fmt.Sprintf(" (%d times)", obj.Count)
+	}
+
+	if obj.InvolvedObject.Kind == "Node" {
+		if node, err := client.CoreV1().Nodes().Get(ctx, obj.InvolvedObject.Name, metav1.GetOptions{}); err == nil {
+			message = fmt.Sprintf("roles/%s %s", nodeRoles(node), message)
+		}
+	}
+
+	// special case some very common events
+	switch obj.Reason {
+	case "":
+	case "Scheduled":
+		if obj.InvolvedObject.Kind == "Pod" {
+			if strings.HasPrefix(message, "Successfully assigned ") {
+				if i := strings.Index(message, " to "); i != -1 {
+					node := message[i+4:]
+					message = fmt.Sprintf("node/%s reason/%s", node, obj.Reason)
+					break
 				}
-				w = watch.Filter(w, func(in watch.Event) (watch.Event, bool) {
-					// TODO: gathering all events results in a 4x increase in e2e.log size, but is is
-					//       valuable enough to gather that the cost is worth it
-					// return in, filterToSystemNamespaces(in.Object)
-					return in, true
-				})
-				func() {
-					defer w.Stop()
-					for event := range w.ResultChan() {
-						switch event.Type {
-						case watch.Added, watch.Modified:
-							obj, ok := event.Object.(*corev1.Event)
-							if !ok {
-								continue
-							}
-							// Record the observed rv version, re-used if we lose our watch connection and re-establish
-							// to prevent missed events.
-							rv = obj.ResourceVersion
-							m.RecordResource("events", obj)
-
-							// Temporary hack by dgoodwin, we're missing events here that show up later in
-							// gather-extra/events.json. Adding some output to see if we can isolate what we saw
-							// and where it might have been filtered out.
-							// TODO: monitor for occurrences of this string, may no longer be needed given the
-							// new rv handling logic added above.
-							osEvent := false
-							if obj.Reason == "OSUpdateStaged" || obj.Reason == "OSUpdateStarted" {
-								osEvent = true
-								fmt.Printf("Watch received OS update event: %s - %s - %s\n",
-									obj.Reason, obj.InvolvedObject.Name, obj.LastTimestamp.Format(time.RFC3339))
-
-							}
-							t := obj.LastTimestamp.Time
-							if t.IsZero() {
-								t = obj.EventTime.Time
-							}
-							if t.IsZero() {
-								t = obj.CreationTimestamp.Time
-							}
-							if t.Before(significantlyBeforeNow) {
-								if osEvent {
-									fmt.Printf("OS update event filtered for being too old: %s - %s - %s (now: %s)\n",
-										obj.Reason, obj.InvolvedObject.Name, obj.LastTimestamp.Format(time.RFC3339),
-										time.Now().Format(time.RFC3339))
-								}
-								break
-							}
-
-							message := obj.Message
-							if obj.Count > 1 {
-								message += fmt.Sprintf(" (%d times)", obj.Count)
-							}
-
-							if obj.InvolvedObject.Kind == "Node" {
-								if node, err := client.CoreV1().Nodes().Get(ctx, obj.InvolvedObject.Name, metav1.GetOptions{}); err == nil {
-									message = fmt.Sprintf("roles/%s %s", nodeRoles(node), message)
-								}
-							}
-
-							// special case some very common events
-							switch obj.Reason {
-							case "":
-							case "Scheduled":
-								if obj.InvolvedObject.Kind == "Pod" {
-									if strings.HasPrefix(message, "Successfully assigned ") {
-										if i := strings.Index(message, " to "); i != -1 {
-											node := message[i+4:]
-											message = fmt.Sprintf("node/%s reason/%s", node, obj.Reason)
-											break
-										}
-									}
-								}
-								message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
-							case "Started", "Created", "Killing":
-								if obj.InvolvedObject.Kind == "Pod" {
-									if containerName, ok := eventForContainer(obj.InvolvedObject.FieldPath); ok {
-										message = fmt.Sprintf("container/%s reason/%s", containerName, obj.Reason)
-										break
-									}
-								}
-								message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
-							case "Pulling", "Pulled":
-								if obj.InvolvedObject.Kind == "Pod" {
-									if containerName, ok := eventForContainer(obj.InvolvedObject.FieldPath); ok {
-										if m := reMatchFirstQuote.FindStringSubmatch(obj.Message); m != nil {
-											if len(m) > 3 {
-												if d, err := time.ParseDuration(m[3]); err == nil {
-													message = fmt.Sprintf("container/%s reason/%s duration/%.3fs image/%s", containerName, obj.Reason, d.Seconds(), m[1])
-													break
-												}
-											}
-											message = fmt.Sprintf("container/%s reason/%s image/%s", containerName, obj.Reason, m[1])
-											break
-										}
-									}
-								}
-								message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
-							default:
-								message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
-							}
-							condition := monitorapi.Condition{
-								Level:   monitorapi.Info,
-								Locator: locateEvent(obj),
-								Message: message,
-							}
-							if obj.Type == corev1.EventTypeWarning {
-								condition.Level = monitorapi.Warning
-							}
-							m.RecordAt(t, condition)
-						case watch.Error:
-							var message string
-							if status, ok := event.Object.(*metav1.Status); ok {
-								if err := errors.FromObject(status); err != nil && errors.IsResourceExpired(err) {
-									expired = true
-									return
-								}
-								message = status.Message
-							} else {
-								message = fmt.Sprintf("event object was not a Status: %T", event.Object)
-							}
-							m.Record(monitorapi.Condition{
-								Level:   monitorapi.Info,
-								Locator: "kube-apiserver",
-								Message: fmt.Sprintf("received an error while watching events: %s", message),
-							})
-							return
-						default:
-						}
-					}
-				}()
 			}
 		}
-	}()
+		message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
+	case "Started", "Created", "Killing":
+		if obj.InvolvedObject.Kind == "Pod" {
+			if containerName, ok := eventForContainer(obj.InvolvedObject.FieldPath); ok {
+				message = fmt.Sprintf("container/%s reason/%s", containerName, obj.Reason)
+				break
+			}
+		}
+		message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
+	case "Pulling", "Pulled":
+		if obj.InvolvedObject.Kind == "Pod" {
+			if containerName, ok := eventForContainer(obj.InvolvedObject.FieldPath); ok {
+				if m := reMatchFirstQuote.FindStringSubmatch(obj.Message); m != nil {
+					if len(m) > 3 {
+						if d, err := time.ParseDuration(m[3]); err == nil {
+							message = fmt.Sprintf("container/%s reason/%s duration/%.3fs image/%s", containerName, obj.Reason, d.Seconds(), m[1])
+							break
+						}
+					}
+					message = fmt.Sprintf("container/%s reason/%s image/%s", containerName, obj.Reason, m[1])
+					break
+				}
+			}
+		}
+		message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
+	default:
+		message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
+	}
+	condition := monitorapi.Condition{
+		Level:   monitorapi.Info,
+		Locator: locateEvent(obj),
+		Message: message,
+	}
+	if obj.Type == corev1.EventTypeWarning {
+		condition.Level = monitorapi.Warning
+	}
+	m.RecordAt(t, condition)
+
 }
 
 func eventForContainer(fieldPath string) (string, bool) {


### PR DESCRIPTION
We have confirmed that events are being missed by the test monitor, which then appear in the events.json in must-gather/gather-extra steps. We believe this is due to the handling of resource version in this custom list watch code. Today is does a list of events and uses that resource version to establish the watch. When we encounter an error (which seems to be possible when apiservers are rolling), we repeat the process leaving a gap between the last event observed, and whatever the latest is when we re-establish and list again.

This is fixed by tracking the last resource version observed from incoming events, and using that to re-establish the watch.