### PR TITLE
getArchitecture: Fix to work with Hypershift

### DIFF
--- a/pkg/synthetictests/platformidentification/types.go
+++ b/pkg/synthetictests/platformidentification/types.go
@@ -123,7 +123,7 @@ func VersionFromHistory(history configv1.UpdateHistory) string {
 }
 
 func getArchitecture(clientConfig *rest.Config) (string, error) {
-	kubeConfig, err := kubernetes.NewForConfig(clientConfig)
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
 		return "", err
 	}
@@ -142,7 +142,7 @@ func getArchitecture(clientConfig *rest.Config) (string, error) {
 		listOpts.LabelSelector = "node-role.kubernetes.io/master"
 	}
 
-	masterNodes, err := kubeConfig.CoreV1().Nodes().List(context.Background(), listOpts)
+	masterNodes, err := kubeClient.CoreV1().Nodes().List(context.Background(), listOpts)
 	if err != nil {
 		return "", err
 	}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -22,6 +22,7 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	authorizationapi "k8s.io/api/authorization/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -2016,6 +2017,23 @@ func GetControlPlaneTopology(ocClient *CLI) (*configv1.TopologyMode, error) {
 
 	if ControlPlaneTopology == nil {
 		infra, err := ocClient.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failure getting test cluster Infrastructure: %s", err.Error())
+		}
+		if &infra.Status.ControlPlaneTopology == nil {
+			return nil, fmt.Errorf("missing Infrastructure.Status.ControlPlaneTopology")
+		}
+		ControlPlaneTopology = &infra.Status.ControlPlaneTopology
+	}
+	return ControlPlaneTopology, nil
+}
+
+func GetControlPlaneTopologyFromConfigClient(client *configclient.ConfigV1Client) (*configv1.TopologyMode, error) {
+	controlPlaneMutex.Lock()
+	defer controlPlaneMutex.Unlock()
+
+	if ControlPlaneTopology == nil {
+		infra, err := client.Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failure getting test cluster Infrastructure: %s", err.Error())
 		}


### PR DESCRIPTION
The `getArchitecture` currently gets a master node to figure out the
arch of the components running on them. Hypershift doesn't have master
nodes so it breaks there.

Check if the cluster has an external controlplane topology and omit the
filter on master nodes if it is external.