### PR TITLE
correct pathological event detection

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -313,6 +313,7 @@ func (d duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOnl
 			if allowed {
 				continue
 			}
+			displayToCount[eventDisplayMessage] = times
 		}
 	}
 

--- a/pkg/synthetictests/duplicated_events_eviction.json
+++ b/pkg/synthetictests/duplicated_events_eviction.json
@@ -1,0 +1,11 @@
+{
+  "items": [
+    {
+      "level": "Warning",
+      "locator": "ns/openshift-ingress-operator deployment/ingress-operator",
+      "message": "reason/MalscheduledPod pod/router-default-84c89f5bf8-5rdcb pod/router-default-84c89f5bf8-bg9ql should be one per node, but all were placed on node/ip-10-0-172-166.ec2.internal; evicting pod/router-default-84c89f5bf8-5rdcb (79 times)",
+      "from": "2022-04-06T21:26:55Z",
+      "to": "2022-04-06T21:26:55Z"
+    }
+  ]
+}


### PR DESCRIPTION
found in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26982/pull-ci-openshift-origin-master-e2e-aws-serial/1511793616459141120 when it did not detect the repeated `Malscheduled` event.