### PR TITLE
MGMT-9440: Fix single node serial tests API crash.

### DIFF
--- a/test/extended/apiserver/resiliency.go
+++ b/test/extended/apiserver/resiliency.go
@@ -94,6 +94,9 @@ var _ = ginkgo.Describe("[Conformance][sig-sno][Serial] Cluster", func() {
 		ginkgo.By("with no pods restarts during API disruption")
 		names := GetRestartedPods(c, restartingContainers)
 		gomega.Expect(len(names)).To(gomega.Equal(0), "Some pods in got restarted during kube-apiserver rollout: %s", strings.Join(names, ", "))
+
+		// Workaround for issues identified in https://bugzilla.redhat.com/show_bug.cgi?id=2059581
+		time.Sleep(60 * time.Second)
 	})
 
 })

--- a/test/extended/apiserver/resiliency.go
+++ b/test/extended/apiserver/resiliency.go
@@ -96,6 +96,7 @@ var _ = ginkgo.Describe("[Conformance][sig-sno][Serial] Cluster", func() {
 		gomega.Expect(len(names)).To(gomega.Equal(0), "Some pods in got restarted during kube-apiserver rollout: %s", strings.Join(names, ", "))
 
 		// Workaround for issues identified in https://bugzilla.redhat.com/show_bug.cgi?id=2059581
+		// TODO: Remove this sleep once that bug is resolved
 		time.Sleep(60 * time.Second)
 	})
 


### PR DESCRIPTION
It has been witnessed and reported in https://bugzilla.redhat.com/show_bug.cgi?id=2059581 that the KubeApi becomes unexpectedly unreachable for a short time after the completion of the  Serial API resiliance test. While we await the resolution of the BZ, I have introduced a 60 second wait at the end of the test to ensure that the tests after do not break.
It is our intention that this wait will be removed after the resolution of the BZ.