### PR TITLE
test: switch to testing CapBnd over CapInh

### DIFF
--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -272,7 +272,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 
 		desiredCapabilities := "000000000000051b"
 
-		capabilities, err := pod.Exec("cat /proc/1/status | grep CapInh | cut -f 2")
+		capabilities, err := pod.Exec("cat /proc/1/status | grep CapBnd | cut -f 2")
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		capString, err := pod.Exec("capsh --decode=" + capabilities)


### PR DESCRIPTION
as CRI-O will soon drop CapInh, see https://github.com/cri-o/cri-o/security/advisories/GHSA-4hj2-r2pm-3hc6 and CVE-2022-27652

Signed-off-by: Peter Hunt <pehunt@redhat.com>