### PR TITLE
bug 2059845: operators should not create watch channels very often: bump OpenStack monitoring operator

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -262,7 +262,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"cluster-autoscaler-operator":            53.0,
 				"cluster-baremetal-operator":             42.0,
 				"cluster-image-registry-operator":        112,
-				"cluster-monitoring-operator":            41,
+				"cluster-monitoring-operator":            48,
 				"cluster-node-tuning-operator":           44.0,
 				"cluster-samples-operator":               26.0,
 				"cluster-storage-operator":               189,


### PR DESCRIPTION
```
Feb 25 11:08:59.756: INFO: operator=cluster-monitoring-operator, watchrequestcount=93, upperbound=82, ratio=1.1341463414634145
Feb 25 11:08:59.756: INFO: Operator "cluster-monitoring-operator" produces more watch requests than expected
```

Backporting https://github.com/openshift/origin/pull/26877