### PR TITLE
Migrate tests away from using samples-operator provided imagestreams

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -545,6 +545,13 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 
 		g.It("should run a successful deployment with multiple triggers", func() {
 			g.By("creating DC")
+
+			_, err := oc.Run("import-image").Args("registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			_, err = oc.Run("import-image").Args("registry.redhat.io/rhel8/postgresql-13:latest", "--confirm", "--reference-policy=local").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
 			dc, err := createDeploymentConfig(oc, multipleICTFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -553,6 +560,10 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 		})
 
 		g.It("should run a successful deployment with a trigger used by different containers", func() {
+
+			_, err := oc.Run("import-image").Args("registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
 			dc, err := createDeploymentConfig(oc, anotherMultiICTFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -81,7 +81,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageAppend] Image append", func
 	oc = exutil.NewCLI("image-append")
 
 	g.It("should create images by appending them", func() {
-		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "php", metav1.GetOptions{})
+		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")
 		registry := strings.Split(is.Status.DockerImageRepository, "/")[0]

--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 	oc = exutil.NewCLI("image-extract")
 
 	g.It("should extract content from an image", func() {
-		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "php", metav1.GetOptions{})
+		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")
 		registry := strings.Split(is.Status.DockerImageRepository, "/")[0]

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -102,8 +102,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 	g.Context("", func() {
 		g.BeforeEach(func() {
 			// Tests that push to an ImageStreamTag need to wait for the internal registry hostname
-			// HACK - wait for OpenShift namespace imagestreams to ensure apiserver has right hostname
-			err := exutil.WaitForOpenShiftNamespaceImageStreams(cli)
+			_, err := exutil.WaitForInternalRegistryHostname(cli)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			err = cli.Run("create").Args("-f", templatefixture).Execute()

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -40822,8 +40822,7 @@ spec:
       - ruby
       from:
         kind: ImageStreamTag
-        name: ruby:latest
-        namespace: openshift
+        name: ruby-30:latest
     type: ImageChange
   - imageChangeParams:
       automatic: true
@@ -40831,8 +40830,7 @@ spec:
       - postgresql
       from:
         kind: ImageStreamTag
-        name: postgresql:latest
-        namespace: openshift
+        name: postgresql-13:latest
     type: ImageChange
 `)
 
@@ -41347,8 +41345,7 @@ spec:
       - ruby2
       from:
         kind: ImageStreamTag
-        name: ruby:latest
-        namespace: openshift
+        name: ruby-30:latest
     type: ImageChange
 `)
 

--- a/test/extended/testdata/deployments/deployment-example.yaml
+++ b/test/extended/testdata/deployments/deployment-example.yaml
@@ -37,8 +37,7 @@ spec:
       - ruby
       from:
         kind: ImageStreamTag
-        name: ruby:latest
-        namespace: openshift
+        name: ruby-30:latest
     type: ImageChange
   - imageChangeParams:
       automatic: true
@@ -46,6 +45,5 @@ spec:
       - postgresql
       from:
         kind: ImageStreamTag
-        name: postgresql:latest
-        namespace: openshift
+        name: postgresql-13:latest
     type: ImageChange

--- a/test/extended/testdata/deployments/multi-ict-deployment.yaml
+++ b/test/extended/testdata/deployments/multi-ict-deployment.yaml
@@ -38,6 +38,5 @@ spec:
       - ruby2
       from:
         kind: ImageStreamTag
-        name: ruby:latest
-        namespace: openshift
+        name: ruby-30:latest
     type: ImageChange


### PR DESCRIPTION
Resolving some of the failures seen in:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-no-capabilities/1503711956505202688

which runs our e2e but with optional capabilities (in this case, samples operator)
disabled.
