### PR TITLE
Implementation for basic egressfw e2e CI test

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -1,0 +1,191 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
+
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+)
+
+const (
+	egressFWTestPod      = "egressfirewall"
+	egressFWE2E          = "egress-firewall-e2e"
+	noEgressFWE2E        = "no-egress-firewall-e2e"
+	egressFWTestImage    = "quay.io/redhat-developer/nfs-server:1.1"
+	oVNKManifest         = "ovnk-egressfirewall-test.yaml"
+	openShiftSDNManifest = "sdn-egressnetworkpolicy-test.yaml"
+)
+
+var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
+
+	egFwoc := exutil.NewCLI(egressFWE2E)
+	egFwf := egFwoc.KubeFramework()
+
+	// The OVNKubernetes subnet plugin supports EgressFirewall objects.
+	InOVNKubernetesContext(
+		func() {
+			g.It("Should ensure egressfirewall is created", func() {
+				doEgressFwTest(egFwf, egFwoc, oVNKManifest)
+			})
+		},
+	)
+	// For Openshift SDN its supports EgressNetworkPolicy objects
+	InOpenShiftSDNContext(
+		func() {
+			g.It("Should ensure egressnetworkpolicy is created", func() {
+				doEgressFwTest(egFwf, egFwoc, openShiftSDNManifest)
+			})
+		},
+	)
+	noegFwoc := exutil.NewCLI(noEgressFWE2E)
+	noegFwf := noegFwoc.KubeFramework()
+	g.It("EgressFirewall should have no impact outside its namespace", func() {
+		g.By("Creating test pod")
+		pod := "dummy"
+		o.Expect(createTestEgressFw(noegFwf, pod)).To(o.Succeed())
+		g.By("Sending traffic should all pass with no egress firewall impact")
+		infra, err := noegFwoc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
+
+		if platformSupportICMP(infra.Status.PlatformStatus.Type) {
+			_, err := noegFwoc.Run("exec").Args(pod, "--", "ping", "-c", "1", "8.8.8.8").Output()
+			expectNoError(err)
+
+			_, err = noegFwoc.Run("exec").Args(pod, "--", "ping", "-c", "1", "1.1.1.1").Output()
+			expectNoError(err)
+		}
+		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m1", "https://docs.openshift.com").Output()
+		expectNoError(err)
+
+		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m1", "http://www.google.com:80").Output()
+		expectNoError(err)
+
+	})
+})
+
+func doEgressFwTest(f *e2e.Framework, oc *exutil.CLI, manifest string) error {
+	g.By("Creating test pod")
+	o.Expect(createTestEgressFw(f, egressFWTestPod)).To(o.Succeed())
+
+	g.By("Creating an egressfirewall object")
+	egFwYaml := exutil.FixturePath("testdata", "egress-firewall", manifest)
+
+	g.By(fmt.Sprintf("Calling oc create -f %s", egFwYaml))
+	err := oc.AsAdmin().Run("create").Args("-f", egFwYaml).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "created egress-firewall object")
+
+	o.Expect(sendEgressFwTraffic(f, oc, egressFWTestPod)).To(o.Succeed())
+
+	g.By("Deleting test pod")
+	deleteTestEgressFw(f)
+	return err
+}
+
+func sendEgressFwTraffic(f *e2e.Framework, oc *exutil.CLI, pod string) error {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
+
+	if platformSupportICMP(infra.Status.PlatformStatus.Type) {
+		// Test ICMP / Ping to Google’s DNS IP (8.8.8.8) should pass
+		// because we have allow cidr rule for 8.8.8.8
+		g.By("Sending traffic that matches allow cidr rule")
+		_, err := oc.Run("exec").Args(pod, "--", "ping", "-c", "1", "8.8.8.8").Output()
+		expectNoError(err)
+
+		// Test ICMP / Ping to Cloudfare DNS IP (1.1.1.1) should fail
+		// because there is no allow cidr match for 1.1.1.1
+		g.By("Sending traffic that does not match allow cidr rule")
+		_, err = oc.Run("exec").Args(pod, "--", "ping", "-c", "1", "1.1.1.1").Output()
+		expectError(err)
+	}
+	// Test curl to docs.openshift.com should pass
+	// because we have allow dns rule for docs.openshift.com
+	g.By("Sending traffic that matches allow dns rule")
+	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m1", "https://docs.openshift.com").Output()
+	expectNoError(err)
+
+	// Test curl to www.google.com:80 should fail
+	// because we don't have allow dns rule for www.google.com:80
+	g.By("Sending traffic that does not match allow dns rule")
+	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m1", "http://www.google.com:80").Output()
+	expectError(err)
+	return nil
+}
+
+func createTestEgressFw(f *e2e.Framework, pod string) error {
+	makeNamespaceScheduleToAllNodes(f)
+
+	var nodes *kapiv1.Node
+	var err error
+	nodes, _, err = findAppropriateNodes(f, DIFFERENT_NODE)
+	if err != nil {
+		return err
+	}
+	err = launchTestEgressFwPod(f, nodes.Name, pod)
+	expectNoError(err)
+
+	_, err = waitForTestEgressFwPod(f, pod)
+	expectNoError(err)
+	return nil
+}
+
+func deleteTestEgressFw(f *e2e.Framework) error {
+	var zero int64
+	pod := egressFWTestPod
+	err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.Background(), pod, metav1.DeleteOptions{GracePeriodSeconds: &zero})
+	return err
+}
+
+func launchTestEgressFwPod(f *e2e.Framework, nodeName string, podName string) error {
+	contName := fmt.Sprintf("%s-container", podName)
+	pod := &kapiv1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+		},
+		Spec: kapiv1.PodSpec{
+			Containers: []kapiv1.Container{
+				{
+					Name:    contName,
+					Image:   image.LocationFor(egressFWTestImage),
+					Command: []string{"sleep", "1000"},
+				},
+			},
+			NodeName:      nodeName,
+			RestartPolicy: kapiv1.RestartPolicyNever,
+		},
+	}
+	_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.Background(), pod, metav1.CreateOptions{})
+	return err
+}
+
+func waitForTestEgressFwPod(f *e2e.Framework, podName string) (string, error) {
+	podIP := ""
+	err := frameworkpod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, podName, "running", podStartTimeout, func(pod *kapiv1.Pod) (bool, error) {
+		podIP = pod.Status.PodIP
+		return (podIP != "" && pod.Status.Phase != kapiv1.PodPending), nil
+	})
+	return podIP, err
+}
+
+func platformSupportICMP(platformType configv1.PlatformType) bool {
+	switch platformType {
+	// Azure has secuirty rules to prevent icmp response from outside the cluster by default
+	case configv1.AzurePlatformType:
+		return false
+	default:
+		return true
+	}
+}

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -49,7 +49,7 @@ const (
 	DIFFERENT_NODE NodeType = iota
 
 	// TODO get these defined as constandts in networkutils
-	openshiftSDNPluginName  = "OpenshiftSDN"
+	openshiftSDNPluginName  = "OpenShiftSDN"
 	OVNKubernetesPluginName = "OVNKubernetes"
 )
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -313,6 +313,8 @@
 // test/extended/testdata/deployments/tag-images-deployment.yaml
 // test/extended/testdata/deployments/test-deployment-broken.yaml
 // test/extended/testdata/deployments/test-deployment-test.yaml
+// test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+// test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
 // test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml
 // test/extended/testdata/egress-router-cni/egress-router-cni-v6-cr.yaml
 // test/extended/testdata/forcepull-test.json
@@ -41557,6 +41559,76 @@ func testExtendedTestdataDeploymentsTestDeploymentTestYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml = []byte(`apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+spec:
+  egress:
+  - type: Allow
+    to:
+      dnsName: docs.openshift.com
+  - type: Deny
+    to:
+      dnsName: www.google.com
+    ports:
+    - port: 80
+      protocol: TCP
+  - type: Allow
+    to:
+      cidrSelector: 8.8.8.8/32
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0
+`)
+
+func testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml, nil
+}
+
+func testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYaml = []byte(`apiVersion: network.openshift.io/v1
+kind: EgressNetworkPolicy
+metadata:
+  name: default
+spec:
+  egress:
+  - type: Allow
+    to:
+      dnsName: docs.openshift.com
+  - type: Allow
+    to:
+      cidrSelector: 8.8.8.8/32
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0
+`)
+
+func testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYaml, nil
+}
+
+func testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml = []byte(`---
 apiVersion: network.operator.openshift.io/v1
 kind: EgressRouter
@@ -52850,6 +52922,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/deployments/tag-images-deployment.yaml":                                          testExtendedTestdataDeploymentsTagImagesDeploymentYaml,
 	"test/extended/testdata/deployments/test-deployment-broken.yaml":                                         testExtendedTestdataDeploymentsTestDeploymentBrokenYaml,
 	"test/extended/testdata/deployments/test-deployment-test.yaml":                                           testExtendedTestdataDeploymentsTestDeploymentTestYaml,
+	"test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml":                                   testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml,
+	"test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml":                               testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYaml,
 	"test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml":                                  testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml,
 	"test/extended/testdata/egress-router-cni/egress-router-cni-v6-cr.yaml":                                  testExtendedTestdataEgressRouterCniEgressRouterCniV6CrYaml,
 	"test/extended/testdata/forcepull-test.json":                                                             testExtendedTestdataForcepullTestJson,
@@ -53525,6 +53599,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"tag-images-deployment.yaml":          {testExtendedTestdataDeploymentsTagImagesDeploymentYaml, map[string]*bintree{}},
 					"test-deployment-broken.yaml":         {testExtendedTestdataDeploymentsTestDeploymentBrokenYaml, map[string]*bintree{}},
 					"test-deployment-test.yaml":           {testExtendedTestdataDeploymentsTestDeploymentTestYaml, map[string]*bintree{}},
+				}},
+				"egress-firewall": {nil, map[string]*bintree{
+					"ovnk-egressfirewall-test.yaml":     {testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml, map[string]*bintree{}},
+					"sdn-egressnetworkpolicy-test.yaml": {testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYaml, map[string]*bintree{}},
 				}},
 				"egress-router-cni": {nil, map[string]*bintree{
 					"egress-router-cni-v4-cr.yaml": {testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml, map[string]*bintree{}},

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+spec:
+  egress:
+  - type: Allow
+    to:
+      dnsName: docs.openshift.com
+  - type: Deny
+    to:
+      dnsName: www.google.com
+    ports:
+    - port: 80
+      protocol: TCP
+  - type: Allow
+    to:
+      cidrSelector: 8.8.8.8/32
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0

--- a/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
+++ b/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: network.openshift.io/v1
+kind: EgressNetworkPolicy
+metadata:
+  name: default
+spec:
+  egress:
+  - type: Allow
+    to:
+      dnsName: docs.openshift.com
+  - type: Allow
+    to:
+      cidrSelector: 8.8.8.8/32
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2491,6 +2491,12 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services when using OpenshiftSDN in a mode that isolates namespaces by default should prevent connections to pods in different namespaces on the same node via service IPs": "should prevent connections to pods in different namespaces on the same node via service IPs [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network][Feature:EgressFirewall] EgressFirewall should have no impact outside its namespace": "EgressFirewall should have no impact outside its namespace [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift ovn-kubernetes Should ensure egressfirewall is created": "Should ensure egressfirewall is created [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift-sdn Should ensure egressnetworkpolicy is created": "Should ensure egressnetworkpolicy is created [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created": "should ensure ipv4 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created": "should ensure ipv6 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
re Adding basic EgressFw CI test with platform check to control on which platform CI can run ping tests

To manually run this test on ovnk cluster
```
./openshift-tests run-test "[sig-network][Feature:EgressFirewall] when using openshift ovn-kubernetes Should ensure egressfirewall is created [Suite:openshift/conformance/parallel]"
```
To manually run this test on openshift-sdn cluster
```
./openshift-tests run-test "[sig-network][Feature:EgressFirewall] when using openshift-sdn Should ensure egressnetworkpolicy is created [Suite:openshift/conformance/parallel]"
```
To run traffic in different name space
```
./openshift-tests run-test "[sig-network][Feature:EgressFirewall] EgressFirewall should have no impact outside its namespace [Suite:openshift/conformance/parallel]"
```