### PR TITLE
Add loki to the known NetworkNotReady repeating events check.

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -135,6 +135,10 @@ var knownEventsBugs = []knownProblem{
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
 	},
 	{
+		Regexp: regexp.MustCompile(`ns/openshift-e2e-loki pod/loki-promtail-[a-z0-9]+ node/[a-z0-9.-]+ - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net\.d/\. Has your network provider started\?`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
+	},
+	{
 		Regexp: regexp.MustCompile(`ns/.* service/.* - reason/FailedToDeleteOVNLoadBalancer .*`),
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1990631",
 	},

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -64,6 +64,12 @@ func TestEventCountExtractor(t *testing.T) {
 			times:   24,
 		},
 		{
+			name:    "loki network not ready",
+			input:   `ns/openshift-e2e-loki pod/loki-promtail-qn854 node/ip-10-0-161-147.us-east-2.compute.internal - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started? (23 times)`,
+			message: `ns/openshift-e2e-loki pod/loki-promtail-qn854 node/ip-10-0-161-147.us-east-2.compute.internal - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?`,
+			times:   23,
+		},
+		{
 			name:    "new lines",
 			input:   "ns/e2e-container-probe-7285 pod/liveness-f0fce2c6-6eed-4ace-bf69-2df5e5b8b1ea node/ci-op-sti304mj-2a78c-pq5zv-worker-b-sknbn reason/ProbeWarning Liveness probe warning: <a href=\"http://0.0.0.0/\">Found</a>.\n\n (22 times)",
 			message: "ns/e2e-container-probe-7285 pod/liveness-f0fce2c6-6eed-4ace-bf69-2df5e5b8b1ea node/ci-op-sti304mj-2a78c-pq5zv-worker-b-sknbn reason/ProbeWarning Liveness probe warning: <a href=\"http://0.0.0.0/\">Found</a>.\n\n",


### PR DESCRIPTION
We already had two flakes for this exact problem but in different namespaces. It appears the loki variant is hitting very often in aws-serial jobs: https://search.ci.openshift.org/?search=loki.*NetworkNotReady+network+is+not+ready&maxAge=48h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

This should help clean them up quite a bit.