### PR TITLE
Bug 2077457: Skip BeforeEach as well for the skipped HAProxy config manager test

### DIFF
--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -44,6 +44,9 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	oc = exutil.NewCLI("router-config-manager")
 
 	g.BeforeEach(func() {
+		// the test has been skipped since July 2018 because it was flaking.
+		// TODO: Fix the test and re-enable it in https://issues.redhat.com/browse/NE-906.
+		g.Skip("HAProxy dynamic config manager tests skipped in 4.x")
 		ns = oc.Namespace()
 
 		routerImage, err := exutil.FindRouterImage(oc)
@@ -55,7 +58,9 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should serve the correct routes when running with the haproxy config manager", func() {
-			g.Skip("TODO: This test is flaking, fix it")
+			// the test has been skipped since July 2018 because it was flaking.
+			// TODO: Fix the test and re-enable it in https://issues.redhat.com/browse/NE-906.
+			g.Skip("HAProxy dynamic config manager tests skipped in 4.x")
 			ns := oc.KubeFramework().Namespace.Name
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
 			defer func() {


### PR DESCRIPTION
Although HAProxy config manager test was skipped, the BeforeEach part of the test was not, and this was causing failures in the CI. This PR makes the BeforeEach part skipped as well. Also, this task https://issues.redhat.com/browse/NE-906 has been created to de-flake and re-enable the test in the future. 