### PR TITLE
EgressIP downstream tests for OVN Kubernetes

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -1,0 +1,837 @@
+package networking
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/skipper"
+)
+
+const (
+	// for all tests
+	namespacePrefix = "egressip"
+	egressIPYaml    = "egressip.yaml"
+	probePodName    = "prober-pod"
+
+	// for tests against host networked pods
+	egressIPTargetHostPortMin = 32667
+	egressIPTargetHostPortMax = 32767
+
+	// Max time that we wait for changes to EgressIP objects
+	// to propagate to the CloudPrivateIPConfig objects.
+	// This can take a significant amount of time on Azure.
+	// BZ https://bugzilla.redhat.com/show_bug.cgi?id=2073045
+	egressUpdateTimeout = 180
+)
+
+var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
+	oc := exutil.NewCLI(namespacePrefix)
+	portAllocator := NewPortAllocator(egressIPTargetHostPortMin, egressIPTargetHostPortMax)
+
+	var (
+		networkPlugin string
+
+		clientset      kubernetes.Interface
+		tmpDirEgressIP string
+
+		workerNodesOrdered        []corev1.Node
+		workerNodesOrderedNames   []string
+		egressIPNodesOrderedNames []string
+		nonEgressIPNodeName       string
+
+		egressIPNamespace      string
+		externalNamespace      string
+		packetSnifferDaemonSet *v1.DaemonSet
+
+		ingressDomain string
+
+		cloudType configv1.PlatformType
+		hasIPv4   bool
+		hasIPv6   bool
+
+		targetProtocol string
+		targetHost     string
+		targetPort     int
+	)
+
+	// BeforeEach for OVN Kubernetes
+	g.BeforeEach(func() {
+		g.By("Verifying that this cluster uses a network plugin that is supported for this test")
+		networkPlugin = networkPluginName()
+		if networkPlugin != OVNKubernetesPluginName &&
+			networkPlugin != openshiftSDNPluginName {
+			skipper.Skipf("This cluster neither uses OVNKubernetes nor OpenShiftSDN")
+		}
+
+		g.By("Creating a temp directory")
+		var err error
+		tmpDirEgressIP, err = ioutil.TempDir("", "egressip-e2e")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Getting the clientset")
+		f := oc.KubeFramework()
+		clientset = f.ClientSet
+
+		g.By("Determining the cloud infrastructure type")
+		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		cloudType = infra.Spec.PlatformSpec.Type
+
+		g.By("Verifying that this is a supported cloud infrastructure platform")
+		isSupportedPlatform := false
+		supportedPlatforms := []configv1.PlatformType{
+			configv1.AWSPlatformType,
+			configv1.GCPPlatformType,
+			configv1.AzurePlatformType,
+		}
+		for _, supportedPlatform := range supportedPlatforms {
+			if cloudType == supportedPlatform {
+				isSupportedPlatform = true
+				break
+			}
+		}
+		if !isSupportedPlatform {
+			skipper.Skipf("This cloud platform (%s) is not supported for this test", cloudType)
+		}
+
+		// A supported version of OpenShift must hold the CloudPrivateIPConfig CRD.
+		// Otherwise, skip this test.
+		g.By("Verifying that this is a supported version of OpenShift")
+		isSupportedOcpVersion, err := exutil.DoesApiResourceExist(oc, "cloudprivateipconfigs")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if !isSupportedOcpVersion {
+			skipper.Skipf("This OCP version is not supported for this test (api-resource cloudprivateipconfigs not found)")
+		}
+
+		g.By("Getting all worker nodes in alphabetical order")
+		// Get all worker nodes, order them alphabetically with stable
+		// sort order.
+		workerNodesOrdered, err = getWorkerNodesOrdered(clientset)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		for _, s := range workerNodesOrdered {
+			workerNodesOrderedNames = append(workerNodesOrderedNames, s.Name)
+		}
+		if len(workerNodesOrdered) < 3 {
+			skipper.Skipf("This test requires a minimum of 3 worker nodes. However, this environment has %d worker nodes.", len(workerNodesOrdered))
+		}
+
+		g.By("Determining the cloud address families")
+		hasIPv4, hasIPv6, err = GetIPAddressFamily(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Determining the target protocol, host and port")
+		targetProtocol, targetHost, targetPort, err = getTargetProtocolHostPort(oc, hasIPv4, hasIPv6, cloudType, networkPlugin)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Testing against: CloudType: %s, Protocol %s, TargetHost: %s, TargetPort: %d",
+			cloudType,
+			targetProtocol,
+			targetHost,
+			targetPort)
+
+		g.By("Creating a project for the prober pod")
+		// Create a target project and assign source and target namespace
+		// to variables for later use.
+		// SetupProject() instead of SetupNamespace() because we need a privileged
+		// namespace: https://kubernetes.io/blog/2021/12/09/pod-security-admission-beta/
+		// and SetupProject() does that for us.
+		egressIPNamespace = f.Namespace.Name
+		externalNamespace = oc.SetupProject()
+
+		g.By("Selecting the EgressIP nodes and a non-EgressIP node")
+		nonEgressIPNodeName = workerNodesOrderedNames[0]
+		egressIPNodesOrderedNames = workerNodesOrderedNames[1:]
+
+		g.By("Setting the ingressdomain")
+		ingressDomain, err = getIngressDomain(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if networkPluginName() == OVNKubernetesPluginName {
+			g.By("Setting the EgressIP nodes as EgressIP assignable")
+			for _, node := range egressIPNodesOrderedNames {
+				_, err = oc.AsAdmin().Run("label").Args("node", node, "k8s.ovn.org/egress-assignable=").Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+		}
+	})
+
+	// Do not check for errors in g.AfterEach as the other cleanup steps will fail, otherwise.
+	g.AfterEach(func() {
+		// Print some useful output on failure.
+		if g.CurrentGinkgoTestDescription().Failed {
+			printEgressIPState(oc)
+		}
+		if networkPluginName() == OVNKubernetesPluginName {
+			g.By("Deleting the EgressIP object if it exists for OVN Kubernetes")
+			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+			if _, err := os.Stat(egressIPYamlPath); err == nil {
+				_, _ = oc.AsAdmin().Run("delete").Args("-f", tmpDirEgressIP+"/"+egressIPYaml).Output()
+			}
+
+			g.By("Removing the EgressIP assignable annotation for OVN Kubernetes")
+			for _, nodeName := range egressIPNodesOrderedNames {
+				_, _ = oc.AsAdmin().Run("label").Args("node", nodeName, "k8s.ovn.org/egress-assignable-").Output()
+			}
+		} else {
+			g.By("Removing any hostsubnet EgressIPs for OpenShiftSDN")
+			for _, nodeName := range egressIPNodesOrderedNames {
+				_ = sdnHostsubnetFlushEgressIPs(oc, nodeName)
+				_ = sdnHostsubnetFlushEgressCIDRs(oc, nodeName)
+			}
+		}
+
+		g.By("Removing the temp directory")
+		os.RemoveAll(tmpDirEgressIP)
+	})
+
+	g.Context("[internal-targets]", func() {
+		g.JustBeforeEach(func() {
+			// Host networked is needed for host networked pods.
+			g.By("Adding SCC hostnetwork to the external namespace")
+			_, err := oc.AsAdmin().Run("adm").Args("policy", "add-scc-to-user", "hostnetwork", fmt.Sprintf("system:serviceaccount:%s:default", externalNamespace)).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
+		g.It("EgressIP pods should query hostNetwork pods with the local node's SNAT", func() {
+			var targetIP string
+			var targetPort int
+
+			g.By("Selecting a single EgressIP node, and one node per source deployment")
+			// Requires a minimum of 3 worker nodes in total:
+			// 1 nonEgressIPNodeName + at least 2 as sources of EgressIP traffic.
+			o.Expect(len(egressIPNodesOrderedNames)).Should(o.BeNumerically(">", 1))
+			egressIPNodeStr := []string{egressIPNodesOrderedNames[0]}
+			deploymentNodeStr := [][]string{
+				{egressIPNodesOrderedNames[0]},
+				{egressIPNodesOrderedNames[1]},
+			}
+
+			g.By("Creating the target DaemonSet with a single hostnetworked pod on the target node")
+			daemonSetName := "hostnetworked"
+			// Try the entire port range to create the DaemonSet.
+			for i := 0; i < egressIPTargetHostPortMax-egressIPTargetHostPortMin; i++ {
+				containerPort, err := portAllocator.AllocateNextPort()
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				// use the port that we got from the port allocator for this
+				// new DS / pod. Store the created daemonset for later.
+				_, err = createHostNetworkedDaemonSetAndProbe(
+					clientset,
+					externalNamespace,
+					nonEgressIPNodeName,
+					daemonSetName,
+					containerPort,
+					10, // every 10 seconds
+					6,  // for 6 retries
+				)
+
+				// If this is a port conflict, then keep the port allocation and
+				// simply continue (but delete the current DS first).
+				// The current port is hence marked as unavailable for
+				// further tries.
+				if err != nil && strings.Contains(err.Error(), "Port conflict when creating pod") {
+					err := deleteDaemonSet(clientset, externalNamespace, daemonSetName)
+					o.Expect(err).NotTo(o.HaveOccurred())
+					continue
+				}
+				// Any other error shoud not have occurred.
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				// Break if no error was found.
+				targetPort = containerPort
+				break
+			}
+
+			g.By("Getting the targetIP for the test from the DaemonSet pod")
+			podIPs, err := getDaemonSetPodIPs(clientset, externalNamespace, daemonSetName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(len(podIPs)).Should(o.BeNumerically(">", 0))
+			targetIP = podIPs[0]
+
+			var routeNames []string
+			for k, v := range deploymentNodeStr {
+				g.By(fmt.Sprintf("Creating EgressIP test source deployment %d with number of pods equals number of EgressIP nodes", k))
+				_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, fmt.Sprint(k), ingressDomain, len(v), v)
+				routeNames = append(routeNames, routeName)
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			// For this test, get a single EgressIP per node.
+			// Note: On some clouds like GCP, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
+			// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
+			// will pick the actual node.
+			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
+			egressIPsPerNode := 1
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, egressIPNodeStr, cloudType, egressIPsPerNode)
+			framework.Logf("%v", nodeEgressIPMap)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Choosing the EgressIPs to be assigned, one per node")
+			egressIPSet := make(map[string]string)
+			for nodeName, eip := range nodeEgressIPMap {
+				_, ok := egressIPSet[eip[0]]
+				if !ok {
+					egressIPSet[eip[0]] = nodeName
+				}
+			}
+
+			g.By("Creating the EgressIP object for OVN Kubernetes")
+			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+			egressIPObjectName := egressIPNamespace
+			ovnKubernetesCreateEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
+
+			g.By("Applying the EgressIP object for OVN Kubernetes")
+			_, err = oc.AsAdmin().Run("create").Args("-f", tmpDirEgressIP+"/"+egressIPYaml).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// This approach here is different from the other tests because:
+			// a) No additional SNAT or similar can be injected by the cloud as we go directly from node and we know that we have
+			// an endpoint on the cloud, always, thus we can directly query agnhost's /clientip.
+			// b) The requests in tcpdump did not expose the request string for some reason (probably needed better filters)
+			// c) It's simpler to just query for the /clientip instead of relying on the packet capture for these tests.
+			for _, routeName := range routeNames {
+				g.By(fmt.Sprintf("Launching a new prober pod and probing for EgressIPs at %s", routeName))
+				numberOfRequestsToSend := 10
+				clientIPSet, err := probeForClientIPs(oc, externalNamespace, probePodName, routeName, targetIP, targetPort, numberOfRequestsToSend)
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				// Note: my interpretation is that it's a bug if we see an egressIP here:
+				// We should never see egressIPs when querying internal targets:
+				// https://bugzilla.redhat.com/show_bug.cgi?id=2070929
+				// However, this was still a subject of discussion. When we enable these tests after
+				// we fix 2070929, decide if we want to see EgressIPs here or not and possibly remove
+				// this verification.
+				g.By("Making sure that EgressIPs were not part of the response")
+				framework.Logf("egressIPSet is: %v", egressIPSet)
+				framework.Logf("clientIPSet is: %v", clientIPSet)
+				o.Expect(len(clientIPSet)).Should(o.BeNumerically(">", 0))
+				o.Expect(
+					// return false if any key of x is in y or vice-versa.
+					func(x map[string]string, y map[string]struct{}) bool {
+						for k := range x {
+							if _, ok := y[k]; ok {
+								return false
+							}
+						}
+						for k := range y {
+							if _, ok := x[k]; ok {
+								return false
+							}
+						}
+						return true
+					}(egressIPSet, clientIPSet)).To(o.BeTrue())
+			}
+		})
+	}) // end testing to internal targets
+
+	g.Context("[external-targets]", func() {
+		g.JustBeforeEach(func() {
+			// SCC privileged is needed to run tcpdump on the packet sniffer containers, and at the minimum host networked is needed for
+			// host networked pods.
+			g.By("Adding SCC privileged to the external namespace")
+			_, err := oc.AsAdmin().Run("adm").Args("policy", "add-scc-to-user", "privileged", fmt.Sprintf("system:serviceaccount:%s:default", externalNamespace)).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Spawning the packet sniffer pods on the EgressIP assignable hosts")
+			packetSnifferDaemonSet, err = createPacketSnifferDaemonSet(oc, externalNamespace, egressIPNodesOrderedNames, targetProtocol, targetPort)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
+		// OVNKubernetes
+		// OpenShiftSDN
+		// Skipped on Azure due to https://bugzilla.redhat.com/show_bug.cgi?id=2073045
+		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure]", func() {
+			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
+			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// For this test, get a single EgressIP per node.
+			// Note: On some clouds like GCP, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
+			// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
+			// will pick the actual node.
+			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
+			egressIPsPerNode := 1
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, egressIPNodesOrderedNames, cloudType, egressIPsPerNode)
+			framework.Logf("%v", nodeEgressIPMap)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Choosing the EgressIPs to be assigned, one per node")
+			egressIPSet := make(map[string]string)
+			for nodeName, eip := range nodeEgressIPMap {
+				_, ok := egressIPSet[eip[0]]
+				if !ok {
+					egressIPSet[eip[0]] = nodeName
+				}
+			}
+
+			numberOfRequestsToSend := 10
+			if targetHost == "self" {
+				targetHost = routeName
+			}
+			// Run this twice to make sure that repeated EgressIP creation and deletion works.
+			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+			egressIPObjectName := egressIPNamespace
+			for i := 0; i < 2; i++ {
+				if networkPlugin == OVNKubernetesPluginName {
+					g.By("Creating the EgressIP object for OVN Kubernetes")
+					ovnKubernetesCreateEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
+
+					g.By("Applying the EgressIP object for OVN Kubernetes")
+					applyEgressIPObject(oc, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+				} else {
+					g.By("Adding EgressIPs to netnamespace and hostsubnet for OpenShiftSDN")
+					openshiftSDNAssignEgressIPsManually(oc, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+				}
+
+				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+				spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+
+				if networkPlugin == OVNKubernetesPluginName {
+					g.By("Deleting the EgressIP object for OVN Kubernetes")
+					// Use cascading foreground deletion to make sure that the EgressIP object and its dependencies are gone.
+					_, err = oc.AsAdmin().Run("delete").Args("egressip", egressIPObjectName, "--cascade=foreground").Output()
+					o.Expect(err).NotTo(o.HaveOccurred())
+				} else {
+					g.By("Removing EgressIPs from netnamespace and hostsubnet for OpenShiftSDN")
+					for eip, nodeName := range egressIPSet {
+						err = sdnNamespaceRemoveEgressIP(oc, egressIPNamespace, eip)
+						o.Expect(err).NotTo(o.HaveOccurred())
+						err = sdnHostsubnetRemoveEgressIP(oc, nodeName, eip)
+						o.Expect(err).NotTo(o.HaveOccurred())
+					}
+				}
+
+				// Azure often fails on this step here - BZ https://bugzilla.redhat.com/show_bug.cgi?id=2073045
+				g.By(fmt.Sprintf("Waiting for maximum %d seconds for the CloudPrivateIPConfig objects to vanish", egressUpdateTimeout))
+				waitForCloudPrivateIPConfigsDeletion(oc, egressIPSet, egressUpdateTimeout)
+
+				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", 0, egressIPSet))
+				spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, 0, packetSnifferDaemonSet, egressIPSet)
+			}
+
+			if networkPlugin == OVNKubernetesPluginName {
+				g.By("Removing the egressIPYaml file to signal that no further cleanup is needed for OVN Kubernetes")
+				os.Remove(egressIPYamlPath)
+			}
+		})
+
+		// OVNKubernetes
+		// OpenShiftSDN
+		g.It("pods should keep the assigned EgressIPs when being rescheduled to another node", func() {
+			g.By("Selecting a single EgressIP node, and a single start node for the pod")
+			// requires a total of 3 worker nodes
+			o.Expect(len(egressIPNodesOrderedNames)).Should(o.BeNumerically(">", 1))
+			leftNode := egressIPNodesOrderedNames[0:1]
+			rightNode := egressIPNodesOrderedNames[1:2]
+
+			g.By(fmt.Sprintf("Creating the EgressIP test source deployment on node %s", rightNode[0]))
+			deploymentName, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(rightNode), rightNode)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Getting an EgressIP for a specific node only works on AWS. However, the important
+			// thing here is that we get only a single EgressIP which will be assigned to one
+			// of the 2 nodes only. On AWS, the EgressIP and the pod will end up on different nodes,
+			// the pod will then always be moved to the node that the EgressIP is on. On other cloud
+			// platforms, what happens depends on the involved controllers. Either, the pod and
+			// EgressIPs start out on the same node, or on different nodes. The end result though
+			// is that we always test both scenarios: pod and EgressIP on the same node, pod and
+			// EgressIP on different nodes. And we also test that pods can be moved between nodes.
+			g.By(fmt.Sprintf("Finding potential Egress IPs for node %s", leftNode[0]))
+			egressIPsPerNode := 1
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, leftNode, cloudType, egressIPsPerNode)
+			framework.Logf("%v", nodeEgressIPMap)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Choosing the single EgressIP to be assigned")
+			egressIPSet := make(map[string]string)
+			for nodeName, eip := range nodeEgressIPMap {
+				_, ok := egressIPSet[eip[0]]
+				if !ok {
+					egressIPSet[eip[0]] = nodeName
+				}
+			}
+
+			// This step is different depending on the network plugin.
+			if networkPlugin == OVNKubernetesPluginName {
+				g.By("Creating the EgressIP object for OVN Kubernetes")
+				egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+				egressIPObjectName := egressIPNamespace
+				ovnKubernetesCreateEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
+
+				g.By("Applying the EgressIP object for OVN Kubernetes")
+				applyEgressIPObject(oc, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+			} else {
+				g.By("Patching the netnamespace and hostsubnet for OpenShiftSDN")
+				openshiftSDNAssignEgressIPsManually(oc, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+			}
+
+			numberOfRequestsToSend := 10
+			if targetHost == "self" {
+				targetHost = routeName
+			}
+			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+
+			g.By("Updating the source deployment's Affinity and moving it to the other source node")
+			err = updateDeploymentAffinity(oc, egressIPNamespace, deploymentName, leftNode)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+		})
+
+		// OVNKubernetes
+		// Skipped on OpenShiftSDN as the plugin does not support pod selectors.
+		g.It("only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN]", func() {
+			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
+			deployment0Name, route0Name, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "0", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating the second EgressIP test source deployment with number of pods equals number of EgressIP nodes")
+			_, route1Name, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "1", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// For this test, get a single EgressIP per node.
+			// Note: On some clouds like GCP, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
+			// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
+			// will pick the actual node.
+			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
+			egressIPsPerNode := 1
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, egressIPNodesOrderedNames, cloudType, egressIPsPerNode)
+			framework.Logf("%v", nodeEgressIPMap)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Choosing the EgressIPs to be assigned, one per node")
+			egressIPSet := make(map[string]string)
+			for nodeName, eip := range nodeEgressIPMap {
+				_, ok := egressIPSet[eip[0]]
+				if !ok {
+					egressIPSet[eip[0]] = nodeName
+				}
+			}
+
+			g.By("Creating the EgressIP object for OVN Kubernetes")
+			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+			egressIPObjectName := egressIPNamespace
+			ovnKubernetesCreateEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, fmt.Sprintf("app: %s", deployment0Name), egressIPSet)
+
+			g.By("Applying the EgressIP object for OVN Kubernetes")
+			applyEgressIPObject(oc, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+
+			numberOfRequestsToSend := 10
+			if targetHost == "self" {
+				targetHost = route0Name
+			}
+			g.By(fmt.Sprintf("Testing first EgressIP test source deployment and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, route0Name, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+
+			if targetHost == "self" {
+				targetHost = route1Name
+			}
+			g.By(fmt.Sprintf("Testing second EgressIP test source deployment and making sure that %d requests with search string and EgressIPs %v were seen", 0, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, route1Name, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, 0, packetSnifferDaemonSet, egressIPSet)
+		})
+
+		// OVNKubernetes
+		// Skipped on OpenShiftSDN as this plugin has no EgressIPs object
+		g.It("pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN]", func() {
+			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
+			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// For this test, get a single EgressIP per node.
+			// Note: On some clouds like GCP, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
+			// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
+			// will pick the actual node.
+			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
+			egressIPsPerNode := 1
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, egressIPNodesOrderedNames, cloudType, egressIPsPerNode)
+			framework.Logf("%v", nodeEgressIPMap)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Choosing the EgressIPs to be assigned, one per node, for a total of 2 nodes")
+			i := 0
+			egressIPSetTemp := make(map[string]string)
+			for nodeName, eip := range nodeEgressIPMap {
+				// only do this for 2 nodes
+				if i > 1 {
+					break
+				}
+				i++
+
+				_, ok := egressIPSetTemp[eip[0]]
+				if !ok {
+					egressIPSetTemp[eip[0]] = nodeName
+				}
+			}
+			o.Expect(len(egressIPSetTemp)).Should(o.BeNumerically("==", 2))
+
+			// Run this for each of the EgressIPs (and because we are applying, this will update the EgressIP object)
+			numberOfRequestsToSend := 10
+			if targetHost == "self" {
+				targetHost = routeName
+			}
+			for eip, nodeName := range egressIPSetTemp {
+				egressIPSet := map[string]string{eip: nodeName}
+
+				g.By("Creating the EgressIP object for OVN Kubernetes")
+				egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+				egressIPObjectName := egressIPNamespace
+				ovnKubernetesCreateEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
+
+				g.By("Applying the EgressIP object for OVN Kubernetes")
+				applyEgressIPObject(oc, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+
+				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+				spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+			}
+		})
+
+		// OpenShiftSDN
+		// Skipped on OVNKubernetes
+		g.It("EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes]", func() {
+			g.By("Adding EgressCIDR configuration to hostSubnets for OpenShiftSDN")
+			for _, eipNodeName := range egressIPNodesOrderedNames {
+				for _, node := range workerNodesOrdered {
+					if node.Name == eipNodeName {
+						nodeEgressIPConfigs, err := getNodeEgressIPConfiguration(&node)
+						if err != nil {
+							o.Expect(err).NotTo(o.HaveOccurred())
+						}
+						o.Expect(len(nodeEgressIPConfigs)).Should(o.BeNumerically("==", 1))
+						// TODO - not ready for dualstack (?)
+						egressCIDR := nodeEgressIPConfigs[0].IFAddr.IPv4
+						if egressCIDR == "" {
+							egressCIDR = nodeEgressIPConfigs[0].IFAddr.IPv6
+						}
+						err = sdnHostsubnetSetEgressCIDR(oc, node.Name, egressCIDR)
+						o.Expect(err).NotTo(o.HaveOccurred())
+					}
+				}
+			}
+			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
+			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// For this test, get a single EgressIP per node.
+			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
+			egressIPsPerNode := 1
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, egressIPNodesOrderedNames, cloudType, egressIPsPerNode)
+			framework.Logf("%v", nodeEgressIPMap)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Choosing the EgressIPs to be assigned, one per node")
+			egressIPSet := make(map[string]string)
+			for nodeName, eip := range nodeEgressIPMap {
+				_, ok := egressIPSet[eip[0]]
+				if !ok {
+					egressIPSet[eip[0]] = nodeName
+				}
+			}
+
+			g.By("Patching the netnamespace for OpenShiftSDN")
+			for eip := range egressIPSet {
+				err := sdnNamespaceAddEgressIP(oc, egressIPNamespace, eip)
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			numberOfRequestsToSend := 10
+			if targetHost == "self" {
+				targetHost = routeName
+			}
+			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+		})
+	}) // end testing to external targets
+})
+
+//
+// Functions to reduce code duplication below - those could also go into egressip_helpers.go, but they feel more appropriate here as they call
+// the various testing framework matchers such as o.Expect, etc. These functions also have no return value.
+// Consider these to be lego pieces that the various different test scenarios above
+// use and that can serve as readymade drop-in replacements for larger chunks of code.
+//
+
+// spawnProberSendEgressIPTrafficCheckLogs is a wrapper function to reduce code duplication when probing for EgressIPs.
+// Unfortunately, it can take a bit of time for EgressIPs to become active, so spawnProberSendEgressIPTrafficCheckLogs adds a 15 second retry
+// mechanism which eventually must observe an EgressIP in the logs before running the actual test.
+// It launches a new prober pod and sends <iterations> of requests with a unique search string. It then makes sure that <expectedHits> number
+// of hits were seen.
+func spawnProberSendEgressIPTrafficCheckLogs(
+	oc *exutil.CLI, externalNamespace, probePodName, routeName, targetProtocol, targetHost string, targetPort, iterations, expectedHits int, packetSnifferDaemonSet *v1.DaemonSet, egressIPSet map[string]string) {
+
+	framework.Logf("Launching a new prober pod")
+	proberPod := createProberPod(oc, externalNamespace, probePodName)
+
+	// Unfortunately, even after we created the EgressIP object and the CloudPrivateIPConfig, it can take some time before everything is applied correctly.
+	// If we expect non-zero number of hits, add this 60 second retry mechanism that waits for the first log hit that contains the EgressIP.
+	// 60 seconds might seems a bit long, but for the UDP tests, agnhost's netexec needs at least 7 seconds to finish the UDP query. Add to this the log parsing
+	// retry mechanism and we are around 10 seconds minimum for a single round. On top of that, I have seen this take quite some time on Azure.
+	if expectedHits > 0 {
+		framework.Logf("Eventually (after max 60 seconds) the EgressIP setup should converge and the EgressIP configuration should be operational")
+		o.Eventually(func() bool {
+			framework.Logf("Sending a single probe and checking if it shows up inside the logs")
+			result, err := sendEgressIPProbesAndCheckPacketSnifferLogs(oc, proberPod, routeName, targetProtocol, targetHost, targetPort, 1, 1, packetSnifferDaemonSet, egressIPSet, 3)
+			return err == nil && result
+		}, 60*time.Second, 1*time.Second).Should(o.BeTrue())
+	}
+
+	framework.Logf("Verifying that the expected number of EgressIP outbound requests can be seen in the packet sniffer logs")
+	result, err := sendEgressIPProbesAndCheckPacketSnifferLogs(oc, proberPod, routeName, targetProtocol, targetHost, targetPort, iterations, expectedHits, packetSnifferDaemonSet, egressIPSet, 10)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(result).To(o.BeTrue())
+
+	framework.Logf("Destroying the prober pod")
+	err = destroyProberPod(oc, proberPod)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+// ovnKubernetesCreateEgressIPObject creates the file containing the EgressIP YAML definition which can
+// then be applied.
+func ovnKubernetesCreateEgressIPObject(oc *exutil.CLI, egressIPYamlPath, egressIPObjectName, egressIPNamespace, podSelector string, egressIPSet map[string]string) string {
+	framework.Logf("Marshalling the desired EgressIPs into a string")
+	var egressIPs []string
+	for eip := range egressIPSet {
+		egressIPs = append(egressIPs, eip)
+	}
+	egressIPsString, err := json.Marshal(egressIPs)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	framework.Logf("Creating the EgressIP object and writing it to disk")
+	var egressIPConfig string
+	if podSelector == "" {
+		egressIPConfig = fmt.Sprintf(
+			egressIPYamlTemplateNamespaceSelector, // template yaml
+			egressIPObjectName,                    // name of EgressIP
+			egressIPsString,                       // compact yaml of egressIPs
+			fmt.Sprintf("kubernetes.io/metadata.name: %s", egressIPNamespace), // namespace selector
+		)
+	} else {
+		egressIPConfig = fmt.Sprintf(
+			egressIPYamlTemplatePodAndNamespaceSelector, // template yaml
+			egressIPNamespace, // name of EgressIP
+			egressIPsString,   // compact yaml of egressIPs
+			podSelector,       // pod selector
+			fmt.Sprintf("kubernetes.io/metadata.name: %s", egressIPNamespace), // namespace selector
+		)
+	}
+	err = ioutil.WriteFile(egressIPYamlPath, []byte(egressIPConfig), 0644)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return egressIPYamlPath
+}
+
+// applyEgressIPObject is a wrapper that applies the EgressIP object in file <egressIPYamlPath> with name <egressIPObjectName>
+// The propagation from a created EgressIP object to CloudPrivateIPConfig can take quite some time on Azure, hence also add a
+// check that waits for the CloudPrivateIPConfigs to be created.
+func applyEgressIPObject(oc *exutil.CLI, egressIPYamlPath, egressIPObjectName string, egressIPSet map[string]string, timeout int) {
+	framework.Logf("Applying the EgressIP object %s", egressIPObjectName)
+	_, err := oc.AsAdmin().Run("apply").Args("-f", egressIPYamlPath).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	framework.Logf(fmt.Sprintf("Waiting for CloudPrivateIPConfig creation for a maximum of %d seconds", timeout))
+	var exists bool
+	o.Eventually(func() bool {
+		for eip := range egressIPSet {
+			exists, err = cloudPrivateIpConfigExists(oc, eip)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if !exists {
+				framework.Logf("CloudPrivateIPConfig for %s not found.", eip)
+				return false
+			}
+		}
+		framework.Logf("CloudPrivateIPConfigs for %v found.", egressIPSet)
+		return true
+	}, time.Duration(timeout)*time.Second, 5*time.Second).Should(o.BeTrue())
+
+	framework.Logf(fmt.Sprintf("Waiting for EgressIP addresses inside status of EgressIP CR %s for a maximum of %d seconds", egressIPObjectName, timeout))
+	var hasIP bool
+	o.Eventually(func() bool {
+		for eip := range egressIPSet {
+			hasIP, err = egressIPStatusHasIP(oc, egressIPObjectName, eip)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if !hasIP {
+				framework.Logf("EgressIP object %s does not have IP %s in its status field.", egressIPObjectName, eip)
+				return false
+			}
+		}
+		framework.Logf("Egress IP object %s does have all IPs for %v.", egressIPObjectName, egressIPSet)
+		return true
+	}, time.Duration(timeout)*time.Second, 5*time.Second).Should(o.BeTrue())
+}
+
+// waitForCloudPrivateIPConfigsDeletion will wait for all cloudprivateipconfig objects for the given IPs
+// to vanish.
+func waitForCloudPrivateIPConfigsDeletion(oc *exutil.CLI, egressIPSet map[string]string, timeout int) {
+	var exists bool
+	var err error
+
+	o.Eventually(func() bool {
+		for eip := range egressIPSet {
+			exists, err = cloudPrivateIpConfigExists(oc, eip)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if exists {
+				framework.Logf("CloudPrivateIPConfig for %s found.", eip)
+				return false
+			}
+		}
+		framework.Logf("CloudPrivateIPConfigs for %v not found.", egressIPSet)
+		return true
+	}, time.Duration(timeout)*time.Second, 5*time.Second).Should(o.BeTrue())
+}
+
+// openshiftSDNAssignEgressIPsManually adds EgressIPs to hostsubnet and netnamespace.
+func openshiftSDNAssignEgressIPsManually(oc *exutil.CLI, egressIPNamespace string, egressIPSet map[string]string, timeout int) {
+	var err error
+	for eip, nodeName := range egressIPSet {
+		framework.Logf("Adding EgressIP %s to hostnamespace %s", eip, egressIPNamespace)
+		err = sdnNamespaceAddEgressIP(oc, egressIPNamespace, eip)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Adding EgressIP %s to hostsubnet %s", eip, nodeName)
+		err = sdnHostsubnetAddEgressIP(oc, nodeName, eip)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+
+	framework.Logf(fmt.Sprintf("Waiting for CloudPrivateIPConfig creation for a maximum of %d seconds", timeout))
+	var exists bool
+	o.Eventually(func() bool {
+		for eip := range egressIPSet {
+			exists, err = cloudPrivateIpConfigExists(oc, eip)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if !exists {
+				framework.Logf("CloudPrivateIPConfig for %s not found.", eip)
+				return false
+			}
+		}
+		framework.Logf("CloudPrivateIPConfigs for %v found.", egressIPSet)
+		return true
+	}, time.Duration(timeout)*time.Second, 5*time.Second).Should(o.BeTrue())
+}
+
+// printEgressIPState allows getting a quick overview of the current state of EgressIP objects.
+func printEgressIPState(oc *exutil.CLI) {
+	for _, object := range []string{"host", "egressip", "hostsubnet", "netnamespace", "cloudprivateipconfigs"} {
+		out, err := oc.AsAdmin().Run("get").Args("-A", "-o", "wide", object).Output()
+		if err != nil {
+			continue
+		}
+		outReader := bufio.NewScanner(strings.NewReader(out))
+		for outReader.Scan() {
+			framework.Logf(outReader.Text())
+		}
+	}
+}

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1,0 +1,1694 @@
+package networking
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	configv1 "github.com/openshift/api/config/v1"
+	networkv1 "github.com/openshift/api/network/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	networkclient "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
+	"github.com/openshift/origin/test/extended/util"
+	exutil "github.com/openshift/origin/test/extended/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/test/e2e/framework"
+	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+// Add EgressIP types (copy/paste) instead of vendoring them.
+// See https://coreos.slack.com/archives/C01CQA76KMX/p1652187067459359?thread_ts=1652129799.456939&cid=C01CQA76KMX
+
+// EgressIP is a CRD allowing the user to define a fixed
+// source IP for all egress traffic originating from any pods which
+// match the EgressIP resource according to its spec definition.
+type EgressIP struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Specification of the desired behavior of EgressIP.
+	Spec EgressIPSpec `json:"spec"`
+	// Observed status of EgressIP. Read-only.
+	// +optional
+	Status EgressIPStatus `json:"status,omitempty"`
+}
+
+type EgressIPStatus struct {
+	// The list of assigned egress IPs and their corresponding node assignment.
+	Items []EgressIPStatusItem `json:"items"`
+}
+
+// The per node status, for those egress IPs who have been assigned.
+type EgressIPStatusItem struct {
+	// Assigned node name
+	Node string `json:"node"`
+	// Assigned egress IP
+	EgressIP string `json:"egressIP"`
+}
+
+// EgressIPSpec is a desired state description of EgressIP.
+type EgressIPSpec struct {
+	// EgressIPs is the list of egress IP addresses requested. Can be IPv4 and/or IPv6.
+	// This field is mandatory.
+	EgressIPs []string `json:"egressIPs"`
+	// NamespaceSelector applies the egress IP only to the namespace(s) whose label
+	// matches this definition. This field is mandatory.
+	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector"`
+	// PodSelector applies the egress IP only to the pods whose label
+	// matches this definition. This field is optional, and in case it is not set:
+	// results in the egress IP being applied to all pods in the namespace(s)
+	// matched by the NamespaceSelector. In case it is set: is intersected with
+	// the NamespaceSelector, thus applying the egress IP to the pods
+	// (in the namespace(s) already matched by the NamespaceSelector) which
+	// match this pod selector.
+	// +optional
+	PodSelector metav1.LabelSelector `json:"podSelector,omitempty"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +resource:path=egressip
+// EgressIPList is the list of EgressIPList.
+type EgressIPList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+
+	// List of EgressIP.
+	Items []EgressIP `json:"items"`
+}
+
+var (
+	egressIPYamlTemplatePodAndNamespaceSelector = `apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: %s
+spec:
+    egressIPs: %s
+    podSelector:
+        matchLabels:
+            %s
+    namespaceSelector:
+        matchLabels:
+            %s`
+
+	egressIPYamlTemplateNamespaceSelector = `apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+    name: %s
+spec:
+    egressIPs: %s
+    namespaceSelector:
+        matchLabels:
+            %s`
+)
+
+const (
+	nodeEgressIPConfigAnnotationKey = "cloud.network.openshift.io/egress-ipconfig"
+)
+
+// TODO: make port allocator a singleton, shared among all test processes for egressip
+// TODO: add an egressip allocator similar to the port allocator
+
+type byName []corev1.Node
+
+func (n byName) Len() int           { return len(n) }
+func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
+
+// GetNodesOrdered returns a sorted slice (by node.Name) of nodes or error.
+func getWorkerNodesOrdered(clientset kubernetes.Interface) ([]corev1.Node, error) {
+	if clientset == nil {
+		return nil, fmt.Errorf("Nil pointer clientset provided")
+	}
+
+	nodes, err := clientset.CoreV1().Nodes().List(
+		context.TODO(),
+		metav1.ListOptions{
+			LabelSelector: "node-role.kubernetes.io/worker=",
+		})
+	if err != nil {
+		return nil, err
+	}
+	items := nodes.Items
+	sort.Sort(byName(items))
+
+	return items, nil
+}
+
+// createPacketSnifferDaemonSet creates packet sniffer pods on the hosts specified in scheduleOnHosts.
+func createPacketSnifferDaemonSet(oc *exutil.CLI, namespace string, scheduleOnHosts []string, packetCaptureProtocol string, packetCapturePort int) (*appsv1.DaemonSet, error) {
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	tcpdumpImage, err := util.DetermineImageFromRelease(oc, "network-tools")
+	if err != nil {
+		return nil, err
+	}
+
+	daemonsetName := fmt.Sprintf("%s-packet-sniffer", namespace)
+	targetDaemonset, err := createHostNetworkedPacketSnifferDaemonSet(
+		clientset,
+		tcpdumpImage,
+		packetCaptureProtocol,
+		packetCapturePort,
+		namespace,
+		daemonsetName,
+		scheduleOnHosts,
+	)
+	if err != nil {
+		return targetDaemonset, err
+	}
+
+	var ds *appsv1.DaemonSet
+	retries := 12
+	pollInterval := 5
+	for i := 0; i < retries; i++ {
+		// Get the DS
+		ds, err = clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), daemonsetName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if NumberReady == DesiredNumberScheduled.
+		// In that case, simply return as all went well.
+		if ds.Status.NumberReady == ds.Status.DesiredNumberScheduled {
+			return ds, nil
+		}
+		// If no port conflict error was found, simply sleep for pollInterval and then
+		// check again.
+		time.Sleep(time.Duration(pollInterval) * time.Second)
+	}
+
+	// The DaemonSet is not ready, but this is not because of a port conflict.
+	// This shouldn't happen and other parts of the code will likely report this error
+	// as a CI failure.
+	return ds, fmt.Errorf("Daemonset still not ready after %d tries", retries)
+}
+
+const (
+	// The tcpCaptureScript runs tcpdump and extracts all GET request strings from the packets.
+	// The resulting lines will be something like:
+	// 10.128.2.15.36749  /f8f721fa-53c9-444f-bc96-69c7388fcb5a
+	tcpCaptureScript = `#!/bin/bash
+tcpdump -nne -i any -l -s 0  'port %d and tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x47455420' | awk '{print $9 " " $(NF-1)}'
+`
+
+	// The udpCaptureScript runs tcpdump with option -xx and then decodes the hexadecimal information.
+	// We have to read the UDP payload and it is actually a bit difficult to get this with just tcpdump.
+	// It is also a bit tricky to know when a UDP payload actually ended (specifically for the last packet
+	// that's captured).
+	// tshark would definitely be the better tool here, but that would introduce another dependency. Hence,
+	// decode the hexadecimal information and look for payload that is marked with 'START(.*)EOF$' and extract
+	// the '(.*)' part. The resulting lines will be `sourceIP + "  " + z.group(1)`, hence something like:
+	// 10.128.2.15.36749 f8f721fa-53c9-444f-bc96-69c7388fcb5a
+	udpCaptureScript = `#!/bin/bash
+
+cat <<'EOF' > capture-python.py
+#!/usr/bin/python
+
+import sys
+import select
+import re
+
+# Source IP is at location 8 in the first line
+sourceIPOffset = 8
+# UDP payload starts at around Byte 21
+# We don't care about the offset though, having everything
+# in one line is enough.
+udpPayloadOffset = 0
+
+# globals
+fullHex = []
+sourceIP = ""
+
+def decodePayload(hexArray):
+    payloadStr = ""
+    for x in hexArray[udpPayloadOffset:]:
+        try:
+            byte_array = bytearray.fromhex(x)
+            payloadStr += byte_array.decode()
+        except:
+            pass
+    return payloadStr
+
+def printLine():
+    global sourceIP
+    global fullHex
+    if sourceIP != "" and fullHex != []:
+        decodedPayload = decodePayload(fullHex)
+        z = re.search(r'START(.*)EOF$', decodedPayload)
+        if z:
+            print(sourceIP + "  " + z.group(1))
+            fullHex = []
+            sourceIP = ""
+
+for line in sys.stdin:
+    if not re.match(r'^$', line) and re.match(r'^\s', line):
+        hexLine = line.split()
+        if re.match(r'^0x', hexLine[0]):
+            for x in hexLine[1:]:
+                fullHex.append(x)
+        printLine()
+    elif not re.match(r'^$', line):
+        printLine()
+        sourceIP = line.split()[sourceIPOffset]
+
+printLine()
+EOF
+chmod +x capture-python.py
+
+tcpdump -nne -i any -l -xx -s0 port %d and udp | ./capture-python.py
+`
+)
+
+// createHostNetworkedPacketSnifferDaemonSet creates a host networked pod in namespace <namespace> on
+// node <nodeName>. It will start a packet sniffer and it will log all GET request's source IP and the actual request string.
+func createHostNetworkedPacketSnifferDaemonSet(clientset kubernetes.Interface, networkPacketSnifferImage, packetCaptureProtocol string, packetCapturePort int,
+	namespace, daemonsetName string, scheduleOnHosts []string) (*appsv1.DaemonSet, error) {
+	if packetCaptureProtocol != "http" && packetCaptureProtocol != "udp" {
+		return nil, fmt.Errorf("createHostNetworkedPacketSnifferDaemonSet supports only 'http' and 'udp' protocols, got: %s", packetCaptureProtocol)
+	}
+	// https://www.middlewareinventory.com/blog/tcpdump-capture-http-get-post-requests-apache-weblogic-websphere/#How_to_capture_All_incoming_HTTP_GET_traffic_or_requests
+	cmd := tcpCaptureScript
+	if packetCaptureProtocol == "udp" {
+		cmd = udpCaptureScript
+	}
+	podCommand := []string{
+		"/bin/bash",
+		"-c",
+		fmt.Sprintf(cmd, packetCapturePort),
+	}
+	podLabels := map[string]string{
+		"app": daemonsetName,
+	}
+	// create deployment
+	nodeAffinity := v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   scheduleOnHosts,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	readinessProbe := &v1.Probe{
+		ProbeHandler: v1.ProbeHandler{
+			Exec: &v1.ExecAction{
+				Command: []string{
+					"echo",
+					"ready",
+				},
+			},
+		},
+	}
+	runAsUser := int64(0)
+	securityContext := &v1.SecurityContext{
+		RunAsUser: &runAsUser,
+		Capabilities: &v1.Capabilities{
+			Add: []v1.Capability{
+				"SETFCAP",
+				"CAP_NET_RAW",
+				"CAP_NET_ADMIN",
+			},
+		},
+	}
+	dsDefinition := &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      daemonsetName,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: corev1.PodSpec{
+					Affinity:    &nodeAffinity,
+					HostNetwork: true,
+					Containers: []v1.Container{
+						{
+							Name:            "tcpdump",
+							Image:           networkPacketSnifferImage,
+							Command:         podCommand,
+							ReadinessProbe:  readinessProbe,
+							SecurityContext: securityContext,
+							TTY:             true, // needed for immediate log propagation
+							Stdin:           true, // needed for immediate log propagation
+						},
+					},
+				},
+			},
+		},
+	}
+	ds, err := clientset.AppsV1().DaemonSets(namespace).Create(context.TODO(), dsDefinition, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return ds, nil
+}
+
+// scanPacketSnifferDaemonSetPodLogs iterates over the pods logs and searches for searchString
+// and then counts the occurrences for each found IP address.
+func scanPacketSnifferDaemonSetPodLogs(oc *exutil.CLI, ds *appsv1.DaemonSet, targetProtocol, searchString string) (map[string]int, error) {
+	if oc == nil {
+		return nil, fmt.Errorf("Nil pointer to exutil.CLI oc was provided in ScanPacketSnifferDaemonSetPodLogs")
+	}
+	if ds == nil {
+		return nil, fmt.Errorf("Nil pointer to DaemonSet ds was provided in ScanPacketSnifferDaemonSetPodLogs")
+	}
+	if targetProtocol != "http" && targetProtocol != "udp" {
+		return nil, fmt.Errorf("ScanPacketSnifferDaemonSetPodLogs supports only 'http' and 'udp' protocols.")
+	}
+
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	pods, err := clientset.CoreV1().Pods(ds.Namespace).List(
+		context.TODO(),
+		metav1.ListOptions{LabelSelector: labels.Set(ds.Spec.Selector.MatchLabels).String()})
+	if err != nil {
+		return nil, err
+	}
+
+	matchedIPs := make(map[string]int)
+	for _, pod := range pods.Items {
+		logOptions := corev1.PodLogOptions{}
+		req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &logOptions)
+		logs, err := req.Stream(context.TODO())
+		if err != nil {
+			return nil, fmt.Errorf("Error in opening log stream")
+		}
+		defer logs.Close()
+
+		buf := new(bytes.Buffer)
+		_, err = io.Copy(buf, logs)
+		if err != nil {
+			return nil, fmt.Errorf("Error in copying info from pod logs to buffer")
+		}
+		_ = buf.String()
+
+		var ip string
+		scanner := bufio.NewScanner(buf)
+		for scanner.Scan() {
+			logLine := scanner.Text()
+			if strings.Contains(logLine, searchString) {
+				// Currently, it is not necessary to discriminate by protocol.
+				// a log line should look like this for http:
+				// 10.0.144.5.33226 /bed729aa-4e83-482d-a433-db798e569147
+				// a log line should look like this for udp:
+				// 10.0.144.5.33226 bed729aa-4e83-482d-a433-db798e569147
+				// Should it ever be necessary, the targetProtocol to this method (which is currently
+				// not used) serves this purpose.
+				framework.Logf("Found hit in log line: %s", logLine)
+				logLineExploded := strings.Fields(logLine)
+				if len(logLineExploded) != 2 {
+					return nil, fmt.Errorf("Unexpected logline content: %s", logLine)
+				}
+				ipAddressPortExploded := strings.Split(logLineExploded[0], ".")
+				if len(ipAddressPortExploded) == 2 {
+					// ipv6
+					ip = ipAddressPortExploded[0]
+				} else if len(ipAddressPortExploded) == 5 {
+					// ipv4
+					ip = strings.Join(ipAddressPortExploded[:len(ipAddressPortExploded)-1], ".")
+				} else {
+					return nil, fmt.Errorf("Unexpected logline content, invalid IP/Port: %s", logLine)
+				}
+				matchedIPs[ip]++
+			}
+		}
+	}
+	return matchedIPs, nil
+}
+
+func getIngressDomain(oc *exutil.CLI) (string, error) {
+	ic, err := oc.AdminOperatorClient().OperatorV1().IngressControllers("openshift-ingress-operator").Get(context.Background(), "default", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return ic.Status.Domain, nil
+}
+
+// createAgnhostDeploymentAndIngressRoute creates the route, service and deployment that will be used as
+// a source for EgressIP tests. Returns the route name that can be queried to run queries against the source pods.
+func createAgnhostDeploymentAndIngressRoute(oc *exutil.CLI, namespace, alias, ingressDomain string, replicas int, scheduleOnHosts []string) (string, string, error) {
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	targetPort := 8000
+	if alias == "" {
+		alias = "0"
+	}
+	namespaceAlias := fmt.Sprintf("%s-%s", namespace, alias)
+	routeName := fmt.Sprintf("%s-route", namespaceAlias)
+	routeHost := fmt.Sprintf("%s.%s", namespaceAlias, ingressDomain)
+	serviceName := fmt.Sprintf("%s-service", namespaceAlias)
+	deploymentName := fmt.Sprintf("%s-deployment", namespaceAlias)
+	weight := int32(100)
+	podLabels := map[string]string{
+		"app": deploymentName,
+	}
+	// TODO: As soon as the framework switches to k8s.gcr.io/e2e-test-images/agnhost:2.36,
+	// it would be nice to add:
+	//		"--udp-port",
+	//		"-1",
+	// to disable UDP (which we don't use) for the agnhost binary.
+	podCommand := []string{
+		"/agnhost",
+		"netexec",
+		"--http-port",
+		fmt.Sprintf("%d", targetPort),
+	}
+	replicaCount := int32(replicas)
+
+	// create route
+	routeDefinition := routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+		},
+		Spec: routev1.RouteSpec{
+			Host: routeHost,
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromInt(targetPort),
+			},
+			To: routev1.RouteTargetReference{
+				Kind:   "Service",
+				Name:   serviceName,
+				Weight: &weight,
+			},
+		},
+	}
+	// we need to run this as admin because we manage several namespaces
+	_, err := oc.AdminRouteClient().RouteV1().Routes(namespace).Create(context.TODO(), &routeDefinition, metav1.CreateOptions{})
+	if err != nil {
+		return "", "", err
+	}
+
+	// create service
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": deploymentName,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Protocol: corev1.ProtocolTCP,
+					Port:     int32(targetPort),
+				},
+			},
+		},
+	}
+	_, err = clientset.CoreV1().Services(namespace).Create(
+		context.Background(),
+		service,
+		metav1.CreateOptions{})
+	if err != nil {
+		return "", "", err
+	}
+
+	// create deployment
+	nodeAffinity := v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   scheduleOnHosts,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: deploymentName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+			Replicas: &replicaCount,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": deploymentName,
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "agnhost",
+							Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+							Command: podCommand,
+						},
+					},
+					Affinity: &nodeAffinity,
+				},
+			},
+		},
+	}
+	_, err = clientset.AppsV1().Deployments(namespace).Create(
+		context.Background(),
+		deployment,
+		metav1.CreateOptions{})
+	if err != nil {
+		return "", "", err
+	}
+
+	// block until the deployment's pods are ready
+	wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+		framework.Logf("Verifying if deployment %s is ready ...", deploymentName)
+		d, err := clientset.AppsV1().Deployments(namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return d.Status.AvailableReplicas == *d.Spec.Replicas, nil
+	})
+
+	return deploymentName, routeHost, nil
+}
+
+// updateDeploymentAffinity updates the deployment's Affinity to match the scheduleOnHosts parameter and
+// scales down and back up the replica count of the deployment.
+func updateDeploymentAffinity(oc *exutil.CLI, namespace, deploymentName string, scheduleOnHosts []string) error {
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	// update deployment affinity
+	nodeAffinity := v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   scheduleOnHosts,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var currentReplicaNumber int32
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		framework.Logf("Updating deployment affinity and lowering replica count to 0")
+		// get deployment
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(
+			context.Background(),
+			deploymentName,
+			metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// update the affinity and lower the replica number to 0
+		deployment.Spec.Template.Spec.Affinity = &nodeAffinity
+		currentReplicaNumber = *deployment.Spec.Replicas
+		deployment.Spec.Replicas = &currentReplicaNumber
+
+		_, err = clientset.AppsV1().Deployments(namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+
+	retryErr = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		framework.Logf("Increasing deployment replica count")
+		// get deployment
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(
+			context.Background(),
+			deploymentName,
+			metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// update the replica count back to what it used to be
+		deployment.Spec.Replicas = &currentReplicaNumber
+
+		_, err = clientset.AppsV1().Deployments(namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+
+	// block until the deployment's pods are ready
+	wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+		framework.Logf("Verifying if deployment %s is ready ...", deploymentName)
+		d, err := clientset.AppsV1().Deployments(namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return d.Status.AvailableReplicas == *d.Spec.Replicas, nil
+	})
+
+	return nil
+}
+
+// from github.com/openshift/cloud-network-config-controller/pkg/cloudprovider/cloudprovider.go
+type NodeEgressIPConfiguration struct {
+	Interface string   `json:"interface"`
+	IFAddr    ifAddr   `json:"ifaddr"`
+	Capacity  capacity `json:"capacity"`
+}
+
+type ifAddr struct {
+	IPv4 string `json:"ipv4,omitempty"`
+	IPv6 string `json:"ipv6,omitempty"`
+}
+
+type capacity struct {
+	IPv4 int `json:"ipv4,omitempty"`
+	IPv6 int `json:"ipv6,omitempty"`
+	IP   int `json:"ip,omitempty"`
+}
+
+// findNodeEgressIPs will return a list of available EgressIPs in a map <nodeName>:<egressIP>.
+// The returned EgressIPs are chosen from the nodes' cloud.network.openshift.io/egress-ipconfig annotation and they
+// depend on the current cloud type, on the currenctly used cloudprivateipconfigs, and on an internal reservation
+// manager. Find <egressIPsPerNode> number of IPs per node.
+// TODO: Create the internal reservation manager, if needed.
+func findNodeEgressIPs(oc *exutil.CLI, nodeNames []string, cloudType configv1.PlatformType, egressIPsPerNode int) (map[string][]string, error) {
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	// Get the node API objects corresponding to the node names.
+	var nodeList []*v1.Node
+	for _, nodeName := range nodeNames {
+		node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		nodeList = append(nodeList, node)
+	}
+
+	// Build the list of reserved IPs. To do so, look at the currently used cloudprivateipconfigs
+	// and egressips as well as nodes.
+	var reservedIPs []string
+	reservedIPs, err := buildReservedEgressIPList(oc)
+	if err != nil {
+		return nil, err
+	}
+
+	// For each node, get the node's Egress IP range (annotation cloud.network.openshift.io/egress-ipconfig).
+	// Then, get the first free suitable IP address(es) for this node and add the mapping <node name>:[<ip address>, <ip address>,...]
+	// to the map.
+	nodeEgressIPs := make(map[string][]string)
+	for _, node := range nodeList {
+		nodeEgressIPConfigs, err := getNodeEgressIPConfiguration(node)
+		if err != nil {
+			return nil, err
+		}
+		if l := len(nodeEgressIPConfigs); l != 1 {
+			return nil, fmt.Errorf("Unexpected length of slice for node egress IP configuration: %d", l)
+		}
+		// TODO - not ready for dualstack (?)
+		ipnetStr := nodeEgressIPConfigs[0].IFAddr.IPv4
+		if ipnetStr == "" {
+			ipnetStr = nodeEgressIPConfigs[0].IFAddr.IPv6
+		}
+		freeIPs, err := getFirstFreeIPs(ipnetStr, reservedIPs, cloudType, egressIPsPerNode)
+		if err != nil {
+			return nil, err
+		}
+		nodeEgressIPs[node.Name] = freeIPs
+		// Most cloud environments such as GCP report a single, common CIDR for
+		// EgresiIPs. Therefore, just add the IPs for this node to the reservedPool.
+		for _, freeIP := range freeIPs {
+			reservedIPs = append(reservedIPs, freeIP)
+		}
+	}
+
+	return nodeEgressIPs, nil
+}
+
+// buildReservedEgressIPList builds the list of reserved IPs. To do so, look at the currently used cloudprivateipconfigs
+// and egressips as well as the node IP addresses.
+// Warning: Some cloud environments have a common CIDR for EgressIPs. In those environments, it is not possible to attribute
+// a specific EgressIP to a specific node so this is just a "best effort" allocation and should be kept in mind when writing
+// tests.
+// TODO: add an internal reservation system based on a singleton to avoid race conditions during
+// concurrent tests.
+// TODO: replace with actual library to access cloudprivateipconfigs and egressips - possibly
+// add to the networkclient
+func buildReservedEgressIPList(oc *exutil.CLI) ([]string, error) {
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	var reservedIPs []string
+
+	// cloudprivateipconfigs
+	out, err := oc.AsAdmin().Run("get").Args("-o", "name", "cloudprivateipconfigs").Output()
+	if err != nil {
+		return nil, err
+	}
+	outReader := bufio.NewScanner(strings.NewReader(out))
+	re := regexp.MustCompile("^cloudprivateipconfig.cloud.network.openshift.io/(.*)")
+	for outReader.Scan() {
+		match := re.FindSubmatch([]byte(outReader.Text()))
+		if len(match) != 2 {
+			continue
+		}
+		reservedIPs = append(reservedIPs, string(match[1]))
+	}
+
+	// egressip for OVNKubernetes - if we receive a failure here, it may simply be because
+	// we are on OpenShiftSDN, so ignore the error.
+	out, err = oc.AsAdmin().Run("get").Args("-o", "name", "egressip").Output()
+	if err == nil {
+		var existingEgressIPs []string
+		outReader = bufio.NewScanner(strings.NewReader(out))
+		re = regexp.MustCompile("^egressip.k8s.ovn.org/(.*)")
+		for outReader.Scan() {
+			match := re.FindSubmatch([]byte(outReader.Text()))
+			if len(match) != 2 {
+				continue
+			}
+			existingEgressIPs = append(existingEgressIPs, string(match[1]))
+		}
+		for _, existingEgressIP := range existingEgressIPs {
+			out, err = oc.AsAdmin().Run("get").Args("egressip", existingEgressIP, "-o", "jsonpath={.spec.egressIPs}").Output()
+			if err != nil {
+				return nil, err
+			}
+			var existingEgressIPList []string
+			err = json.Unmarshal([]byte(out), &existingEgressIPList)
+			if err != nil {
+				return nil, err
+			}
+			for _, ip := range existingEgressIPList {
+				reservedIPs = append(reservedIPs, ip)
+			}
+		}
+	}
+	// egressip for OpenShiftSDN - if we receive a failure here, it may simply be because
+	// we are on OVNKubernetes, so ignore the error.
+	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
+	hostSubnets, err := networkClient.HostSubnets().List(context.Background(), metav1.ListOptions{})
+	if err == nil {
+		for _, hostSubnet := range hostSubnets.Items {
+			for _, eip := range hostSubnet.EgressIPs {
+				reservedIPs = append(reservedIPs, string(eip))
+			}
+		}
+	}
+
+	// node internal IP addresses
+	nodes, err := clientset.CoreV1().Nodes().List(
+		context.TODO(),
+		metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodes.Items {
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				reservedIPs = append(reservedIPs, addr.Address)
+			}
+		}
+	}
+
+	return reservedIPs, nil
+}
+
+// getFirstFreeIPs returns the first available IP addresses from the IP network (CIDR notation). reservedIPs are
+// eliminated from the choice and the cloudType is taken into account.
+func getFirstFreeIPs(ipnetStr string, reservedIPs []string, cloudType configv1.PlatformType, egressIPsPerNode int) ([]string, error) {
+	// Parse the CIDR notation and enumerate all IPs inside the subnet.
+	_, ipnet, err := net.ParseCIDR(ipnetStr)
+	if err != nil {
+		return []string{}, err
+	}
+	ipList, err := SubnetIPs(*ipnet)
+	if err != nil {
+		return []string{}, err
+	}
+
+	// For AWS, skip the first 5 addresses:
+	// https://stackoverflow.com/questions/64212709/how-do-i-assign-an-ec2-instance-to-a-fixed-ip-address-within-a-subnet
+	// For Azure, skip the first 3 addresses:
+	// https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-faq
+	// For GCP, the .1 address is reserved / already used.
+	switch cloudType {
+	case configv1.AWSPlatformType:
+		if len(ipList) < 6 {
+			return []string{}, fmt.Errorf("Cloud type is AWS, but there are less than 6 IPs available in the IP network %s", ipnetStr)
+		}
+		ipList = ipList[5 : len(ipList)-1]
+	case configv1.AzurePlatformType:
+		if len(ipList) < 5 {
+			return []string{}, fmt.Errorf("Cloud type is Azure, but there are less than 4 IPs available in the IP network %s", ipnetStr)
+		}
+		ipList = ipList[4 : len(ipList)-1]
+	case configv1.GCPPlatformType:
+		if len(ipList) < 3 {
+			return []string{}, fmt.Errorf("Cloud type is GCP, but there are less than 3 IPs available in the IP network %s", ipnetStr)
+		}
+		ipList = ipList[2 : len(ipList)-1]
+	default:
+		// Skip the network address and the broadcast address
+		ipList = ipList[1 : len(ipList)-1]
+	}
+
+	// Eliminate reserved IPs and return the first hits
+	var freeIPList []string
+outer:
+	for _, ip := range ipList {
+		for _, rip := range reservedIPs {
+			if ip.String() == rip {
+				continue outer
+			}
+		}
+
+		freeIPList = append(freeIPList, ip.String())
+		if len(freeIPList) >= egressIPsPerNode {
+			return freeIPList, nil
+		}
+	}
+
+	return freeIPList, fmt.Errorf(
+		"Could not find requested number of suitable IPs ipnet: %s, reserved IPs %v. Only got %v",
+		ipnetStr, reservedIPs, freeIPList)
+}
+
+// getNodeEgressIPConfiguration returns the parsed NodeEgressIPConfiguration for the node.
+func getNodeEgressIPConfiguration(node *corev1.Node) ([]*NodeEgressIPConfiguration, error) {
+	annotation, ok := node.Annotations[nodeEgressIPConfigAnnotationKey]
+	if !ok {
+		return nil, fmt.Errorf("Cannot find annotation %s on node %s", nodeEgressIPConfigAnnotationKey, node)
+	}
+
+	var nodeEgressIPConfigs []*NodeEgressIPConfiguration
+	err := json.Unmarshal([]byte(annotation), &nodeEgressIPConfigs)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeEgressIPConfigs, nil
+}
+
+// createProberPod creates a prober pod in the proberPodNamespace.
+func createProberPod(oc *exutil.CLI, proberPodNamespace, proberPodName string) *v1.Pod {
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	return frameworkpod.CreateExecPodOrFail(clientset, proberPodNamespace, proberPodName, func(pod *corev1.Pod) {})
+}
+
+// destroyProberPod destroys the given proberPod.
+func destroyProberPod(oc *exutil.CLI, proberPod *v1.Pod) error {
+	if oc == nil {
+		return fmt.Errorf("Nil pointer to exutil.CLI oc was provided in destroyProberPod.")
+	}
+	if proberPod == nil {
+		return fmt.Errorf("Nil pointer to proberPod was provided in destroyProberPod.")
+	}
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	// delete the exec pod again - in foreground, so that it blocks
+	deletePolicy := metav1.DeletePropagationForeground
+	return clientset.CoreV1().Pods(proberPod.Namespace).Delete(
+		context.TODO(),
+		proberPod.Name,
+		metav1.DeleteOptions{
+			PropagationPolicy: &deletePolicy,
+		},
+	)
+}
+
+// sendEgressIPProbesAndCheckPacketSnifferLogs sends requests with a unique search string from the prober pod. It then
+// makes sure that the expectedHits number of requests were seen in the packetSnifferDaemonSet's pod logs.
+// We are only interested in sending our searchString (a unique UUID per query).
+// We do not care about the response because:
+// a) We inspect the traffic that we are sending and we search for the unique searchString
+// b) We make sure that the request leaves from one of the EgressIPs
+// Therefore, we can send our request against any destination.
+// If we tests against any TCP/HTTP endpoint, we can additionally
+// c) Prove that we established a bidirectional stream.
+//
+// Parameters:
+//
+// oc: the CLI
+// proberPod: a pointer to the pod that sends the probes (this is not an EgressIP pod, instead, it dials into the route/service of the EgressIP pods)
+// routeName: Name of the routes that covers the EgressIP nodes
+// targetProtocol: one of http or udp, protocol that EgressIP outbound traffic will use
+// targetHost: a host that resides outside of the cluster, target for EgressIP traffic
+// targetPort: the target port of outbound EgressIP traffic
+// probeCount: the number of probes to send
+// expectedHits: the number of expected log hits (usually, either 0 or expectedHits == probeCount)
+// packetSnifferDaemonSet: the DaemonSet that runs the tcpdump processes (we must check the logs of each pod in this DaemonSet)
+// egressIPSet: Those are the EgressIPs that we are looking for. The sum of log hits for seach EgressIP must be == expectedHits
+// logScanMaxTries: Needed do deal with log propagation delay. Rescan logs every second for logScanMaxTries if expectedHits != probeCount
+func sendEgressIPProbesAndCheckPacketSnifferLogs(
+	oc *exutil.CLI, proberPod *corev1.Pod, routeName, targetProtocol, targetHost string, targetPort,
+	probeCount, expectedHits int, packetSnifferDaemonSet *appsv1.DaemonSet, egressIPSet map[string]string, logScanMaxTries int) (bool, error) {
+
+	// Send requests.
+	framework.Logf("Sending requests with a unique search string from prober pod %s/%s", proberPod.Namespace, proberPod.Name)
+	searchString, err := sendProbesToHostPort(oc, proberPod, routeName, targetProtocol, targetHost, targetPort, probeCount)
+	if err != nil {
+		return false, err
+	}
+
+	// Tcpdump runs with -l for line buffered and the container runs with a TTY.
+	// Even with all of this in place, it can still take a while for log entries to show up inside the container logs so add this retry mechanism.
+	for i := 0; i < logScanMaxTries; i++ {
+		// Collect log entries inside map "found".
+		framework.Logf("Making sure that %d requests with search string %s and EgressIPs %v were seen (try %d of %d)", expectedHits, searchString, egressIPSet, i+1, logScanMaxTries)
+		numberFound := 0
+		found, err := scanPacketSnifferDaemonSetPodLogs(oc, packetSnifferDaemonSet, targetProtocol, searchString)
+		if err != nil {
+			return false, err
+		}
+		framework.Logf("Found map is: %v", found)
+
+		// Count number of found entries for all EgressIPs.
+		for egressIP := range egressIPSet {
+			if n, ok := found[egressIP]; ok {
+				framework.Logf("Found EgressIP %s for string %s %d times", egressIP, searchString, n)
+				numberFound += n
+			}
+		}
+
+		// Return true if number found and expectHits count match.
+		if numberFound == expectedHits {
+			return true, nil
+		}
+
+		// If numberFound > expectedHits, then something is wrong that we can't fix by rescanning the logs.
+		if numberFound > expectedHits {
+			return false, nil
+		}
+
+		framework.Logf("Sleeping for 1 seconds to give container logs and tcpdump some more time to refresh")
+		time.Sleep(1 * time.Second)
+	}
+	return false, nil
+}
+
+// sendProbesToHostPort generates a random string and runs curl against
+// http://%s/dial?host=%s&port=%d&request=<random-string> for the specified number of iterations.
+// Returns the random string that was used as a request.
+func sendProbesToHostPort(oc *exutil.CLI, proberPod *v1.Pod, url, targetProtocol, targetHost string, targetPort, iterations int) (string, error) {
+	if oc == nil {
+		return "", fmt.Errorf("Nil pointer to exutil.CLI oc was provided in sendProbesToHostPort.")
+	}
+	if proberPod == nil {
+		return "", fmt.Errorf("Nil pointer to proberPod was provided in sendProbesToHostPort.")
+	}
+	if targetProtocol != "http" && targetProtocol != "udp" {
+		return "", fmt.Errorf("sendProbesToHostPort supports only 'http' and 'udp' protocols.")
+	}
+
+	randomID := uuid.New()
+	randomIDStr := randomID.String()
+	if targetProtocol == "udp" {
+		randomIDStr = fmt.Sprintf("START%sEOF", randomIDStr)
+	}
+
+	// Connect to the url, instruct the netexec server running on the other side to dial targetProtocol/targetHost/targetPort and insert
+	// the randomIDStr in the request. Run these tests in their own go routines to speed this up (for UDP, agnhost unfortunately has a
+	// 7 second or so wait time before it returns and the delay here compounds a lot when running several iterations).
+	request := fmt.Sprintf("http://%s/dial?protocol=%s&host=%s&port=%d&request=%s", url, targetProtocol, targetHost, targetPort, randomIDStr)
+	var wg sync.WaitGroup
+	errChan := make(chan error, iterations)
+	for i := 0; i < iterations; i++ {
+		// Make sure that we don´t reuse the i variable when passing it to the go func.
+		i := i
+		// Randomize the start time a little bit per go routine.
+		// Max of 250 ms * current iteration counter
+		n := rand.Intn(250) * i
+		framework.Logf("Sleeping for %d ms for iteration %d", n, i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			maxTimeouts := 3
+			time.Sleep(time.Duration(n) * time.Millisecond)
+			for j := 1; j <= maxTimeouts; j++ {
+				output, err := oc.AsAdmin().Run("exec").Args(proberPod.Name, "--", "curl", "-s", request).Output()
+				// No error found. Return.
+				if err == nil {
+					return
+				}
+				// If we hit an i/o timeout, retry for up to maxTimeouts times (however, if this is the last iteration and it still fails, then
+				// report the error).
+				if timeoutError, _ := regexp.Match("^Unable to connect to the server: dial tcp.*i/o timeout$", []byte(output)); timeoutError && j != maxTimeouts {
+					framework.Logf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
+					continue
+				}
+				// Any other error, return.
+				errChan <- fmt.Errorf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
+				return
+			}
+		}()
+	}
+	wg.Wait()
+
+	// If the above yielded any errors, then append them to a list and report them.
+	if len(errChan) > 0 {
+		errList := "Encountered the following errors: "
+		for e := range errChan {
+			errList = fmt.Sprintf("%s {%s}", errList, e.Error())
+		}
+		return "", fmt.Errorf(errList)
+	}
+
+	return randomID.String(), nil
+}
+
+// TODO: make port allocator a singleton, shared among all test processes for egressip
+// TODO: add an egressip allocator similar to the port allocator
+
+// PortAllocator is a simple class to allocate ports serially.
+type PortAllocator struct {
+	minPort, maxPort int
+	reservedPorts    map[int]struct{}
+	nextPort         int
+	numAllocated     int
+	mu               sync.Mutex
+}
+
+// NewPortAllocator initialized a new object of type PortAllocator and returns
+// a pointer to that object.
+func NewPortAllocator(minPort, maxPort int) *PortAllocator {
+	pa := PortAllocator{
+		minPort:       minPort,
+		maxPort:       maxPort,
+		reservedPorts: make(map[int]struct{}),
+		nextPort:      minPort,
+		numAllocated:  0,
+	}
+	return &pa
+}
+
+// AllocateNextPort will allocate a new port, serially. If the end of the range is
+// reached, start over again at the start of the range and look for gaps.
+func (p *PortAllocator) AllocateNextPort() (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	rangeSize := p.maxPort - p.minPort
+	if p.numAllocated > rangeSize {
+		return -1, fmt.Errorf("No more free ports to allocate")
+	}
+
+	for i := 0; i < rangeSize; i++ {
+		if p.nextPort > p.maxPort || p.nextPort < p.minPort {
+			p.nextPort = p.minPort
+		}
+		if p.allocatePort(p.nextPort) == nil {
+			return p.nextPort, nil
+		}
+		p.nextPort++
+	}
+
+	return -1, fmt.Errorf("Cannot allocate new port after %d tries.", rangeSize)
+}
+
+// ReleasePort will release the allocatoin for port <port>.
+func (p *PortAllocator) ReleasePort(port int) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, ok := p.reservedPorts[port]; !ok {
+		return fmt.Errorf("Chosen port %d is not allocated", port)
+	}
+
+	delete(p.reservedPorts, port)
+	p.numAllocated--
+
+	return nil
+}
+
+// isPortFree is a helper method. Not to be used by its own.
+func (p *PortAllocator) isPortFree(port int) bool {
+	_, ok := p.reservedPorts[port]
+	return !ok
+}
+
+// allocatemPort is a helper method. Not to be used by its own.
+func (p *PortAllocator) allocatePort(port int) error {
+	if port < p.minPort || port > p.maxPort {
+		return fmt.Errorf("Chosen port %d is not part of valid range %d - %d",
+			port, p.minPort, p.maxPort)
+	}
+
+	if _, ok := p.reservedPorts[port]; ok {
+		return fmt.Errorf("Chosen port %d is already reserved", port)
+	}
+
+	p.reservedPorts[port] = struct{}{}
+	p.numAllocated++
+
+	return nil
+}
+
+// deleteDaemonSet deletes the Daemonset <namespace>/<dsName>.
+func deleteDaemonSet(clientset kubernetes.Interface, namespace, dsName string) error {
+	deleteOptions := metav1.DeleteOptions{}
+	if err := clientset.AppsV1().DaemonSets(namespace).Delete(context.TODO(), dsName, deleteOptions); err != nil {
+		return fmt.Errorf("Failed to delete DaemonSet %s/%s: %v", namespace, dsName, err)
+	}
+	return nil
+}
+
+// createHostNetworkedDaemonSetAndProbe creates a host networked pod in namespace <namespace> on
+// node <nodeName>. It will allocate a port to listen on and it will return
+// the DaemonSet or an error.
+func createHostNetworkedDaemonSet(clientset kubernetes.Interface, namespace, nodeName, daemonsetName string, containerPort int) (*appsv1.DaemonSet, error) {
+	// TODO: As soon as the framework switches to k8s.gcr.io/e2e-test-images/agnhost:2.36,
+	// it would be nice to add:
+	//		"--udp-port",
+	//		"-1",
+	// to disable UDP (which we don't use) for the agnhost binary.
+	// Also disable the UDP port reservation.
+	podCommand := []string{
+		"/agnhost",
+		"netexec",
+		"--udp-port",
+		fmt.Sprintf("%d", containerPort),
+		"--http-port",
+		fmt.Sprintf("%d", containerPort),
+	}
+
+	podLabels := map[string]string{
+		"app": daemonsetName,
+	}
+	nodeSelector := map[string]string{"kubernetes.io/hostname": nodeName}
+	containerPorts := []v1.ContainerPort{
+		{
+			Name:          fmt.Sprintf("port-%d-tcp", containerPort),
+			HostPort:      int32(containerPort),
+			ContainerPort: int32(containerPort),
+			Protocol:      v1.ProtocolTCP,
+		},
+		{
+			Name:          fmt.Sprintf("port-%d-udp", containerPort),
+			HostPort:      int32(containerPort),
+			ContainerPort: int32(containerPort),
+			Protocol:      v1.ProtocolUDP,
+		},
+	}
+	readinessProbe := &v1.Probe{
+		ProbeHandler: v1.ProbeHandler{
+			HTTPGet: &v1.HTTPGetAction{
+				Port: intstr.FromInt(int(containerPort)),
+				Path: "/clientip",
+			},
+		},
+	}
+
+	dsDefinition := &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      daemonsetName,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: nodeSelector,
+					HostNetwork:  true,
+					Containers: []v1.Container{
+						{
+							Name:           daemonsetName,
+							Image:          imageutils.GetE2EImage(imageutils.Agnhost),
+							Command:        podCommand,
+							Ports:          containerPorts,
+							ReadinessProbe: readinessProbe,
+						},
+					},
+				},
+			},
+		},
+	}
+	ds, err := clientset.AppsV1().DaemonSets(namespace).Create(context.TODO(), dsDefinition, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return ds, nil
+}
+
+// createHostNetworkedDaemonSetAndProbe creates a host networked pod in namespace <namespace> on
+// node <nodeName>. It will allocate a port to listen on and it will return
+// the DaemonSet or an error. It will probe the container and return an error such as the custom
+// "Port conflict when creating pod" error message when the pod failed due to port binding issues.
+func createHostNetworkedDaemonSetAndProbe(clientset kubernetes.Interface, namespace, nodeName, daemonsetName string, port, pollInterval, retries int) (*appsv1.DaemonSet, error) {
+	targetDaemonset, err := createHostNetworkedDaemonSet(
+		clientset,
+		namespace,
+		nodeName,
+		daemonsetName,
+		port,
+	)
+	if err != nil {
+		return targetDaemonset, err
+	}
+
+	var ds *appsv1.DaemonSet
+	for i := 0; i < retries; i++ {
+		// Get the DS
+		ds, err = clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), daemonsetName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if NumberReady == DesiredNumberScheduled.
+		// In that case, simply return as all went well.
+		if ds.Status.NumberReady == ds.Status.DesiredNumberScheduled {
+			return ds, nil
+		}
+
+		// Iterate over the pods (should only be one) and check if we couldn't spawn
+		// because of duplicate assigned ports.
+		// In case of a duplicate port conflict, we return an error message starting with
+		// 'Port conflict when creating pod' so that other parts of the code can react to this.
+		pods, err := clientset.CoreV1().Pods(namespace).List(
+			context.TODO(),
+			metav1.ListOptions{LabelSelector: labels.Set(ds.Spec.Selector.MatchLabels).String()})
+		if err != nil {
+			return nil, err
+		}
+		for _, pod := range pods.Items {
+			hasPortConflict, err := podHasPortConflict(clientset, pod)
+			if err != nil {
+				return ds, err
+			}
+			if hasPortConflict {
+				return ds, fmt.Errorf("Port conflict when creating pod %s/%s", namespace, pod.Name)
+			}
+		}
+
+		// If no port conflict error was found, simply sleep for pollInterval and then
+		// check again.
+		time.Sleep(time.Duration(pollInterval) * time.Second)
+	}
+
+	// The DaemonSet is not ready, but this is not because of a port conflict.
+	// This shouldn't happen and other parts of the code will likely report this error
+	// as a CI failure.
+	return ds, fmt.Errorf("Daemonset still not ready after %d tries", retries)
+}
+
+// podHasPortConflict scans the pod for a port conflict message and also scans the
+// pod's logs for error messages that might indicate such a conflict.
+func podHasPortConflict(clientset kubernetes.Interface, pod v1.Pod) (bool, error) {
+	msg := "have free ports for the requested pod ports"
+	if pod.Status.Phase == v1.PodPending {
+		conditions := pod.Status.Conditions
+		for _, condition := range conditions {
+			if strings.Contains(condition.Message, msg) {
+				return true, nil
+			}
+
+		}
+	} else if pod.Status.Phase == v1.PodRunning {
+		logOptions := corev1.PodLogOptions{}
+		req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &logOptions)
+		logs, err := req.Stream(context.TODO())
+		if err != nil {
+			return false, fmt.Errorf("Error in opening log stream")
+		}
+		defer logs.Close()
+
+		buf := new(bytes.Buffer)
+		_, err = io.Copy(buf, logs)
+		if err != nil {
+			return false, fmt.Errorf("Error in copying info from pod logs to buffer")
+		}
+		logStr := buf.String()
+		if strings.Contains(logStr, "address already in use") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// getDaemonSetPodIPs returns the IPs of all pods in the DaemonSet.
+func getDaemonSetPodIPs(clientset kubernetes.Interface, namespace, daemonsetName string) ([]string, error) {
+	var ds *appsv1.DaemonSet
+	var podIPs []string
+	// Get the DS
+	ds, err := clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), daemonsetName, metav1.GetOptions{})
+	if err != nil {
+		return []string{}, err
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(
+		context.TODO(),
+		metav1.ListOptions{LabelSelector: labels.Set(ds.Spec.Selector.MatchLabels).String()})
+	if err != nil {
+		return []string{}, err
+	}
+	for _, pod := range pods.Items {
+		podIPs = append(podIPs, pod.Status.PodIP)
+	}
+
+	return podIPs, nil
+}
+
+// probeForClientIPs spawns a prober pod inside the prober namespace. It then runs curl against http://%s/dial?host=%s&port=%d&request=/clientip
+// for the specified number of iterations and returns a set of the clientIP addresses that were returned.
+// At the end of the test, the prober pod is deleted again.
+func probeForClientIPs(oc *exutil.CLI, proberPodNamespace, proberPodName, url, targetIP string, targetPort, iterations int) (map[string]struct{}, error) {
+	if oc == nil {
+		return nil, fmt.Errorf("Nil pointer to exutil.CLI oc was provided in SendProbesToHostPort.")
+	}
+
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
+
+	clientIpSet := make(map[string]struct{})
+
+	proberPod := frameworkpod.CreateExecPodOrFail(clientset, proberPodNamespace, probePodName, func(pod *corev1.Pod) {
+		// pod.ObjectMeta.Annotations = annotation
+	})
+	request := fmt.Sprintf("http://%s/dial?host=%s&port=%d&request=/clientip", url, targetIP, targetPort)
+	maxTimeouts := 3
+	for i := 0; i < iterations; i++ {
+		output, err := oc.AsAdmin().Run("exec").Args(proberPod.Name, "--", "curl", "-s", request).Output()
+		if err != nil {
+			// if we hit an i/o timeout, retry
+			if timeoutError, _ := regexp.Match("^Unable to connect to the server: dial tcp.*i/o timeout$", []byte(output)); timeoutError && maxTimeouts > 0 {
+				framework.Logf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
+				iterations++
+				maxTimeouts--
+				continue
+			}
+			return nil, fmt.Errorf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
+		}
+		dialResponse := &struct {
+			Responses []string
+		}{}
+		err = json.Unmarshal([]byte(output), dialResponse)
+		if err != nil {
+			continue
+		}
+		if len(dialResponse.Responses) != 1 {
+			continue
+		}
+		clientIpPort := strings.Split(dialResponse.Responses[0], ":")
+		if len(clientIpPort) != 2 {
+			continue
+		}
+		clientIp := clientIpPort[0]
+		clientIpSet[clientIp] = struct{}{}
+	}
+
+	// delete the exec pod again - in foreground, so that it blocks
+	deletePolicy := metav1.DeletePropagationForeground
+	if err := clientset.CoreV1().Pods(proberPod.Namespace).Delete(context.TODO(), proberPod.Name, metav1.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	}); err != nil {
+		return nil, err
+	}
+
+	return clientIpSet, nil
+}
+
+// getTargetProtocolHostPort gets targetProtocol, targetHost, targetPort.
+// Special targetHost keyword "self" means that the tests should be against th cluster router.
+// networkPluginName is currently unused but passed in here in case it is needed in the future e.g. to modify the default settings
+// based on the pluginName, for example: if networkPluginName == OVNKubernetesPluginName {
+func getTargetProtocolHostPort(oc *exutil.CLI, hasIPv4, hasIPv6 bool, cloudType configv1.PlatformType, networkPluginName string) (string, string, int, error) {
+	var targetProtocol string
+	var targetPort int
+	var targetHost string
+	var err error
+
+	// default settings based on cloud type
+	if cloudType == configv1.AWSPlatformType {
+		// exploiting https://bugzilla.redhat.com/show_bug.cgi?id=2071960
+		targetProtocol = "http"
+		targetHost = "self"
+		targetPort = 80
+	} else {
+		targetProtocol = "udp"
+		targetPort = 80
+		// https://en.wikipedia.org/wiki/Reserved_IP_addresses
+		if hasIPv4 {
+			targetHost = "192.0.2.10"
+		} else {
+			targetHost = "2001:db8::10"
+		}
+	}
+
+	// manual overrides
+	if tp, found := os.LookupEnv("EGRESSIP_TARGET_PROTOCOL"); found {
+		if tp != "udp" && tp != "http" {
+			return "", "", 0, fmt.Errorf("EGRESSIP_TARGET_PROTOCOL must be set to either of 'udp' or 'http', invalid value: %s", tp)
+		}
+		targetProtocol = tp
+	}
+	if th, found := os.LookupEnv("EGRESSIP_TARGET_HOST"); found {
+		targetHost = th
+	}
+	if tp, found := os.LookupEnv("EGRESSIP_TARGET_PORT"); found {
+		targetPort, err = strconv.Atoi(tp)
+		if err != nil {
+			return "", "", 0, fmt.Errorf("EGRESSIP_TARGET_PORT is invalid: %v", err)
+		}
+	}
+	return targetProtocol, targetHost, targetPort, nil
+}
+
+// cloudPrivateIpConfigExists returns if a given ip was found as a cloudprivateipconfigs object.
+// TODO: use k8s API instead of CLI.
+func cloudPrivateIpConfigExists(oc *exutil.CLI, ip string) (bool, error) {
+	out, err := oc.AsAdmin().Run("get").Args("-o", "name", "cloudprivateipconfigs", ip).Output()
+	if err != nil {
+		if strings.Contains(out, "not found") {
+			return false, nil
+		}
+		return false, fmt.Errorf("Error looking up cloudprivateipconfigs %s: out: %s, err: %v", ip, out, err)
+	}
+	return true, nil
+}
+
+// egressIPStatusHasIP returns if a given ip was found in a given EgressIP object's status field.
+// TODO: use k8s API instead of CLI.
+func egressIPStatusHasIP(oc *exutil.CLI, egressIPObjectName string, ip string) (bool, error) {
+	out, err := oc.AsAdmin().Run("get").Args("-o", "json", "egressip", egressIPObjectName).Output()
+	if err != nil {
+		if strings.Contains(out, "not found") {
+			return false, nil
+		}
+		return false, fmt.Errorf("Error looking up EgressIP %s: out: %s, err: %v", egressIPObjectName, out, err)
+	}
+	parsedEgressIP := EgressIP{}
+	err = json.Unmarshal([]byte(out), &parsedEgressIP)
+	if err != nil {
+		return false, err
+	}
+	for _, egressIPStatusItem := range parsedEgressIP.Status.Items {
+		if egressIPStatusItem.EgressIP == ip {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// sdnNamespaceAddEgressIP adds EgressIP <egressip> to netnamespace <namespace>.
+// oc patch netnamespace project1 --type=merge \  -p '{"egressIPs": ["192.168.1.100","192.168.1.101"]}'
+func sdnNamespaceAddEgressIP(oc *exutil.CLI, namespace string, egressIP string) error {
+	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
+	netns, err := networkClient.NetNamespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	netns.EgressIPs = append(netns.EgressIPs, networkv1.NetNamespaceEgressIP(egressIP))
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = networkClient.NetNamespaces().Update(context.Background(), netns, metav1.UpdateOptions{})
+		return err
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+	return nil
+}
+
+// sdnHostsubnetAddEgressIP adds EgressIP <egressIP> to hostsubnet <nodeName>.
+// oc patch hostsubnet node1 --type=merge -p \'{"egressIPs": ["192.168.1.100", "192.168.1.101", "192.168.1.102"]}'
+func sdnHostsubnetAddEgressIP(oc *exutil.CLI, nodeName string, egressIP string) error {
+	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
+	hostSubnet, err := networkClient.HostSubnets().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	hostSubnet.EgressIPs = append(hostSubnet.EgressIPs, networkv1.HostSubnetEgressIP(egressIP))
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = networkClient.HostSubnets().Update(context.Background(), hostSubnet, metav1.UpdateOptions{})
+		return err
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+	return nil
+}
+
+// sdnNamespaceRemoveEgressIP removes EgressIP <egressip> to netnamespace <namespace>.
+func sdnNamespaceRemoveEgressIP(oc *exutil.CLI, namespace string, egressIP string) error {
+	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
+	netns, err := networkClient.NetNamespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	var newEgressIPs []networkv1.NetNamespaceEgressIP
+	for _, eip := range netns.EgressIPs {
+		if eip != networkv1.NetNamespaceEgressIP(egressIP) {
+			newEgressIPs = append(newEgressIPs, eip)
+		}
+	}
+	netns.EgressIPs = newEgressIPs
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = networkClient.NetNamespaces().Update(context.Background(), netns, metav1.UpdateOptions{})
+		return err
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+	return nil
+}
+
+// sdnHostsubnetRemoveEgressIP removes EgressIP <egressIP> to hostsubnet <nodeName>.
+func sdnHostsubnetRemoveEgressIP(oc *exutil.CLI, nodeName string, egressIP string) error {
+	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
+	hostSubnet, err := networkClient.HostSubnets().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	var newEgressIPs []networkv1.HostSubnetEgressIP
+	for _, eip := range hostSubnet.EgressIPs {
+		if eip != networkv1.HostSubnetEgressIP(egressIP) {
+			newEgressIPs = append(newEgressIPs, eip)
+		}
+	}
+	hostSubnet.EgressIPs = newEgressIPs
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = networkClient.HostSubnets().Update(context.Background(), hostSubnet, metav1.UpdateOptions{})
+		return err
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+	return nil
+}
+
+// sdnHostsubnetSetEgressCIDR sets EgressIPCIDR <egressCIDR> for hostsubnet <nodeName>.
+func sdnHostsubnetSetEgressCIDR(oc *exutil.CLI, nodeName string, egressCIDR string) error {
+	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
+	hostSubnet, err := networkClient.HostSubnets().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	hostSubnet.EgressCIDRs = []networkv1.HostSubnetEgressCIDR{networkv1.HostSubnetEgressCIDR(egressCIDR)}
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = networkClient.HostSubnets().Update(context.Background(), hostSubnet, metav1.UpdateOptions{})
+		return err
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+	return nil
+}
+
+// sdnHostsubnetFlushEgressIPs removes all EgressIPs from hostsubnet <nodeName>.
+func sdnHostsubnetFlushEgressIPs(oc *exutil.CLI, nodeName string) error {
+	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
+	hostSubnet, err := networkClient.HostSubnets().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	hostSubnet.EgressIPs = []networkv1.HostSubnetEgressIP{}
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = networkClient.HostSubnets().Update(context.Background(), hostSubnet, metav1.UpdateOptions{})
+		return err
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+	return nil
+}
+
+// sdnHostsubnetFlushEgressCIDRs removes all EgressCIDRs from hostsubnet <nodeName>.
+func sdnHostsubnetFlushEgressCIDRs(oc *exutil.CLI, nodeName string) error {
+	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
+	hostSubnet, err := networkClient.HostSubnets().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	hostSubnet.EgressCIDRs = []networkv1.HostSubnetEgressCIDR{}
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err = networkClient.HostSubnets().Update(context.Background(), hostSubnet, metav1.UpdateOptions{})
+		return err
+	})
+	if retryErr != nil {
+		return fmt.Errorf("Update failed: %v", retryErr)
+	}
+	return nil
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2495,6 +2495,18 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift-sdn should ensure egressnetworkpolicy is created": "should ensure egressnetworkpolicy is created [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes]": "EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes] [Serial] [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN]": "only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure]": "pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure] [Serial] [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN]": "pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should keep the assigned EgressIPs when being rescheduled to another node": "pods should keep the assigned EgressIPs when being rescheduled to another node [Serial] [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [sig-network][Feature:EgressIP] [internal-targets] EgressIP pods should query hostNetwork pods with the local node's SNAT": "EgressIP pods should query hostNetwork pods with the local node's SNAT [Disabled:Broken] [Serial]",
+
 	"[Top Level] [sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created": "should ensure ipv4 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created": "should ensure ipv6 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -66,6 +66,9 @@ var (
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=2004074
 			`\[sig-network-edge\]\[Feature:Idling\] Unidling should work with TCP \(while idling\)`,
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=2070929
+			`\[sig-network\]\[Feature:EgressIP\] \[internal-targets\]`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {
@@ -86,7 +89,9 @@ var (
 			`openshift mongodb replication creating from a template`, // flaking on deployment
 		},
 		// tests that must be run without competition
-		"[Serial]": {},
+		"[Serial]": {
+			`\[sig-network\]\[Feature:EgressIP\]`,
+		},
 		// tests that can't be run in parallel with a copy of itself
 		"[Serial:Self]": {
 			`\[sig-network\] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol`,

--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/library-go/pkg/crypto"
 
 	"github.com/openshift/origin/test/extended/testdata"
+	"github.com/openshift/origin/test/extended/util"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/oauthserver/tokencmd"
 )
@@ -488,48 +489,7 @@ func getImage(oc *exutil.CLI) (string, error) {
 }
 
 func determineImageFromRelease(oc *exutil.CLI) (string, error) {
-	cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	releaseImage := cv.Status.Desired.Image
-	if len(releaseImage) == 0 {
-		return "", fmt.Errorf("cannot determine release image from ClusterVersion resource")
-	}
-	oc.KubeFramework().PodClient().CreateSync(&corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "extract-release-imagerefs"},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:    "imagerefs",
-					Image:   releaseImage,
-					Command: []string{"/bin/sleep", "10000"},
-				},
-			},
-		},
-	})
-	defer oc.KubeFramework().PodClient().Delete(context.Background(), "extract-release-imagerefs", metav1.DeleteOptions{})
-	imageRefsString := oc.KubeFramework().ExecShellInContainer("extract-release-imagerefs", "imagerefs", "cat /release-manifests/image-references")
-	imageRefs := struct {
-		Spec struct {
-			Tags []struct {
-				Name string `json:"name"`
-				From struct {
-					Name string `json:"name"`
-				} `json:"from"`
-			} `json:"tags"`
-		} `json:"spec"`
-	}{}
-	err = json.Unmarshal([]byte(imageRefsString), &imageRefs)
-	if err != nil {
-		return "", err
-	}
-	for _, t := range imageRefs.Spec.Tags {
-		if t.Name == "oauth-server" {
-			return t.From.Name, nil
-		}
-	}
-	return "", fmt.Errorf("Could not find oauth-server image")
+	return util.DetermineImageFromRelease(oc, "oauth-server")
 }
 
 func newRequestTokenOptions(config *restclient.Config, oauthServerURL, oauthClientName, username, password string) *tokencmd.RequestTokenOptions {

--- a/test/extended/util/release.go
+++ b/test/extended/util/release.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DetermineImageFromRelease will get the image and tag for imageTagName from the release image.
+// For example, you can specify oauth-server for the oauth-server image or network-tools to get the image
+// and tag for that image.
+func DetermineImageFromRelease(oc *CLI, imageTagName string) (string, error) {
+	cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	releaseImage := cv.Status.Desired.Image
+	if len(releaseImage) == 0 {
+		return "", fmt.Errorf("cannot determine release image from ClusterVersion resource")
+	}
+	oc.KubeFramework().PodClient().CreateSync(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "extract-release-imagerefs"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "imagerefs",
+					Image:   releaseImage,
+					Command: []string{"/bin/sleep", "10000"},
+				},
+			},
+		},
+	})
+	defer oc.KubeFramework().PodClient().Delete(context.Background(), "extract-release-imagerefs", metav1.DeleteOptions{})
+	imageRefsString := oc.KubeFramework().ExecShellInContainer("extract-release-imagerefs", "imagerefs", "cat /release-manifests/image-references")
+	imageRefs := struct {
+		Spec struct {
+			Tags []struct {
+				Name string `json:"name"`
+				From struct {
+					Name string `json:"name"`
+				} `json:"from"`
+			} `json:"tags"`
+		} `json:"spec"`
+	}{}
+	err = json.Unmarshal([]byte(imageRefsString), &imageRefs)
+	if err != nil {
+		return "", err
+	}
+	for _, t := range imageRefs.Spec.Tags {
+		if t.Name == imageTagName {
+			return t.From.Name, nil
+		}
+	}
+	return "", fmt.Errorf("Could not find image: %s", imageTagName)
+}


### PR DESCRIPTION
Implementation of the EgressIP downstream tests for OVN Kubernetes.
Given that these tests manipulate node and hostSubnet annotations, they must run without competition 
as part of the serial conformance suite.
Test behavior can be changed using several env variables:
EGRESSIP_TARGET_PROTOCOL, EGRESSIP_TARGET_HOST, EGRESSIP_TARGET_PORT

This is a first take on the tests and only tests IPv4 for OVNKubernetes and OpenShiftSDN on Azure, GCP and AWS. 

**Note:** The `vendor-update` label here is a legacy label that the bot added for an earlier version of this PR. The newest version does not modify the vendor folder, yet the bot still reports this.

**Note:** These tests only run on AWS, Azure and GCP and only run in serial. They skip anything baremetal and thus failing baremetal tests would not be due to these tests.
See: https://github.com/openshift/origin/pull/26999/commits/c69664a6d037b433a22036bdce9d41b5829d28bc#diff-dfcd246ff964649f05970d223aea24d306b7c748c8c9c094455fd01c34411303R109