### PR TITLE
NE-626: Add DNS CI coverage for golang and glibc resolver libraries

### DIFF
--- a/test/extended/dns/dns_libraries.go
+++ b/test/extended/dns/dns_libraries.go
@@ -1,0 +1,115 @@
+package dns
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	watchtools "k8s.io/client-go/tools/watch"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+// checkForPodLogFailures goes through the pod logs and determines if there was a failure
+// by looking for "fail" keyword in the logs.
+func checkForPodLogFailures(f *e2e.Framework, pod *kapiv1.Pod) {
+	By("submitting the pod to kubernetes")
+	podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
+	updated, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		e2e.Failf("Failed to create %s pod: %v", pod.Name, err)
+	}
+
+	w, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Watch(context.Background(), metav1.SingleObject(metav1.ObjectMeta{Name: pod.Name, ResourceVersion: updated.ResourceVersion}))
+	if err != nil {
+		e2e.Failf("Failed to watch pods: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), e2e.PodStartTimeout)
+	defer cancel()
+	if _, err = watchtools.UntilWithoutRetry(ctx, w, PodSucceeded); err != nil {
+		e2e.Failf("Failed: %v", err)
+	}
+
+	By("retrieving the pod logs")
+	r, err := podClient.GetLogs(pod.Name, &kapiv1.PodLogOptions{Container: "querier"}).Stream(context.Background())
+	if err != nil {
+		e2e.Failf("Failed to get pod logs %s: %v", pod.Name, err)
+	}
+
+	scan := bufio.NewScanner(r)
+	for scan.Scan() {
+		line := scan.Text()
+		if strings.Contains(line, "fail") {
+			e2e.Failf("DNS resolution failed: %s", line)
+		}
+	}
+}
+
+var _ = Describe("[sig-network-edge] DNS lookup", func() {
+	f := e2e.NewDefaultFramework("dns-libraries")
+	oc := exutil.NewCLI("dns-libraries")
+	buildFixture := exutil.FixturePath("testdata", "dns", "dns_libraries_go.yaml")
+	dnsFixture := exutil.FixturePath("testdata", "dns")
+	labels := exutil.ParseLabelsOrDie("app=dns-libraries-go")
+
+	// creates a simple Pod that is using the image under /testdata/dns, which performs a DNS query to make sure Go's DNS resolver works fine with OpenShift DNS.
+	It("using Go's DNS resolver", func() {
+		dnsService, err := f.ClientSet.CoreV1().Services("openshift-dns").Get(context.Background(), "dns-default", metav1.GetOptions{})
+		if err != nil {
+			e2e.Failf("Failed to get default DNS service: %v", err)
+		}
+		By("creating build and deployment config for dns-libraries-go")
+		err = oc.Run("create").Args("-f", buildFixture).Execute()
+		if err != nil {
+			e2e.Failf("Failed to create build configs and deployment config for dns-libraries-go: %v", err)
+		}
+		By("starting the builder image build with a directory")
+		err = oc.Run("start-build").Args("dns-libraries-go", fmt.Sprintf("--from-dir=%s", dnsFixture)).Execute()
+		if err != nil {
+			e2e.Failf("Failed to start the builder image build: %v", err)
+		}
+		By("expect the builds to complete successfully and deploy a dns-libraries-go pod")
+		pods, err := exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), labels, exutil.CheckPodIsRunning, 1, 5*time.Minute)
+		if err != nil {
+			e2e.Failf("Failed to start the dns-libraries-go pod: %v", err)
+		}
+		if len(pods) != 1 {
+			e2e.Failf("Got %d pods with labels %v, expected 1", len(pods), labels)
+		}
+
+		By("expect the go application to successfully resolve DNS")
+		pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), pods[0], metav1.GetOptions{})
+		if err != nil {
+			e2e.Failf("Failed to get dns-libraries-go pod: %v", err)
+		}
+		//execute "go run /go/dns_libraries.go -cluster-ip={CLUSTER_IP}" command inside the pod
+		args := []string{pod.Name, "-c", pod.Spec.Containers[0].Name, "--", "bash", "-c", fmt.Sprintf("go run /go/dns_libraries.go -cluster-ip=%q", dnsService.Spec.ClusterIP)}
+		output, err := oc.Run("exec").Args(args...).Output()
+		if err != nil {
+			e2e.Failf("Failed to exec dns-libraries-go pod: %v", err)
+		}
+		if !strings.Contains(output, "Successfully") {
+			e2e.Failf("DNS resolution failed: %s", output)
+		}
+	})
+
+	// creates a simple Pod that is using getent to perform DNS queries, to make sure glibc's DNS resolver works fine with OpenShift DNS.
+	It("using glibc's DNS resolver", func() {
+		// using www.redhat.com just as a sample host for dns queries
+		const host = "www.redhat.com"
+
+		// running getent command 10 times to see if it can resolve the dns steadily
+		cmd := repeatCommand(
+			10,
+			fmt.Sprintf("getent -s dns ahosts %s || echo $(date) fail", host),
+		)
+		pod := createDNSPod(f.Namespace.Name, cmd)
+		checkForPodLogFailures(f, pod)
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -311,6 +311,9 @@
 // test/extended/testdata/deployments/tag-images-deployment.yaml
 // test/extended/testdata/deployments/test-deployment-broken.yaml
 // test/extended/testdata/deployments/test-deployment-test.yaml
+// test/extended/testdata/dns/Dockerfile
+// test/extended/testdata/dns/dns_libraries_go
+// test/extended/testdata/dns/dns_libraries_go.yaml
 // test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
 // test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
 // test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml
@@ -41630,6 +41633,156 @@ func testExtendedTestdataDeploymentsTestDeploymentTestYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataDnsDockerfile = []byte(`FROM golang:1.18
+
+ENV GOCACHE=/tmp/
+
+COPY dns_libraries_go /go/dns_libraries.go
+
+CMD ["/bin/sh", "-c", "sleep 9999999"]
+`)
+
+func testExtendedTestdataDnsDockerfileBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsDockerfile, nil
+}
+
+func testExtendedTestdataDnsDockerfile() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsDockerfileBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/Dockerfile", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataDnsDns_libraries_go = []byte(`package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"time"
+)
+
+func main() {
+	clusterIP := flag.String("cluster-ip", "", "clusterIP for CoreDNS service")
+	flag.Parse()
+	if *clusterIP == "" {
+		log.Fatal("cluster-ip must be set")
+	}
+
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 10 * time.Second,
+			}
+			return d.DialContext(ctx, network, net.JoinHostPort(*clusterIP, "53"))
+		},
+	}
+	addrs, err := r.LookupHost(context.Background(), "www.redhat.com")
+	if err != nil {
+		log.Fatalf("Failed to look up host: %v", err)
+	}
+
+	log.Printf("Successfully resolved: %q", addrs)
+}
+`)
+
+func testExtendedTestdataDnsDns_libraries_goBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsDns_libraries_go, nil
+}
+
+func testExtendedTestdataDnsDns_libraries_go() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsDns_libraries_goBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/dns_libraries_go", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataDnsDns_libraries_goYaml = []byte(`apiVersion: v1
+kind: List
+metadata: {}
+items:
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      labels:
+        build: dns-libraries-go
+      name: dns-libraries-go
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: dns-libraries-go:latest
+      source:
+        binary: {}
+        type: Binary
+      strategy:
+        dockerStrategy: {}
+        type: Docker
+      triggers: []
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      labels:
+        build: dns-libraries-go
+      name: dns-libraries-go
+    spec: { }
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: dns-libraries-go
+      name: dns-libraries-go
+    spec:
+      replicas: 1
+      selector:
+        app: dns-libraries-go
+        deploymentconfig: dns-libraries-go
+      template:
+        metadata:
+          labels:
+            app: dns-libraries-go
+            deploymentconfig: dns-libraries-go
+        spec:
+          containers:
+            - image: dns-libraries-go
+              imagePullPolicy: Always
+              name: dns-libraries-go
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - dns-libraries-go
+            from:
+              kind: ImageStreamTag
+              name: dns-libraries-go:latest
+          type: ImageChange
+`)
+
+func testExtendedTestdataDnsDns_libraries_goYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsDns_libraries_goYaml, nil
+}
+
+func testExtendedTestdataDnsDns_libraries_goYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsDns_libraries_goYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/dns_libraries_go.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml = []byte(`apiVersion: k8s.ovn.org/v1
 kind: EgressFirewall
 metadata:
@@ -53303,6 +53456,9 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/deployments/tag-images-deployment.yaml":                                          testExtendedTestdataDeploymentsTagImagesDeploymentYaml,
 	"test/extended/testdata/deployments/test-deployment-broken.yaml":                                         testExtendedTestdataDeploymentsTestDeploymentBrokenYaml,
 	"test/extended/testdata/deployments/test-deployment-test.yaml":                                           testExtendedTestdataDeploymentsTestDeploymentTestYaml,
+	"test/extended/testdata/dns/Dockerfile":                                                                  testExtendedTestdataDnsDockerfile,
+	"test/extended/testdata/dns/dns_libraries_go":                                                            testExtendedTestdataDnsDns_libraries_go,
+	"test/extended/testdata/dns/dns_libraries_go.yaml":                                                       testExtendedTestdataDnsDns_libraries_goYaml,
 	"test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml":                                   testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml,
 	"test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml":                               testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYaml,
 	"test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml":                                  testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml,
@@ -53978,6 +54134,11 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"tag-images-deployment.yaml":          {testExtendedTestdataDeploymentsTagImagesDeploymentYaml, map[string]*bintree{}},
 					"test-deployment-broken.yaml":         {testExtendedTestdataDeploymentsTestDeploymentBrokenYaml, map[string]*bintree{}},
 					"test-deployment-test.yaml":           {testExtendedTestdataDeploymentsTestDeploymentTestYaml, map[string]*bintree{}},
+				}},
+				"dns": {nil, map[string]*bintree{
+					"Dockerfile":            {testExtendedTestdataDnsDockerfile, map[string]*bintree{}},
+					"dns_libraries_go":      {testExtendedTestdataDnsDns_libraries_go, map[string]*bintree{}},
+					"dns_libraries_go.yaml": {testExtendedTestdataDnsDns_libraries_goYaml, map[string]*bintree{}},
 				}},
 				"egress-firewall": {nil, map[string]*bintree{
 					"ovnk-egressfirewall-test.yaml":     {testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml, map[string]*bintree{}},

--- a/test/extended/testdata/dns/Dockerfile
+++ b/test/extended/testdata/dns/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.18
+
+ENV GOCACHE=/tmp/
+
+COPY dns_libraries_go /go/dns_libraries.go
+
+CMD ["/bin/sh", "-c", "sleep 9999999"]

--- a/test/extended/testdata/dns/dns_libraries_go
+++ b/test/extended/testdata/dns/dns_libraries_go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"time"
+)
+
+func main() {
+	clusterIP := flag.String("cluster-ip", "", "clusterIP for CoreDNS service")
+	flag.Parse()
+	if *clusterIP == "" {
+		log.Fatal("cluster-ip must be set")
+	}
+
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 10 * time.Second,
+			}
+			return d.DialContext(ctx, network, net.JoinHostPort(*clusterIP, "53"))
+		},
+	}
+	addrs, err := r.LookupHost(context.Background(), "www.redhat.com")
+	if err != nil {
+		log.Fatalf("Failed to look up host: %v", err)
+	}
+
+	log.Printf("Successfully resolved: %q", addrs)
+}

--- a/test/extended/testdata/dns/dns_libraries_go.yaml
+++ b/test/extended/testdata/dns/dns_libraries_go.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      labels:
+        build: dns-libraries-go
+      name: dns-libraries-go
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: dns-libraries-go:latest
+      source:
+        binary: {}
+        type: Binary
+      strategy:
+        dockerStrategy: {}
+        type: Docker
+      triggers: []
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      labels:
+        build: dns-libraries-go
+      name: dns-libraries-go
+    spec: { }
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: dns-libraries-go
+      name: dns-libraries-go
+    spec:
+      replicas: 1
+      selector:
+        app: dns-libraries-go
+        deploymentconfig: dns-libraries-go
+      template:
+        metadata:
+          labels:
+            app: dns-libraries-go
+            deploymentconfig: dns-libraries-go
+        spec:
+          containers:
+            - image: dns-libraries-go
+              imagePullPolicy: Always
+              name: dns-libraries-go
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - dns-libraries-go
+            from:
+              kind: ImageStreamTag
+              name: dns-libraries-go:latest
+          type: ImageChange

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1951,6 +1951,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics": "should start and expose a secured proxy and verify build metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network-edge] DNS lookup using Go's DNS resolver": "using Go's DNS resolver [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-network-edge] DNS lookup using glibc's DNS resolver": "using glibc's DNS resolver [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service": "should answer A and AAAA queries for a dual-stack service [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": "should answer endpoint and wildcard queries for the cluster [Disabled:Broken]",


### PR DESCRIPTION
This PR is adding an e2e test for go and glibc resolver libraries to reduce the risk that changes to our CoreDNS configuration break DNS resolution for clients. 
- `DNS lookup using Go's DNS resolver` test creates a pod using build and deployment configs where the pod has a simple go application which uses the `net` package to create a resolver targeting CoreDNS service clusterIP. It then calls `LookupHost` function to test DNS resolution for `www.redhat.com`. 
- `DNS lookup using glibc's DNS resolver` test creates a pod using jessie image and executes `getent -s dns ahosts www.redhat.com || echo $(date) fail` ten times to test DNS resolution for `www.redhat.com`. `getent` is a tool that comes with glibc library and can be used to test DNS resolution. It does not have any functionality for us to provide a custom DNS server, but since the `resolv.conf` file has the clusterIP of CoreDNS service in the `nameserver` field, it does a lookup against our server.   