### PR TITLE
MON-2148: Handle 401 code for prometheus api route

### DIFF
--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -60,10 +60,10 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 			name   string
 			scheme string
 			path   string
-			expect int
+			expect []int
 		}{
-			{ns: "openshift-console", name: "console", scheme: "https", path: "", expect: 200},
-			{ns: "openshift-monitoring", name: "prometheus-k8s", scheme: "https", path: "api/v1/targets", expect: 403},
+			{ns: "openshift-console", name: "console", scheme: "https", path: "", expect: []int{200}},
+			{ns: "openshift-monitoring", name: "prometheus-k8s", scheme: "https", path: "api/v1/targets", expect: []int{403, 401}},
 		}
 		for _, r := range routes {
 			g.By(fmt.Sprintf("verifying the %s/%s route has an ingress host", r.ns, r.name))
@@ -86,7 +86,7 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 			} else {
 				url = fmt.Sprintf("%s://%s/%s", r.scheme, hostname, r.path)
 			}
-			tests = append(tests, exurl.Expect("GET", url).SkipTLSVerification().HasStatusCode(r.expect))
+			tests = append(tests, exurl.Expect("GET", url).SkipTLSVerification().HasStatusCode(r.expect...))
 			g.By(fmt.Sprintf("verifying the %s/%s route serves %d from %s", r.ns, r.name, r.expect, url))
 		}
 


### PR DESCRIPTION
Currently prometheus apis exposed through oauth-proxy returns 403 on
unauthorized access. However the monitoring team is working on to
migrate to kube-rbac-proxy[1] which would 401 for unauthorized access.

This commit adds logic to handle both 401 and 403 status code.

A similar solution[2] has been employed already to fix other part of the relevant test.

[1] https://github.com/openshift/cluster-monitoring-operator/pull/1631
[2] https://github.com/openshift/origin/pull/26695

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>