### PR TITLE
Treat simpletest-rc-to-be-deleted pod sandbox failure as expected

### DIFF
--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -70,6 +70,14 @@ func testPodSandboxCreation(events monitorapi.Intervals) []*junitapi.JUnitTestCa
 			// See https://github.com/openshift/origin/blob/93eb467cc8d293ba977549b05ae2e4b818c64327/test/extended/networking/whereabouts.go#L52
 			continue
 		}
+		if strings.Contains(event.Locator, "pod/simpletest-rc-to-be-deleted") &&
+			strings.Contains(event.Message, "failed to create pod network sandbox k8s_simpletest-rc-to-be-deleted") &&
+			strings.HasSuffix(event.Message, " not found") {
+			// This failed to create a sandbox case is expected due to the ovnkube-msater pod trying to bring up the logical port
+			// for a pod that is in the process of being deleted.
+			// See https://github.com/openshift/origin/blob/36ddf0503bbb9f7adf9fe3481f85c856ec0a2f31/vendor/k8s.io/kubernetes/test/e2e/apimachinery/garbage_collector.go#L739
+			continue
+		}
 		deletionTime := getPodDeletionTime(eventsForPods[event.Locator], event.Locator)
 		if deletionTime == nil {
 			// mark sandboxes errors as flakes if networking is being updated


### PR DESCRIPTION
The test that creates pod (via a ReplicationController), also deletes them (by deleting a ReplicationController).  The pods come up, and while their networks (logical ports) are in the process of being added, the pods are deleted (as part of the test).

As a result, the network cannot come up because the pod is already gone (the message in the `ovnkube-master` pod says something like `Unable to get pod e2e-gc-6231/simpletest-rc-to-be-deleted-7kz7f for pod update, most likely it was already deleted`).

The kubelet log (in the ci-op-xy9lvk43-de73b-lnh2s-worker-a-bjsmj/journal file) will say something like: `error getting pod: pods \"simpletest-rc-to-be-deleted-7kz7f\" not found`.  The `Failed to create sandbox for pod` message follows.

The job where I looked into it is [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-gcp-ovn-upgrade/1511221283516321792) and failing on `: [sig-network] pods should successfully create sandboxes by getting pod`.

The name of the test is `[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]`