### PR TITLE
synthetic: cloud api quota synthetic test should always be present

### DIFF
--- a/pkg/synthetictests/storage.go
+++ b/pkg/synthetictests/storage.go
@@ -49,5 +49,10 @@ func testAPIQuotaEvents(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 			},
 		}
 	}
-	return nil
+
+	return []*junitapi.JUnitTestCase{
+		{
+			Name: testName,
+		},
+	}
 }


### PR DESCRIPTION
The latest CI payload was rejected on a test we only had 1 instance of
across the 10 runs [sig-arch] cloud API quota should not be exceeded:

  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-aws-ovn-upgrade-4.11-micro-release-openshift-release-analysis-aggregator/1517414586238636032

Tests should always be present so we can track failure % and aggregate
properly.