### PR TITLE
Use ServerGroupResources instead deprecated ServerResources

### DIFF
--- a/test/extended/authorization/authorization.go
+++ b/test/extended/authorization/authorization.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 				discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(clusterAdminClientConfig)
 
 				// (map[string]*metav1.APIResourceList, error)
-				allResourceList, err := discoveryClient.ServerResources()
+				_, allResourceList, err := discoveryClient.ServerGroupsAndResources()
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}

--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -365,7 +365,7 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, kubeConfig *restclient.Config, e
 	etcdSeen := map[schema.GroupVersionResource]empty{}
 	cohabitatingResources := map[string]map[schema.GroupVersionKind]empty{}
 
-	serverResources, err := kubeClient.Discovery().ServerResources()
+	_, serverResources, err := kubeClient.Discovery().ServerGroupsAndResources()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`ServerResources` function was removed in Kubernetes 1.24(ref: https://github.com/kubernetes/kubernetes/pull/107180). This PR changes places to `ServerGroupResources` to prevent any build errors in bump to 1.24.