### PR TITLE
Ignore FailedCreatePodSandBox event that is expected to happen

### DIFF
--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -62,6 +62,14 @@ func testPodSandboxCreation(events monitorapi.Intervals) []*junitapi.JUnitTestCa
 			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to get pods as ovnkube-node pod has not yet written readinessindicatorfile (possibly not running due to image pull delays) https://bugzilla.redhat.com/show_bug.cgi?id=20671320 - %v", event.Locator, event.Message))
 			continue
 		}
+		if strings.Contains(event.Locator, "pod/whereabouts-pod") &&
+			strings.Contains(event.Message, "error adding container to network") &&
+			strings.Contains(event.Message, "Error at storage engine: Could not allocate IP in range: ip: 192.168.2.225 / - 192.168.2.230 ") {
+			// This failed to create sandbox case is expected due to the whereabouts-e2e test which creates a pod that is expected to
+			// not come up due to IP range exhausted.
+			// See https://github.com/openshift/origin/blob/93eb467cc8d293ba977549b05ae2e4b818c64327/test/extended/networking/whereabouts.go#L52
+			continue
+		}
 		deletionTime := getPodDeletionTime(eventsForPods[event.Locator], event.Locator)
 		if deletionTime == nil {
 			// mark sandboxes errors as flakes if networking is being updated


### PR DESCRIPTION
In https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26908/pull-ci-openshift-origin-master-e2e-gcp/1509938673548791808 , we get:

```
$ cat e2e-events_20220401-174716.json | jq '.items[]|select (.message|test("Error at storage engine: Could not allocate IP in range"))'
{
  "level": "Warning",
  "locator": "ns/e2e-test-whereabouts-e2e-59pln pod/whereabouts-pod-fgf26 node/ci-op-vqn19vmz-2a78c-tgfb2-worker-c-drphp",
  "message": "reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_whereabouts-pod-fgf26_e2e-test-whereabouts-e2e-59pln_3a5636c4-7d4d-4e2c-ad3c-e35ba7bc63df_0(83b31776a78f0592ff291661771cfed6a1af6d718fc348e73b8f73f1fa549c62): error adding pod e2e-test-whereabouts-e2e-59pln_whereabouts-pod-fgf26 to CNI network \"multus-cni-network\": plugin type=\"multus\" name=\"multus-cni-network\" failed (add): [e2e-test-whereabouts-e2e-59pln/whereabouts-pod-fgf26/3a5636c4-7d4d-4e2c-ad3c-e35ba7bc63df:whereaboutstestbridge]: error adding container to network \"whereaboutstestbridge\": Error at storage engine: Could not allocate IP in range: ip: 192.168.2.225 / - 192.168.2.230 / range: net.IPNet{IP:net.IP{0xc0, 0xa8, 0x2, 0xe0}, Mask:net.IPMask{0xff, 0xff, 0xff, 0xf8}}",
  "from": "2022-04-01T18:21:51Z",
  "to": "2022-04-01T18:21:51Z"
}
...
```

But that is expected because of [this test](https://github.com/openshift/origin/blob/93eb467cc8d293ba977549b05ae2e4b818c64327/test/extended/networking/whereabouts.go#L52).  So, this PR ignores it and does not count it as another `FailedCreatePodSandBox` failure.

cc @nicklesimba