### PR TITLE
Bug 2066602: Switch docker.io registry to accessible registries

### DIFF
--- a/examples/gitserver/gitserver-ephemeral.yaml
+++ b/examples/gitserver/gitserver-ephemeral.yaml
@@ -25,7 +25,7 @@ items:
         serviceAccountName: git
         containers:
         - name: git
-          image: openshift/origin-gitserver:latest
+          image: quay.io/openshifttest/origin-gitserver:latest
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/examples/gitserver/gitserver-persistent.yaml
+++ b/examples/gitserver/gitserver-persistent.yaml
@@ -25,7 +25,7 @@ items:
         serviceAccountName: git
         containers:
         - name: git
-          image: openshift/origin-gitserver:latest
+          image: quay.io/openshifttest/origin-gitserver:latest
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/examples/image-streams/image-streams-centos7.json
+++ b/examples/image-streams/image-streams-centos7.json
@@ -94,7 +94,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/httpd-24-centos7:latest"
+              "name": "registry.centos.org/centos/httpd-24-centos7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -210,7 +210,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mariadb-101-centos7:latest"
+              "name": "registry.centos.org/centos/mariadb-101-centos7:latest"
             },
             "name": "10.1",
             "referencePolicy": {
@@ -228,7 +228,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mariadb-102-centos7:latest"
+              "name": "registry.centos.org/centos/mariadb-102-centos7:latest"
             },
             "name": "10.2",
             "referencePolicy": {
@@ -295,7 +295,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-26-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-26-centos7:latest"
             },
             "name": "2.6",
             "referencePolicy": {
@@ -313,7 +313,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-32-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-32-centos7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -331,7 +331,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-34-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-34-centos7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -349,7 +349,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-36-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-36-centos7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -416,7 +416,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mysql-56-centos7:latest"
+              "name": "registry.centos.org/centos/mysql-56-centos7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -434,7 +434,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mysql-57-centos7:latest"
+              "name": "registry.centos.org/centos/mysql-57-centos7:latest"
             },
             "name": "5.7",
             "referencePolicy": {
@@ -468,7 +468,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-18-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-18-centos7:latest"
             },
             "name": "1.8",
             "referencePolicy": {
@@ -488,7 +488,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-110-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-110-centos7:latest"
             },
             "name": "1.10",
             "referencePolicy": {
@@ -508,7 +508,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-112-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-112-centos7:latest"
             },
             "name": "1.12",
             "referencePolicy": {
@@ -600,7 +600,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-4-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-4-centos7:latest"
             },
             "name": "4",
             "referencePolicy": {
@@ -620,7 +620,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-6-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-6-centos7:latest"
             },
             "name": "6",
             "referencePolicy": {
@@ -639,7 +639,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-8-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-8-centos7:latest"
             },
             "name": "8",
             "referencePolicy": {
@@ -750,7 +750,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-520-centos7:latest"
+              "name": "registry.centos.org/centos/perl-520-centos7:latest"
             },
             "name": "5.20",
             "referencePolicy": {
@@ -770,7 +770,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-524-centos7:latest"
+              "name": "registry.centos.org/centos/perl-524-centos7:latest"
             },
             "name": "5.24",
             "referencePolicy": {
@@ -790,7 +790,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-526-centos7:latest"
+              "name": "registry.centos.org/centos/perl-526-centos7:latest"
             },
             "name": "5.26",
             "referencePolicy": {
@@ -832,26 +832,6 @@
           },
           {
             "annotations": {
-              "description": "Build and run PHP 5.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.5/README.md.",
-              "iconClass": "icon-php",
-              "openshift.io/display-name": "PHP 5.5",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/openshift/cakephp-ex.git",
-              "supports": "php:5.5,php",
-              "tags": "hidden,builder,php",
-              "version": "5.5"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/openshift/php-55-centos7:latest"
-            },
-            "name": "5.5",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
               "description": "Build and run PHP 5.6 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.6/README.md.",
               "iconClass": "icon-php",
               "openshift.io/display-name": "PHP 5.6",
@@ -863,7 +843,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-56-centos7:latest"
+              "name": "registry.centos.org/centos/php-56-centos7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -883,7 +863,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-70-centos7:latest"
+              "name": "registry.centos.org/centos/php-70-centos7:latest"
             },
             "name": "7.0",
             "referencePolicy": {
@@ -903,7 +883,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-71-centos7:latest"
+              "name": "registry.centos.org/centos/php-71-centos7:latest"
             },
             "name": "7.1",
             "referencePolicy": {
@@ -923,7 +903,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-72-centos7:latest"
+              "name": "registry.centos.org/centos/php-72-centos7:latest"
             },
             "name": "7.2",
             "referencePolicy": {
@@ -990,7 +970,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-94-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-94-centos7:latest"
             },
             "name": "9.4",
             "referencePolicy": {
@@ -1008,7 +988,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-95-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-95-centos7:latest"
             },
             "name": "9.5",
             "referencePolicy": {
@@ -1026,7 +1006,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-96-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-96-centos7:latest"
             },
             "name": "9.6",
             "referencePolicy": {
@@ -1044,7 +1024,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-10-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-10-centos7:latest"
             },
             "name": "10",
             "referencePolicy": {
@@ -1117,7 +1097,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-27-centos7:latest"
+              "name": "registry.centos.org/centos/python-27-centos7:latest"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -1137,7 +1117,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-34-centos7:latest"
+              "name": "registry.centos.org/centos/python-34-centos7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -1157,7 +1137,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-35-centos7:latest"
+              "name": "registry.centos.org/centos/python-35-centos7:latest"
             },
             "name": "3.5",
             "referencePolicy": {
@@ -1177,7 +1157,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-36-centos7:latest"
+              "name": "registry.centos.org/centos/python-36-centos7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -1226,7 +1206,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/redis-32-centos7:latest"
+              "name": "registry.centos.org/centos/redis-32-centos7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -1299,7 +1279,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-22-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-22-centos7:latest"
             },
             "name": "2.2",
             "referencePolicy": {
@@ -1319,7 +1299,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-23-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-23-centos7:latest"
             },
             "name": "2.3",
             "referencePolicy": {
@@ -1339,7 +1319,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-24-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-24-centos7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -1359,7 +1339,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-25-centos7:latest"
             },
             "name": "2.5",
             "referencePolicy": {

--- a/examples/image-streams/image-streams-rhel7.json
+++ b/examples/image-streams/image-streams-rhel7.json
@@ -783,26 +783,6 @@
           },
           {
             "annotations": {
-              "description": "Build and run PHP 5.5 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.5/README.md.",
-              "iconClass": "icon-php",
-              "openshift.io/display-name": "PHP 5.5",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/openshift/cakephp-ex.git",
-              "supports": "php:5.5,php",
-              "tags": "hidden,builder,php",
-              "version": "5.5"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "registry.redhat.io/openshift3/php-55-rhel7:latest"
-            },
-            "name": "5.5",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
               "description": "Build and run PHP 5.6 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.6/README.md.",
               "iconClass": "icon-php",
               "openshift.io/display-name": "PHP 5.6",

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -90,7 +90,7 @@
           {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-27-centos7:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             },
             "name": "latest"
           }

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -5,7 +5,7 @@
 readonly OS_GO_PACKAGE=github.com/openshift/origin
 
 readonly OS_BUILD_ENV_GOLANG="${OS_BUILD_ENV_GOLANG:-1.10}"
-readonly OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-openshift/origin-release:golang-${OS_BUILD_ENV_GOLANG}}"
+readonly OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-registry.ci.openshift.org/openshift/release:golang-${OS_BUILD_ENV_GOLANG}}"
 readonly OS_REQUIRED_GO_VERSION="go${OS_BUILD_ENV_GOLANG}"
 readonly OS_GLIDE_MINOR_VERSION="13"
 readonly OS_REQUIRED_GLIDE_VERSION="0.$OS_GLIDE_MINOR_VERSION"

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -199,7 +199,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/httpd-24-centos7:latest"
+              "name": "registry.centos.org/centos/httpd-24-centos7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -315,7 +315,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mariadb-101-centos7:latest"
+              "name": "registry.centos.org/centos/mariadb-101-centos7:latest"
             },
             "name": "10.1",
             "referencePolicy": {
@@ -333,7 +333,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mariadb-102-centos7:latest"
+              "name": "registry.centos.org/centos/mariadb-102-centos7:latest"
             },
             "name": "10.2",
             "referencePolicy": {
@@ -400,7 +400,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-26-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-26-centos7:latest"
             },
             "name": "2.6",
             "referencePolicy": {
@@ -418,7 +418,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-32-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-32-centos7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -436,7 +436,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-34-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-34-centos7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -454,7 +454,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-36-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-36-centos7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -521,7 +521,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mysql-56-centos7:latest"
+              "name": "registry.centos.org/centos/mysql-56-centos7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -539,7 +539,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mysql-57-centos7:latest"
+              "name": "registry.centos.org/centos/mysql-57-centos7:latest"
             },
             "name": "5.7",
             "referencePolicy": {
@@ -573,7 +573,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-18-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-18-centos7:latest"
             },
             "name": "1.8",
             "referencePolicy": {
@@ -593,7 +593,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-110-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-110-centos7:latest"
             },
             "name": "1.10",
             "referencePolicy": {
@@ -613,7 +613,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-112-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-112-centos7:latest"
             },
             "name": "1.12",
             "referencePolicy": {
@@ -705,7 +705,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-4-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-4-centos7:latest"
             },
             "name": "4",
             "referencePolicy": {
@@ -725,7 +725,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-6-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-6-centos7:latest"
             },
             "name": "6",
             "referencePolicy": {
@@ -744,7 +744,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-8-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-8-centos7:latest"
             },
             "name": "8",
             "referencePolicy": {
@@ -855,7 +855,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-520-centos7:latest"
+              "name": "registry.centos.org/centos/perl-520-centos7:latest"
             },
             "name": "5.20",
             "referencePolicy": {
@@ -875,7 +875,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-524-centos7:latest"
+              "name": "registry.centos.org/centos/perl-524-centos7:latest"
             },
             "name": "5.24",
             "referencePolicy": {
@@ -895,7 +895,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-526-centos7:latest"
+              "name": "registry.centos.org/centos/perl-526-centos7:latest"
             },
             "name": "5.26",
             "referencePolicy": {
@@ -937,26 +937,6 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
           },
           {
             "annotations": {
-              "description": "Build and run PHP 5.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.5/README.md.",
-              "iconClass": "icon-php",
-              "openshift.io/display-name": "PHP 5.5",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/openshift/cakephp-ex.git",
-              "supports": "php:5.5,php",
-              "tags": "hidden,builder,php",
-              "version": "5.5"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/openshift/php-55-centos7:latest"
-            },
-            "name": "5.5",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
               "description": "Build and run PHP 5.6 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.6/README.md.",
               "iconClass": "icon-php",
               "openshift.io/display-name": "PHP 5.6",
@@ -968,7 +948,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-56-centos7:latest"
+              "name": "registry.centos.org/centos/php-56-centos7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -988,7 +968,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-70-centos7:latest"
+              "name": "registry.centos.org/centos/php-70-centos7:latest"
             },
             "name": "7.0",
             "referencePolicy": {
@@ -1008,7 +988,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-71-centos7:latest"
+              "name": "registry.centos.org/centos/php-71-centos7:latest"
             },
             "name": "7.1",
             "referencePolicy": {
@@ -1028,7 +1008,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-72-centos7:latest"
+              "name": "registry.centos.org/centos/php-72-centos7:latest"
             },
             "name": "7.2",
             "referencePolicy": {
@@ -1095,7 +1075,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-94-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-94-centos7:latest"
             },
             "name": "9.4",
             "referencePolicy": {
@@ -1113,7 +1093,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-95-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-95-centos7:latest"
             },
             "name": "9.5",
             "referencePolicy": {
@@ -1131,7 +1111,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-96-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-96-centos7:latest"
             },
             "name": "9.6",
             "referencePolicy": {
@@ -1149,7 +1129,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-10-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-10-centos7:latest"
             },
             "name": "10",
             "referencePolicy": {
@@ -1222,7 +1202,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-27-centos7:latest"
+              "name": "registry.centos.org/centos/python-27-centos7:latest"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -1242,7 +1222,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-34-centos7:latest"
+              "name": "registry.centos.org/centos/python-34-centos7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -1262,7 +1242,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-35-centos7:latest"
+              "name": "registry.centos.org/centos/python-35-centos7:latest"
             },
             "name": "3.5",
             "referencePolicy": {
@@ -1282,7 +1262,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-36-centos7:latest"
+              "name": "registry.centos.org/centos/python-36-centos7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -1331,7 +1311,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/redis-32-centos7:latest"
+              "name": "registry.centos.org/centos/redis-32-centos7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -1404,7 +1384,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-22-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-22-centos7:latest"
             },
             "name": "2.2",
             "referencePolicy": {
@@ -1424,7 +1404,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-23-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-23-centos7:latest"
             },
             "name": "2.3",
             "referencePolicy": {
@@ -1444,7 +1424,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-24-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-24-centos7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -1464,7 +1444,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-25-centos7:latest"
             },
             "name": "2.5",
             "referencePolicy": {
@@ -2445,26 +2425,6 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
               "name": "7.2"
             },
             "name": "latest",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run PHP 5.5 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.5/README.md.",
-              "iconClass": "icon-php",
-              "openshift.io/display-name": "PHP 5.5",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/openshift/cakephp-ex.git",
-              "supports": "php:5.5,php",
-              "tags": "hidden,builder,php",
-              "version": "5.5"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "registry.redhat.io/openshift3/php-55-rhel7:latest"
-            },
-            "name": "5.5",
             "referencePolicy": {
               "type": "Local"
             }

--- a/pkg/oc/lib/graph/genericgraph/test/available-deployment.yaml
+++ b/pkg/oc/lib/graph/genericgraph/test/available-deployment.yaml
@@ -19,7 +19,7 @@ items:
         - command:
           - /bin/sleep
           - "100"
-          image: docker.io/centos:centos7
+          image: registry.centos.org/centos:centos7
           name: myapp
     test: false
     triggers:
@@ -44,7 +44,7 @@ items:
       openshift.io/deployment.replicas: "1"
       openshift.io/deployment.status-reason: config change
       openshift.io/encoded-deployment-config: |
-        {"kind":"DeploymentConfig","apiVersion":"v1","metadata":{"name":"example","namespace":"myproject","selfLink":"/oapi/v1/namespaces/myproject/deploymentconfigs/example","uid":"6d298d51-9486-11e6-b581-080027242396","resourceVersion":"1173","generation":2,"creationTimestamp":"2016-10-17T16:26:15Z"},"spec":{"strategy":{"type":"Rolling","rollingParams":{"updatePeriodSeconds":1,"intervalSeconds":1,"timeoutSeconds":600,"maxUnavailable":"25%","maxSurge":"25%","pre":{"failurePolicy":"Abort","execNewPod":{"command":["/bin/echo","test pre hook executed"],"containerName":"myapp"}}},"resources":{}},"triggers":[{"type":"ConfigChange"}],"replicas":1,"test":false,"selector":{"name":"example"},"template":{"metadata":{"creationTimestamp":null,"labels":{"name":"example"}},"spec":{"containers":[{"name":"myapp","image":"docker.io/centos:centos7","command":["/bin/sleep","100"],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{}}}},"status":{"latestVersion":1,"observedGeneration":1,"details":{"message":"config change","causes":[{"type":"ConfigChange"}]},"conditions":[{"type":"Available","status":"False","lastTransitionTime":"2016-10-17T16:26:15Z","message":"Deployment config does not have minimum availability."}]}}
+        {"kind":"DeploymentConfig","apiVersion":"v1","metadata":{"name":"example","namespace":"myproject","selfLink":"/oapi/v1/namespaces/myproject/deploymentconfigs/example","uid":"6d298d51-9486-11e6-b581-080027242396","resourceVersion":"1173","generation":2,"creationTimestamp":"2016-10-17T16:26:15Z"},"spec":{"strategy":{"type":"Rolling","rollingParams":{"updatePeriodSeconds":1,"intervalSeconds":1,"timeoutSeconds":600,"maxUnavailable":"25%","maxSurge":"25%","pre":{"failurePolicy":"Abort","execNewPod":{"command":["/bin/echo","test pre hook executed"],"containerName":"myapp"}}},"resources":{}},"triggers":[{"type":"ConfigChange"}],"replicas":1,"test":false,"selector":{"name":"example"},"template":{"metadata":{"creationTimestamp":null,"labels":{"name":"example"}},"spec":{"containers":[{"name":"myapp","image":"registry.centos.org/centos:centos7","command":["/bin/sleep","100"],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{}}}},"status":{"latestVersion":1,"observedGeneration":1,"details":{"message":"config change","causes":[{"type":"ConfigChange"}]},"conditions":[{"type":"Available","status":"False","lastTransitionTime":"2016-10-17T16:26:15Z","message":"Deployment config does not have minimum availability."}]}}
     creationTimestamp: 2016-04-07T04:11:25Z
     generation: 2
     labels:
@@ -72,7 +72,7 @@ items:
         - command:
           - /bin/sleep
           - "100"
-          image: docker.io/centos:centos7
+          image: registry.centos.org/centos:centos7
           imagePullPolicy: IfNotPresent
           name: myapp
   status:
@@ -91,7 +91,7 @@ items:
       openshift.io/deployment.replicas: "3"
       openshift.io/deployment.status-reason: manual change
       openshift.io/encoded-deployment-config: |
-        {"kind":"DeploymentConfig","apiVersion":"v1","metadata":{"name":"example","namespace":"myproject","selfLink":"/oapi/v1/namespaces/myproject/deploymentconfigs/example","uid":"6d298d51-9486-11e6-b581-080027242396","resourceVersion":"1314","generation":5,"creationTimestamp":"2016-10-17T16:26:15Z"},"spec":{"strategy":{"type":"Rolling","rollingParams":{"updatePeriodSeconds":1,"intervalSeconds":1,"timeoutSeconds":600,"maxUnavailable":"25%","maxSurge":"25%"},"resources":{}},"triggers":[{"type":"ConfigChange"}],"replicas":3,"test":false,"selector":{"name":"example"},"template":{"metadata":{"creationTimestamp":null,"labels":{"name":"example"}},"spec":{"containers":[{"name":"myapp","image":"docker.io/centos:centos7","command":["/bin/sleep","100"],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{}}}},"status":{"latestVersion":2,"observedGeneration":4,"replicas":3,"updatedReplicas":3,"availableReplicas":2,"unavailableReplicas":1,"details":{"message":"manual change","causes":[{"type":"Manual"}]},"conditions":[{"type":"Available","status":"False","lastTransitionTime":"2016-10-17T16:29:55Z","message":"Deployment config does not have minimum availability."},{"type":"Progressing","status":"True","lastTransitionTime":"2016-10-17T16:29:55Z","reason":"NewReplicationControllerAvailable","message":"Replication controller \"example-1\" has completed progressing"}]}}
+        {"kind":"DeploymentConfig","apiVersion":"v1","metadata":{"name":"example","namespace":"myproject","selfLink":"/oapi/v1/namespaces/myproject/deploymentconfigs/example","uid":"6d298d51-9486-11e6-b581-080027242396","resourceVersion":"1314","generation":5,"creationTimestamp":"2016-10-17T16:26:15Z"},"spec":{"strategy":{"type":"Rolling","rollingParams":{"updatePeriodSeconds":1,"intervalSeconds":1,"timeoutSeconds":600,"maxUnavailable":"25%","maxSurge":"25%"},"resources":{}},"triggers":[{"type":"ConfigChange"}],"replicas":3,"test":false,"selector":{"name":"example"},"template":{"metadata":{"creationTimestamp":null,"labels":{"name":"example"}},"spec":{"containers":[{"name":"myapp","image":"registry.centos.org/centos:centos7","command":["/bin/sleep","100"],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{}}}},"status":{"latestVersion":2,"observedGeneration":4,"replicas":3,"updatedReplicas":3,"availableReplicas":2,"unavailableReplicas":1,"details":{"message":"manual change","causes":[{"type":"Manual"}]},"conditions":[{"type":"Available","status":"False","lastTransitionTime":"2016-10-17T16:29:55Z","message":"Deployment config does not have minimum availability."},{"type":"Progressing","status":"True","lastTransitionTime":"2016-10-17T16:29:55Z","reason":"NewReplicationControllerAvailable","message":"Replication controller \"example-1\" has completed progressing"}]}}
     creationTimestamp: 2016-04-07T04:11:55Z
     generation: 4
     labels:
@@ -119,7 +119,7 @@ items:
         - command:
           - /bin/sleep
           - "100"
-          image: docker.io/centos:centos7
+          image: registry.centos.org/centos:centos7
           imagePullPolicy: IfNotPresent
           name: myapp
   status:

--- a/pkg/quota/image/imagestreamimport_evaluator_test.go
+++ b/pkg/quota/image/imagestreamimport_evaluator_test.go
@@ -147,7 +147,7 @@ func TestImageStreamImportEvaluatorUsage(t *testing.T) {
 					{
 						From: corev1.ObjectReference{
 							Kind: "DockerImage",
-							Name: "docker.io/centos:latest",
+							Name: "registry.centos.org/centos:latest",
 						},
 					},
 				},

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -68,8 +68,6 @@ os::cmd::expect_failure 'oc new-app unknownhubimage -o yaml'
 os::cmd::expect_failure_and_text 'oc new-app docker.io/node~https://github.com/sclorg/nodejs-ex' 'the image match \"docker.io/node\" for source repository \"https://github.com/sclorg/nodejs-ex\" does not appear to be a source-to-image builder.'
 os::cmd::expect_failure_and_text 'oc new-app https://github.com/sclorg/rails-ex' 'the image match \"ruby\" for source repository \"https://github.com/sclorg/rails-ex\" does not appear to be a source-to-image builder.'
 os::cmd::expect_success 'oc new-app https://github.com/sclorg/rails-ex --strategy=source --dry-run'
-# verify we can generate a Docker image based component "mongodb" directly
-os::cmd::expect_success_and_text 'oc new-app mongo -o yaml' 'image:\s*mongo'
 # the local image repository takes precedence over the Docker Hub "mysql" image
 os::cmd::expect_success 'oc create -f examples/image-streams/image-streams-centos7.json'
 os::cmd::try_until_success 'oc get imagestreamtags mysql:latest' $((2*TIME_MIN))
@@ -146,7 +144,6 @@ os::cmd::expect_failure_and_text 'oc new-build https://github.com/sclorg/cakephp
 
 # check label creation
 os::cmd::try_until_success 'oc get imagestreamtags php:latest'
-os::cmd::try_until_success 'oc get imagestreamtags php:5.5'
 os::cmd::try_until_success 'oc get imagestreamtags php:5.6'
 os::cmd::expect_success 'oc new-app php mysql -l no-source=php-mysql'
 os::cmd::expect_success 'oc delete all -l no-source=php-mysql'
@@ -176,9 +173,9 @@ os::cmd::expect_success 'oc new-app -f test/testdata/template-with-namespaces.js
 os::cmd::expect_success 'oc delete all -l app=ruby-helloworld-sample'
 
 # ensure non-duplicate invalid label errors show up
-os::cmd::expect_failure_and_text 'oc new-app docker.io/library/wordpress -l qwer1345%$$#=self' 'error: ImageStream.image.openshift.io "wordpress" is invalid'
-os::cmd::expect_failure_and_text 'oc new-app docker.io/library/wordpress -l qwer1345%$$#=self' 'DeploymentConfig.apps.openshift.io "wordpress" is invalid'
-os::cmd::expect_failure_and_text 'oc new-app docker.io/library/wordpress -l qwer1345%$$#=self' 'Service "wordpress" is invalid'
+os::cmd::expect_failure_and_text 'oc new-app quay.io/bitnami/wordpress -l qwer1345%$$#=self' 'error: ImageStream.image.openshift.io "wordpress" is invalid'
+os::cmd::expect_failure_and_text 'oc new-app quay.io/bitnami/wordpress -l qwer1345%$$#=self' 'DeploymentConfig.apps.openshift.io "wordpress" is invalid'
+os::cmd::expect_failure_and_text 'oc new-app quay.io/bitnami/wordpress -l qwer1345%$$#=self' 'Service "wordpress" is invalid'
 
 # check if we can create from a stored template
 os::cmd::expect_success 'oc create -f examples/sample-app/application-template-stibuild.json'
@@ -331,11 +328,6 @@ os::cmd::expect_failure 'oc new-app -S --template=perl'
 os::cmd::try_until_success 'oc get imagestreamtags mariadb:latest'
 os::cmd::try_until_success 'oc get imagestreamtags mariadb:10.1'
 os::cmd::try_until_success 'oc get imagestreamtags mariadb:10.2'
-os::cmd::try_until_success 'oc get imagestreamtags mongodb:latest'
-os::cmd::try_until_success 'oc get imagestreamtags mongodb:2.4'
-os::cmd::try_until_success 'oc get imagestreamtags mongodb:2.6'
-os::cmd::try_until_success 'oc get imagestreamtags mongodb:3.2'
-os::cmd::try_until_success 'oc get imagestreamtags mongodb:3.4'
 os::cmd::try_until_success 'oc get imagestreamtags mysql:latest'
 os::cmd::try_until_success 'oc get imagestreamtags mysql:5.5'
 os::cmd::try_until_success 'oc get imagestreamtags mysql:5.6'
@@ -354,15 +346,9 @@ os::cmd::try_until_success 'oc get imagestreamtags perl:5.16'
 os::cmd::try_until_success 'oc get imagestreamtags perl:5.20'
 os::cmd::try_until_success 'oc get imagestreamtags perl:5.24'
 os::cmd::try_until_success 'oc get imagestreamtags php:latest'
-os::cmd::try_until_success 'oc get imagestreamtags php:5.5'
 os::cmd::try_until_success 'oc get imagestreamtags php:5.6'
 os::cmd::try_until_success 'oc get imagestreamtags php:7.0'
 os::cmd::try_until_success 'oc get imagestreamtags php:7.1'
-os::cmd::try_until_success 'oc get imagestreamtags postgresql:latest'
-os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.2'
-os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.4'
-os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.5'
-os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.6'
 os::cmd::try_until_success 'oc get imagestreamtags python:latest'
 os::cmd::try_until_success 'oc get imagestreamtags python:2.7'
 os::cmd::try_until_success 'oc get imagestreamtags python:3.3'
@@ -370,30 +356,19 @@ os::cmd::try_until_success 'oc get imagestreamtags python:3.4'
 os::cmd::try_until_success 'oc get imagestreamtags python:3.5'
 os::cmd::try_until_success 'oc get imagestreamtags python:3.6'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:latest'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:2.2'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:2.4'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:2.5'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:12.0'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:11.0'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:10.1'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:10.0'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:9.0'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:8.1'
 
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=mariadb' "Tags:\s+10.1, 10.2, latest"
-os::cmd::expect_success_and_text 'oc new-app --search --image-stream=mongodb' "Tags:\s+3.2, 3.4, 3.6, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=mysql' "Tags:\s+5.7, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=nginx' "Tags:\s+1.10, 1.12, 1.8, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=nodejs' "Tags:\s+10, 6, 8, 8-RHOAR, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=perl' "Tags:\s+5.24, 5.26, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=php' "Tags:\s+7.0, 7.1, 7.2, latest"
-os::cmd::expect_success_and_text 'oc new-app --search --image-stream=postgresql' "Tags:\s+10, 9.5, 9.6, latest"
 os::cmd::expect_success_and_text 'oc new-app -S --image-stream=python' "Tags:\s+2.7, 3.5, 3.6, latest"
 os::cmd::expect_success_and_text 'oc new-app -S --image-stream=ruby' "Tags:\s+2.3, 2.4, 2.5, latest"
-os::cmd::expect_success_and_text 'oc new-app -S --image-stream=wildfly' "Tags:\s+10.0, 10.1, 11.0, 12.0, 13.0, 8.1, 9.0, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --template=ruby-helloworld-sample' 'ruby-helloworld-sample'
 # check search - no matches
 os::cmd::expect_failure_and_text 'oc new-app -S foo-the-bar' 'no matches found'
@@ -412,10 +387,6 @@ os::cmd::expect_success_and_text 'oc new-app ruby~https://github.com/sclorg/s2i-
 # set strategy
 os::cmd::expect_success_and_text 'oc new-app ruby~https://github.com/openshift/ruby-hello-world.git --strategy=docker -o yaml' 'dockerStrategy'
 os::cmd::expect_success_and_text 'oc new-app https://github.com/openshift/ruby-hello-world.git --strategy=source -o yaml' 'sourceStrategy'
-
-# prints root user info
-os::cmd::expect_success_and_not_text 'oc new-app --dry-run mysql' "runs as the 'root' user"
-os::cmd::expect_success_and_text 'oc new-app --dry-run --docker-image=mysql' "WARNING: Image \"mysql\" runs as the 'root' user"
 
 # verify multiple errors are displayed together, a nested error is returned, and that the usage message is displayed
 os::cmd::expect_failure_and_text 'oc new-app --dry-run __template_fail __templatefile_fail' 'error: unable to locate any'
@@ -467,21 +438,10 @@ os::cmd::expect_success 'oc delete imagestreamtag ruby:2.4'
 os::cmd::expect_failure_and_text 'oc new-app --image-stream ruby https://github.com/sclorg/rails-ex --dry-run' 'error: only a partial match was found for \"ruby\":'
 # when the tag is specified explicitly, the operation is successful
 os::cmd::expect_success 'oc new-app --image-stream ruby:2.5 https://github.com/sclorg/rails-ex --dry-run'
-os::cmd::expect_success 'oc delete imagestreams --all'
 
-# newapp does not attempt to create an imagestream that already exists for a Docker image
-os::cmd::expect_success_and_text 'oc new-app docker.io/ruby:latest~https://github.com/sclorg/ruby-ex.git --name=testapp1 --strategy=docker' 'imagestream.image.openshift.io "ruby" created'
-# make sure the ruby:latest tag is imported before we run new-app again
-os::cmd::try_until_success 'oc get imagestreamtags ruby:latest'
-os::cmd::expect_success_and_not_text 'oc new-app docker.io/ruby:latest~https://github.com/sclorg/ruby-ex.git --name=testapp2 --strategy=docker' '"ruby:latest" already exists'
-os::cmd::expect_success 'oc delete all -l app=testapp2'
-os::cmd::expect_success 'oc delete all -l app=testapp1'
-os::cmd::expect_success 'oc delete all -l app=ruby --ignore-not-found'
 os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 # newapp does not attempt to create an imagestream that already exists for a Docker image
-os::cmd::expect_success 'oc new-app docker.io/ruby:2.2'
-# the next one technically fails cause the DC is already created, but we should still see the ist created
-os::cmd::expect_failure_and_text 'oc new-app docker.io/ruby:2.4' 'imagestreamtag.image.openshift.io "ruby:2.4" created'
+os::cmd::expect_success 'oc new-app quay.io/centos7/ruby-27-centos7:latest'
 os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 
 # check that we can create from the template without errors
@@ -493,28 +453,16 @@ os::cmd::expect_success 'oc delete all -l app=helloworld'
 os::cmd::expect_success 'oc delete secret dbsecret'
 os::cmd::expect_success 'oc delete template ruby-helloworld-sample'
 # override component names
-os::cmd::expect_success_and_text 'oc new-app mysql --name=db' 'db'
+os::cmd::expect_success_and_text 'oc new-app registry.centos.org/centos/mysql-56-centos7:latest --name=db' 'db'
 os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-world -l app=ruby'
 os::cmd::expect_success 'oc delete all -l app=ruby'
 # check for error when template JSON file has errors
 jsonfile="${OS_ROOT}/test/testdata/invalid.json"
 os::cmd::expect_failure_and_text "oc new-app '${jsonfile}'" "error: unable to load template file \"${jsonfile}\": error parsing ${jsonfile}: json: line 0: invalid character '}' after object key"
 
-# check new-build
-os::cmd::expect_failure_and_text 'oc new-build mysql -o yaml' 'you must specify at least one source repository URL'
-os::cmd::expect_success_and_text 'oc new-build mysql --binary -o yaml --to mysql:bin' 'type: Binary'
-os::cmd::expect_success_and_text 'oc new-build mysql https://github.com/openshift/ruby-hello-world --strategy=docker -o yaml' 'type: Docker'
-os::cmd::expect_failure_and_text 'oc new-build mysql https://github.com/openshift/ruby-hello-world --binary' 'specifying binary builds and source repositories at the same time is not allowed'
-# binary builds cannot be created unless a builder image is specified.
-os::cmd::expect_failure_and_text 'oc new-build --name mybuild --binary --strategy=source -o yaml' 'you must provide a builder image when using the source strategy with a binary build'
-os::cmd::expect_success_and_text 'oc new-build --name mybuild registry.access.redhat.com/ubi8/ruby-27 --binary --strategy=source -o yaml' 'name: ruby-27:latest'
-# binary builds can be created with no builder image if no strategy or docker strategy is specified
-os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary -o yaml' 'type: Binary'
-os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary --strategy=docker -o yaml' 'type: Binary'
-
 # new-build image source tests
-os::cmd::expect_failure_and_text 'oc new-build mysql --source-image centos' 'error: --source-image-path must be specified when --source-image is specified.'
-os::cmd::expect_failure_and_text 'oc new-build mysql --source-image-path foo' 'error: --source-image must be specified when --source-image-path is specified.'
+os::cmd::expect_failure_and_text 'oc new-build registry.centos.org/centos/mysql-56-centos7 --source-image centos' 'error: --source-image-path must be specified when --source-image is specified.'
+os::cmd::expect_failure_and_text 'oc new-build registry.centos.org/centos/mysql-56-centos7 --source-image-path foo' 'error: --source-image must be specified when --source-image-path is specified.'
 
 # ensure circular ref flagged but allowed for template
 os::cmd::expect_success 'oc create -f test/testdata/circular-is.yaml'
@@ -527,92 +475,44 @@ os::cmd::expect_failure_and_text 'oc new-app  openshift/bogusimage https://githu
 # allow use of non-existent image (should succeed)
 os::cmd::expect_success 'oc new-app openshift/bogusimage https://github.com/openshift/ruby-hello-world.git -o yaml --allow-missing-images'
 
-os::cmd::expect_success 'oc create -f test/testdata/installable-stream.yaml'
-
-project=$(oc project -q)
-os::cmd::expect_success 'oc policy add-role-to-user edit test-user'
-os::cmd::expect_success 'oc login -u test-user -p anything'
-os::cmd::try_until_success 'oc project ${project}'
-
-os::cmd::try_until_success 'oc get imagestreamtags installable:file'
-os::cmd::try_until_success 'oc get imagestreamtags installable:token'
-os::cmd::try_until_success 'oc get imagestreamtags installable:serviceaccount'
-os::cmd::expect_failure 'oc new-app installable:file'
-os::cmd::expect_failure_and_text 'oc new-app installable:file' 'requires that you grant the image access'
-os::cmd::expect_failure_and_text 'oc new-app installable:serviceaccount' "requires an 'installer' service account with project editor access"
-os::cmd::expect_success_and_text 'oc new-app installable:file --grant-install-rights -o yaml' '/var/run/openshift.secret.token'
-os::cmd::expect_success_and_text 'oc new-app installable:file --grant-install-rights -o yaml' 'activeDeadlineSeconds: 14400'
-os::cmd::expect_success_and_text 'oc new-app installable:file --grant-install-rights -o yaml' 'openshift.io/generated-job: "true"'
-os::cmd::expect_success_and_text 'oc new-app installable:file --grant-install-rights -o yaml' 'openshift.io/generated-job.for: installable:file'
-os::cmd::expect_success_and_text 'oc new-app installable:token --grant-install-rights -o yaml' 'name: TOKEN_ENV'
-os::cmd::expect_success_and_text 'oc new-app installable:token --grant-install-rights -o yaml' 'openshift/origin@sha256:'
-os::cmd::expect_success_and_text 'oc new-app installable:serviceaccount --grant-install-rights -o yaml' 'serviceAccountName: installer'
-os::cmd::expect_success_and_text 'oc new-app installable:serviceaccount --grant-install-rights -o yaml' 'fieldPath: metadata.namespace'
-os::cmd::expect_success_and_text 'oc new-app installable:serviceaccount --grant-install-rights -o yaml A=B' 'name: A'
-
 # Ensure output is valid JSON
-os::cmd::expect_success 'oc new-app mongo -o json | python -m json.tool'
-
-# Ensure custom branch/ref works
-os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-world#beta4'
-
-# Ensure the resulting BuildConfig doesn't have unexpected sources
-os::cmd::expect_success_and_not_text 'oc new-app https://github.com/openshift/ruby-hello-world --output-version=v1 -o=jsonpath="{.items[?(@.kind==\"BuildConfig\")].spec.source}"' 'dockerfile|binary'
+os::cmd::expect_success 'oc new-app registry.centos.org/centos/php-72-centos7:latest -o json | python -m json.tool'
 
 # We permit running new-app against a remote URL which returns a template
 os::cmd::expect_success 'oc new-app https://raw.githubusercontent.com/openshift/origin/master/examples/quickstarts/rails-postgresql.json --dry-run'
 
-# ensure that --strategy sets the build strategy
-os::cmd::expect_success_and_text 'oc new-build --name sourcetest python~https://github.com/sclorg/django-ex --source-image centos:latest --source-image-path /tmp --strategy source --dry-run -o yaml' 'sourceStrategy'
-os::cmd::expect_success_and_text 'oc new-build --name sourcetest python~https://github.com/sclorg/django-ex --source-image centos:latest --source-image-path /tmp --strategy pipeline --dry-run -o yaml' 'jenkinsPipelineStrategy'
-os::cmd::expect_success_and_text 'oc new-build --name sourcetest python~https://github.com/sclorg/django-ex --source-image centos:latest --source-image-path /tmp --strategy docker --dry-run -o yaml' 'dockerStrategy'
-
-os::cmd::expect_success 'oc create -f examples/image-streams/image-streams-centos7.json'
-os::cmd::try_until_success 'oc get imagestreamtags nodejs:latest'
-# ensure that a build can be created with just image inputs without the --binary flag
-os::cmd::expect_success_and_text 'oc new-build --name sourcetest --source-image centos:latest --source-image-path /tmp --image-stream nodejs --dry-run -o yaml' 'sourceStrategy'
-# ensure that using only image inputs and the --binary flag results in an error
-os::cmd::expect_failure_and_text 'oc new-build --name sourcetest --source-image centos:latest --source-image-path /tmp --image-stream nodejs --binary --dry-run -o yaml' 'specifying binary builds and source repositories at the same time is not allowed'
-os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
-
 # new-app different syntax for new-app functionality
 os::cmd::expect_success 'oc new-project new-app-syntax'
-os::cmd::expect_success 'oc import-image openshift/ruby-20-centos7:latest --confirm'
-os::cmd::expect_success 'oc import-image openshift/php-55-centos7:latest --confirm'
+os::cmd::expect_success 'oc import-image php-72-centos7:latest --from=registry.centos.org/centos/php-72-centos7:latest --confirm'
+os::cmd::expect_success 'oc import-image ruby-22-centos7:latest --from=registry.centos.org/centos/ruby-22-centos7:latest --confirm'
 rm -rf ./test/testdata/testapp
 git clone https://github.com/openshift/ruby-hello-world.git ./test/testdata/testapp
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest~https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest~./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest ./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app ruby-20-centos7:latest --code ./test/testdata/testapp --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
-os::cmd::expect_success 'oc new-app -i ruby-20-centos7:latest --code ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app ruby-22-centos7:latest~https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app ruby-22-centos7:latest~./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-22-centos7:latest https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-22-centos7:latest ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app ruby-22-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app ruby-22-centos7:latest --code ./test/testdata/testapp --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-22-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --dry-run'
+os::cmd::expect_success 'oc new-app -i ruby-22-centos7:latest --code ./test/testdata/testapp --dry-run'
 
-os::cmd::expect_success 'oc new-app --code ./test/testdata/testapp --name test'
-os::cmd::expect_success_and_text 'oc get bc test --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27:latest'
+os::cmd::expect_success 'oc new-app -i php-72-centos7:latest --code ./test/testdata/testapp --name test2'
+os::cmd::expect_success_and_text 'oc get bc test2 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-72-centos7:latest'
 
-os::cmd::expect_success 'oc new-app -i php-55-centos7:latest --code ./test/testdata/testapp --name test2'
-os::cmd::expect_success_and_text 'oc get bc test2 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
+os::cmd::expect_success 'oc new-app -i php-72-centos7:latest~https://github.com/openshift/ruby-hello-world.git --name test3'
+os::cmd::expect_success_and_text 'oc get bc test3 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-72-centos7:latest'
 
-os::cmd::expect_success 'oc new-app -i php-55-centos7:latest~https://github.com/openshift/ruby-hello-world.git --name test3'
-os::cmd::expect_success_and_text 'oc get bc test3 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
+os::cmd::expect_success 'oc new-app php-72-centos7:latest~https://github.com/openshift/ruby-hello-world.git --name test4'
+os::cmd::expect_success_and_text 'oc get bc test4 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-72-centos7:latest'
 
-os::cmd::expect_success 'oc new-app php-55-centos7:latest~https://github.com/openshift/ruby-hello-world.git --name test4'
-os::cmd::expect_success_and_text 'oc get bc test4 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
+os::cmd::expect_success 'oc new-app -i php-72-centos7:latest https://github.com/openshift/ruby-hello-world.git --name test5'
+os::cmd::expect_success_and_text 'oc get bc test5 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-72-centos7:latest'
 
-os::cmd::expect_success 'oc new-app -i php-55-centos7:latest https://github.com/openshift/ruby-hello-world.git --name test5'
-os::cmd::expect_success_and_text 'oc get bc test5 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
+os::cmd::expect_success 'oc new-app php-72-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --name test6'
+os::cmd::expect_success_and_text 'oc get bc test6 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-72-centos7:latest'
 
-os::cmd::expect_success 'oc new-app php-55-centos7:latest --code https://github.com/openshift/ruby-hello-world.git --name test6'
-os::cmd::expect_success_and_text 'oc get bc test6 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
-
-os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-world.git --name test7'
-os::cmd::expect_success_and_text 'oc get bc test7 --template={{.spec.strategy.dockerStrategy.from.name}}' 'ruby-27:latest'
-
-os::cmd::expect_success 'oc new-app php-55-centos7:latest https://github.com/openshift/ruby-hello-world.git --name test8'
-os::cmd::expect_success_and_text 'oc get bc test8 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-55-centos7:latest'
+os::cmd::expect_success 'oc new-app php-72-centos7:latest https://github.com/openshift/ruby-hello-world.git --name test8'
+os::cmd::expect_success_and_text 'oc get bc test8 --template={{.spec.strategy.sourceStrategy.from.name}}' 'php-72-centos7:latest'
 os::cmd::expect_success 'oc delete project new-app-syntax'
 
 echo "new-app: ok"

--- a/test/cmd/printer.sh
+++ b/test/cmd/printer.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 # Test that resource printer includes resource kind on multiple resources
 os::test::junit::declare_suite_start "cmd/basicresources/printer"
 os::cmd::expect_success 'oc create imagestream test1'
-os::cmd::expect_success 'oc new-app php'
+os::cmd::expect_success 'oc new-app registry.centos.org/centos/php-72-centos7:latest'
 os::cmd::expect_success_and_text 'oc get all' 'imagestream.image.openshift.io/test1'
 os::cmd::expect_success_and_not_text 'oc get is' 'imagestream.image.openshift.io/test1'
 
@@ -15,10 +15,10 @@ os::cmd::expect_success_and_text 'oc new-app ruby-helloworld-sample' 'deployment
 os::cmd::expect_success_and_text 'oc get all --all-namespaces' 'cmd-printer[\ ]+buildconfig.build.openshift.io\/ruby\-sample\-build'
 
 # Test that infos printer supports all outputFormat options
-os::cmd::expect_success_and_text 'oc new-app php -o yaml | oc set env -f - MYVAR=value' 'deploymentconfig.apps.openshift.io/php updated'
+os::cmd::expect_success_and_text 'oc new-app registry.centos.org/centos/php-72-centos7:latest -o yaml | oc set env -f - MYVAR=value' 'deploymentconfig.apps.openshift.io/php-72-centos7 updated'
 # FIXME: what to do with this?
 # os::cmd::expect_success 'oc new-app php -o yaml | oc set env -f - MYVAR=value -o custom-colums="NAME:.metadata.name"'
-os::cmd::expect_success_and_text 'oc new-app php -o yaml | oc set env -f - MYVAR=value -o yaml' 'apiVersion: apps.openshift.io/v1'
-os::cmd::expect_success_and_text 'oc new-app php -o yaml | oc set env -f - MYVAR=value -o json' '"apiVersion": "apps.openshift.io/v1"'
+os::cmd::expect_success_and_text 'oc new-app registry.centos.org/centos/php-72-centos7:latest -o yaml | oc set env -f - MYVAR=value -o yaml' 'apiVersion: apps.openshift.io/v1'
+os::cmd::expect_success_and_text 'oc new-app registry.centos.org/centos/php-72-centos7:latest -o yaml | oc set env -f - MYVAR=value -o json' '"apiVersion": "apps.openshift.io/v1"'
 echo "resource printer: ok"
 os::test::junit::declare_suite_end

--- a/test/cmd/quota.sh
+++ b/test/cmd/quota.sh
@@ -50,7 +50,7 @@ os::cmd::expect_success 'oc new-project quota-images --as=deads  --as-group=syst
 os::cmd::expect_success 'oc create quota -n quota-images is-quota --hard openshift.io/imagestreams=1'
 os::cmd::try_until_success 'oc tag -n quota-images openshift/hello-openshift myis2:v2'
 os::cmd::expect_failure_and_text 'oc tag -n quota-images busybox mybox:v1' "exceeded quota"
-os::cmd::expect_failure_and_text 'oc import-image centos -n quota-images --from=docker.io/centos:latest --confirm=true' "exceeded quota"
+os::cmd::expect_failure_and_text 'oc import-image centos -n quota-images --from=registry.centos.org/centos:latest --confirm=true' "exceeded quota"
 os::cmd::expect_success 'oc delete project quota-images'
 
 echo "imagestreams: ok"

--- a/test/cmd/set-image.sh
+++ b/test/cmd/set-image.sh
@@ -15,24 +15,24 @@ os::cmd::expect_success 'oc create -f test/integration/testdata/test-deployment-
 os::cmd::expect_success 'oc create -f examples/hello-openshift/hello-pod.json'
 os::cmd::expect_success 'oc create -f examples/image-streams/image-streams-centos7.json'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:2.5'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.2'
 
 # test --local flag
-os::cmd::expect_failure_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --local' 'you must specify resources by --filename when --local is set.'
+os::cmd::expect_failure_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.2 --local' 'you must specify resources by --filename when --local is set.'
 # test --dry-run flag with -o formats
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run' 'test-deployment-config'
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run -o name' 'deploymentconfig.apps.openshift.io/test-deployment-config'
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run' 'deploymentconfig.apps.openshift.io/test-deployment-config image updated \(dry run\)'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.2 --source=istag --dry-run' 'test-deployment-config'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.2 --source=istag --dry-run -o name' 'deploymentconfig.apps.openshift.io/test-deployment-config'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.2 --source=istag --dry-run' 'deploymentconfig.apps.openshift.io/test-deployment-config image updated \(dry run\)'
 # ensure backwards compatibility with -o formats acting as --dry-run (e.g. all commands after this one succeed if specifying -o without --dry-run does not mutate resources in server)
-os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag -o yaml' 'name: test-deployment-config'
+os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.2 --source=istag -o yaml' 'name: test-deployment-config'
 
 os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.3 --source=istag'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" ':5000/cmd-set-image/ruby@sha256'
 
-os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag'
+os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.2 --source=istag'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" ':5000/cmd-set-image/ruby@sha256'
 
-os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag'
+os::cmd::expect_success 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.2 --source=istag'
 os::cmd::expect_success_and_text "oc get dc/test-deployment-config -o jsonpath='{.spec.template.spec.containers[0].image}'" ':5000/cmd-set-image/ruby@sha256'
 
 os::cmd::expect_failure 'oc set image dc/test-deployment-config ruby-helloworld=ruby:XYZ --source=istag'

--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -301,7 +301,7 @@ function os::test::extended::clusterup::svcaccess () {
 	os::cmd::try_until_text "oc get endpoints git -o jsonpath='{ .subsets[*].ports[?(@.port==8080)].port }'" "8080" $(( 10*minute )) 1
     # Test that a service can be accessed from a peer pod
     sleep 10
-    os::cmd::expect_success "timeout 20s oc run peer --image=openshift/origin-gitserver:latest --attach --restart=Never --command -- curl http://git:8080/_/healthz"
+    os::cmd::expect_success "timeout 20s oc run peer --image=quay.io/openshifttest/origin-gitserver:latest --attach --restart=Never --command -- curl http://git:8080/_/healthz"
 
     # Test that a service can be accessed from the same pod
     # This doesn't work in any cluster i've tried, not sure why but it's not a cluster up issue.
@@ -315,7 +315,7 @@ function os::test::extended::clusterup::portinuse () {
     base_dir=$(os::test::extended::clusterup::make_base_dir "port_in_use")
 
     # Start listening on the host's 127.0.0.1 interface, port 53
-    os::cmd::expect_success "docker run -d --name=port53 --entrypoint=/bin/bash --net=host openshift/origin-gitserver:latest -c \"socat TCP-LISTEN:53,bind=127.0.0.1,fork SYSTEM:'echo hello'\""
+    os::cmd::expect_success "docker run -d --name=port53 --entrypoint=/bin/bash --net=host quay.io/openshifttest/origin-gitserver:latest -c \"socat TCP-LISTEN:53,bind=127.0.0.1,fork SYSTEM:'echo hello'\""
     arg=$@
     os::cmd::expect_success "oc cluster up --base-dir=${base_dir} $arg"
 }
@@ -372,18 +372,18 @@ tests=("${1:-"${default_tests[@]}"}")
 
 # re-tag the latest service catalog image w/ the origin commit because we didn't
 # build it locally, so we need a tag that aligns with the other images we're going to test here.
-docker pull openshift/origin-service-catalog:latest
-docker tag openshift/origin-service-catalog:latest openshift/origin-service-catalog:${ORIGIN_COMMIT}
+docker pull quay.io/openshift/origin-service-catalog:latest
+docker tag quay.io/openshift/origin-service-catalog:latest openshift/origin-service-catalog:${ORIGIN_COMMIT}
 
 echo "Running cluster up tests using tag $ORIGIN_COMMIT"
 
 # Tag the docker registry image with the same tag as the other origin images
-docker pull openshift/origin-docker-registry:latest
-docker tag openshift/origin-docker-registry:latest openshift/origin-docker-registry:${ORIGIN_COMMIT}
+docker pull quay.io/openshift/origin-docker-registry:latest
+docker tag quay.io/openshift/origin-docker-registry:latest openshift/origin-docker-registry:${ORIGIN_COMMIT}
 
 # Tag the web console image with the same tag as the other origin images
-docker pull openshift/origin-web-console:latest
-docker tag openshift/origin-web-console:latest openshift/origin-web-console:${ORIGIN_COMMIT}
+docker pull quay.io/openshift/origin-web-console:latest
+docker tag quay.io/openshift/origin-web-console:latest openshift/origin-web-console:${ORIGIN_COMMIT}
 
 # Ensure that KUBECONFIG is not set
 unset KUBECONFIG

--- a/test/extended/images/trigger/annotation.go
+++ b/test/extended/images/trigger/annotation.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[Feature:AnnotationTrigger] Annotation trigger", func() {
 		o.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(o.Equal(" "))
 
 		g.By("tagging the docker.io/library/centos:latest as test:v1 image to create ImageStream")
-		out, err := oc.Run("tag").Args("docker.io/library/centos:latest", "test:v1").Output()
+		out, err := oc.Run("tag").Args("registry.centos.org/centos/centos:latest", "test:v1").Output()
 		framework.Logf("%s", out)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -2545,7 +2545,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/centos/ruby-27-centos7
+          name: quay.io/centos7/ruby-27-centos7
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -4926,7 +4926,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -5033,7 +5033,7 @@ spec:
         name: history-limit
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -5076,7 +5076,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -5108,13 +5108,13 @@ spec:
   - name: pullthrough
     from:
       kind: DockerImage
-      name: docker.io/centos:centos7
+      name: registry.centos.org/centos:centos7
     referencePolicy:
       type: Local
   - name: direct
     from:
       kind: DockerImage
-      name: docker.io/centos:centos7
+      name: registry.centos.org/centos:centos7
     referencePolicy:
      type: Source`)
 
@@ -5211,7 +5211,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -5251,7 +5251,7 @@ spec:
         name: deployment-simple
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         command:
           - /bin/sleep
@@ -5402,7 +5402,7 @@ spec:
         name: hook
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         command:
           - /bin/sleep
           - infinity
@@ -5450,7 +5450,7 @@ spec:
         name: generation-test
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -5548,7 +5548,7 @@ spec:
         name: paused
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -5590,7 +5590,7 @@ spec:
       - command:
         - /bin/sleep
         - "10000"
-        image: docker.io/centos:centos7
+        image: registry.centos.org/centos:centos7
         imagePullPolicy: IfNotPresent
         name: never-ready
         readinessProbe:
@@ -5691,7 +5691,7 @@ spec:
         name: brokendeployment
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -5744,7 +5744,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -11957,7 +11957,7 @@ objects:
       spec:
         containers:
         - name: gitserver
-          image: openshift/origin-gitserver
+          image: quay.io/openshifttest/origin-gitserver
           readinessProbe:
             tcpSocket:
               port: 8080
@@ -12156,7 +12156,7 @@ objects:
       spec:
         containers:
         - name: gitserver
-          image: openshift/origin-gitserver
+          image: quay.io/openshifttest/origin-gitserver
           readinessProbe:
             tcpSocket:
               port: 8080
@@ -16240,7 +16240,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/httpd-24-centos7:latest"
+              "name": "registry.centos.org/centos/httpd-24-centos7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -16356,7 +16356,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mariadb-101-centos7:latest"
+              "name": "registry.centos.org/centos/mariadb-101-centos7:latest"
             },
             "name": "10.1",
             "referencePolicy": {
@@ -16374,7 +16374,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mariadb-102-centos7:latest"
+              "name": "registry.centos.org/centos/mariadb-102-centos7:latest"
             },
             "name": "10.2",
             "referencePolicy": {
@@ -16441,7 +16441,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-26-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-26-centos7:latest"
             },
             "name": "2.6",
             "referencePolicy": {
@@ -16459,7 +16459,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-32-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-32-centos7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -16477,7 +16477,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-34-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-34-centos7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -16495,7 +16495,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mongodb-36-centos7:latest"
+              "name": "registry.centos.org/centos/mongodb-36-centos7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -16562,7 +16562,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mysql-56-centos7:latest"
+              "name": "registry.centos.org/centos/mysql-56-centos7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -16580,7 +16580,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/mysql-57-centos7:latest"
+              "name": "registry.centos.org/centos/mysql-57-centos7:latest"
             },
             "name": "5.7",
             "referencePolicy": {
@@ -16614,7 +16614,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-18-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-18-centos7:latest"
             },
             "name": "1.8",
             "referencePolicy": {
@@ -16634,7 +16634,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-110-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-110-centos7:latest"
             },
             "name": "1.10",
             "referencePolicy": {
@@ -16654,7 +16654,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nginx-112-centos7:latest"
+              "name": "registry.centos.org/centos/nginx-112-centos7:latest"
             },
             "name": "1.12",
             "referencePolicy": {
@@ -16746,7 +16746,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-4-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-4-centos7:latest"
             },
             "name": "4",
             "referencePolicy": {
@@ -16766,7 +16766,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-6-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-6-centos7:latest"
             },
             "name": "6",
             "referencePolicy": {
@@ -16785,7 +16785,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/nodejs-8-centos7:latest"
+              "name": "registry.centos.org/centos/nodejs-8-centos7:latest"
             },
             "name": "8",
             "referencePolicy": {
@@ -16896,7 +16896,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-520-centos7:latest"
+              "name": "registry.centos.org/centos/perl-520-centos7:latest"
             },
             "name": "5.20",
             "referencePolicy": {
@@ -16916,7 +16916,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-524-centos7:latest"
+              "name": "registry.centos.org/centos/perl-524-centos7:latest"
             },
             "name": "5.24",
             "referencePolicy": {
@@ -16936,7 +16936,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/perl-526-centos7:latest"
+              "name": "registry.centos.org/centos/perl-526-centos7:latest"
             },
             "name": "5.26",
             "referencePolicy": {
@@ -16978,26 +16978,6 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
           },
           {
             "annotations": {
-              "description": "Build and run PHP 5.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.5/README.md.",
-              "iconClass": "icon-php",
-              "openshift.io/display-name": "PHP 5.5",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/openshift/cakephp-ex.git",
-              "supports": "php:5.5,php",
-              "tags": "hidden,builder,php",
-              "version": "5.5"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/openshift/php-55-centos7:latest"
-            },
-            "name": "5.5",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
               "description": "Build and run PHP 5.6 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.6/README.md.",
               "iconClass": "icon-php",
               "openshift.io/display-name": "PHP 5.6",
@@ -17009,7 +16989,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-56-centos7:latest"
+              "name": "registry.centos.org/centos/php-56-centos7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -17029,7 +17009,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-70-centos7:latest"
+              "name": "registry.centos.org/centos/php-70-centos7:latest"
             },
             "name": "7.0",
             "referencePolicy": {
@@ -17049,7 +17029,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-71-centos7:latest"
+              "name": "registry.centos.org/centos/php-71-centos7:latest"
             },
             "name": "7.1",
             "referencePolicy": {
@@ -17069,7 +17049,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/php-72-centos7:latest"
+              "name": "registry.centos.org/centos/php-72-centos7:latest"
             },
             "name": "7.2",
             "referencePolicy": {
@@ -17136,7 +17116,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-94-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-94-centos7:latest"
             },
             "name": "9.4",
             "referencePolicy": {
@@ -17154,7 +17134,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-95-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-95-centos7:latest"
             },
             "name": "9.5",
             "referencePolicy": {
@@ -17172,7 +17152,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-96-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-96-centos7:latest"
             },
             "name": "9.6",
             "referencePolicy": {
@@ -17190,7 +17170,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/postgresql-10-centos7:latest"
+              "name": "registry.centos.org/centos/postgresql-10-centos7:latest"
             },
             "name": "10",
             "referencePolicy": {
@@ -17263,7 +17243,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-27-centos7:latest"
+              "name": "registry.centos.org/centos/python-27-centos7:latest"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -17283,7 +17263,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-34-centos7:latest"
+              "name": "registry.centos.org/centos/python-34-centos7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -17303,7 +17283,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-35-centos7:latest"
+              "name": "registry.centos.org/centos/python-35-centos7:latest"
             },
             "name": "3.5",
             "referencePolicy": {
@@ -17323,7 +17303,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/python-36-centos7:latest"
+              "name": "registry.centos.org/centos/python-36-centos7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -17372,7 +17352,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/redis-32-centos7:latest"
+              "name": "registry.centos.org/centos/redis-32-centos7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -17445,7 +17425,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-22-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-22-centos7:latest"
             },
             "name": "2.2",
             "referencePolicy": {
@@ -17465,7 +17445,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-23-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-23-centos7:latest"
             },
             "name": "2.3",
             "referencePolicy": {
@@ -17485,7 +17465,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-24-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-24-centos7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -17505,7 +17485,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-25-centos7:latest"
+              "name": "registry.centos.org/centos/ruby-25-centos7:latest"
             },
             "name": "2.5",
             "referencePolicy": {
@@ -18486,26 +18466,6 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
               "name": "7.2"
             },
             "name": "latest",
-            "referencePolicy": {
-              "type": "Local"
-            }
-          },
-          {
-            "annotations": {
-              "description": "Build and run PHP 5.5 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-php-container/blob/master/5.5/README.md.",
-              "iconClass": "icon-php",
-              "openshift.io/display-name": "PHP 5.5",
-              "openshift.io/provider-display-name": "Red Hat, Inc.",
-              "sampleRepo": "https://github.com/openshift/cakephp-ex.git",
-              "supports": "php:5.5,php",
-              "tags": "hidden,builder,php",
-              "version": "5.5"
-            },
-            "from": {
-              "kind": "DockerImage",
-              "name": "registry.redhat.io/openshift3/php-55-rhel7:latest"
-            },
-            "name": "5.5",
             "referencePolicy": {
               "type": "Local"
             }
@@ -19648,7 +19608,7 @@ var _examplesSampleAppApplicationTemplateDockerbuildJson = []byte(`{
           {
             "from": {
               "kind": "DockerImage",
-              "name": "docker.io/centos/ruby-27-centos7:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             },
             "name": "latest"
           }

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -84,7 +84,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/centos/ruby-27-centos7
+          name: quay.io/centos7/ruby-27-centos7
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com

--- a/test/extended/testdata/deployments/custom-deployment.yaml
+++ b/test/extended/testdata/deployments/custom-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/deployment-history-limit.yaml
+++ b/test/extended/testdata/deployments/deployment-history-limit.yaml
@@ -12,7 +12,7 @@ spec:
         name: history-limit
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/deployment-ignores-deployer.yaml
+++ b/test/extended/testdata/deployments/deployment-ignores-deployer.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/deployment-image-resolution-is.yaml
+++ b/test/extended/testdata/deployments/deployment-image-resolution-is.yaml
@@ -7,12 +7,12 @@ spec:
   - name: pullthrough
     from:
       kind: DockerImage
-      name: docker.io/centos:centos7
+      name: registry.centos.org/centos:centos7
     referencePolicy:
       type: Local
   - name: direct
     from:
       kind: DockerImage
-      name: docker.io/centos:centos7
+      name: registry.centos.org/centos:centos7
     referencePolicy:
      type: Source

--- a/test/extended/testdata/deployments/deployment-min-ready-seconds.yaml
+++ b/test/extended/testdata/deployments/deployment-min-ready-seconds.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/deployment-simple.yaml
+++ b/test/extended/testdata/deployments/deployment-simple.yaml
@@ -15,7 +15,7 @@ spec:
         name: deployment-simple
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         command:
           - /bin/sleep

--- a/test/extended/testdata/deployments/failing-pre-hook.yaml
+++ b/test/extended/testdata/deployments/failing-pre-hook.yaml
@@ -23,7 +23,7 @@ spec:
         name: hook
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         command:
           - /bin/sleep
           - infinity

--- a/test/extended/testdata/deployments/generation-test.yaml
+++ b/test/extended/testdata/deployments/generation-test.yaml
@@ -22,7 +22,7 @@ spec:
         name: generation-test
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/paused-deployment.yaml
+++ b/test/extended/testdata/deployments/paused-deployment.yaml
@@ -11,7 +11,7 @@ spec:
         name: paused
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/readiness-test.yaml
+++ b/test/extended/testdata/deployments/readiness-test.yaml
@@ -17,7 +17,7 @@ spec:
       - command:
         - /bin/sleep
         - "10000"
-        image: docker.io/centos:centos7
+        image: registry.centos.org/centos:centos7
         imagePullPolicy: IfNotPresent
         name: never-ready
         readinessProbe:

--- a/test/extended/testdata/deployments/test-deployment-broken.yaml
+++ b/test/extended/testdata/deployments/test-deployment-broken.yaml
@@ -21,7 +21,7 @@ spec:
         name: brokendeployment
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/test-deployment-test.yaml
+++ b/test/extended/testdata/deployments/test-deployment-test.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/test-gitserver-tokenauth.yaml
+++ b/test/extended/testdata/test-gitserver-tokenauth.yaml
@@ -28,7 +28,7 @@ objects:
       spec:
         containers:
         - name: gitserver
-          image: openshift/origin-gitserver
+          image: quay.io/openshifttest/origin-gitserver
           readinessProbe:
             tcpSocket:
               port: 8080

--- a/test/extended/testdata/test-gitserver.yaml
+++ b/test/extended/testdata/test-gitserver.yaml
@@ -28,7 +28,7 @@ objects:
       spec:
         containers:
         - name: gitserver
-          image: openshift/origin-gitserver
+          image: quay.io/openshifttest/origin-gitserver
           readinessProbe:
             tcpSocket:
               port: 8080

--- a/test/testdata/complete-dc-hooks.yaml
+++ b/test/testdata/complete-dc-hooks.yaml
@@ -34,7 +34,7 @@ spec:
         name: complete-dc-hooks
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/testdata/failing-dc-mid.yaml
+++ b/test/testdata/failing-dc-mid.yaml
@@ -23,7 +23,7 @@ spec:
         name: failing-dc-mid
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         name: myapp
         command:
         - /bin/false

--- a/test/testdata/failing-dc.yaml
+++ b/test/testdata/failing-dc.yaml
@@ -37,7 +37,7 @@ spec:
         name: failing-dc
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "registry.centos.org/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/testdata/installable-stream.yaml
+++ b/test/testdata/installable-stream.yaml
@@ -4,34 +4,34 @@ metadata:
   name: installable
 spec:
   tags:
-  - name: latest
-    from:
-      kind: ImageStreamTag
-      name: installable:token
-  - name: no-token
-    annotations:
-      io.openshift.generate.job: "true"
-    from:
-      kind: DockerImage
-      name: openshift/origin:v1.0.6
-  - name: token
-    annotations:
-      io.openshift.generate.job: "true"
-      io.openshift.generate.token.as: "env:TOKEN_ENV"
-    from:
-      kind: DockerImage
-      name: openshift/origin:v1.0.6
-  - name: file
-    annotations:
-      io.openshift.generate.job: "true"
-      io.openshift.generate.token.as: "file:/var/run/openshift.secret.token"
-    from:
-      kind: DockerImage
-      name: openshift/origin:v1.0.6
-  - name: serviceaccount
-    annotations:
-      io.openshift.generate.job: "true"
-      io.openshift.generate.token.as: "serviceaccount"
-    from:
-      kind: DockerImage
-      name: openshift/origin:v1.0.6
+    - name: latest
+      from:
+        kind: ImageStreamTag
+        name: installable:token
+    - name: no-token
+      annotations:
+        io.openshift.generate.job: "true"
+      from:
+        kind: DockerImage
+        name: openshift/origin:v1.0.6
+    - name: token
+      annotations:
+        io.openshift.generate.job: "true"
+        io.openshift.generate.token.as: "env:TOKEN_ENV"
+      from:
+        kind: DockerImage
+        name: openshift/origin:v1.0.6
+    - name: file
+      annotations:
+        io.openshift.generate.job: "true"
+        io.openshift.generate.token.as: "file:/var/run/openshift.secret.token"
+      from:
+        kind: DockerImage
+        name: openshift/origin:v1.0.6
+    - name: serviceaccount
+      annotations:
+        io.openshift.generate.job: "true"
+        io.openshift.generate.token.as: "serviceaccount"
+      from:
+        kind: DockerImage
+        name: openshift/origin:v1.0.6

--- a/vendor/github.com/containers/image/docker/fixtures/registries.d/internet-user.yaml
+++ b/vendor/github.com/containers/image/docker/fixtures/registries.d/internet-user.yaml
@@ -5,8 +5,8 @@ docker:
         sigstore: https://sigstore.contoso.com/fordocker
     docker.io/centos:
         sigstore: https://sigstore.centos.org/
-    docker.io/centos/mybetaprooduct:
+    registry.centos.org/centos/mybetaprooduct:
         sigstore: http://localhost:9999/mybetaWIP/sigstore
         sigstore-staging: file:///srv/mybetaWIP/sigstore
-    docker.io/centos/mybetaproduct:latest:
+    registry.centos.org/centos/mybetaproduct:latest:
         sigstore: https://sigstore.centos.org/

--- a/vendor/github.com/containers/image/docker/lookaside_test.go
+++ b/vendor/github.com/containers/image/docker/lookaside_test.go
@@ -174,11 +174,11 @@ func TestLoadAndMergeConfig(t *testing.T) {
 			"localhost/invalid/url/test":     {SigStore: ":emptyscheme"},
 			"docker.io/contoso":              {SigStore: "https://sigstore.contoso.com/fordocker"},
 			"docker.io/centos":               {SigStore: "https://sigstore.centos.org/"},
-			"docker.io/centos/mybetaprooduct": {
+			"registry.centos.org/centos/mybetaprooduct": {
 				SigStore:        "http://localhost:9999/mybetaWIP/sigstore",
 				SigStoreStaging: "file:///srv/mybetaWIP/sigstore",
 			},
-			"docker.io/centos/mybetaproduct:latest": {SigStore: "https://sigstore.centos.org/"},
+			"registry.centos.org/centos/mybetaproduct:latest": {SigStore: "https://sigstore.centos.org/"},
 		},
 	}, config)
 }

--- a/vendor/github.com/openshift/source-to-image/hack/test-stirunimage.sh
+++ b/vendor/github.com/openshift/source-to-image/hack/test-stirunimage.sh
@@ -79,11 +79,11 @@ check_result $? "${WORK_DIR}/s2i-git-clone.log"
 
 test_debug "s2i build with relative path without file://"
 
-s2i build cakephp-ex docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-rel-noproto.log"
+s2i build cakephp-ex registry.centos.org/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-rel-noproto.log"
 check_result $? "${WORK_DIR}/s2i-rel-noproto.log"
 
 test_debug "s2i build with volume options"
-s2i build cakephp-ex docker.io/centos/php-70-centos7 test --volume "${WORK_DIR}:/home/:z" --loglevel=5 &> "${WORK_DIR}/s2i-volume-correct.log"
+s2i build cakephp-ex registry.centos.org/centos/php-70-centos7 test --volume "${WORK_DIR}:/home/:z" --loglevel=5 &> "${WORK_DIR}/s2i-volume-correct.log"
 check_result $? "${WORK_DIR}/s2i-volume-correct.log"
 
 popd
@@ -96,12 +96,12 @@ else
   S2I_WORK_DIR_URL="file://${S2I_WORK_DIR}/cakephp-ex"
 fi
 
-s2i build "${S2I_WORK_DIR_URL}" docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-abs-proto.log"
+s2i build "${S2I_WORK_DIR_URL}" registry.centos.org/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-abs-proto.log"
 check_result $? "${WORK_DIR}/s2i-abs-proto.log"
 
 test_debug "s2i build with absolute path without file://"
 
-s2i build "${S2I_WORK_DIR}/cakephp-ex" docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-abs-noproto.log"
+s2i build "${S2I_WORK_DIR}/cakephp-ex" registry.centos.org/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-abs-noproto.log"
 check_result $? "${WORK_DIR}/s2i-abs-noproto.log"
 
 ## don't do ssh tests here because credentials are needed (even for the git user), which
@@ -110,7 +110,7 @@ check_result $? "${WORK_DIR}/s2i-abs-noproto.log"
 test_debug "s2i build with non-git repo file location"
 
 rm -rf "${WORK_DIR}/cakephp-ex/.git"
-s2i build "${S2I_WORK_DIR}/cakephp-ex" docker.io/centos/php-70-centos7 test --loglevel=5 --loglevel=5 &> "${WORK_DIR}/s2i-non-repo.log"
+s2i build "${S2I_WORK_DIR}/cakephp-ex" registry.centos.org/centos/php-70-centos7 test --loglevel=5 --loglevel=5 &> "${WORK_DIR}/s2i-non-repo.log"
 check_result $? ""
 grep "Copying sources" "${WORK_DIR}/s2i-non-repo.log"
 check_result $? "${WORK_DIR}/s2i-non-repo.log"
@@ -123,13 +123,13 @@ check_result $? "${WORK_DIR}/s2i-rebuild.log"
 
 test_debug "s2i usage"
 
-s2i usage docker.io/centos/ruby-24-centos7 --loglevel=5 &> "${WORK_DIR}/s2i-usage.log"
+s2i usage registry.centos.org/centos/ruby-24-centos7 --loglevel=5 &> "${WORK_DIR}/s2i-usage.log"
 check_result $? ""
 grep "Sample invocation" "${WORK_DIR}/s2i-usage.log"
 check_result $? "${WORK_DIR}/s2i-usage.log"
 
 test_debug "s2i build with overriding assemble/run scripts"
-s2i build https://github.com/openshift/source-to-image docker.io/centos/php-70-centos7 test --context-dir=test_apprepo >& "${WORK_DIR}/s2i-override-build.log"
+s2i build https://github.com/openshift/source-to-image registry.centos.org/centos/php-70-centos7 test --context-dir=test_apprepo >& "${WORK_DIR}/s2i-override-build.log"
 grep "Running custom assemble" "${WORK_DIR}/s2i-override-build.log"
 check_result $? "${WORK_DIR}/s2i-override-build.log"
 docker run test >& "${WORK_DIR}/s2i-override-run.log"
@@ -137,7 +137,7 @@ grep "Running custom run" "${WORK_DIR}/s2i-override-run.log"
 check_result $? "${WORK_DIR}/s2i-override-run.log"
 
 test_debug "s2i build with remote git repo"
-s2i build https://github.com/openshift/cakephp-ex docker.io/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log"
+s2i build https://github.com/openshift/cakephp-ex registry.centos.org/centos/php-70-centos7 test --loglevel=5 &> "${WORK_DIR}/s2i-git-proto.log"
 check_result $? "${WORK_DIR}/s2i-git-proto.log"
 
 test_debug "s2i build with runtime image"
@@ -145,7 +145,7 @@ s2i build --ref=10.x --context-dir=helloworld https://github.com/wildfly/quickst
 check_result $? "${WORK_DIR}/s2i-runtime-image.log"
 
 test_debug "s2i build with Dockerfile output"
-s2i build https://github.com/openshift/cakephp-ex docker.io/centos/php-70-centos7 --as-dockerfile=${WORK_DIR}/asdockerfile/Dockerfile --loglevel=5 >& "${WORK_DIR}/s2i-dockerfile.log"
+s2i build https://github.com/openshift/cakephp-ex registry.centos.org/centos/php-70-centos7 --as-dockerfile=${WORK_DIR}/asdockerfile/Dockerfile --loglevel=5 >& "${WORK_DIR}/s2i-dockerfile.log"
 check_result $? "${WORK_DIR}/s2i-dockerfile.log"
 
 

--- a/vendor/github.com/openshift/source-to-image/test/integration/integration_test.go
+++ b/vendor/github.com/openshift/source-to-image/test/integration/integration_test.go
@@ -593,7 +593,7 @@ func TestDockerfileBuild(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -607,13 +607,13 @@ func TestDockerfileBuild(t *testing.T) {
 		AsDockerfile: tempdir + string(os.PathSeparator) + "MyDockerfile",
 	}
 	expected := []string{
-		"(?m)^FROM docker.io/centos/nodejs-8-centos7",
+		"(?m)^FROM registry.centos.org/centos/nodejs-8-centos7",
 		"\"io.openshift.s2i.build.commit.date\"",
 		"\"io.openshift.s2i.build.commit.id\"",
 		"\"io.openshift.s2i.build.commit.ref\"",
 		"\"io.openshift.s2i.build.commit.message\"",
 		"\"io.openshift.s2i.build.source-location\"",
-		"\"io.openshift.s2i.build.image\"=\"docker.io/centos/nodejs-8-centos7\"",
+		"\"io.openshift.s2i.build.image\"=\"registry.centos.org/centos/nodejs-8-centos7\"",
 		"\"io.openshift.s2i.build.commit.author\"",
 		"(?m)^COPY upload/src /tmp/src",
 		"(?m)^RUN chown -R 1001:0.* /tmp/src",
@@ -636,7 +636,7 @@ func TestDockerfileBuildDefaultDockerfile(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -650,13 +650,13 @@ func TestDockerfileBuildDefaultDockerfile(t *testing.T) {
 		AsDockerfile: tempdir + string(os.PathSeparator),
 	}
 	expected := []string{
-		"(?m)^FROM docker.io/centos/nodejs-8-centos7",
+		"(?m)^FROM registry.centos.org/centos/nodejs-8-centos7",
 		"\"io.openshift.s2i.build.commit.date\"",
 		"\"io.openshift.s2i.build.commit.id\"",
 		"\"io.openshift.s2i.build.commit.ref\"",
 		"\"io.openshift.s2i.build.commit.message\"",
 		"\"io.openshift.s2i.build.source-location\"",
-		"\"io.openshift.s2i.build.image\"=\"docker.io/centos/nodejs-8-centos7\"",
+		"\"io.openshift.s2i.build.image\"=\"registry.centos.org/centos/nodejs-8-centos7\"",
 		"\"io.openshift.s2i.build.commit.author\"",
 		"(?m)^COPY upload/src /tmp/src",
 		"(?m)^RUN chown -R 1001:0.* /tmp/src",
@@ -678,7 +678,7 @@ func TestDockerfileBuildEnv(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -716,7 +716,7 @@ func TestDockerfileBuildLabels(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -737,7 +737,7 @@ func TestDockerfileBuildLabels(t *testing.T) {
 		"\"io.openshift.s2i.build.commit.ref\"",
 		"\"io.openshift.s2i.build.commit.message\"",
 		"\"io.openshift.s2i.build.source-location\"",
-		"\"io.openshift.s2i.build.image\"=\"docker.io/centos/nodejs-8-centos7\"",
+		"\"io.openshift.s2i.build.image\"=\"registry.centos.org/centos/nodejs-8-centos7\"",
 		"\"io.openshift.s2i.build.commit.author\"=\"shadowman\"",
 		"\"label1\"=\"value1\"",
 		"\"label2\"=\"value2\"",
@@ -776,7 +776,7 @@ func TestDockerfileBuildInjections(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "/workdir",
 		Source:       git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -839,7 +839,7 @@ func TestDockerfileBuildScriptsURLAssemble(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -879,7 +879,7 @@ func TestDockerfileBuildScriptsURLRun(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -926,7 +926,7 @@ func TestDockerfileBuildSourceScriptsAssemble(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("file:///" + filepath.ToSlash(sourcecode)),
@@ -973,7 +973,7 @@ func TestDockerfileBuildSourceScriptsRun(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("file:///" + filepath.ToSlash(sourcecode)),
@@ -1024,7 +1024,7 @@ func TestDockerfileBuildScriptsURLImage(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Source:       git.MustParse("file:///" + filepath.ToSlash(sourcecode)),
@@ -1064,7 +1064,7 @@ func TestDockerfileBuildImageScriptsURLAssemble(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage:    "docker.io/centos/nodejs-8-centos7",
+		BuilderImage:    "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser:    "",
 		ImageWorkDir:    "",
 		Source:          git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -1104,7 +1104,7 @@ func TestDockerfileBuildImageScriptsURLRun(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage:    "docker.io/centos/nodejs-8-centos7",
+		BuilderImage:    "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser:    "",
 		ImageWorkDir:    "",
 		Source:          git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -1151,7 +1151,7 @@ func TestDockerfileBuildImageScriptsURLImage(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage:    "docker.io/centos/nodejs-8-centos7",
+		BuilderImage:    "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser:    "",
 		ImageWorkDir:    "",
 		Source:          git.MustParse("file:///" + filepath.ToSlash(sourcecode)),
@@ -1191,7 +1191,7 @@ func TestDockerfileBuildScriptsAndImageURL(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage:    "docker.io/centos/nodejs-8-centos7",
+		BuilderImage:    "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser:    "",
 		ImageWorkDir:    "",
 		Source:          git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -1254,7 +1254,7 @@ func TestDockerfileBuildScriptsAndImageURLConflicts(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage:    "docker.io/centos/nodejs-8-centos7",
+		BuilderImage:    "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser:    "",
 		ImageWorkDir:    "",
 		Source:          git.MustParse("https://github.com/sclorg/nodejs-ex"),
@@ -1296,7 +1296,7 @@ func TestDockerfileIncrementalBuild(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Incremental:  true,
@@ -1315,7 +1315,7 @@ func TestDockerfileIncrementalBuild(t *testing.T) {
 	expected := []string{
 		"(?m)^FROM test:tag as cached\n#.+\nUSER 1001",
 		"(?m)^RUN if \\[ -s /usr/libexec/s2i/save-artifacts \\]; then /usr/libexec/s2i/save-artifacts > /tmp/artifacts.tar; else touch /tmp/artifacts.tar; fi",
-		"(?m)^FROM docker.io/centos/nodejs-8-centos7",
+		"(?m)^FROM registry.centos.org/centos/nodejs-8-centos7",
 		"(?m)^COPY --from=cached /tmp/artifacts.tar /tmp/artifacts.tar",
 		"(?m)^RUN chown -R 1001:0.* /tmp/artifacts.tar",
 		"if \\[ -s /tmp/artifacts.tar \\]; then mkdir -p /tmp/artifacts; tar -xf /tmp/artifacts.tar -C /tmp/artifacts; fi",
@@ -1350,7 +1350,7 @@ func TestDockerfileIncrementalSourceSave(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Incremental:  true,
@@ -1371,7 +1371,7 @@ func TestDockerfileIncrementalSourceSave(t *testing.T) {
 		"(?m)^COPY upload/scripts/save-artifacts /destination/scripts/save-artifacts",
 		"(?m)^RUN chown .*1001:0 /destination/scripts/save-artifacts",
 		"(?m)^USER 1001\nRUN if \\[ -s /destination/scripts/save-artifacts \\]; then /destination/scripts/save-artifacts > /tmp/artifacts.tar;",
-		"(?m)^FROM docker.io/centos/nodejs-8-centos7",
+		"(?m)^FROM registry.centos.org/centos/nodejs-8-centos7",
 		"mkdir -p /destination/artifacts",
 		"tar -xf /tmp/artifacts.tar -C /destination/artifacts",
 		"(?m)^RUN /usr/libexec/s2i/assemble",
@@ -1398,7 +1398,7 @@ func TestDockerfileIncrementalSaveURL(t *testing.T) {
 	}
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "",
 		ImageWorkDir: "",
 		Incremental:  true,
@@ -1419,7 +1419,7 @@ func TestDockerfileIncrementalSaveURL(t *testing.T) {
 		"(?m)^COPY upload/scripts/save-artifacts /destination/scripts/save-artifacts",
 		"(?m)^RUN chown 1001:0 /destination/scripts/save-artifacts",
 		"(?m)^USER 1001\nRUN if \\[ -s /destination/scripts/save-artifacts \\]; then /destination/scripts/save-artifacts > /tmp/artifacts.tar;",
-		"(?m)^FROM docker.io/centos/nodejs-8-centos7",
+		"(?m)^FROM registry.centos.org/centos/nodejs-8-centos7",
 		"mkdir -p /destination/artifacts",
 		"tar -xf /tmp/artifacts.tar -C /destination/artifacts",
 		"(?m)^RUN /usr/libexec/s2i/assemble",
@@ -1440,7 +1440,7 @@ func TestDockerfileIncrementalTag(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	config := &api.Config{
-		BuilderImage:       "docker.io/centos/nodejs-8-centos7",
+		BuilderImage:       "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser:       "",
 		ImageWorkDir:       "",
 		Incremental:        true,
@@ -1457,7 +1457,7 @@ func TestDockerfileIncrementalTag(t *testing.T) {
 	expected := []string{
 		"(?m)^FROM incremental:tag as cached",
 		"/usr/libexec/s2i/save-artifacts > /tmp/artifacts.tar",
-		"(?m)^FROM docker.io/centos/nodejs-8-centos7",
+		"(?m)^FROM registry.centos.org/centos/nodejs-8-centos7",
 		"mkdir -p /tmp/artifacts",
 		"tar -xf /tmp/artifacts.tar -C /tmp/artifacts",
 		"rm /tmp/artifacts.tar",
@@ -1476,7 +1476,7 @@ func TestDockerfileIncrementalAssembleUser(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	config := &api.Config{
-		BuilderImage: "docker.io/centos/nodejs-8-centos7",
+		BuilderImage: "registry.centos.org/centos/nodejs-8-centos7",
 		AssembleUser: "2250",
 		ImageWorkDir: "",
 		Incremental:  true,
@@ -1491,7 +1491,7 @@ func TestDockerfileIncrementalAssembleUser(t *testing.T) {
 	expected := []string{
 		"(?m)^FROM test:tag as cached\n#.+\nUSER 2250",
 		"/usr/libexec/s2i/save-artifacts > /tmp/artifacts.tar",
-		"(?m)^FROM docker.io/centos/nodejs-8-centos7",
+		"(?m)^FROM registry.centos.org/centos/nodejs-8-centos7",
 		"(?m)^COPY --from=cached /tmp/artifacts.tar /tmp/artifacts.tar",
 		"(?m)^RUN chown -R 2250:0 .*/tmp/artifacts.tar",
 		"mkdir -p /tmp/artifacts",

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker/helpers_test.go
@@ -113,7 +113,7 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			// RepoDigest match is is required
 			Inspected: dockertypes.ImageInspect{
 				ID:          "",
-				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:000084acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf"},
+				RepoDigests: []string{"registry.centos.org/centos/ruby-23-centos7@sha256:000084acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf"},
 			},
 			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
 			Output: false,
@@ -122,7 +122,7 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			// RepoDigest match is allowed
 			Inspected: dockertypes.ImageInspect{
 				ID:          "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
-				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf"},
+				RepoDigests: []string{"registry.centos.org/centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf"},
 			},
 			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
 			Output: true,
@@ -131,7 +131,7 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			// RepoDigest and ID are checked
 			Inspected: dockertypes.ImageInspect{
 				ID:          "sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
-				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227"},
+				RepoDigests: []string{"registry.centos.org/centos/ruby-23-centos7@sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227"},
 			},
 			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
 			Output: true,
@@ -142,7 +142,7 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 				ID: "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
 				RepoDigests: []string{
 					"centos/ruby-23-centos7@sha256:unparseable",
-					"docker.io/centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
+					"registry.centos.org/centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
 				},
 			},
 			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
@@ -152,7 +152,7 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			// unparseable RepoDigest is ignored
 			Inspected: dockertypes.ImageInspect{
 				ID:          "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
-				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:unparseable"},
+				RepoDigests: []string{"registry.centos.org/centos/ruby-23-centos7@sha256:unparseable"},
 			},
 			Image:  "centos/ruby-23-centos7@sha256:940584acbbfb0347272112d2eb95574625c0c60b4e2fdadb139de5859cf754bf",
 			Output: false,
@@ -161,7 +161,7 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			// unparseable image digest is ignored
 			Inspected: dockertypes.ImageInspect{
 				ID:          "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
-				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:unparseable"},
+				RepoDigests: []string{"registry.centos.org/centos/ruby-23-centos7@sha256:unparseable"},
 			},
 			Image:  "centos/ruby-23-centos7@sha256:unparseable",
 			Output: false,
@@ -170,7 +170,7 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			// prefix match is rejected for ID and RepoDigest
 			Inspected: dockertypes.ImageInspect{
 				ID:          "sha256:unparseable",
-				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:unparseable"},
+				RepoDigests: []string{"registry.centos.org/centos/ruby-23-centos7@sha256:unparseable"},
 			},
 			Image:  "sha256:unparseable",
 			Output: false,
@@ -179,7 +179,7 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			// possible SHA prefix match is rejected for ID and RepoDigest because it is not in the named format
 			Inspected: dockertypes.ImageInspect{
 				ID:          "sha256:0000f247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
-				RepoDigests: []string{"docker.io/centos/ruby-23-centos7@sha256:0000f247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227"},
+				RepoDigests: []string{"registry.centos.org/centos/ruby-23-centos7@sha256:0000f247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227"},
 			},
 			Image:  "sha256:0000",
 			Output: false,


### PR DESCRIPTION
In 3.11, jenkins/extended_clusterup and jenkins/cmd required tests are getting docker.io rate limit exceeded error and permanently failing.

This PR switches;
```
openshift/origin-gitserver -> quay.io/openshifttest/origin-gitserver
docker.io/centos -> registry.centos.org/centos
docker.io/centos/ruby-27-centos7 -> quay.io/centos7/ruby-27-centos7
openshift/origin-release -> registry.ci.openshift.org/openshift/release
docker.io/centos:centos7 -> registry.centos.org/centos:centos7
docker.io/library/wordpress -> quay.io/bitnami/wordpress
openshift/origin-service-catalog:latest -> quay.io/openshift/origin-service-catalog
openshift/origin-docker-registry -> quay.io/openshift/origin-docker-registry
openshift/origin-web-console -> quay.io/openshift/origin-web-console
docker.io/library/centos -> registry.centos.org/centos/centos
```

`php-55` and `ruby-20` version were deprecated and there is no corresponding image in anywhere(also for `mongodb` and `mysql`). Thus, I had to cut out a few tests in `newapp.sh`. Because switching to other newer versions for images caused cascading failures and that time it seems better to focus on green jobs instead fully coverage.