### PR TITLE
Bug 2030972: test/extended/util/openshift/clusterversionoperator: Survive API hiccups

### DIFF
--- a/test/e2e/upgrade/adminack/adminack.go
+++ b/test/e2e/upgrade/adminack/adminack.go
@@ -42,8 +42,6 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 // modifies the admin-acks configmap to ack the necessary admin-ack gate and then waits for the Upgradeable
 // condition to change to true.
 func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
-	ctx := context.Background()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {

--- a/test/extended/util/openshift/clusterversionoperator/adminack.go
+++ b/test/extended/util/openshift/clusterversionoperator/adminack.go
@@ -72,7 +72,6 @@ func (t *AdminAckTest) test(ctx context.Context, exercisedGates map[string]struc
 		framework.Fail(err.Error())
 	}
 	currentVersion := getCurrentVersion(ctx, t.Config)
-	var msg string
 	for k, v := range gateCm.Data {
 		if exercisedGates != nil {
 			if _, ok := exercisedGates[k]; ok {
@@ -103,14 +102,14 @@ func (t *AdminAckTest) test(ctx context.Context, exercisedGates map[string]struc
 				framework.Fail(err.Error())
 			}
 		}
-		if err := waitForAdminAckRequired(ctx, t.Config, msg); err != nil {
+		if err := waitForAdminAckRequired(ctx, t.Config, v); err != nil {
 			framework.Fail(err.Error())
 		}
 		// Update admin ack configmap with ack
 		if err := setAdminGate(ctx, k, "true", t.Oc); err != nil {
 			framework.Fail(err.Error())
 		}
-		if err = waitForAdminAckNotRequired(ctx, t.Config, msg); err != nil {
+		if err = waitForAdminAckNotRequired(ctx, t.Config, v); err != nil {
 			framework.Fail(err.Error())
 		}
 		if exercisedGates != nil {


### PR DESCRIPTION
The test case:

    [sig-cluster-lifecycle] TestAdminAck should succeed [Suite:openshift/conformance/parallel]

is vulnerable to brief API-server hiccups [like][1]:

    Dec  6 00:00:10.440: FAIL: Error accessing configmap openshift-config-managed/admin-gates: Get "https://api.ci-op-g2m38jp7-eafe9.origin-ci-int-aws.dev.rhcloud.com:6443/api/v1/namespaces/openshift-config-managed/configmaps/admin-gates": dial tcp: lookup api.ci-op-g2m38jp7-eafe9.origin-ci-int-aws.dev.rhcloud.com on 172.30.0.10:53: no such host

[and][2]:

    Dec  9 19:53:20.747: FAIL: Error accessing configmap openshift-config-managed/admin-gates: Get "https://api.ci-op-w5q90zpi-9278e.origin-ci-int-aws.dev.rhcloud.com:6443/api/v1/namespaces/openshift-config-managed/configmaps/admin-gates": dial tcp 100.21.251.165:6443: i/o timeout

This commit logs the error and continues to the next poll, in case that works.  We keep track of these "I couldn't get far enough in to confirm whether this works or not" issues, and complain about the most recent if we reach the end of the run and have never successfully passed a test-attempt.

There's still some false-failure exposure risk if we fail in `setAdminGate` or one of those steps, but the exposure is "once per ack being excercised" which is a lot smaller than the initial gets' "twice per poll attempt".

There's also a risk of false-success, if we pass on an early version (e.g. "Admin ack is not in this baseline or contains no gates"), but then fail to reach the Kube API for the rest of the run after updating to some later version.  But I expect situations where our poller repeatedly fails to connect to the Kube API server without ever recovering while we're on a particular version will be rare, and that some other Kube-API reachability test-case will fail the overall suite.

Also fixes an empty string in the `waitForAdminAck(Not)Required` message, and drops an unused `Context` variable.

[0]: https://bugzilla.redhat.com/show_bug.cgi?id=2030972
[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2026806#c8
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2027929#c1

