### PR TITLE
Best matcher single node OVN

### DIFF
--- a/pkg/synthetictests/allowedbackenddisruption/matches_test.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches_test.go
@@ -60,6 +60,38 @@ func TestGetClosestP95Value(t *testing.T) {
 			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"ingress-to-oauth-server-reused-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.11", Platform:"azure", Architecture:"amd64", Network:"sdn", Topology:"ha"}}, fell back to historicaldata.DataKey{Name:"ingress-to-oauth-server-reused-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.10", Platform:"azure", Architecture:"amd64", Network:"sdn", Topology:"ha"}})`,
 		},
 		{
+			name: "fuzzy-match-single-ovn-on-sdn",
+			args: args{
+				backendName: "image-registry-reused-connections",
+				jobType: platformidentification.JobType{
+					Release:      "4.10",
+					FromRelease:  "4.10",
+					Platform:     "aws",
+					Network:      "ovn",
+					Architecture: "amd64",
+					Topology:     "single",
+				},
+			},
+			expectedDuration: mustDuration("261.2s"),
+			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"image-registry-reused-connections", JobType:platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"aws", Architecture:"amd64", Network:"ovn", Topology:"single"}}, fell back to historicaldata.DataKey{Name:"image-registry-reused-connections", JobType:platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"aws", Architecture:"amd64", Network:"sdn", Topology:"single"}})`,
+		},
+		{
+			name: "fuzzy-match-single-ovn-on-sdn-previous",
+			args: args{
+				backendName: "image-registry-new-connections",
+				jobType: platformidentification.JobType{
+					Release:      "4.11",
+					FromRelease:  "4.11",
+					Platform:     "aws",
+					Network:      "ovn",
+					Architecture: "amd64",
+					Topology:     "single",
+				},
+			},
+			expectedDuration: mustDuration("263.3s"),
+			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"image-registry-new-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.11", Platform:"aws", Architecture:"amd64", Network:"ovn", Topology:"single"}}, fell back to historicaldata.DataKey{Name:"image-registry-new-connections", JobType:platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"aws", Architecture:"amd64", Network:"sdn", Topology:"single"}})`,
+		},
+		{
 			name: "missing",
 			args: args{
 				backendName: "kube-api-reused-connections",

--- a/pkg/synthetictests/historicaldata/next_best_guess.go
+++ b/pkg/synthetictests/historicaldata/next_best_guess.go
@@ -46,6 +46,9 @@ var nextBestGuessers = []NextBestKey{
 	combine(OnArchitecture("ppc64le"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
 	combine(OnArchitecture("s390x"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
 	combine(OnArchitecture("arm64"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
+
+	combine(ForTopology("single"), OnSDN),
+	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade),
 }
 
 // NextBestKey returns the next best key in the query_results.json generated from BigQuery and a bool indicating whether this guesser has an opinion.
@@ -156,6 +159,16 @@ func OnArchitecture(architecture string) func(in platformidentification.JobType)
 		ret := platformidentification.CloneJobType(in)
 		ret.Architecture = architecture
 		return ret, true
+	}
+}
+
+// ForTopology we match on exact topology
+func ForTopology(topology string) func(in platformidentification.JobType) (platformidentification.JobType, bool) {
+	return func(in platformidentification.JobType) (platformidentification.JobType, bool) {
+		if in.Topology != topology {
+			return platformidentification.JobType{}, false
+		}
+		return in, true
 	}
 }
 


### PR DESCRIPTION
SNO disruption tests for OVN will fail due to stricter fuzzy matching on P99 historical duration data, this PR opens the fuzzy matching to allow SDN historical data to be used on OVN cluster tests.

Signed-off-by: ehila <ehila@redhat.com>