### PR TITLE
test: update synthetic test node restart count

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -53,7 +53,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testPodTransitions(events)...)
 	tests = append(tests, testPodSandboxCreation(events)...)
 	tests = append(tests, testOvnNodeReadinessProbe(events, kubeClientConfig)...)
-	tests = append(tests, testNodeUpgradeTransitions(events)...)
+	tests = append(tests, testNodeUpgradeTransitions(events, kubeClientConfig)...)
 	tests = append(tests, testUpgradeOperatorStateTransitions(events)...)
 	tests = append(tests, testDuplicatedEventForUpgrade(events, kubeClientConfig, testSuite)...)
 	tests = append(tests, testStaticPodLifecycleFailure(events, kubeClientConfig, testSuite)...)

--- a/pkg/synthetictests/platformidentification/types.go
+++ b/pkg/synthetictests/platformidentification/types.go
@@ -47,11 +47,11 @@ func GetJobType(ctx context.Context, clientConfig *rest.Config) (*JobType, error
 		return nil, err
 	}
 
-	release := versionFromHistory(clusterVersion.Status.History[0])
+	release := VersionFromHistory(clusterVersion.Status.History[0])
 
 	fromRelease := ""
 	if len(clusterVersion.Status.History) > 1 {
-		fromRelease = versionFromHistory(clusterVersion.Status.History[1])
+		fromRelease = VersionFromHistory(clusterVersion.Status.History[1])
 	}
 
 	platform := ""
@@ -97,7 +97,7 @@ func GetJobType(ctx context.Context, clientConfig *rest.Config) (*JobType, error
 	}, nil
 }
 
-func versionFromHistory(history configv1.UpdateHistory) string {
+func VersionFromHistory(history configv1.UpdateHistory) string {
 	versionParts := strings.Split(history.Version, ".")
 	if len(versionParts) < 2 {
 		return ""


### PR DESCRIPTION
Due to recent nto update `stalld` will be packaged via rhcos on OCP 4.11. This means that `tuned` profiles that make use of `stalld` in realtime kernel workers may experience an extra restart during upgrade.

Note that this is a one time occurrence, once upgraded and using the OS version of `stalld` going forward this should no longer trigger this test failure.

Signed-off-by: ehila <ehila@redhat.com>