### PR TITLE
Bug 2075584: Use substring match instead of exact match

### DIFF
--- a/test/extended/builds/volumes.go
+++ b/test/extended/builds/volumes.go
@@ -182,7 +182,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Phase).To(o.Equal(buildv1.BuildPhaseNew))
 			o.Expect(build.Status.Reason).To(o.BeEquivalentTo("CannotCreateBuildPodSpec"))
-			o.Expect(build.Status.Message).To(o.BeEquivalentTo("Failed to create pod spec."))
+			o.Expect(build.Status.Message).To(o.ContainSubstring("Failed to create pod spec"))
 
 		})
 		g.It("should fail mounting given csi shared resource secret into the build pod for docker strategy builds", func() {
@@ -203,7 +203,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Phase).To(o.Equal(buildv1.BuildPhaseNew))
 			o.Expect(build.Status.Reason).To(o.BeEquivalentTo("CannotCreateBuildPodSpec"))
-			o.Expect(build.Status.Message).To(o.BeEquivalentTo("Failed to create pod spec."))
+			o.Expect(build.Status.Message).To(o.ContainSubstring("Failed to create pod spec"))
 		})
 	})
 })


### PR DESCRIPTION
Relax error string match to check for a substring instead
of an exact match so that we can bubble up better error messages
for these tests.

Supports https://github.com/openshift/openshift-controller-manager/pull/220