### PR TITLE
Add networking test for invalid external gateway

### DIFF
--- a/test/extended/networking/external_gateway.go
+++ b/test/extended/networking/external_gateway.go
@@ -1,0 +1,48 @@
+package networking
+
+import (
+	"context"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	exutil "github.com/openshift/origin/test/extended/util"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+var _ = g.Describe("[sig-network] external gateway address", func() {
+	oc := exutil.NewCLI("ns-global")
+
+	InOVNKubernetesContext(func() {
+		f := oc.KubeFramework()
+
+		g.It("Should validate failure if an external gateway address does not match the address family of the pod", func() {
+			err := createPod(f.ClientSet, f.Namespace.Name, "test-valid-gateway-pod")
+			expectNoError(err)
+			// Set external gateway address into an IPv6 address that does not match the
+			// address family of the pod.
+			makeNamespaceWithExternalGatewaySet(f, "fd00:10:244:2::6")
+			err = createPod(f.ClientSet, f.Namespace.Name, "test-invalid-gateway-pod")
+			expectError(err, "pod creation failed due to invalid gateway address")
+		})
+	})
+
+})
+
+func createPod(client clientset.Interface, ns, generateName string) error {
+	pod := frameworkpod.NewAgnhostPod(ns, "", nil, nil, nil)
+	pod.ObjectMeta.GenerateName = generateName
+	execPod, err := client.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+	expectNoError(err, "failed to create new pod in namespace: %s", ns)
+	err = wait.PollImmediate(poll, 2*time.Minute, func() (bool, error) {
+		retrievedPod, err := client.CoreV1().Pods(execPod.Namespace).Get(context.TODO(), execPod.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return retrievedPod.Status.Phase == v1.PodRunning, nil
+	})
+	return err
+}

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -248,6 +248,25 @@ func makeNamespaceScheduleToAllNodes(f *e2e.Framework) {
 	}
 }
 
+func makeNamespaceWithExternalGatewaySet(f *e2e.Framework, gatewayIP string) {
+	for {
+		ns, err := f.ClientSet.CoreV1().Namespaces().Get(context.Background(), f.Namespace.Name, metav1.GetOptions{})
+		expectNoError(err)
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		ns.Annotations["k8s.ovn.org/routing-external-gws"] = gatewayIP
+		_, err = f.ClientSet.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
+		if err == nil {
+			return
+		}
+		if kapierrs.IsConflict(err) {
+			continue
+		}
+		expectNoError(err)
+	}
+}
+
 // findAppropriateNodes tries to find a source and destination for a type of node connectivity
 // test (same node, or different node).
 func findAppropriateNodes(f *e2e.Framework, nodeType NodeType) (*corev1.Node, *corev1.Node, error) {

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2457,6 +2457,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] [Feature:PerformanceDNS][Serial] Should answer DNS query for maximum number of services per cluster": "Should answer DNS query for maximum number of services per cluster [Slow] [Suite:k8s]",
 
+	"[Top Level] [sig-network] external gateway address when using openshift ovn-kubernetes Should validate failure if an external gateway address does not match the address family of the pod": "Should validate failure if an external gateway address does not match the address family of the pod [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network] multicast when using one of the OpenshiftSDN modes 'redhat/openshift-ovs-multitenant, redhat/openshift-ovs-networkpolicy' should allow multicast traffic in namespaces where it is enabled": "should allow multicast traffic in namespaces where it is enabled [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network] multicast when using one of the OpenshiftSDN modes 'redhat/openshift-ovs-multitenant, redhat/openshift-ovs-networkpolicy' should block multicast traffic in namespaces where it is disabled": "should block multicast traffic in namespaces where it is disabled [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This validates pod creation fails when supplying an external gateway
address to the namespace that does not match the address family
of the pod.

This PR is continuation of this e2e test (https://github.com/ovn-org/ovn-kubernetes/pull/1881) in ovn-kubernetes.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>