### PR TITLE
Use common threshold constant as other event tests

### DIFF
--- a/pkg/synthetictests/image_pulls.go
+++ b/pkg/synthetictests/image_pulls.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	imagePullRedhatRegEx          = `reason/[a-zA-Z]+ .*Back-off pulling image .*registry.redhat.io`
-	imagePullRedhatFailThreshold  = 8
 	imagePullRedhatFlakeThreshold = 5
 )
 
@@ -83,7 +82,7 @@ func newSingleEventCheckRegex(testName, regex string) *singleEventCheckRegex {
 	return &singleEventCheckRegex{
 		testName:       testName,
 		recognizer:     matchEventForRegexOrDie(regex),
-		failThreshold:  imagePullRedhatFailThreshold,
+		failThreshold:  duplicateEventThreshold,
 		flakeThreshold: imagePullRedhatFlakeThreshold,
 	}
 }


### PR DESCRIPTION
followup to https://github.com/openshift/origin/pull/26858 re: "set to duplicateEventThreshold in a followup"