### PR TITLE
Bug 2060498: only add failure when no event was found for the target revision

### DIFF
--- a/pkg/synthetictests/static_pod_test.go
+++ b/pkg/synthetictests/static_pod_test.go
@@ -21,7 +21,7 @@ func Test_staticPodFailureFromMessage(t *testing.T) {
 			want: &staticPodFailure{
 				namespace:      "openshift-etcd",
 				node:           "ovirt10-gh8t5-master-2",
-				revision:       "6",
+				revision:       6,
 				failureMessage: `static pod lifecycle failure - static pod: "etcd" in namespace: "openshift-etcd" for revision: 6 on node: "ovirt10-gh8t5-master-2" didn't show up, waited: 2m30s`,
 			},
 		},


### PR DESCRIPTION
The static pod synthetic test looks for a message specifying the
explicit revision, but it added a failure for each and every event that
was for another revision. This moves the failure adding to the outer
loop.