### PR TITLE
util: curl connect-to requires bracketed IPv6 address

### DIFF
--- a/test/extended/util/url/url.go
+++ b/test/extended/util/url/url.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -281,14 +282,19 @@ func (ut *Test) WithHeader(hdr, value string) *Test {
 }
 
 // Through configures the test to send requests through the given host.  The
-// host may be specified as a host name, IPv4 address, or bracketed IPv6
-// address.  Use this method when the request specifies some host A that is
+// host may be specified as a host name, IPv4 address, IPv6 address, or bracketed
+// IPv6  address.  Use this method when the request specifies some host A that is
 // different from the actual host B to which the connection must be made.  For
 // example, host A may belong to a route, and host B may be an HAProxy pod that
 // serves the route.  This method is useful when DNS is not configured to
 // resolve host A's host name.
 func (ut *Test) Through(host string) *Test {
-	ut.ProxyHost = host
+	if host[0] != '[' {
+		ipv6CompatHost := net.JoinHostPort(host, "")
+		ut.ProxyHost = ipv6CompatHost[:len(ipv6CompatHost)-1]
+	} else {
+		ut.ProxyHost = host
+	}
 	return ut
 }
 

--- a/test/extended/util/url/url_test.go
+++ b/test/extended/util/url/url_test.go
@@ -3,6 +3,8 @@ package url
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTestsToScript(t *testing.T) {
@@ -10,4 +12,39 @@ func TestTestsToScript(t *testing.T) {
 		Expect("GET", "https://www.google.com"),
 	}
 	fmt.Println(testsToScript(tests))
+}
+
+func TestURL_Through(t *testing.T) {
+	testcases := []struct {
+		name    string
+		through string
+		wants   string
+	}{
+		{
+			name:    "IPv4",
+			through: "10.1.1.5",
+			wants:   "10.1.1.5",
+		},
+		{
+			name:    "IPv6",
+			through: "fe80::cafe",
+			wants:   "[fe80::cafe]",
+		},
+		{
+			name:    "IPv6 already bracketed",
+			through: "[fe80::cafe]",
+			wants:   "[fe80::cafe]",
+		},
+		{
+			name:    "Host",
+			through: "example.com",
+			wants:   "example.com",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ut := Expect("GET", "http://www.google.com/").Through(tc.through)
+			assert.Equal(t, tc.wants, ut.ProxyHost)
+		})
+	}
 }


### PR DESCRIPTION
curl `--connect-to` allows you to direct a request to a specific server,
bypassing DNS.  This is used in various router tests to push the request
through the haproxy instance, but in an IPv6 environment `--connect-to`
needs to be bracketed.

This makes the `.Through` helper accept either bracketed or unbracketed
IPv6 addresses.