### PR TITLE
Implementation for egress-router-cni e2e ci test

### DIFF
--- a/test/extended/networking/egress_router_cni.go
+++ b/test/extended/networking/egress_router_cni.go
@@ -1,0 +1,94 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+)
+
+const (
+	egressRouterCNIE2E        = "egress-router-cni-e2e"
+	egressRouterCNIDeployment = "egress-router-cni-deployment"
+	egressRouterCNINadObject  = "egress-router-cni-nad"
+	// Manifests at testdata/egress-router-cni
+	egressRouterCNIV4Manifest = "egress-router-cni-v4-cr.yaml"
+	egressRouterCNIV6Manifest = "egress-router-cni-v6-cr.yaml"
+	egressRouterCNILogs       = "/tmp/egress-router-log"
+	// Match patterns are based on what is in testdata/egress-router-cni manifests
+	ipv4MatchPattern = "IP Destinations: [80 UDP 10.100.3.0 8080 SCTP 203.0.113.26 80 8443 TCP 203.0.113.27 443]"
+	ipv6MatchPattern = "IP Destinations: [80 UDP 10:100:3::0 8080 SCTP 203:0:113::26 80 8443 TCP 203:0:113::27 443]"
+	timeOut          = 1 * time.Minute
+	interval         = 5 * time.Second
+)
+
+var _ = g.Describe("[sig-network][Feature:EgressRouterCNI]", func() {
+	oc := exutil.NewCLI(egressRouterCNIE2E)
+
+	g.It("should ensure ipv4 egressrouter cni resources are created", func() {
+		doEgressRouterCNI(egressRouterCNIV4Manifest, oc, ipv4MatchPattern)
+	})
+	InOVNKubernetesContext(
+		func() {
+			g.It("should ensure ipv6 egressrouter cni resources are created", func() {
+				doEgressRouterCNI(egressRouterCNIV6Manifest, oc, ipv6MatchPattern)
+			})
+		},
+	)
+})
+
+func doEgressRouterCNI(manifest string, oc *exutil.CLI, matchString string) error {
+	var deployment *appsv1.Deployment
+	var podList *v1.PodList
+	f := oc.KubeFramework()
+
+	g.By("creating an egressroutercni object")
+	egressRouterCNIYaml := exutil.FixturePath("testdata", "egress-router-cni", manifest)
+
+	g.By(fmt.Sprintf("calling oc create -f %s", egressRouterCNIYaml))
+	err := oc.AsAdmin().Run("create").Args("-f", egressRouterCNIYaml).Execute()
+	e2e.ExpectNoError(err, "while creating egress-router-cni object")
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("making sure egressroutercni deployment is created")
+	o.Eventually(func() error {
+		deployment, err = f.ClientSet.AppsV1().Deployments(f.Namespace.Name).Get(context.Background(), egressRouterCNIDeployment, metav1.GetOptions{})
+		return err
+	}, timeOut, interval).Should(o.Succeed())
+
+	g.By("checking network-attachment-definition resource is created")
+	output, err := oc.AsAdmin().Run("get").Args("network-attachment-definition", "-o=jsonpath={.items[0].metadata.name}").Output()
+	e2e.ExpectNoError(err, "while creating egress-router-cni network-attachement-definition")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(output).Should(o.ContainSubstring(egressRouterCNINadObject))
+
+	g.By("getting a pod from deployment in running state")
+	o.Eventually(func() error {
+		podList, err = e2edeployment.GetPodsForDeployment(f.ClientSet, deployment)
+		return err
+	}, timeOut, interval).Should(o.Succeed())
+
+	o.Expect(podList.Items).NotTo(o.BeEmpty())
+	pod := podList.Items[0]
+	e2e.Logf("egress router cni pod %s is created\n", pod.Spec.Containers[0].Name)
+
+	node := pod.Spec.NodeName
+	expectNoError(err)
+	g.By("checking for specific output in the egress-router log on the node " + node)
+	o.Eventually(func() (string, error) {
+		result, err := oc.AsAdmin().Run("debug").Args("node/"+node, "--", "chroot", "/host", "/bin/bash", "-c", "cat /tmp/egress-router-log").Output()
+		return result, err
+	}, timeOut, interval).Should(o.ContainSubstring(matchString))
+
+	return nil
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -313,6 +313,8 @@
 // test/extended/testdata/deployments/tag-images-deployment.yaml
 // test/extended/testdata/deployments/test-deployment-broken.yaml
 // test/extended/testdata/deployments/test-deployment-test.yaml
+// test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml
+// test/extended/testdata/egress-router-cni/egress-router-cni-v6-cr.yaml
 // test/extended/testdata/forcepull-test.json
 // test/extended/testdata/gssapi/config/kubeconfig
 // test/extended/testdata/gssapi/config/oauth_config.json
@@ -41619,6 +41621,110 @@ func testExtendedTestdataDeploymentsTestDeploymentTestYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml = []byte(`---
+apiVersion: network.operator.openshift.io/v1
+kind: EgressRouter
+metadata:
+  name: egress-router-ipv4-test
+spec:
+  addresses: [
+    {
+      ip: "192.168.3.10/24",
+      gateway: "192.168.3.1",
+    },
+  ]
+  mode: Redirect
+  redirect: {
+    redirectRules: [
+      {
+        destinationIP: "10.100.3.0",
+        port: 80,
+        protocol: UDP,
+      },
+      {
+        destinationIP: "203.0.113.26",
+        port: 8080,
+        protocol: SCTP,
+        targetPort: 80
+      },
+      {
+        destinationIP: "203.0.113.27",
+        port: 8443,
+        protocol: TCP,
+        targetPort: 443
+      },
+    ]
+  }
+
+`)
+
+func testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml, nil
+}
+
+func testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataEgressRouterCniEgressRouterCniV6CrYaml = []byte(`---
+apiVersion: network.operator.openshift.io/v1
+kind: EgressRouter
+metadata:
+  name: egress-router-ipv6-test
+spec:
+  addresses: [
+    {
+      ip: "192:168:3::10/64",
+      gateway: "192:168:3::1",
+    },
+  ]
+  mode: Redirect
+  redirect: {
+    redirectRules: [
+      {
+        destinationIP: "10:100:3::0",
+        port: 80,
+        protocol: UDP,
+      },
+      {
+        destinationIP: "203:0:113::26",
+        port: 8080,
+        protocol: SCTP,
+        targetPort: 80
+      },
+      {
+        destinationIP: "203:0:113::27",
+        port: 8443,
+        protocol: TCP,
+        targetPort: 443
+      },
+    ]
+  }
+
+`)
+
+func testExtendedTestdataEgressRouterCniEgressRouterCniV6CrYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataEgressRouterCniEgressRouterCniV6CrYaml, nil
+}
+
+func testExtendedTestdataEgressRouterCniEgressRouterCniV6CrYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataEgressRouterCniEgressRouterCniV6CrYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/egress-router-cni/egress-router-cni-v6-cr.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataForcepullTestJson = []byte(`{
 	"kind": "List",
 	"apiVersion": "v1",
@@ -54188,6 +54294,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/deployments/tag-images-deployment.yaml":                                          testExtendedTestdataDeploymentsTagImagesDeploymentYaml,
 	"test/extended/testdata/deployments/test-deployment-broken.yaml":                                         testExtendedTestdataDeploymentsTestDeploymentBrokenYaml,
 	"test/extended/testdata/deployments/test-deployment-test.yaml":                                           testExtendedTestdataDeploymentsTestDeploymentTestYaml,
+	"test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml":                                  testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml,
+	"test/extended/testdata/egress-router-cni/egress-router-cni-v6-cr.yaml":                                  testExtendedTestdataEgressRouterCniEgressRouterCniV6CrYaml,
 	"test/extended/testdata/forcepull-test.json":                                                             testExtendedTestdataForcepullTestJson,
 	"test/extended/testdata/gssapi/config/kubeconfig":                                                        testExtendedTestdataGssapiConfigKubeconfig,
 	"test/extended/testdata/gssapi/config/oauth_config.json":                                                 testExtendedTestdataGssapiConfigOauth_configJson,
@@ -54879,6 +54987,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"tag-images-deployment.yaml":          {testExtendedTestdataDeploymentsTagImagesDeploymentYaml, map[string]*bintree{}},
 					"test-deployment-broken.yaml":         {testExtendedTestdataDeploymentsTestDeploymentBrokenYaml, map[string]*bintree{}},
 					"test-deployment-test.yaml":           {testExtendedTestdataDeploymentsTestDeploymentTestYaml, map[string]*bintree{}},
+				}},
+				"egress-router-cni": {nil, map[string]*bintree{
+					"egress-router-cni-v4-cr.yaml": {testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml, map[string]*bintree{}},
+					"egress-router-cni-v6-cr.yaml": {testExtendedTestdataEgressRouterCniEgressRouterCniV6CrYaml, map[string]*bintree{}},
 				}},
 				"forcepull-test.json": {testExtendedTestdataForcepullTestJson, map[string]*bintree{}},
 				"gssapi": {nil, map[string]*bintree{

--- a/test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml
+++ b/test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: network.operator.openshift.io/v1
+kind: EgressRouter
+metadata:
+  name: egress-router-ipv4-test
+spec:
+  addresses: [
+    {
+      ip: "192.168.3.10/24",
+      gateway: "192.168.3.1",
+    },
+  ]
+  mode: Redirect
+  redirect: {
+    redirectRules: [
+      {
+        destinationIP: "10.100.3.0",
+        port: 80,
+        protocol: UDP,
+      },
+      {
+        destinationIP: "203.0.113.26",
+        port: 8080,
+        protocol: SCTP,
+        targetPort: 80
+      },
+      {
+        destinationIP: "203.0.113.27",
+        port: 8443,
+        protocol: TCP,
+        targetPort: 443
+      },
+    ]
+  }
+

--- a/test/extended/testdata/egress-router-cni/egress-router-cni-v6-cr.yaml
+++ b/test/extended/testdata/egress-router-cni/egress-router-cni-v6-cr.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: network.operator.openshift.io/v1
+kind: EgressRouter
+metadata:
+  name: egress-router-ipv6-test
+spec:
+  addresses: [
+    {
+      ip: "192:168:3::10/64",
+      gateway: "192:168:3::1",
+    },
+  ]
+  mode: Redirect
+  redirect: {
+    redirectRules: [
+      {
+        destinationIP: "10:100:3::0",
+        port: 80,
+        protocol: UDP,
+      },
+      {
+        destinationIP: "203:0:113::26",
+        port: 8080,
+        protocol: SCTP,
+        targetPort: 80
+      },
+      {
+        destinationIP: "203:0:113::27",
+        port: 8443,
+        protocol: TCP,
+        targetPort: 443
+      },
+    ]
+  }
+

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2499,6 +2499,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services when using OpenshiftSDN in a mode that isolates namespaces by default should prevent connections to pods in different namespaces on the same node via service IPs": "should prevent connections to pods in different namespaces on the same node via service IPs [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created": "should ensure ipv4 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created": "should ensure ipv6 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network][Feature:Multus] should use multus to create net1 device from network-attachment-definition": "should use multus to create net1 device from network-attachment-definition [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:Network Policy Audit logging] when using openshift ovn-kubernetes should ensure acl logs are created and correct": "should ensure acl logs are created and correct [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Adding basic egress-router-cni CI e2e test
- build ci test
```
make WHAT=cmd/openshift-tests
```
- manually invoke the test on an existing cluster
```
./openshift-tests run-test "[sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created [Suite:openshift/conformance/parallel]"
```
and for ovnk we can run this additional test
```
./openshift-tests run-test "[sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created [Suite:openshift/conformance/parallel]"
```

run this test manually for ovnk and openshift-sdn
```
STEP: Creating an egressroutercni object
STEP: Calling oc create -f /tmp/fixture-testdata-dir3344212678/test/extended/testdata/egress-router-cni/egress-router-cni-cr.yaml
Mar  2 10:54:29.898: INFO: Running 'oc --namespace=e2e-test-egress-router-cni-e2e-rcpjx --kubeconfig=/home/mmahmoud/Downloads/cluster-bot-2022-03-02-152432.kubeconfig.txt create -f /tmp/fixture-testdata-dir3344212678/test/extended/testdata/egress-router-cni/egress-router-cni-cr.yaml'
egressrouter.network.operator.openshift.io/egress-router-test created
STEP: Making sure egressroutercni deployment is created
STEP: Getting a pod from deployment in running state
Mar  2 10:54:30.445: INFO: egress router cni pod egress-router-cni-pod is created

```
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>