### PR TITLE
CLI buildconfig: Don't expect apiserver port to end with 443

### DIFF
--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -11,7 +11,7 @@ trap "cleanup" EXIT
 
 os::test::junit::declare_suite_start "verify/generated"
 os::cmd::expect_success "${OS_ROOT}/hack/update-generated.sh"
-os::cmd::expect_success "git diff --quiet ${OS_ROOT}/test/extended/util/annotate/generated/"
-os::cmd::expect_success "git diff --quiet ${OS_ROOT}/test/extended/util/image/zz_generated.txt"
+os::cmd::expect_success "git diff --exit-code ${OS_ROOT}/test/extended/util/annotate/generated/"
+os::cmd::expect_success "git diff --exit-code ${OS_ROOT}/test/extended/util/image/zz_generated.txt"
 
 os::test::junit::declare_suite_end

--- a/test/extended/cli/builds.go
+++ b/test/extended/cli/builds.go
@@ -194,7 +194,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 	g.Describe("complex build", func() {
 		var (
 			appTemplatePath = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "application-template-dockerbuild.json")
-			apiServer       = ""
+			apiServer       = oc.AdminConfig().Host
 		)
 
 		getTriggerURL := func(secret, name string) string {
@@ -203,13 +203,6 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		}
 
 		g.JustBeforeEach(func() {
-			g.By("getting the api server host")
-			out, err := oc.WithoutNamespace().Run("--namespace=default", "status").Args().Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			e2e.Logf("got status value of: %s", out)
-			matcher := regexp.MustCompile("https?://.*?443")
-			apiServer = matcher.FindString(out)
-			o.Expect(apiServer).NotTo(o.BeEmpty())
 
 			g.By("install application")
 			appObjects, _, err := oc.Run("process").Args("-f", appTemplatePath, "-l", "build=docker").Outputs()

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1433,10 +1433,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc basics can process templates": "can process templates [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc builds complex build start-build": "start-build [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-cli] oc builds complex build webhooks CRUD": "webhooks CRUD [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
-
 	"[Top Level] [sig-cli] oc builds get buildconfig": "get buildconfig [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc builds new-build": "new-build [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
The tests currently get the apiserver address by calling `oc
--namespace=default status` and then extracting the apiserver with a
regex that expects its port to end with 443. This breaks when the
apiserver doesn't have such a port.

Just use the host from the kubeconfig instead.