### PR TITLE
Push metal multiport service ipv6 test service IP further into service network.

### DIFF
--- a/test/extended/testdata/cmd/test/cmd/testdata/external-service-ipv6.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/external-service-ipv6.yaml
@@ -7,7 +7,7 @@ metadata:
   resourceVersion: "1"
   uid: 19cff995-5546-11e5-9f57-080027c5bfa9
 spec:
-  clusterIP: fd02::8
+  clusterIP: fd02::dace
   ports:
   - nodePort: 0
     port: 443

--- a/test/extended/testdata/cmd/test/cmd/testdata/multiport-service-ipv6.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/multiport-service-ipv6.yaml
@@ -11,7 +11,7 @@ items:
     resourceVersion: "259"
     uid: 024d82eb-7193-11e5-b84d-080027c5bfa9
   spec:
-    clusterIP: fd02::9
+    clusterIP: fd02::face
     ports:
     - name: web
       port: 5432


### PR DESCRIPTION
Service network reportedly goes from fd02::0 to fd02::ffff so we're
grabbing 'face'.

This isn't failing often but we did see it twice in a row and thus
failing a payload.
