### PR TITLE
Add missing operators from the known operators list

### DIFF
--- a/pkg/synthetictests/operator_mapping.go
+++ b/pkg/synthetictests/operator_mapping.go
@@ -87,6 +87,8 @@ var (
 	// nothing fancy, I just copied the listing
 	KnownOperators = sets.NewString(
 		"authentication",
+		"baremetal",
+		"cloud-controller-manager",
 		"cloud-credential",
 		"cluster-autoscaler",
 		"config-operator",
@@ -94,8 +96,8 @@ var (
 		"csi-snapshot-controller",
 		"dns",
 		"etcd",
-		"ingress",
 		"image-registry",
+		"ingress",
 		"insights",
 		"kube-apiserver",
 		"kube-controller-manager",
@@ -123,6 +125,8 @@ var (
 
 func init() {
 	utilruntime.Must(addOperatorMapping("authentication", "apiserver-auth"))
+	utilruntime.Must(addOperatorMapping("baremetal", "Bare Metal Hardware Provisioning"))
+	utilruntime.Must(addOperatorMapping("cloud-controller-manager", "Cloud Compute"))
 	utilruntime.Must(addOperatorMapping("cloud-credential", "Cloud Credential Operator"))
 	utilruntime.Must(addOperatorMapping("cluster-autoscaler", "Cloud Compute"))
 	utilruntime.Must(addOperatorMapping("config-operator", "config-operator"))
@@ -130,8 +134,8 @@ func init() {
 	utilruntime.Must(addOperatorMapping("csi-snapshot-controller", "Storage"))
 	utilruntime.Must(addOperatorMapping("dns", "DNS"))
 	utilruntime.Must(addOperatorMapping("etcd", "Etcd"))
-	utilruntime.Must(addOperatorMapping("ingress", "Routing"))
 	utilruntime.Must(addOperatorMapping("image-registry", "Image Registry"))
+	utilruntime.Must(addOperatorMapping("ingress", "Routing"))
 	utilruntime.Must(addOperatorMapping("insights", "Insights Operator"))
 	utilruntime.Must(addOperatorMapping("kube-apiserver", "kube-apiserver"))
 	utilruntime.Must(addOperatorMapping("kube-controller-manager", "kube-controller-manager"))


### PR DESCRIPTION
CCM and baremetal are missing.  List updated based on list from a 4.11
cluster:

```
$ oc get clusteroperators -o name | sort
clusteroperator.config.openshift.io/authentication
clusteroperator.config.openshift.io/baremetal
clusteroperator.config.openshift.io/cloud-controller-manager
clusteroperator.config.openshift.io/cloud-credential
clusteroperator.config.openshift.io/cluster-autoscaler
clusteroperator.config.openshift.io/config-operator
clusteroperator.config.openshift.io/console
clusteroperator.config.openshift.io/csi-snapshot-controller
clusteroperator.config.openshift.io/dns
clusteroperator.config.openshift.io/etcd
clusteroperator.config.openshift.io/image-registry
clusteroperator.config.openshift.io/ingress
clusteroperator.config.openshift.io/insights
clusteroperator.config.openshift.io/kube-apiserver
clusteroperator.config.openshift.io/kube-controller-manager
clusteroperator.config.openshift.io/kube-scheduler
clusteroperator.config.openshift.io/kube-storage-version-migrator
clusteroperator.config.openshift.io/machine-api
clusteroperator.config.openshift.io/machine-approver
clusteroperator.config.openshift.io/machine-config
clusteroperator.config.openshift.io/marketplace
clusteroperator.config.openshift.io/monitoring
clusteroperator.config.openshift.io/network
clusteroperator.config.openshift.io/node-tuning
clusteroperator.config.openshift.io/openshift-apiserver
clusteroperator.config.openshift.io/openshift-controller-manager
clusteroperator.config.openshift.io/openshift-samples
clusteroperator.config.openshift.io/operator-lifecycle-manager
clusteroperator.config.openshift.io/operator-lifecycle-manager-catalog
clusteroperator.config.openshift.io/operator-lifecycle-manager-packageserver
clusteroperator.config.openshift.io/service-ca
clusteroperator.config.openshift.io/storage
```