### PR TITLE
WIP: Fix another issue with CVO upgrade ack timeout.

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -373,7 +373,8 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			case configv1.OpenStackPlatformType:
 				cvoAckTimeout = 4 * time.Minute
 			default:
-				cvoAckTimeout = defaultCVOUpdateAckTimeout
+				//cvoAckTimeout = defaultCVOUpdateAckTimeout
+				cvoAckTimeout = 2 * time.Minute
 			}
 
 			start := time.Now()

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -90,7 +90,7 @@ var (
 // upgradeAbortAtRandom is a special value indicating the abort should happen at a random percentage
 // between (0,100].
 const upgradeAbortAtRandom = -1
-const defaultCVOUpdateAckTimeout = 10 * time.Second
+const defaultCVOUpdateAckTimeout = 2 * time.Minute
 
 // SetTests controls the list of tests to run during an upgrade. See AllTests for the supported
 // suite.
@@ -395,10 +395,10 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			// We allow extra time on a couple platforms above, if we're over the default we'll flake this test
 			// to allow insight into how often we're hitting this problem and when the issue is fixed.
 			timeToAck := time.Now().Sub(start)
-			if timeToAck > defaultCVOUpdateAckTimeout {
-				return fmt.Errorf("CVO took %s to acknowledge upgrade (> %s), flaking test", timeToAck, defaultCVOUpdateAckTimeout), true
-			}
-			return nil, false
+			//if timeToAck > defaultCVOUpdateAckTimeout {
+			return fmt.Errorf("CVO took %s to acknowledge upgrade (> %s), flaking test", timeToAck, defaultCVOUpdateAckTimeout), true
+			//}
+			//return nil, false
 		},
 	); err != nil {
 		recordClusterEvent(kubeClient, uid, "Upgrade", "UpgradeFailed", fmt.Sprintf("failed to acknowledge version: %v", err), true)

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -90,7 +90,7 @@ var (
 // upgradeAbortAtRandom is a special value indicating the abort should happen at a random percentage
 // between (0,100].
 const upgradeAbortAtRandom = -1
-const defaultCVOUpdateAckTimeout = 2 * time.Minute
+const defaultCVOUpdateAckTimeout = 10 * time.Second
 
 // SetTests controls the list of tests to run during an upgrade. See AllTests for the supported
 // suite.
@@ -373,9 +373,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			case configv1.OpenStackPlatformType:
 				cvoAckTimeout = 4 * time.Minute
 			default:
-				//cvoAckTimeout = defaultCVOUpdateAckTimeout
-				// TODO: do not merge, testing in CI
-				cvoAckTimeout = 2 * time.Second
+				cvoAckTimeout = defaultCVOUpdateAckTimeout
 			}
 
 			start := time.Now()

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -373,7 +373,9 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			case configv1.OpenStackPlatformType:
 				cvoAckTimeout = 4 * time.Minute
 			default:
-				cvoAckTimeout = defaultCVOUpdateAckTimeout
+				//cvoAckTimeout = defaultCVOUpdateAckTimeout
+				// TODO: do not merge, testing in CI
+				cvoAckTimeout = 2 * time.Second
 			}
 
 			start := time.Now()

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -366,20 +366,22 @@ func RecordJUnit(f *framework.Framework, name string, fn func() (err error, flak
 	var failure string
 	if err != nil {
 		failure = err.Error()
-
-		if flake {
-			// Append an additional result with empty failure to trigger a flake.
-			f.TestSummaries = append(f.TestSummaries, additionalTest{
-				Name:     name,
-				Duration: duration,
-			})
-		}
 	}
 	f.TestSummaries = append(f.TestSummaries, additionalTest{
 		Name:     name,
 		Duration: duration,
 		Failure:  failure,
 	})
+	if flake {
+		if err != nil {
+			// Append an additional result with empty failure to trigger a flake.
+			f.TestSummaries = append(f.TestSummaries, additionalTest{
+				Name:     name,
+				Duration: duration,
+			})
+		}
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
Previous attempt did not account for a secondary test that would fail
due to error being returned.
