### PR TITLE
Bug 1996883: Increasing log level to support decrease in default buildah log level

### DIFF
--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -58,7 +58,14 @@ COPY --from=%[2]s /bin/ping /test/
 						},
 					},
 					Strategy: buildv1.BuildStrategy{
-						DockerStrategy: &buildv1.DockerBuildStrategy{},
+						DockerStrategy: &buildv1.DockerBuildStrategy{
+							Env: []corev1.EnvVar{
+								{
+									Name:  "BUILD_LOGLEVEL",
+									Value: "2",
+								},
+							},
+						},
 					},
 					Output: buildv1.BuildOutput{
 						To: &corev1.ObjectReference{
@@ -82,7 +89,7 @@ COPY --from=%[2]s /bin/ping /test/
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(s).ToNot(o.ContainSubstring("--> FROM scratch"))
 		o.Expect(s).ToNot(o.ContainSubstring("FROM busybox"))
-		o.Expect(s).To(o.MatchRegexp("(\\[1/2\\] STEP 1/2|STEP 1): FROM %s AS test", regexp.QuoteMeta(image.ShellImage())))
+		o.Expect(s).To(o.MatchRegexp("(\\[1/2\\] STEP 1/3|STEP 1/2|STEP 1): FROM %s AS test", regexp.QuoteMeta(image.ShellImage())))
 		o.Expect(s).To(o.ContainSubstring("COPY --from"))
 		o.Expect(s).To(o.ContainSubstring("\"OPENSHIFT_BUILD_NAMESPACE\"=\"%s\"", oc.Namespace()))
 		e2e.Logf("Build logs:\n%s", result)

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -8,6 +8,7 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
@@ -56,6 +57,12 @@ USER 1001
 						Strategy: buildv1.BuildStrategy{
 							DockerStrategy: &buildv1.DockerBuildStrategy{
 								ImageOptimizationPolicy: &skipLayers,
+								Env: []corev1.EnvVar{
+									{
+										Name:  "BUILD_LOGLEVEL",
+										Value: "2",
+									},
+								},
 							},
 						},
 					},

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17215,6 +17215,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
         from:
           kind: DockerImage
           name: quay.io/redhat-developer/test-build-simples2i:1.2
@@ -17354,6 +17357,8 @@ spec:
     type: Source
     sourceStrategy:
       env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
         - name: FIELDREF_ENV
           valueFrom:
             fieldRef:
@@ -17395,6 +17400,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+      - name: "BUILD_LOGLEVEL"
+        value: "2"
       from:
         kind: DockerImage
         name: registry.redhat.io/ubi8/php-74:latest
@@ -17481,7 +17489,10 @@ spec:
       FROM image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
       RUN touch /php-file
   strategy:
-    dockerStrategy: {}`)
+    dockerStrategy:
+      env:
+      - name: "BUILD_LOGLEVEL"
+        value: "2"`)
 
 func testExtendedTestdataBuildsBuildPruningSuccessfulBuildConfigYamlBytes() ([]byte, error) {
 	return _testExtendedTestdataBuildsBuildPruningSuccessfulBuildConfigYaml, nil
@@ -18696,6 +18707,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+      - name: "BUILD_LOGLEVEL"
+        value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/nodejs:latest
@@ -18866,6 +18880,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+      - name: "BUILD_LOGLEVEL"
+        value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
@@ -18997,6 +19014,9 @@ spec:
   strategy:
     type: Docker
     dockerStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
@@ -19028,6 +19048,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
@@ -19059,6 +19082,7 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
@@ -19066,6 +19090,8 @@ spec:
       env:
         - name: http_proxy
           value: "http://%"
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
 `)
 
 func testExtendedTestdataBuildsStatusfailGenericreasonYamlBytes() ([]byte, error) {
@@ -19097,6 +19123,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
@@ -19131,6 +19160,9 @@ spec:
       - failme
   strategy:
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: quay.io/redhat-developer/test-build-simples2i:1.2
@@ -19167,6 +19199,9 @@ spec:
       name: bogus.registry/image
   strategy:
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: quay.io/redhat-developer/test-build-simples2i:1.2
@@ -19270,6 +19305,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: python:latest
@@ -19292,6 +19330,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: DockerImage
           name: registry.redhat.io/ubi8/python-36:latest
@@ -19543,6 +19584,8 @@ items:
           value: 127.0.0.1:3128
         - name: HTTP_PROXY
           value: 127.0.0.1:3128
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
         from:
           kind: DockerImage
           name: quay.io/redhat-developer/test-build-simples2i:1.2
@@ -19573,6 +19616,8 @@ items:
           value: https://envuser:password@proxy3.com
         - name: SOME_HTTPS_PROXY
           value: https://envuser:password@proxy4.com
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -19600,6 +19645,8 @@ items:
           value: https://envuser:password@proxy3.com
         - name: SOME_HTTPS_PROXY
           value: https://envuser:password@proxy4.com
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
 - kind: BuildConfig
   apiVersion: build.openshift.io/v1
   metadata:
@@ -19612,6 +19659,9 @@ items:
         RUN cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     strategy:
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: cli
@@ -19634,42 +19684,51 @@ func testExtendedTestdataBuildsTestBuildProxyYaml() (*asset, error) {
 }
 
 var _testExtendedTestdataBuildsTestBuildRevisionJson = []byte(`{
-  "kind": "List",
-  "apiVersion": "v1",
-  "metadata": {},
-  "items": [
-    {
-      "kind": "BuildConfig",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "sample-build",
-        "creationTimestamp": null
-      },
-      "spec": {
-        "source": {
-          "type": "Git",
-          "git": {
-            "uri": "https://github.com/openshift/ruby-hello-world.git"
-          }
+  "kind":"List",
+  "apiVersion":"v1",
+  "metadata":{
+     
+  },
+  "items":[
+     {
+        "kind":"BuildConfig",
+        "apiVersion":"v1",
+        "metadata":{
+           "name":"sample-build",
+           "creationTimestamp":null
         },
-        "strategy": {
-          "type": "Source",
-          "sourceStrategy": {
-            "from": {
-              "kind": "DockerImage",
-              "name": "quay.io/redhat-developer/test-build-simples2i:1.2"
-            }
-          }
+        "spec":{
+           "source":{
+              "type":"Git",
+              "git":{
+                 "uri":"https://github.com/openshift/ruby-hello-world.git"
+              }
+           },
+           "strategy":{
+              "type":"Source",
+              "sourceStrategy":{
+                 "env":[
+                    {
+                       "name":"BUILD_LOGLEVEL",
+                       "value":"2"
+                    }
+                 ],
+                 "from":{
+                    "kind":"DockerImage",
+                    "name":"quay.io/redhat-developer/test-build-simples2i:1.2"
+                 }
+              }
+           },
+           "resources":{
+              
+           }
         },
-        "resources": {}
-      },
-      "status": {
-        "lastVersion": 0
-      }
-    }
+        "status":{
+           "lastVersion":0
+        }
+     }
   ]
-}
-`)
+}`)
 
 func testExtendedTestdataBuildsTestBuildRevisionJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataBuildsTestBuildRevisionJson, nil
@@ -19906,6 +19965,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: DockerImage
           name: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
@@ -19932,6 +19994,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: DockerImage
           name: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
@@ -20002,6 +20067,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStream
           name: test
@@ -20032,6 +20100,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStream
           name: test
@@ -20083,6 +20154,12 @@ var _testExtendedTestdataBuildsTestCdsDockerbuildJson = []byte(`{
     "strategy":{
       "type":"Docker",
       "dockerStrategy":{
+        "env":[
+          {
+             "name":"BUILD_LOGLEVEL",
+             "value":"2"
+          }
+        ],
         "from":{
           "kind":"DockerImage",
           "name":"image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
@@ -20140,6 +20217,12 @@ var _testExtendedTestdataBuildsTestCdsSourcebuildJson = []byte(`{
         "strategy": {
           "type": "Source",
           "sourceStrategy": {
+            "env":[
+              {
+                 "name":"BUILD_LOGLEVEL",
+                 "value":"2"
+              }
+           ],
             "from": {
               "kind": "DockerImage",
               "name": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
@@ -20356,6 +20439,9 @@ items:
     strategy:
       type: Custom
       customStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         forcePull: true
         from:
           kind: ImageStreamTag
@@ -20431,6 +20517,12 @@ var _testExtendedTestdataBuildsTestDockerBuildPullsecretJson = []byte(`{
       "strategy": {
         "type": "Docker",
         "dockerStrategy": {
+          "env":[
+            {
+               "name":"BUILD_LOGLEVEL",
+               "value":"2"
+            }
+         ],
           "from": {
             "kind": "DockerImage",
             "name": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
@@ -20461,6 +20553,12 @@ var _testExtendedTestdataBuildsTestDockerBuildPullsecretJson = []byte(`{
       "strategy": {
         "type": "Docker",
         "dockerStrategy": {
+          "env":[
+            {
+               "name":"BUILD_LOGLEVEL",
+               "value":"2"
+            }
+         ],
           "from": {
             "kind": "ImageStreamTag",
             "name": "image1:latest"
@@ -20492,51 +20590,58 @@ var _testExtendedTestdataBuildsTestDockerBuildJson = []byte(`{
   "kind":"BuildConfig",
   "apiVersion":"v1",
   "metadata":{
-    "name":"test",
-    "labels":{
-      "name":"test"
-    }
+     "name":"test",
+     "labels":{
+        "name":"test"
+     }
   },
   "spec":{
-    "triggers":[],
-    "source":{
-      "git": {
-        "uri":"https://github.com/sclorg/nodejs-ex"        
-      },
-      "dockerfile": "FROM image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
-    },
-    "strategy":{
-      "type":"Docker",
-      "dockerStrategy":{
-        "from":{
-          "kind":"DockerImage",
-          "name":"image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
-        }
-      }
-    },
-    "output":{
-      "to":{
-        "kind":"ImageStreamTag",
-        "name":"test:latest"
-      },
-      "imageLabels": [
-        {
-          "name": "user-specified-label",
-          "value": "arbitrary-value"
+     "triggers":[
+        
+     ],
+     "source":{
+        "git":{
+           "uri":"https://github.com/sclorg/nodejs-ex"
         },
-        {
-          "name": "io.k8s.display-name",
-          "value": "overridden"
-        },
-        {
-          "name": "io.openshift.builder-version",
-          "value": "overridden2"
+        "dockerfile":"FROM image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
+     },
+     "strategy":{
+        "type":"Docker",
+        "dockerStrategy":{
+           "env":[
+              {
+                 "name":"BUILD_LOGLEVEL",
+                 "value":"2"
+              }
+           ],
+           "from":{
+              "kind":"DockerImage",
+              "name":"image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
+           }
         }
-      ]
-    }
+     },
+     "output":{
+        "to":{
+           "kind":"ImageStreamTag",
+           "name":"test:latest"
+        },
+        "imageLabels":[
+           {
+              "name":"user-specified-label",
+              "value":"arbitrary-value"
+           },
+           {
+              "name":"io.k8s.display-name",
+              "value":"overridden"
+           },
+           {
+              "name":"io.openshift.builder-version",
+              "value":"overridden2"
+           }
+        ]
+     }
   }
-}
-`)
+}`)
 
 func testExtendedTestdataBuildsTestDockerBuildJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataBuildsTestDockerBuildJson, nil
@@ -20618,6 +20723,12 @@ var _testExtendedTestdataBuildsTestEnvBuildJson = []byte(`{
     "strategy":{
       "type":"Source",
       "sourceStrategy":{
+        "env":[
+          {
+             "name":"BUILD_LOGLEVEL",
+             "value":"2"
+          }
+       ],
         "from":{
           "kind":"DockerImage",
           "name":"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
@@ -20706,6 +20817,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: nodejs-ex:latest
@@ -20727,6 +20841,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: nodejs-ex:latest
@@ -20745,6 +20862,9 @@ items:
     strategy:
       type: Custom
       customStrategy:
+        env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
         from:
           kind: ImageStreamTag
           name: nodejs-ex:latest
@@ -20763,6 +20883,9 @@ items:
     strategy:
       type: Jenkins
       jenkinsPipelineStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         jenkinsfile: node {}
     triggers:
     - type: ImageChange
@@ -20951,6 +21074,9 @@ items:
             ln -s ../../rh/6/root/usr/bin /opt/app-root/test-links/bin
     strategy:
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: ruby:2.7-ubi8
@@ -21010,7 +21136,10 @@ items:
         - destinationDir: injected/usr/bin
           sourcePath: /usr/bin/ruby
     strategy:
-      dockerStrategy: {}
+      dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
 
 - apiVersion: v1
   kind: ImageStream
@@ -21164,6 +21293,12 @@ var _testExtendedTestdataBuildsTestNosrcBuildJson = []byte(`{
         "strategy": {
           "type": "Source",
           "sourceStrategy": {
+            "env":[
+              {
+                 "name":"BUILD_LOGLEVEL",
+                 "value":"2"
+              }
+           ],
             "from": {
               "kind": "DockerImage",
               "name": "quay.io/redhat-developer/test-build-simples2i:1.2"
@@ -21386,6 +21521,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: nodejs:latest
@@ -21853,6 +21991,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: quay.io/redhat-developer/test-build-simples2i:1.2
@@ -22245,6 +22386,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: quay.io/redhat-developer/test-build-simples2i:1.2
@@ -50387,6 +50531,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: DockerImage
           name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
@@ -51655,6 +51802,12 @@ var _testExtendedTestdataTestBuildcliJson = []byte(`{
           "strategy": {
             "type": "Source",
             "sourceStrategy": {
+              "env":[
+                {
+                   "name":"BUILD_LOGLEVEL",
+                   "value":"2"
+                }
+             ],
               "from": {
                 "kind": "DockerImage",
                 "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby"
@@ -51697,6 +51850,12 @@ var _testExtendedTestdataTestBuildcliJson = []byte(`{
           "strategy": {
             "type": "Source",
             "sourceStrategy": {
+              "env":[
+                {
+                   "name":"BUILD_LOGLEVEL",
+                   "value":"2"
+                }
+             ],
               "from": {
                 "kind": "DockerImage",
                 "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby"

--- a/test/extended/testdata/builds/build-postcommit/sti.yaml
+++ b/test/extended/testdata/builds/build-postcommit/sti.yaml
@@ -18,6 +18,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
         from:
           kind: DockerImage
           name: quay.io/redhat-developer/test-build-simples2i:1.2

--- a/test/extended/testdata/builds/build-pruning/errored-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/errored-build-config.yaml
@@ -13,6 +13,8 @@ spec:
     type: Source
     sourceStrategy:
       env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
         - name: FIELDREF_ENV
           valueFrom:
             fieldRef:

--- a/test/extended/testdata/builds/build-pruning/failed-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/failed-build-config.yaml
@@ -15,6 +15,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+      - name: "BUILD_LOGLEVEL"
+        value: "2"
       from:
         kind: DockerImage
         name: registry.redhat.io/ubi8/php-74:latest

--- a/test/extended/testdata/builds/build-pruning/successful-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/successful-build-config.yaml
@@ -13,4 +13,7 @@ spec:
       FROM image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
       RUN touch /php-file
   strategy:
-    dockerStrategy: {}
+    dockerStrategy:
+      env:
+      - name: "BUILD_LOGLEVEL"
+        value: "2"

--- a/test/extended/testdata/builds/pullsecret/linked-nodejs-bc.yaml
+++ b/test/extended/testdata/builds/pullsecret/linked-nodejs-bc.yaml
@@ -9,6 +9,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+      - name: "BUILD_LOGLEVEL"
+        value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/nodejs:latest

--- a/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
+++ b/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
@@ -10,6 +10,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+      - name: "BUILD_LOGLEVEL"
+        value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
@@ -9,6 +9,9 @@ spec:
   strategy:
     type: Docker
     dockerStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
@@ -9,6 +9,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8

--- a/test/extended/testdata/builds/statusfail-genericreason.yaml
+++ b/test/extended/testdata/builds/statusfail-genericreason.yaml
@@ -9,6 +9,7 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
@@ -16,3 +17,5 @@ spec:
       env:
         - name: http_proxy
           value: "http://%"
+        - name: "BUILD_LOGLEVEL"
+          value: "2"

--- a/test/extended/testdata/builds/statusfail-oomkilled.yaml
+++ b/test/extended/testdata/builds/statusfail-oomkilled.yaml
@@ -12,6 +12,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8

--- a/test/extended/testdata/builds/statusfail-postcommithook.yaml
+++ b/test/extended/testdata/builds/statusfail-postcommithook.yaml
@@ -11,6 +11,9 @@ spec:
       - failme
   strategy:
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: quay.io/redhat-developer/test-build-simples2i:1.2

--- a/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
+++ b/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
@@ -13,6 +13,9 @@ spec:
       name: bogus.registry/image
   strategy:
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: quay.io/redhat-developer/test-build-simples2i:1.2

--- a/test/extended/testdata/builds/test-bc-with-pr-ref.yaml
+++ b/test/extended/testdata/builds/test-bc-with-pr-ref.yaml
@@ -22,6 +22,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: python:latest
@@ -44,6 +47,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: DockerImage
           name: registry.redhat.io/ubi8/python-36:latest

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -33,6 +33,8 @@ items:
           value: 127.0.0.1:3128
         - name: HTTP_PROXY
           value: 127.0.0.1:3128
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
         from:
           kind: DockerImage
           name: quay.io/redhat-developer/test-build-simples2i:1.2
@@ -63,6 +65,8 @@ items:
           value: https://envuser:password@proxy3.com
         - name: SOME_HTTPS_PROXY
           value: https://envuser:password@proxy4.com
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -90,6 +94,8 @@ items:
           value: https://envuser:password@proxy3.com
         - name: SOME_HTTPS_PROXY
           value: https://envuser:password@proxy4.com
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
 - kind: BuildConfig
   apiVersion: build.openshift.io/v1
   metadata:
@@ -102,6 +108,9 @@ items:
         RUN cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     strategy:
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: cli

--- a/test/extended/testdata/builds/test-build-revision.json
+++ b/test/extended/testdata/builds/test-build-revision.json
@@ -1,36 +1,46 @@
 {
-  "kind": "List",
-  "apiVersion": "v1",
-  "metadata": {},
-  "items": [
-    {
-      "kind": "BuildConfig",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "sample-build",
-        "creationTimestamp": null
-      },
-      "spec": {
-        "source": {
-          "type": "Git",
-          "git": {
-            "uri": "https://github.com/openshift/ruby-hello-world.git"
-          }
+  "kind":"List",
+  "apiVersion":"v1",
+  "metadata":{
+     
+  },
+  "items":[
+     {
+        "kind":"BuildConfig",
+        "apiVersion":"v1",
+        "metadata":{
+           "name":"sample-build",
+           "creationTimestamp":null
         },
-        "strategy": {
-          "type": "Source",
-          "sourceStrategy": {
-            "from": {
-              "kind": "DockerImage",
-              "name": "quay.io/redhat-developer/test-build-simples2i:1.2"
-            }
-          }
+        "spec":{
+           "source":{
+              "type":"Git",
+              "git":{
+                 "uri":"https://github.com/openshift/ruby-hello-world.git"
+              }
+           },
+           "strategy":{
+              "type":"Source",
+              "sourceStrategy":{
+                 "env":[
+                    {
+                       "name":"BUILD_LOGLEVEL",
+                       "value":"2"
+                    }
+                 ],
+                 "from":{
+                    "kind":"DockerImage",
+                    "name":"quay.io/redhat-developer/test-build-simples2i:1.2"
+                 }
+              }
+           },
+           "resources":{
+              
+           }
         },
-        "resources": {}
-      },
-      "status": {
-        "lastVersion": 0
-      }
-    }
+        "status":{
+           "lastVersion":0
+        }
+     }
   ]
 }

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -186,6 +186,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: DockerImage
           name: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
@@ -212,6 +215,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: DockerImage
           name: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest

--- a/test/extended/testdata/builds/test-buildconfigsecretinjector.yaml
+++ b/test/extended/testdata/builds/test-buildconfigsecretinjector.yaml
@@ -40,6 +40,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStream
           name: test
@@ -70,6 +73,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStream
           name: test

--- a/test/extended/testdata/builds/test-cds-dockerbuild.json
+++ b/test/extended/testdata/builds/test-cds-dockerbuild.json
@@ -14,6 +14,12 @@
     "strategy":{
       "type":"Docker",
       "dockerStrategy":{
+        "env":[
+          {
+             "name":"BUILD_LOGLEVEL",
+             "value":"2"
+          }
+        ],
         "from":{
           "kind":"DockerImage",
           "name":"image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"

--- a/test/extended/testdata/builds/test-cds-sourcebuild.json
+++ b/test/extended/testdata/builds/test-cds-sourcebuild.json
@@ -30,6 +30,12 @@
         "strategy": {
           "type": "Source",
           "sourceStrategy": {
+            "env":[
+              {
+                 "name":"BUILD_LOGLEVEL",
+                 "value":"2"
+              }
+           ],
             "from": {
               "kind": "DockerImage",
               "name": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"

--- a/test/extended/testdata/builds/test-custom-build.yaml
+++ b/test/extended/testdata/builds/test-custom-build.yaml
@@ -17,6 +17,9 @@ items:
     strategy:
       type: Custom
       customStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         forcePull: true
         from:
           kind: ImageStreamTag

--- a/test/extended/testdata/builds/test-docker-build-pullsecret.json
+++ b/test/extended/testdata/builds/test-docker-build-pullsecret.json
@@ -30,6 +30,12 @@
       "strategy": {
         "type": "Docker",
         "dockerStrategy": {
+          "env":[
+            {
+               "name":"BUILD_LOGLEVEL",
+               "value":"2"
+            }
+         ],
           "from": {
             "kind": "DockerImage",
             "name": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
@@ -60,6 +66,12 @@
       "strategy": {
         "type": "Docker",
         "dockerStrategy": {
+          "env":[
+            {
+               "name":"BUILD_LOGLEVEL",
+               "value":"2"
+            }
+         ],
           "from": {
             "kind": "ImageStreamTag",
             "name": "image1:latest"

--- a/test/extended/testdata/builds/test-docker-build.json
+++ b/test/extended/testdata/builds/test-docker-build.json
@@ -2,47 +2,55 @@
   "kind":"BuildConfig",
   "apiVersion":"v1",
   "metadata":{
-    "name":"test",
-    "labels":{
-      "name":"test"
-    }
+     "name":"test",
+     "labels":{
+        "name":"test"
+     }
   },
   "spec":{
-    "triggers":[],
-    "source":{
-      "git": {
-        "uri":"https://github.com/sclorg/nodejs-ex"        
-      },
-      "dockerfile": "FROM image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
-    },
-    "strategy":{
-      "type":"Docker",
-      "dockerStrategy":{
-        "from":{
-          "kind":"DockerImage",
-          "name":"image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
-        }
-      }
-    },
-    "output":{
-      "to":{
-        "kind":"ImageStreamTag",
-        "name":"test:latest"
-      },
-      "imageLabels": [
-        {
-          "name": "user-specified-label",
-          "value": "arbitrary-value"
+     "triggers":[
+        
+     ],
+     "source":{
+        "git":{
+           "uri":"https://github.com/sclorg/nodejs-ex"
         },
-        {
-          "name": "io.k8s.display-name",
-          "value": "overridden"
-        },
-        {
-          "name": "io.openshift.builder-version",
-          "value": "overridden2"
+        "dockerfile":"FROM image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
+     },
+     "strategy":{
+        "type":"Docker",
+        "dockerStrategy":{
+           "env":[
+              {
+                 "name":"BUILD_LOGLEVEL",
+                 "value":"2"
+              }
+           ],
+           "from":{
+              "kind":"DockerImage",
+              "name":"image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
+           }
         }
-      ]
-    }
+     },
+     "output":{
+        "to":{
+           "kind":"ImageStreamTag",
+           "name":"test:latest"
+        },
+        "imageLabels":[
+           {
+              "name":"user-specified-label",
+              "value":"arbitrary-value"
+           },
+           {
+              "name":"io.k8s.display-name",
+              "value":"overridden"
+           },
+           {
+              "name":"io.openshift.builder-version",
+              "value":"overridden2"
+           }
+        ]
+     }
   }
 }

--- a/test/extended/testdata/builds/test-env-build.json
+++ b/test/extended/testdata/builds/test-env-build.json
@@ -15,6 +15,12 @@
     "strategy":{
       "type":"Source",
       "sourceStrategy":{
+        "env":[
+          {
+             "name":"BUILD_LOGLEVEL",
+             "value":"2"
+          }
+       ],
         "from":{
           "kind":"DockerImage",
           "name":"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"

--- a/test/extended/testdata/builds/test-imagechangetriggers.yaml
+++ b/test/extended/testdata/builds/test-imagechangetriggers.yaml
@@ -24,6 +24,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: nodejs-ex:latest
@@ -45,6 +48,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: nodejs-ex:latest
@@ -63,6 +69,9 @@ items:
     strategy:
       type: Custom
       customStrategy:
+        env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
         from:
           kind: ImageStreamTag
           name: nodejs-ex:latest
@@ -81,6 +90,9 @@ items:
     strategy:
       type: Jenkins
       jenkinsPipelineStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         jenkinsfile: node {}
     triggers:
     - type: ImageChange

--- a/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
+++ b/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
@@ -21,6 +21,9 @@ items:
             ln -s ../../rh/6/root/usr/bin /opt/app-root/test-links/bin
     strategy:
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: ruby:2.7-ubi8
@@ -80,7 +83,10 @@ items:
         - destinationDir: injected/usr/bin
           sourcePath: /usr/bin/ruby
     strategy:
-      dockerStrategy: {}
+      dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
 
 - apiVersion: v1
   kind: ImageStream

--- a/test/extended/testdata/builds/test-nosrc-build.json
+++ b/test/extended/testdata/builds/test-nosrc-build.json
@@ -30,6 +30,12 @@
         "strategy": {
           "type": "Source",
           "sourceStrategy": {
+            "env":[
+              {
+                 "name":"BUILD_LOGLEVEL",
+                 "value":"2"
+              }
+           ],
             "from": {
               "kind": "DockerImage",
               "name": "quay.io/redhat-developer/test-build-simples2i:1.2"

--- a/test/extended/testdata/builds/test-symlink-build.yaml
+++ b/test/extended/testdata/builds/test-symlink-build.yaml
@@ -16,6 +16,9 @@ items:
     strategy:
       type: Source
       sourceStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: ImageStreamTag
           name: nodejs:latest

--- a/test/extended/testdata/builds/volumes/csi-s2i-buildconfig.yaml
+++ b/test/extended/testdata/builds/volumes/csi-s2i-buildconfig.yaml
@@ -19,6 +19,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: quay.io/redhat-developer/test-build-simples2i:1.2

--- a/test/extended/testdata/builds/volumes/s2i-buildconfig.yaml
+++ b/test/extended/testdata/builds/volumes/s2i-buildconfig.yaml
@@ -19,6 +19,9 @@ spec:
   strategy:
     type: Source
     sourceStrategy:
+      env:
+        - name: "BUILD_LOGLEVEL"
+          value: "2"
       from:
         kind: DockerImage
         name: quay.io/redhat-developer/test-build-simples2i:1.2

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -38,6 +38,9 @@ items:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
         from:
           kind: DockerImage
           name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest

--- a/test/extended/testdata/test-buildcli.json
+++ b/test/extended/testdata/test-buildcli.json
@@ -45,6 +45,12 @@
           "strategy": {
             "type": "Source",
             "sourceStrategy": {
+              "env":[
+                {
+                   "name":"BUILD_LOGLEVEL",
+                   "value":"2"
+                }
+             ],
               "from": {
                 "kind": "DockerImage",
                 "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby"
@@ -87,6 +93,12 @@
           "strategy": {
             "type": "Source",
             "sourceStrategy": {
+              "env":[
+                {
+                   "name":"BUILD_LOGLEVEL",
+                   "value":"2"
+                }
+             ],
               "from": {
                 "kind": "DockerImage",
                 "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby"


### PR DESCRIPTION
This pull request is the prerequisite for https://github.com/openshift/builder/pull/288 which disables the printing of build steps by buildah. This pull request bumps the BUILD_LOGLEVEL to 2 in all of the tests that depend on reading the build steps.