### PR TITLE
Add e2e tests for ExternalIP Policy and AutoAssignCIDRs

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -85,6 +85,8 @@ var staticSuites = testSuites{
 				}
 				return strings.Contains(name, "[Suite:openshift/conformance/serial") || isStandardEarlyOrLateTest(name)
 			},
+			// doubling default test timeout (15 mins) which is needed for external ip configuration related serial tests.
+			TestTimeout:         30 * time.Minute,
 			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.StableSystemEventInvariants),
 		},
 		PreSuite: suiteWithProviderPreSuite,

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -3,11 +3,17 @@ package networking
 import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	"context"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
+	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("[sig-network] services", func() {
@@ -75,6 +81,127 @@ var _ = Describe("[sig-network] services", func() {
 		It("should allow connections from pods in the default namespace to a service in another namespace on a different node", func() {
 			makeNamespaceGlobal(oc, f2.Namespace)
 			Expect(checkServiceConnectivity(f1, f2, DIFFERENT_NODE)).To(Succeed())
+		})
+	})
+
+	var retryInterval = 1 * time.Minute
+
+	Context("external ip", func() {
+		It("ensures policy is configured correctly on the cluster [Serial]", func() {
+			namespace := oc.Namespace()
+			adminConfigClient := oc.AdminConfigClient()
+			k8sClient := oc.KubeClient()
+			serviceClient := k8sClient.CoreV1().Services(namespace)
+			// Test a load balancer service with default cluster networks config
+			// In this case service creation must throw an error for non admin user
+			By("create service of type load balancer with default cluster networks config")
+			serviceName := "svc-without-ext-ip"
+			By("check load balance service creation fails")
+			err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
+			deleteService(serviceClient, serviceName)
+			Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
+
+			// Test external ip policy configured with allowedCIDRs. Make sure service
+			// is created if that is within allowedCIDRs range and service creation
+			// fails if its outside the allowed range.
+			By("update network config with allowed cidr for external ip")
+			modifyNetworkConfig(adminConfigClient, nil, []string{"192.168.132.10/32"}, nil)
+			serviceName = "svc-with-ext-ip"
+			By("check service is within external ip within allowed range")
+			for {
+				err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
+				deleteService(serviceClient, serviceName)
+				if err != nil && kapierrs.IsForbidden(err) {
+					time.Sleep(retryInterval)
+					continue
+				}
+				expectNoError(err)
+				break
+			}
+			By("check service creation fails when external ip outside the allowed range")
+			err = createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.20"}, nil)
+			deleteService(serviceClient, serviceName)
+			Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
+
+			// Revert cluster networks config into default settings and make sure
+			// service creation must fail with an error for non admin user.
+			By("update network config without external ip")
+			modifyNetworkConfig(adminConfigClient, []string{}, []string{}, []string{})
+			serviceName = "svc-without-ext-ip-2"
+			By("check load balance service creation fails")
+			for {
+				err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
+				deleteService(serviceClient, serviceName)
+				if err == nil {
+					e2e.Logf("error not occurred while creating %s/%s service", namespace, serviceName)
+					time.Sleep(retryInterval)
+					continue
+				}
+				e2e.Logf("error occurred while creating %s/%s service: %v", namespace, serviceName, err)
+				Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
+				break
+			}
+		})
+	})
+
+	InBareMetalClusterContext(oc, func() {
+		It("ensures external auto assign cidr is configured correctly on the cluster [Serial]", func() {
+			namespace := oc.Namespace()
+			adminConfigClient := oc.AdminConfigClient()
+			k8sClient := oc.KubeClient()
+			serviceClient := k8sClient.CoreV1().Services(namespace)
+			// Test a load balancer service with default cluster networks config
+			// In this case service creation must throw an error for non admin user.
+			By("create service of type load balancer with default cluster networks config")
+			serviceName := "svc-without-ext-ip-3"
+			By("check load balance service creation fails")
+			err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
+			Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
+
+			// Test external ip policy configured with both policy and auto assign cidr. Make sure service
+			// is assigned with an ip address from auto assign cidr.
+			By("update network config with auto assign cidr")
+			modifyNetworkConfig(adminConfigClient, []string{"192.168.132.254/29"}, []string{"192.168.132.0/29"}, []string{"192.168.132.8/29"})
+			serviceName = "svc-ext-ip-auto-assign"
+			By("check load balancer service having desired ingress ip prefix")
+			for {
+				err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{}, nil)
+				if err != nil && kapierrs.IsForbidden(err) {
+					deleteService(serviceClient, serviceName)
+					time.Sleep(retryInterval)
+					continue
+				}
+				expectNoError(err)
+				service, err := serviceClient.Get(context.Background(), serviceName, metav1.GetOptions{})
+				expectNoError(err)
+				var ingressIP string
+				if len(service.Status.LoadBalancer.Ingress) > 0 {
+					ingressIP = service.Status.LoadBalancer.Ingress[0].IP
+				}
+				deleteService(serviceClient, serviceName)
+				if !strings.HasPrefix(ingressIP, "192.168.132") {
+					time.Sleep(retryInterval)
+					continue
+				}
+				break
+			}
+
+			// Revert cluster networks config into default settings and make sure
+			// service creation must fail with an error for non admin user.
+			By("update network config without external ip")
+			modifyNetworkConfig(adminConfigClient, []string{}, []string{}, []string{})
+			serviceName = "svc-without-ext-ip-4"
+			By("check load balance service creation fails")
+			for {
+				err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
+				deleteService(serviceClient, serviceName)
+				if err == nil {
+					time.Sleep(retryInterval)
+					continue
+				}
+				Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
+				break
+			}
 		})
 	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2493,6 +2493,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services basic functionality should allow connections to another pod on the same node via a service IP": "should allow connections to another pod on the same node via a service IP [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network] services external ip ensures policy is configured correctly on the cluster [Serial]": "ensures policy is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [sig-network] services when running openshift cluster on bare metal ensures external auto assign cidr is configured correctly on the cluster [Serial]": "ensures external auto assign cidr is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
+
 	"[Top Level] [sig-network] services when using OpenshiftSDN in a mode that does not isolate namespaces by default should allow connections to pods in different namespaces on different nodes via service IPs": "should allow connections to pods in different namespaces on different nodes via service IPs [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network] services when using OpenshiftSDN in a mode that does not isolate namespaces by default should allow connections to pods in different namespaces on the same node via service IPs": "should allow connections to pods in different namespaces on the same node via service IPs [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -60,6 +60,7 @@ import (
 	"github.com/openshift/library-go/pkg/image/imageutil"
 	"github.com/openshift/origin/test/extended/testdata"
 	utilimage "github.com/openshift/origin/test/extended/util/image"
+	k8sclient "k8s.io/client-go/kubernetes"
 )
 
 // WaitForInternalRegistryHostname waits for the internal registry hostname to be made available to the cluster.
@@ -1602,7 +1603,7 @@ func ParseLabelsOrDie(str string) labels.Selector {
 // as the target for networking connectivity checks.  The ip address
 // of the created pod will be returned if the pod is launched
 // successfully.
-func LaunchWebserverPod(f *e2e.Framework, podName, nodeName string) (ip string) {
+func LaunchWebserverPod(client k8sclient.Interface, namespace, podName, nodeName string) (ip string) {
 	containerName := fmt.Sprintf("%s-container", podName)
 	port := 8080
 	pod := &corev1.Pod{
@@ -1622,10 +1623,10 @@ func LaunchWebserverPod(f *e2e.Framework, podName, nodeName string) (ip string) 
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
+	podClient := client.CoreV1().Pods(namespace)
 	_, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{})
 	e2e.ExpectNoError(err)
-	e2e.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, podName, f.Namespace.Name))
+	e2e.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(client, podName, namespace))
 	createdPod, err := podClient.Get(context.Background(), podName, metav1.GetOptions{})
 	e2e.ExpectNoError(err)
 	ip = net.JoinHostPort(createdPod.Status.PodIP, strconv.Itoa(port))


### PR DESCRIPTION
This adds relevant e2e tests covering ExternalIP's `AutoAssignCIDRs` and `Policy`. 
For more details about `ExternalIP` feature, refer [here](https://docs.openshift.com/container-platform/4.9/networking/configuring_ingress_cluster_traffic/configuring-externalip.html).

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>