### PR TITLE
Bug 2072533: synthetictests: skip "alert/Watchdog must have no gaps or changes" on SNO upgrades

### DIFF
--- a/pkg/synthetictests/allowedalerts/watchdog.go
+++ b/pkg/synthetictests/allowedalerts/watchdog.go
@@ -10,9 +10,12 @@ import (
 	o "github.com/onsi/gomega"
 	helper "github.com/openshift/origin/test/extended/util/prometheus"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -72,7 +75,47 @@ func IsWatchdogAlert(eventInterval monitorapi.EventInterval) bool {
 	return eventInterval.Locator == "alert/Watchdog ns/openshift-monitoring"
 }
 
+func isSNOUpgradeTest(ctx context.Context, restConfig *rest.Config) (bool, error) {
+	configClient, err := configclient.NewForConfig(restConfig)
+	if err != nil {
+		return false, fmt.Errorf("Failed to establish API server connection")
+	}
+	infra, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("Failed to find Infra config")
+	}
+	// Exit early if its not SNO
+	if infra.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
+		return false, nil
+	}
+
+	clusterVersion, err := configClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("Failed to find cluster version")
+	}
+	// Make sure this cluster is being upgraded
+	return len(clusterVersion.Status.History) > 1, nil
+}
+
 func (a *watchdogAlertTest) InvariantCheck(ctx context.Context, restConfig *rest.Config, alertIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+
+	// Skip this test when SNO is being upgraded
+	isSNOUpgrade, err := isSNOUpgradeTest(ctx, restConfig)
+	if err != nil {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: a.InvariantTestName(),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: err.Error(),
+				},
+				SystemOut: err.Error(),
+			},
+		}, nil
+	}
+	if isSNOUpgrade {
+		return []*junitapi.JUnitTestCase{}, nil
+	}
+
 	watchdogIntervals := alertIntervals.Filter(IsWatchdogAlert)
 	describe := watchdogIntervals.Strings()
 


### PR DESCRIPTION
SNO are running a single Prometheus replica and require reboots during upgrades. This test is skipped if its running on single node cluster.

cluster-bot's [test upgrade 4.10 4.11,https://github.com/openshift/origin/pull/26976 aws,single-node](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1512331511691481088)