### PR TITLE
Bug 2026063: build-quota test: fix cgroupv2 parsing holes exposed by buildah upgrade

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17557,48 +17557,47 @@ func testExtendedTestdataBuildsBuildPruningSuccessfulPipelineYaml() (*asset, err
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsBuildQuotaS2iBinAssemble = []byte(`#!/bin/sh
+var _testExtendedTestdataBuildsBuildQuotaS2iBinAssemble = []byte(`#!/bin/bash
 
 # Seeing issues w/ buildah log output being intermingled with the container
 # output, so adding a sleep in an attempt to let the buildah log output
 # stop before the container output starts
 sleep 10
+unifiedMount=$(awk '{if ($3 == "cgroup2") {print $2; exit}}' /proc/self/mounts)
+echo "cgroupv2 mount point is ${unifiedMount}"
+unifiedName=$(awk -F: '/^0:/ {if ($1 == "0") {print $3; exit}}' /proc/self/cgroup)
+echo "unified cgroup name is ${unifiedName}"
+if test -e /"$unifiedMount"/"$unifiedName"/cgroup.controllers ; then
+  unifiedControllers=$(cat /"$unifiedMount"/"$unifiedName"/cgroup.controllers)
+fi
+echo "cgroupv2 controllers are ${unifiedControllers}"
+
 cgroupv1Val=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) || true
 echo "cgroupv1Val is ${cgroupv1Val}"
-if [ "$cgroupv1Val" = "419430400" ]; then
+if [ "$cgroupv1Val" != "" ]; then
   echo "MEMORY=${cgroupv1Val}"
-else
-  memory_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.max)
-  for item in ${memory_max_list};
-  do
-    echo "${item}"
-    cgroupv2Val=$(cat "${item}")
-    echo "cgroupv2Val is ${cgroupv2Val}"
-    if [ "$cgroupv2Val" = "419430400" ]; then
-      echo "MEMORY=${cgroupv2Val}"
-    fi
-  done
 fi
+cgroupv2Val=$(cat /"$unifiedMount"/"$unifiedName"/memory.max) || true
+echo "cgroupv2Val is ${cgroupv2Val}"
+if [ "$cgroupv2Val" != "" ]; then
+  echo "MEMORY=${cgroupv2Val}"
+  MEMORY="${cgroupv2Val}"
+fi
+
 cgroupv1Val=$(cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes) || true
 echo "cgroupv1Val is ${cgroupv1Val}"
-if [ "$cgroupv1Val" = "419430400" ]; then
+if [ "$cgroupv1Val" != "" ]; then
   echo "MEMORYSWAP=${cgroupv1Val}"
-else
-  # ok swap is treated differently between cgroup v1 and v2.  In v1, memory.memsw.limit_in_bytes
-  # is memory+swap.  In v2, memory.swap.max is just swap.  So with our quota in place, we will
-  # find a memory.swap.max file with a value of '0' instead of 'max'.
-  memory_swap_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.swap.max)
-  for item in ${memory_swap_max_list};
-  do
-    echo "${item}"
-    cgroupv2Val=$(cat "${item}")
-    echo "cgroupv2Val is ${cgroupv2Val}"
-    if [ "$cgroupv2Val" = "0" ]; then
-      # so that our associated ginkgo test case does not have to distinguish between cgroup v1
-      # and v2, we echo the expected v1 string when we find a memory.swap.max file with '0' in it.
-      echo "MEMORYSWAP=419430400"
-    fi
-  done
+fi
+# ok swap is treated differently between cgroup v1 and v2.  In v1, memory.memsw.limit_in_bytes
+# is memory+swap.  In v2, memory.swap.max is just swap.  So with our quota in place, we will
+# find a memory.swap.max file with a value of '0' instead of 'max'.
+cgroupv2Val=$(cat /"$unifiedMount"/"$unifiedName"/memory.swap.max) || true
+echo "cgroupv2Val is ${cgroupv2Val}"
+if [ "$cgroupv2Val" != "" ]; then
+  # so that our associated ginkgo test case does not have to distinguish between cgroup v1
+  # and v2, we calculate the equivalent v1 value
+  echo MEMORYSWAP=$(($cgroup2Val + $MEMORY))
 fi
 
 if [ -e /sys/fs/cgroup/cpuacct,cpu ]; then

--- a/test/extended/testdata/builds/build-quota/.s2i/bin/assemble
+++ b/test/extended/testdata/builds/build-quota/.s2i/bin/assemble
@@ -1,45 +1,44 @@
-#!/bin/sh
+#!/bin/bash
 
 # Seeing issues w/ buildah log output being intermingled with the container
 # output, so adding a sleep in an attempt to let the buildah log output
 # stop before the container output starts
 sleep 10
+unifiedMount=$(awk '{if ($3 == "cgroup2") {print $2; exit}}' /proc/self/mounts)
+echo "cgroupv2 mount point is ${unifiedMount}"
+unifiedName=$(awk -F: '/^0:/ {if ($1 == "0") {print $3; exit}}' /proc/self/cgroup)
+echo "unified cgroup name is ${unifiedName}"
+if test -e /"$unifiedMount"/"$unifiedName"/cgroup.controllers ; then
+  unifiedControllers=$(cat /"$unifiedMount"/"$unifiedName"/cgroup.controllers)
+fi
+echo "cgroupv2 controllers are ${unifiedControllers}"
+
 cgroupv1Val=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) || true
 echo "cgroupv1Val is ${cgroupv1Val}"
-if [ "$cgroupv1Val" = "419430400" ]; then
+if [ "$cgroupv1Val" != "" ]; then
   echo "MEMORY=${cgroupv1Val}"
-else
-  memory_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.max)
-  for item in ${memory_max_list};
-  do
-    echo "${item}"
-    cgroupv2Val=$(cat "${item}")
-    echo "cgroupv2Val is ${cgroupv2Val}"
-    if [ "$cgroupv2Val" = "419430400" ]; then
-      echo "MEMORY=${cgroupv2Val}"
-    fi
-  done
 fi
+cgroupv2Val=$(cat /"$unifiedMount"/"$unifiedName"/memory.max) || true
+echo "cgroupv2Val is ${cgroupv2Val}"
+if [ "$cgroupv2Val" != "" ]; then
+  echo "MEMORY=${cgroupv2Val}"
+  MEMORY="${cgroupv2Val}"
+fi
+
 cgroupv1Val=$(cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes) || true
 echo "cgroupv1Val is ${cgroupv1Val}"
-if [ "$cgroupv1Val" = "419430400" ]; then
+if [ "$cgroupv1Val" != "" ]; then
   echo "MEMORYSWAP=${cgroupv1Val}"
-else
-  # ok swap is treated differently between cgroup v1 and v2.  In v1, memory.memsw.limit_in_bytes
-  # is memory+swap.  In v2, memory.swap.max is just swap.  So with our quota in place, we will
-  # find a memory.swap.max file with a value of '0' instead of 'max'.
-  memory_swap_max_list=$(find /sys/fs/cgroup/kubepods.slice -name memory.swap.max)
-  for item in ${memory_swap_max_list};
-  do
-    echo "${item}"
-    cgroupv2Val=$(cat "${item}")
-    echo "cgroupv2Val is ${cgroupv2Val}"
-    if [ "$cgroupv2Val" = "0" ]; then
-      # so that our associated ginkgo test case does not have to distinguish between cgroup v1
-      # and v2, we echo the expected v1 string when we find a memory.swap.max file with '0' in it.
-      echo "MEMORYSWAP=419430400"
-    fi
-  done
+fi
+# ok swap is treated differently between cgroup v1 and v2.  In v1, memory.memsw.limit_in_bytes
+# is memory+swap.  In v2, memory.swap.max is just swap.  So with our quota in place, we will
+# find a memory.swap.max file with a value of '0' instead of 'max'.
+cgroupv2Val=$(cat /"$unifiedMount"/"$unifiedName"/memory.swap.max) || true
+echo "cgroupv2Val is ${cgroupv2Val}"
+if [ "$cgroupv2Val" != "" ]; then
+  # so that our associated ginkgo test case does not have to distinguish between cgroup v1
+  # and v2, we calculate the equivalent v1 value
+  echo MEMORYSWAP=$(($cgroup2Val + $MEMORY))
 fi
 
 if [ -e /sys/fs/cgroup/cpuacct,cpu ]; then


### PR DESCRIPTION
In the build-quota test script that we use to confirm that memory limits have been correctly set, do more of the work to find the right cgroup memory limit to read when we're in a cgroupsv2 setting.

The script already used some bash-specific syntax, so make that clear in the shebang line.