### PR TITLE
Allow CurrentVersionNotVerified alert

### DIFF
--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -132,6 +132,10 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 			Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
 			Text:     "Loki is nice to have, but we can allow it to be down",
 		},
+		{
+			Selector: map[string]string{"alertname": "CurrentVersionNotVerified", "namespace": "openshift-cluster-version"},
+			Text:     "Versions of the clusters used in the CI may not be signed, and in these cases, it is expected for the verification to fail",
+		},
 	}
 
 	pendingAlertsWithBugs := helper.MetricConditions{

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -350,6 +350,10 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 				Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
 				Text:     "high CPU utilization during e2e runs is normal",
 			},
+			{
+				Selector: map[string]string{"alertname": "CurrentVersionNotVerified", "namespace": "openshift-cluster-version"},
+				Text:     "Versions of the clusters used in the CI may not be signed, and in these cases, it is expected for the verification to fail",
+			},
 		}
 
 		if isTechPreviewCluster(oc) {
@@ -753,6 +757,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 				"AlertmanagerReceiversNotConfigured",
 				"PrometheusRemoteWriteDesiredShards",
 				"KubeJobFailed", // this is a result of bug https://bugzilla.redhat.com/show_bug.cgi?id=2054426 .  We should catch these in the late test above.
+				"CurrentVersionNotVerified",
 			}
 
 			// we exclude alerts that have their own separate tests.


### PR DESCRIPTION
This pull request should add the alert `CurrentVersionNotVerified` as an allowed alert to tests that are making sure any unexpected alerts are not firing.

The `CurrentVersionNotVerified` alert is supposed to be firing when the verification of the current version of a cluster has failed and the version was forcefully applied to the cluster. Versions of the clusters used in the CI are forcefully applied and may not be signed. Thus the verification is expected to fail.

The alert `CurrentVersionNotVerified` is not as of this moment present. The alert will be added in the https://github.com/openshift/cluster-version-operator/pull/734 which is currently failing the CI tests regarding unexpected alerts firing. This pull request should solve this issue. 

Pull Request related to https://issues.redhat.com/browse/OTA-187