### PR TITLE
Disable FIPS disabled serving routes test on BM

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2559,7 +2559,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:Router] The HAProxy router should support reencrypt to services backed by a serving certificate automatically": "should support reencrypt to services backed by a serving certificate automatically [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] when FIPS is disabled the HAProxy router should serve routes when configured with a 1024-bit RSA key": "should serve routes when configured with a 1024-bit RSA key [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] when FIPS is disabled the HAProxy router should serve routes when configured with a 1024-bit RSA key": "should serve routes when configured with a 1024-bit RSA key [Feature:Networking-IPv4] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:Router] when FIPS is enabled the HAProxy router should not work when configured with a 1024-bit RSA key": "should not work when configured with a 1024-bit RSA key [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -131,6 +131,7 @@ var (
 		},
 
 		"[Feature:Networking-IPv4]": {
+			`\[sig-network\]\[Feature:Router\] when FIPS is disabled the HAProxy router should serve routes when configured with a 1024-bit RSA key`,
 			`\[sig-network\] NetworkPolicyLegacy \[LinuxOnly\] NetworkPolicy between server and client should allow egress access to server in CIDR block`,
 			`\[sig-network\] NetworkPolicyLegacy \[LinuxOnly\] NetworkPolicy between server and client should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector`,
 			`\[sig-network\] NetworkPolicyLegacy \[LinuxOnly\] NetworkPolicy between server and client should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector`,


### PR DESCRIPTION
[slack conversation](https://coreos.slack.com/archives/CFP6ST0A3/p1650380304125629)

Apparently, this test is failing a lot on the `pull-ci-openshift-cluster-etcd-operator-master-e2e-metal-ipi-ovn-ipv6)` job on https://github.com/openshift/cluster-etcd-operator/pull/781

We will disable it on BM so it can continue to run elsewhere.
Here's a [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2076701) to track the progress on getting that test fixed.