### PR TITLE
Bug 2059299: IBMCloud: Ignore CRB already exists

### DIFF
--- a/test/extended/util/ibmcloud/provider.go
+++ b/test/extended/util/ibmcloud/provider.go
@@ -56,6 +56,10 @@ func (p *Provider) FrameworkBeforeEach(f *framework.Framework) {
 			},
 		}
 		_, err = f.ClientSet.RbacV1().ClusterRoleBindings().Create(context.Background(), rb, metav1.CreateOptions{})
+		// Ignore errors when CRB already exists when trying to create it, as Mutex isn't configured or working properly
+		if errors.IsAlreadyExists(err) {
+			err = nil
+		}
 	}
 	o.Expect(err).NotTo(o.HaveOccurred())
 }


### PR DESCRIPTION
For IBM Cloud testing, ignore errors when attempting to create
the 'e2e-node-attacher' CRB when it already exists, even after
attempting to configure a mutex to prevent concurrent creations.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2059299