### PR TITLE
WIP: Add tuning cni tests

### DIFF
--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -1,0 +1,140 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	g "github.com/onsi/ginkgo"
+	t "github.com/onsi/ginkgo/extensions/table"
+	o "github.com/onsi/gomega"
+	"github.com/openshift/origin/test/extended/util"
+	exutil "github.com/openshift/origin/test/extended/util"
+	kappsv1 "k8s.io/api/apps/v1"
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"strings"
+)
+
+const (
+	AllowlistDsName        = "allowlist-ds"
+	AllowlistCleanupDsName = "allowlistcleanup-ds"
+	AllowlistConfigMapName = "allowlist-cm"
+	TuningNadName          = "tuningnad"
+	AllowlistPodName       = "allowlist-pod"
+	RbacName               = "allowlistrbac"
+)
+
+var _ = g.Describe("[sig-network][Feature:tuning]", func() {
+	oc := exutil.NewCLI("tuning")
+	f := oc.KubeFramework()
+
+	t.DescribeTable("pod should start for each sysctl on whitelist", func(sysctl, value, path string) {
+		namespace := f.Namespace.Name
+		err := configureRbac(f.ClientSet, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred(), "unable to create config map")
+		err = configureAllowlistOnNodes(f.ClientSet, namespace, []string{"^net\\.ipv4\\.conf\\.IFNAME\\.[a-z_]*$\n"})
+		o.Expect(err).NotTo(o.HaveOccurred(), "unable to configure allowlists on nodes")
+
+		err = createTuningNad(oc.AdminConfig(), namespace, TuningNadName, map[string]string{sysctl: value})
+		o.Expect(err).NotTo(o.HaveOccurred(), "unable to create nad")
+
+		util.CreateExecPodOrFail(f.ClientSet, namespace, AllowlistPodName, func(pod *kapiv1.Pod) {
+			pod.ObjectMeta.Annotations =  map[string]string{"k8s.v1.cni.cncf.io/networks": fmt.Sprintf("%s/%s", namespace, TuningNadName)}
+		})
+		result, err := isPodSysctlApplied(oc, namespace, AllowlistPodName, []string{"/bin/bash", "-c", fmt.Sprintf("cat %s", path)}, value)
+		o.Expect(err).NotTo(o.HaveOccurred(), "error checking pod sysctls")
+		o.Expect(result).To(o.BeTrue(), "unable to create daemonset")
+
+		err = cleanupAllowlistsOnNodes(f.ClientSet, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred(), "unable to create daemonset")
+	},
+		t.Entry("net.ipv4.conf.IFNAME.arp_filter", "net.ipv4.conf.IFNAME.arp_filter", "1", "/proc/sys/net/ipv4/conf/net1/arp_filter"),
+	)
+})
+
+func configureRbac(c kclientset.Interface, namespace string) error {
+	err := util.CreateRole(c, namespace, RbacName)
+	if err != nil {
+		return err
+	}
+	return util.CreateRoleBinding(c, namespace, RbacName)
+}
+
+func configureAllowlistOnNodes(c kclientset.Interface, namespace string, sysctls []string) error {
+	err := createConfigMap(c, namespace, AllowlistConfigMapName, sysctls)
+	if err != nil {
+		return err
+	}
+	_, err = createDS(c, namespace, AllowlistDsName, "cp /allowlist/allowlist.conf /host/ && sleep INF", "test -f /host/allowlist.conf", AllowlistConfigMapName)
+	if err != nil {
+		return err
+	}
+	return util.WaitForDSRunning(c, namespace, AllowlistDsName)
+}
+
+func cleanupAllowlistsOnNodes(c kclientset.Interface, namespace string) error {
+	_, err := createDS(c, namespace, AllowlistCleanupDsName, "rm -f /host/allowlist.conf && sleep INF", "! test -f /host/allowlist.conf", AllowlistConfigMapName)
+	if err != nil {
+		return err
+	}
+	return util.WaitForDSRunning(c, namespace, AllowlistCleanupDsName)
+}
+
+func isPodSysctlApplied(oc *exutil.CLI, namespace string, name string, command []string, expectedResult string) (bool, error) {
+	pod, err := oc.KubeFramework().ClientSet.CoreV1().Pods(namespace).Get(context.Background(), AllowlistPodName, metav1.GetOptions{})
+	if err != nil {
+		return true, err
+	}
+	output, err := util.ExecCommandOnPod(oc, *pod, command)
+	if err != nil {
+		return true, err
+	}
+	return strings.TrimSpace(output.String()) == expectedResult, nil
+}
+
+func createConfigMap(c kclientset.Interface, namespace string, name string, sysctls []string) error {
+	allowList := ""
+	for _, sysctl := range sysctls {
+		allowList = allowList + sysctl + "\n"
+	}
+	configMap := &kapiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: map[string]string{"allowlist.conf": allowList},
+	}
+	_, err := c.CoreV1().ConfigMaps(namespace).Create(context.Background(), configMap, metav1.CreateOptions{})
+	return err
+}
+
+func createDS(c kclientset.Interface, namespace string, name string, command string, readinessCommand string, mountCM string) (*kappsv1.DaemonSet, error) {
+	var volumesDefaultMode int32 = 444
+	var hostPathType kapiv1.HostPathType = kapiv1.HostPathDirectoryOrCreate
+	return util.CreateDS(c, namespace, name, command, readinessCommand,
+		[]kapiv1.VolumeMount{
+			{Name: "allowlist", MountPath: "/allowlist"},
+			{Name: "tuningdir", MountPath: "/host", ReadOnly: false},
+		},
+		[]kapiv1.Volume{
+			{Name: "allowlist", VolumeSource: kapiv1.VolumeSource{ConfigMap: &kapiv1.ConfigMapVolumeSource{LocalObjectReference: kapiv1.LocalObjectReference{Name: mountCM}, DefaultMode: &volumesDefaultMode}}},
+			{Name: "tuningdir", VolumeSource: kapiv1.VolumeSource{HostPath: &kapiv1.HostPathVolumeSource{Path: "/etc/cni/tuning/", Type: &hostPathType}}},
+		},
+	)
+}
+
+func createTuningNad(config *rest.Config, namespace string, nadName string, sysctls map[string]string) error {
+	sysctlString := ""
+	first := true
+	for sysctl, value := range sysctls {
+		if first {
+			first = false
+		} else {
+			sysctlString = sysctlString + ","
+		}
+		sysctlString = sysctlString + fmt.Sprintf("\"%s\":\"%s\"", sysctl, value)
+	}
+	nadConfig := fmt.Sprintf(`{"cniVersion":"0.4.0","name":"%s","plugins":[{"type":"bridge","bridge":"tunbr","ipam":{"type":"static","addresses":[{"address":"10.10.0.1/24"}]}},{"type":"tuning","sysctl":{%s}}]}`, nadName, sysctlString)
+	return util.CreateNetworkAttachmentDefinition(config, namespace, TuningNadName, nadConfig)
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2541,6 +2541,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:Whereabouts] should use whereabouts net-attach-def to limit IP ranges for newly created pods": "should use whereabouts net-attach-def to limit IP ranges for newly created pods [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network][Feature:tuning] pod should start for each sysctl on whitelist net.ipv4.conf.IFNAME.arp_filter": "net.ipv4.conf.IFNAME.arp_filter [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network][endpoints] admission blocks manual creation of EndpointSlices pointing to the cluster or service network": "blocks manual creation of EndpointSlices pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][endpoints] admission blocks manual creation of Endpoints pointing to the cluster or service network": "blocks manual creation of Endpoints pointing to the cluster or service network [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/ds.go
+++ b/test/extended/util/ds.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"time"
+
+	kappsv1 "k8s.io/api/apps/v1"
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclientset "k8s.io/client-go/kubernetes"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+func CreateDS(c kclientset.Interface, namespace string, name string, command string, readinessCommand string, vms []kapiv1.VolumeMount, volumes []kapiv1.Volume) (*kappsv1.DaemonSet, error) {
+	privileged := true
+	var graceTime int64 = 0
+	ds, err := c.AppsV1().DaemonSets(namespace).Create(context.TODO(), &kappsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kappsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"resolve": "true"},
+			},
+			Template: kapiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"resolve": "true"},
+				},
+				Spec: kapiv1.PodSpec{
+					TerminationGracePeriodSeconds: &graceTime,
+					Containers: []kapiv1.Container{
+						{
+							Name:    name,
+							Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+							Command: []string{"/bin/bash", "-c", command},
+							ReadinessProbe: &kapiv1.Probe{
+								ProbeHandler: kapiv1.ProbeHandler{Exec: &kapiv1.ExecAction{Command: []string{"/bin/bash", "-c", readinessCommand}}},
+							},
+							SecurityContext: &kapiv1.SecurityContext{Privileged: &privileged},
+							VolumeMounts:    vms,
+						},
+					},
+					Volumes: volumes,
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	return ds, err
+}
+
+func WaitForDSRunning(c kclientset.Interface, namespace string, name string) error {
+	return wait.Poll(200*time.Millisecond, 3*time.Minute, func() (bool, error) {
+		daemonset, err := c.AppsV1().DaemonSets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return daemonset.Status.NumberReady == daemonset.Status.DesiredNumberScheduled, nil
+	})
+}

--- a/test/extended/util/network.go
+++ b/test/extended/util/network.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+func CreateNetworkAttachmentDefinition(config *rest.Config, namespace string, name string, nadConfig string) error {
+	nadClient, err := networkAttachmentDefinitionClient(config)
+	if err != nil {
+		return err
+	}
+	networkAttachmentDefintion := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "k8s.cni.cncf.io/v1",
+			"kind":       "NetworkAttachmentDefinition",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"config": nadConfig,
+			},
+		},
+	}
+	_, err = nadClient.Namespace(namespace).Create(context.TODO(), networkAttachmentDefintion, metav1.CreateOptions{})
+	return err
+}
+
+func networkAttachmentDefinitionClient(config *rest.Config) (dynamic.NamespaceableResourceInterface, error) {
+	dynClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	nadGVR := schema.GroupVersionResource{
+		Group:    "k8s.cni.cncf.io",
+		Version:  "v1",
+		Resource: "network-attachment-definitions",
+	}
+	nadClient := dynClient.Resource(nadGVR)
+	return nadClient, nil
+}

--- a/test/extended/util/rbac.go
+++ b/test/extended/util/rbac.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"context"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclientset "k8s.io/client-go/kubernetes"
+)
+
+func CreateRole(c kclientset.Interface, namespace string, name string) error {
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				ResourceNames: []string{"privileged"},
+				Resources:     []string{"securitycontextconstraints"},
+				Verbs:         []string{"use"},
+			},
+		}}
+	_, err := c.RbacV1().Roles(namespace).Create(context.Background(), role, metav1.CreateOptions{})
+	return err
+}
+
+func CreateRoleBinding(c kclientset.Interface, namespace string, name string) error {
+	roleBinding := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		RoleRef: rbacv1.RoleRef{
+			Name:     name,
+			Kind:     "Role",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "ServiceAccount",
+				Name: "default",
+			},
+		},
+	}
+	_, err := c.RbacV1().RoleBindings(namespace).Create(context.Background(), roleBinding, metav1.CreateOptions{})
+	return err
+}


### PR DESCRIPTION
This PR adds the first test for the tuning-cni metaplugin sysctl whitelist feature.

The tuning-cni allows to set sysctl on the created container. The sysctls can be restricted by specifying a predefined whitelist of sysctls on each node. The PR for this was already merged upstream: [U/S PR693](https://github.com/containernetworking/plugins/pull/693)
Support for this feature is requested for 4.11.

Note: this PR must wait until the u/s tuning cni changes are merged d/s. The d/s tuning cni does not have the required features yet