### PR TITLE
Bug 2072924: increase the threshold on the number of telemetry series

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1931,7 +1931,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]": "should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent] [Disabled:Unimplemented] [Suite:k8s]",
 
-	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't exceed the 500 series limit of total series sent via telemetry from each cluster": "shouldn't exceed the 500 series limit of total series sent via telemetry from each cluster [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster": "shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any unexpected alerts in firing or pending state": "shouldn't report any unexpected alerts in firing or pending state [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
Looking at the telemetry data, 4.11 clusters send a bit more metrics on average
to telemetry than the previous versions. The threshold value needs to be
increased accordingly.

To calculate the new value, I've used the following PromQL query which averages
the cluster:telemetry_selected_series:count metric over the last 30 minutes for
all 4.11 installations and then returns the 99th percentile.

```
quantile(0.99,
  avg_over_time(
    (
      cluster:telemetry_selected_series:count
      *
      on (_id) group_left group by(_id) (cluster_version{version=~"4.11.0-0.ci.+"})
    )[30m:1m]
  )
)
```

![image](https://user-images.githubusercontent.com/2587585/162175418-8de83758-88a7-4e1b-afd6-504d563cac4e.png)
