### PR TITLE
Migrate builds tests away from using sample imagestreams since samples will be optional

### DIFF
--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -39,14 +39,9 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 		})
 
 		g.JustBeforeEach(func() {
-			g.By("waiting for openshift namespace imagestreams")
-			err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
 			g.By("creating test image stream")
-			err = oc.Run("create").Args("-f", isFixture).Execute()
+			err := oc.Run("create").Args("-f", isFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-
 		})
 
 		g.AfterEach(func() {

--- a/test/extended/builds/clone_git_protocol.go
+++ b/test/extended/builds/clone_git_protocol.go
@@ -18,13 +18,6 @@ var _ = g.Describe("[sig-builds][Feature:Builds] clone repository using git:// p
 			exutil.PreTestDump()
 		})
 
-		g.JustBeforeEach(func() {
-			g.By("waiting for openshift namespace imagestreams")
-			err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-		})
-
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
@@ -32,9 +25,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] clone repository using git:// p
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})
-
 		g.It("should clone using git:// if no proxy is configured", func() {
-
 			if true {
 				// TODO:
 				g.Skip("test disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=2019433 and https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting: 'The unauthenticated git protocol on port 9418 is no longer supported'")
@@ -48,7 +39,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] clone repository using git:// p
 			}
 
 			g.By("creating a new application using the git:// protocol")
-			err = oc.Run("new-app").Args("git://github.com/sclorg/ruby-ex.git").Execute()
+			err = oc.Run("new-app").Args("registry.redhat.io/ubi8/ruby-30:latest~git://github.com/sclorg/ruby-ex.git").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 	})

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -56,7 +56,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 
 		g.It("should succeed with a --name of 58 characters", func() {
 			g.By("calling oc new-app")
-			err := oc.Run("new-app").Args("https://github.com/sclorg/nodejs-ex", "--name", a58, "--build-env=BUILD_LOGLEVEL=5").Execute()
+			err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--name", a58, "--build-env=BUILD_LOGLEVEL=5").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the build to complete")
@@ -83,7 +83,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 
 		g.It("should fail with a --name longer than 58 characters", func() {
 			g.By("calling oc new-app")
-			out, err := oc.Run("new-app").Args("https://github.com/sclorg/nodejs-ex", "--name", a59).Output()
+			out, err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--name", a59).Output()
 			o.Expect(err).To(o.HaveOccurred())
 			o.Expect(out).To(o.ContainSubstring("error: invalid name: "))
 		})
@@ -91,7 +91,10 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 		g.It("should succeed with an imagestream", func() {
 			// Bug 1767163 - oc new-app with --image-stream produced invalid labels
 			g.By("calling oc new-app with imagestream")
-			out, err := oc.Run("new-app").Args("https://github.com/sclorg/nodejs-ex", "--image-stream=nodejs:latest").Output()
+			// Note: the imagestream used here does not matter (does not have to a valid builder) since we are not checking
+			// the output results.  Since we can't rely on the samples operator being present to install sample s2i-enabled
+			// imagestreams, just use one of the static imagestreams instead (cli:latest)
+			out, err := oc.Run("new-app").Args("https://github.com/sclorg/nodejs-ex", "--image-stream=cli:latest").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(out).NotTo(o.ContainSubstring("error:"))
 		})

--- a/test/extended/builds/service.go
+++ b/test/extended/builds/service.go
@@ -43,7 +43,7 @@ RUN curl -vvv hello-nodejs:8080
 		g.Describe("with a build being created from new-build", func() {
 			g.It("should be able to run a build that references a cluster service", func() {
 				g.By("standing up a new hello world nodejs service via oc new-app")
-				err := oc.Run("new-app").Args("nodejs~https://github.com/sclorg/nodejs-ex.git", "--name", "hello-nodejs").Execute()
+				err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex.git", "--name", "hello-nodejs").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				err = exutil.WaitForABuild(oc.BuildClient().BuildV1().Builds(oc.Namespace()), "hello-nodejs-1", nil, nil, nil)

--- a/test/extended/builds/valuefrom.go
+++ b/test/extended/builds/valuefrom.go
@@ -37,12 +37,8 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 		})
 
 		g.JustBeforeEach(func() {
-			g.By("waiting for openshift namespace imagestreams")
-			err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
 			g.By("creating test image stream")
-			err = oc.Run("create").Args("-f", testImageStreamFixture, "--validate=false").Execute()
+			err := oc.Run("create").Args("-f", testImageStreamFixture, "--validate=false").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("creating test secret")

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17304,9 +17304,8 @@ spec:
     type: Source
     sourceStrategy:
       from:
-        kind: ImageStreamTag
-        namespace: openshift
-        name: 'php:7.4-ubi8'
+        kind: DockerImage
+        name: registry.redhat.io/ubi8/php-74:latest
 `)
 
 func testExtendedTestdataBuildsBuildPruningDefaultGroupBuildConfigYamlBytes() ([]byte, error) {
@@ -17324,31 +17323,21 @@ func testExtendedTestdataBuildsBuildPruningDefaultGroupBuildConfigYaml() (*asset
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsBuildPruningDefaultLegacyBuildConfigYaml = []byte(`{
-  "apiVersion": "v1",
-  "kind": "BuildConfig",
-  "metadata": {
-    "name": "myphp"
-  },
-  "spec": {
-    "source": {
-      "type": "Git",
-      "git": {
-        "uri": "https://github.com/sclorg/cakephp-ex.git"
-      }
-    },
-    "strategy": {
-      "type": "Source",
-      "sourceStrategy": {
-        "from": {
-          "kind": "ImageStreamTag",
-          "namespace": "openshift",
-          "name": "php:7.4-ubi8"
-        }
-      }
-    }
-  }
-}
+var _testExtendedTestdataBuildsBuildPruningDefaultLegacyBuildConfigYaml = []byte(`apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: myphp
+spec:
+  source:
+    type: Git
+    git:
+      uri: https://github.com/sclorg/cakephp-ex.git
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/ubi8/php-74:latest
 `)
 
 func testExtendedTestdataBuildsBuildPruningDefaultLegacyBuildConfigYamlBytes() ([]byte, error) {
@@ -17386,9 +17375,8 @@ spec:
             fieldRef:
               fieldPath: metadata.nofield
       from:
-        kind: ImageStreamTag
-        namespace: openshift
-        name: 'php:7.4-ubi8'
+        kind: DockerImage
+        name: registry.redhat.io/ubi8/php-74:latest
 `)
 
 func testExtendedTestdataBuildsBuildPruningErroredBuildConfigYamlBytes() ([]byte, error) {
@@ -17424,9 +17412,8 @@ spec:
     type: Source
     sourceStrategy:
       from:
-        kind: ImageStreamTag
-        namespace: openshift
-        name: 'php:7.4-ubi8'
+        kind: DockerImage
+        name: registry.redhat.io/ubi8/php-74:latest
 `)
 
 func testExtendedTestdataBuildsBuildPruningFailedBuildConfigYamlBytes() ([]byte, error) {
@@ -29589,7 +29576,7 @@ os::cmd::try_until_success 'oc rollout history dc/database --revision=2'
 # rolling back to the same revision should fail
 os::cmd::expect_failure 'oc rollback dc/database --to-version=2'
 # undo --dry-run should report the original image
-os::cmd::expect_success_and_text 'oc rollout undo dc/database --dry-run' 'image-registry.openshift-image-registry.svc:5000/openshift/mysql:8.0-el8'
+os::cmd::expect_success_and_text 'oc rollout undo dc/database --dry-run' 'registry.redhat.io/rhel8/mysql-80:latest'
 echo "rollback: ok"
 os::test::junit::declare_suite_end
 
@@ -33625,7 +33612,7 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateDockerbuildJson = 
           {
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:latest"
+              "name": "registry.redhat.io/ubi8/ruby-30:latest"
             },
             "name": "latest"
           }
@@ -33889,7 +33876,7 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateDockerbuildJson = 
             "containers": [
               {
                 "name": "ruby-helloworld-database",
-                "image": "image-registry.openshift-image-registry.svc:5000/openshift/mysql:8.0-el8",
+                "image": "registry.redhat.io/rhel8/mysql-80:latest",
                 "ports": [
                   {
                     "containerPort": 3306,

--- a/test/extended/testdata/builds/build-pruning/default-group-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/default-group-build-config.yaml
@@ -11,6 +11,5 @@ spec:
     type: Source
     sourceStrategy:
       from:
-        kind: ImageStreamTag
-        namespace: openshift
-        name: 'php:7.4-ubi8'
+        kind: DockerImage
+        name: registry.redhat.io/ubi8/php-74:latest

--- a/test/extended/testdata/builds/build-pruning/default-legacy-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/default-legacy-build-config.yaml
@@ -1,25 +1,15 @@
-{
-  "apiVersion": "v1",
-  "kind": "BuildConfig",
-  "metadata": {
-    "name": "myphp"
-  },
-  "spec": {
-    "source": {
-      "type": "Git",
-      "git": {
-        "uri": "https://github.com/sclorg/cakephp-ex.git"
-      }
-    },
-    "strategy": {
-      "type": "Source",
-      "sourceStrategy": {
-        "from": {
-          "kind": "ImageStreamTag",
-          "namespace": "openshift",
-          "name": "php:7.4-ubi8"
-        }
-      }
-    }
-  }
-}
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: myphp
+spec:
+  source:
+    type: Git
+    git:
+      uri: https://github.com/sclorg/cakephp-ex.git
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/ubi8/php-74:latest

--- a/test/extended/testdata/builds/build-pruning/errored-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/errored-build-config.yaml
@@ -18,6 +18,5 @@ spec:
             fieldRef:
               fieldPath: metadata.nofield
       from:
-        kind: ImageStreamTag
-        namespace: openshift
-        name: 'php:7.4-ubi8'
+        kind: DockerImage
+        name: registry.redhat.io/ubi8/php-74:latest

--- a/test/extended/testdata/builds/build-pruning/failed-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/failed-build-config.yaml
@@ -16,6 +16,5 @@ spec:
     type: Source
     sourceStrategy:
       from:
-        kind: ImageStreamTag
-        namespace: openshift
-        name: 'php:7.4-ubi8'
+        kind: DockerImage
+        name: registry.redhat.io/ubi8/php-74:latest

--- a/test/extended/testdata/cmd/test/cmd/deployments.sh
+++ b/test/extended/testdata/cmd/test/cmd/deployments.sh
@@ -122,7 +122,7 @@ os::cmd::try_until_success 'oc rollout history dc/database --revision=2'
 # rolling back to the same revision should fail
 os::cmd::expect_failure 'oc rollback dc/database --to-version=2'
 # undo --dry-run should report the original image
-os::cmd::expect_success_and_text 'oc rollout undo dc/database --dry-run' 'image-registry.openshift-image-registry.svc:5000/openshift/mysql:8.0-el8'
+os::cmd::expect_success_and_text 'oc rollout undo dc/database --dry-run' 'registry.redhat.io/rhel8/mysql-80:latest'
 echo "rollback: ok"
 os::test::junit::declare_suite_end
 

--- a/test/extended/testdata/cmd/test/cmd/testdata/application-template-dockerbuild.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/application-template-dockerbuild.json
@@ -90,7 +90,7 @@
           {
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:latest"
+              "name": "registry.redhat.io/ubi8/ruby-30:latest"
             },
             "name": "latest"
           }
@@ -354,7 +354,7 @@
             "containers": [
               {
                 "name": "ruby-helloworld-database",
-                "image": "image-registry.openshift-image-registry.svc:5000/openshift/mysql:8.0-el8",
+                "image": "registry.redhat.io/rhel8/mysql-80:latest",
                 "ports": [
                   {
                     "containerPort": 3306,


### PR DESCRIPTION
Resolving some of the failures seen in:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-no-capabilities/1503711956505202688

which runs our e2e but with optional capabilities (in this case, samples operator)
disabled.

Note, in a few cases we used "foo:latest" as the imagestream reference which had the nice property that it protected us as the imagestream version (e.g. nodejs:16) moved on to, say, nodejs:17.  None of these tests really care about the underlying image they are using, but it does mean the tests will no longer be automatically picking up newer versions of images as they become available, for better or worse.
