### PR TITLE
Give each interval chart a title

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -3,7 +3,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>e2e-chart</title>
+    <title>EVENT_INTERVAL_TITLE_GOES_HERE</title>
     <script src="https://unpkg.com/timelines-chart"></script>
     <script src="https://d3js.org/d3-array.v1.min.js"></script>
     <script src="https://d3js.org/d3-collection.v1.min.js"></script>

--- a/pkg/monitor/intervalcreation/rendering.go
+++ b/pkg/monitor/intervalcreation/rendering.go
@@ -41,7 +41,9 @@ func (r eventIntervalRenderer) WriteEventData(artifactDir string, events monitor
 
 	}
 	e2eChartTemplate := testdata.MustAsset("e2echart/e2e-chart-template.html")
-	e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)
+	e2eChartTitle := fmt.Sprintf("Intervals - %s%s", r.name, timeSuffix)
+	e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_TITLE_GOES_HERE"), []byte(e2eChartTitle))
+	e2eChartHTML = bytes.ReplaceAll(e2eChartHTML, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)
 	e2eChartHTMLPath := filepath.Join(artifactDir, fmt.Sprintf("e2e-intervals_%s%s.html", r.name, timeSuffix))
 	if err := ioutil.WriteFile(e2eChartHTMLPath, e2eChartHTML, 0644); err != nil {
 		errs = append(errs, err)

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53495,7 +53495,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>e2e-chart</title>
+    <title>EVENT_INTERVAL_TITLE_GOES_HERE</title>
     <script src="https://unpkg.com/timelines-chart"></script>
     <script src="https://d3js.org/d3-array.v1.min.js"></script>
     <script src="https://d3js.org/d3-collection.v1.min.js"></script>


### PR DESCRIPTION
A recent change in the Spyglass HTML lens means if a `<title>` tag is
present, it shows that instead of the file name.  Currently each
interval chart is showing up as just `e2e-chart`.