### PR TITLE
Bug 2067323: extended/test/router: omit DNS managed conditions for shards

### DIFF
--- a/test/extended/router/shard/shard.go
+++ b/test/extended/router/shard/shard.go
@@ -29,8 +29,6 @@ var ingressControllerNonDefaultAvailableConditions = []operatorv1.OperatorCondit
 	{Type: operatorv1.IngressControllerAvailableConditionType, Status: operatorv1.ConditionTrue},
 	{Type: operatorv1.LoadBalancerManagedIngressConditionType, Status: operatorv1.ConditionTrue},
 	{Type: operatorv1.LoadBalancerReadyIngressConditionType, Status: operatorv1.ConditionTrue},
-	{Type: operatorv1.DNSManagedIngressConditionType, Status: operatorv1.ConditionTrue},
-	{Type: operatorv1.DNSReadyIngressConditionType, Status: operatorv1.ConditionTrue},
 	{Type: "Admitted", Status: operatorv1.ConditionTrue},
 }
 


### PR DESCRIPTION
When standing up a new router shard omit the DNS managed conditions.
The remainder of the tests that spin up new shards go on to assert
that host names can be resolved so these conditions are not necessary
and will, in general, avoid tests failing on UPI platforms that don't
manage DNS.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2067323
