### PR TITLE
Add exception for etcd guard pod readiness probe error events

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -160,6 +160,10 @@ var knownEventsBugs = []knownProblem{
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2000234",
 	},
 	{
+		Regexp: regexp.MustCompile(`ns/openshift-etcd pod/etcd-guard-.* node/.* - reason/ProbeError Readiness probe error: .* connect: connection refused`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2075204",
+	},
+	{
 		Regexp: regexp.MustCompile("ns/openshift-etcd-operator namespace/openshift-etcd-operator -.*rpc error: code = Canceled desc = grpc: the client connection is closing.*"),
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
 	},


### PR DESCRIPTION
Needed in order to switch over to using static guard pods for etcd.
https://github.com/openshift/cluster-etcd-operator/pull/789

Associated BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2075204
See also: https://bugzilla.redhat.com/show_bug.cgi?id=2075015

/cc @deads2k 