### PR TITLE
Tools - etcdhelper functionality increase

### DIFF
--- a/tools/etcdhelper/README.md
+++ b/tools/etcdhelper/README.md
@@ -100,7 +100,7 @@ data:
   .dockercfg: eyIxMC4~~~rest of the data~~~ifx013= 
 kind: Secret
 metadata:
-  ~~~~~
+~~~
 ```
 
 As opposed to what happens if you do not decrypt:

--- a/tools/etcdhelper/README.md
+++ b/tools/etcdhelper/README.md
@@ -20,7 +20,7 @@ Once these are set properly, one can invoke the following actions:
 * `get` - get the specific value of a key
 * `dump` - dump the entire contents of the etcd
 
-## Sample Usage
+## Sample Basic Usage
 
 List all keys starting with `/openshift.io`:
 
@@ -38,4 +38,76 @@ Dump the contents of etcd to stdout:
 
 ```
 etcdhelper -key master.etcd-client.key -cert master.etcd-client.crt -cacert ca.crt dump
+```
+
+## Advanced Usage
+
+If your OpenShift cluster has `etcd` [encryption enabled](https://docs.openshift.com/container-platform/4.9/security/encrypting-etcd.html), you will not be able to retrieve the values for these objcets in ETCD:
+
+* `ConfigMaps`
+* `Secrets`
+* `Routes`
+* `OAuth tokens*`
+
+**NOTE** Currently this only supports encryption of the `aescbc` type. This is only noted in case future releases add in various encryption types.
+
+Once these are set properly, one can invoke the following actions:
+
+* `secrets` - get the decrypted value of an ecnrypted key
+
+This requires setting the following flags:
+
+* `-encryption-key`
+* `-encryption-secret`
+
+### Getting the Encryption Keys
+
+To get these values you have a few options, but it depends on how you are using this (from an `etcd` backup or a live `etcd` cluster).
+
+When `etcd` encryption is enabled you will not be able to retrieve values for the key types listed above. However, you can obtain the Encryption Key and Secret used if you have access to the `openshift-config-managed` namespace. These `Secrets` are rotated, so you will need to look for the latest (or highest numbered) `Secret`. Example using `jq` to trim down the `Secret`:
+
+```sh
+$ oc get secret -n openshift-config-managed encryption-config-openshift-kube-apiserver -o json | jq -r '.data."encryption-config"' | base64 -d | jq -r '.resources[0].providers[0].aescbc.keys'
+[
+  {
+    "name": "1",
+    "secret": "8kU3ejkS86Au/eLzQ4rBR//O1spU0Lbno1JzEBxI="
+  }
+]
+```
+
+If you are backing up `etcd` through the [supported method for OpenShift](https://docs.openshift.com/container-platform/4.9/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.html), the backup will contain an `etcd` snapshot and a `tarball` of static Kubernetes resources. The resources will contain the active encryption key/secret for the keys inside of the `etcd` snapshot. Once you extract the contents, you can run a simple `find` command to get what is needed:
+
+```sh
+$ find static-pod-resources -iname encryption-config* -type f -printf '%T+ %p\n' | sort | head -n 1 | awk '{print $2}'
+static-pod-resources/kube-apiserver-pod-1/secrets/encryption-config/encryption-config
+## Then run the above jq command on this file to get the encryption key/secret used for this backup
+cat static-pod-resources/kube-apiserver-pod-1/secrets/encryption-config/encryption-config | jq -r '.data."encryption-config"' | base64 -d | jq -r '.resources[0].providers[0].aescbc.keys'
+[
+  {
+    "name": "1",
+    "secret": "8kU3ejkS86Au/eLzQ4rBR//O1spU0Lbno1JzEBxI="
+  }
+]
+```
+
+### Retrieve Encrypted Values
+
+With this data in hand, you can now get the values and decrypt them so they can be read/used:
+
+```sh
+$ etcdhelper -encryption-key="1" -encryption-secret="8kU3ejkS86Au/eLzQ4rBR//O1spU0Lbno1JzEBxI=" -key master.etcd-client.key -cert master.etcd-client.crt -cacert ca.crt secrets /kubernetes.io/secrets/openshift-network-operator/default-dockercfg-1h8g7
+apiVersion: v1
+data:
+  .dockercfg: eyIxMC4~~~rest of the data~~~ifx013= 
+kind: Secret
+metadata:
+  ~~~~~
+```
+
+As opposed to what happens if you do not decrypt:
+
+```sh
+$ etcdhelper -encryption-key="1" -encryption-secret="8kU3ejkS86Au/eLzQ4rBR//O1spU0Lbno1JzEBxI=" -key master.etcd-client.key -cert master.etcd-client.crt -cacert ca.crt get /kubernetes.io/secrets/openshift-network-operator/default-dockercfg-1h8g7
+WARN: unable to decode /kubernetes.io/secrets/openshift-network-operator/default-dockercfg-1h8g7: yaml: invalid leading UTF-8 octet
 ```

--- a/tools/etcdhelper/README.md
+++ b/tools/etcdhelper/README.md
@@ -51,10 +51,6 @@ If your OpenShift cluster has `etcd` [encryption enabled](https://docs.openshift
 
 **NOTE** Currently this only supports encryption of the `aescbc` type. This is only noted in case future releases add in various encryption types.
 
-Once these are set properly, one can invoke the following actions:
-
-* `secrets` - get the decrypted value of an ecnrypted key
-
 This requires setting the following flags:
 
 * `-encryption-key`
@@ -93,7 +89,9 @@ cat static-pod-resources/kube-apiserver-pod-1/secrets/encryption-config/encrypti
 
 ### Retrieve Encrypted Values
 
-With this data in hand, you can now get the values and decrypt them so they can be read/used:
+Once these are set properly, one can invoke the `secrets` action:
+
+* `secrets` - get the decrypted value of an ecnrypted key
 
 ```sh
 $ etcdhelper -encryption-key="1" -encryption-secret="8kU3ejkS86Au/eLzQ4rBR//O1spU0Lbno1JzEBxI=" -key master.etcd-client.key -cert master.etcd-client.crt -cacert ca.crt secrets /kubernetes.io/secrets/openshift-network-operator/default-dockercfg-1h8g7

--- a/tools/etcdhelper/etcdhelper.go
+++ b/tools/etcdhelper/etcdhelper.go
@@ -3,27 +3,27 @@ package main
 import (
 	"bytes"
 	"context"
-    "crypto/aes"
-    "crypto/cipher"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
-    "encoding/base64"
 	"flag"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/openshift/api"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/v3"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apiserver/pkg/storage/value"
+	aestransformer "k8s.io/apiserver/pkg/storage/value/encrypt/aes"
 	"k8s.io/kubectl/pkg/scheme"
-    "k8s.io/apiserver/pkg/storage/value"
-    aestransformer "k8s.io/apiserver/pkg/storage/value/encrypt/aes"
-	"github.com/openshift/api"
 )
 
 const (
-    AESCBC_PREFIX = "k8s:enc:aescbc:v1:"
+	AESCBC_PREFIX = "k8s:enc:aescbc:v1:"
 )
 
 func init() {
@@ -37,8 +37,8 @@ func main() {
 	flag.StringVar(&keyFile, "key", "", "TLS client key.")
 	flag.StringVar(&certFile, "cert", "", "TLS client certificate.")
 	flag.StringVar(&caFile, "cacert", "", "Server TLS CA certificate.")
-    flag.StringVar(&encryptionkey, "encryption-key", getenv("ENCRYPTION_KEY"), "Encryption Key.")
-    flag.StringVar(&encryptionSecret, "encryption-secret", getenv("ENCRYPTION_SECRET"), "Encryption Secret.")
+	flag.StringVar(&encryptionkey, "encryption-key", getenv("ENCRYPTION_KEY"), "Encryption Key.")
+	flag.StringVar(&encryptionSecret, "encryption-secret", getenv("ENCRYPTION_SECRET"), "Encryption Secret.")
 
 	flag.Parse()
 
@@ -177,7 +177,7 @@ func getKey(client *clientv3.Client, key string) error {
 	}
 
 	decoder := scheme.Codecs.UniversalDeserializer()
-    encoder := jsonserializer.NewYAMLSerializer(jsonserializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+	encoder := jsonserializer.NewYAMLSerializer(jsonserializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
 
 	for _, kv := range resp.Kvs {
 		obj, gvk, err := decoder.Decode(kv.Value, nil, nil)
@@ -195,8 +195,6 @@ func getKey(client *clientv3.Client, key string) error {
 
 	return nil
 }
-
-
 
 func secrets(encryptionkey string, encryptionSecret string, client *clientv3.Client, key string) error {
 


### PR DESCRIPTION
# Reason for PR

This PR increases the functionality of the `etcdhelper` tool by adding in support for decrypting values stored in an `etcd` cluster that have been encrypted through supported OpenShift methods[1]. This tool has been tested and verified to work with OpenShift 4.6 `etcd` cluster backups. The `README` has been updated to include examples and details about using this new option: `secrets`.

# Changes to code

The `etcdhelper.go` tool has had a new function added, `func secrets`, which adds in logic to decrypt values stored in the `aescbc` method inside of `etcd`. This work was primarily done by @sabre1041 as its own standalone tool, but has been converted into a function to be used as a single binary.

Links:
[1] https://docs.openshift.com/container-platform/4.9/security/encrypting-etcd.html