### PR TITLE
router: construct url with net.JoinHostPort

### DIFF
--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -90,7 +90,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			routerURL := fmt.Sprintf("http://%s", routerIP)
 
 			g.By("waiting for the healthz endpoint to respond")
-			healthzURI := fmt.Sprintf("http://%s:1936/healthz", routerIP)
+			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
 			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
I missed one in https://github.com/openshift/origin/pull/26983.

This ensures we construct the host:port correctly in a URL when working
with IPv6 addresses.