### PR TITLE
[release-4.9] Bug 2076256: Remove BlueOcean annotation check

### DIFF
--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -485,10 +485,6 @@ var _ = g.Describe("[sig-builds][Feature:Builds][sig-devex][Feature:Jenkins][Slo
 					}
 					br.AssertSuccess()
 
-					g.By("confirm all the log annotations are there")
-					_, err = jenkins.ProcessLogURLAnnotations(oc, br)
-					o.Expect(err).NotTo(o.HaveOccurred())
-
 					g.By("get build console logs and see if succeeded")
 					out, err := j.GetJobConsoleLogsAndMatchViaBuildResult(br, "Finished: SUCCESS")
 					if err != nil {


### PR DESCRIPTION
The BlueOcean annotation is no longer applied by the new version of
the plugin which we are upgrading to in 4.9. This test has already
been removed from 4.10 when the plugin was upgraded.