### PR TITLE
Bug 2066457: don't fail when a query returns warnings

### DIFF
--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -144,11 +144,7 @@ func RunQueryAtTime(ctx context.Context, prometheusClient prometheusv1.API, quer
 		return nil, err
 	}
 	if len(warnings) > 0 {
-		errs := []error{}
-		for _, warning := range warnings {
-			errs = append(errs, fmt.Errorf("%s", warning))
-		}
-		return nil, errors.NewAggregate(errs)
+		framework.Logf("#### warnings \n\t%v\n", strings.Join(warnings, "\n\t"))
 	}
 	if result.Type() != model.ValVector {
 		return nil, fmt.Errorf("result type is not the vector: %v", result.Type())


### PR DESCRIPTION
The Thanos API may return warnings when it sends back a partial response
(e.g. some of the requests to the Thanos stores have failed). This
happens in particular when the cluster is upgraded and Prometheus pods
are rolled out because the sidecar might be up while Prometheus hasn't
finished loading the WAL.

With this commit, RunQueryAtTime() logs the warnings when they exist
instead of returning an error.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>