### PR TITLE
Separate out 'Back-off restarting failed container' from pathological test

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -105,6 +105,9 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 
 	// Separated out in testRequiredInstallerResourcesMissing
 	regexp.MustCompile(requiredResourcesMissingRegEx),
+
+	// Separated out in testBackoffStartingFailedContainer
+	regexp.MustCompile(backoffRestartingFailedRegEx),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -38,6 +38,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 	tests = append(tests, testBackoffPullingRegistryRedhatImage(events)...)
 	tests = append(tests, testRequiredInstallerResourcesMissing(events)...)
+	tests = append(tests, testBackoffStartingFailedContainer(events)...)
 	tests = append(tests, testAPIQuotaEvents(events)...)
 
 	return tests
@@ -69,6 +70,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
 	tests = append(tests, testBackoffPullingRegistryRedhatImage(events)...)
 	tests = append(tests, testRequiredInstallerResourcesMissing(events)...)
+	tests = append(tests, testBackoffStartingFailedContainer(events)...)
 	tests = append(tests, testAPIQuotaEvents(events)...)
 
 	return tests

--- a/pkg/synthetictests/image_pulls.go
+++ b/pkg/synthetictests/image_pulls.go
@@ -15,6 +15,8 @@ const (
 	imagePullRedhatFlakeThreshold         = 5
 	requiredResourcesMissingRegEx         = `reason/RequiredInstallerResourcesMissing secrets: etcd-all-certs-[0-9]+`
 	requiredResourceMissingFlakeThreshold = 10
+	backoffRestartingFailedRegEx          = `reason/BackOff Back-off restarting failed container`
+	backoffRestartingFlakeThreshold       = 10
 )
 
 type eventRecognizerFunc func(event monitorapi.EventInterval) bool
@@ -107,4 +109,12 @@ func testBackoffPullingRegistryRedhatImage(events monitorapi.Intervals) []*junit
 func testRequiredInstallerResourcesMissing(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[bz-etcd] should not see excessive RequiredInstallerResourcesMissing secrets"
 	return newSingleEventCheckRegex(testName, requiredResourcesMissingRegEx, duplicateEventThreshold, requiredResourceMissingFlakeThreshold).test(events)
+}
+
+// testBackoffStartingFailedContainer looks for this symptom:
+//   reason/BackOff Back-off restarting failed container
+//
+func testBackoffStartingFailedContainer(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	testName := "[sig-cluster-lifecycle] should not see excessive Back-off restarting failed containers"
+	return newSingleEventCheckRegex(testName, backoffRestartingFailedRegEx, duplicateEventThreshold, backoffRestartingFlakeThreshold).test(events)
 }

--- a/pkg/synthetictests/image_pulls_test.go
+++ b/pkg/synthetictests/image_pulls_test.go
@@ -106,24 +106,24 @@ func Test_testBackoffPullingRegistryRedhatImage(t *testing.T) {
 					To:   time.Unix(1, 0),
 				},
 			}
-			junit_tests := testBackoffPullingRegistryRedhatImage(e)
+			junitTests := testBackoffPullingRegistryRedhatImage(e)
 			switch tt.kind {
 			case "pass":
-				if len(junit_tests) != 1 {
-					t.Errorf("This should've been a single passing test, but got %d tests", len(junit_tests))
+				if len(junitTests) != 1 {
+					t.Errorf("This should've been a single passing test, but got %d tests", len(junitTests))
 				}
-				if len(junit_tests[0].SystemOut) != 0 {
-					t.Errorf("This should've been a pass, but got %s", junit_tests[0].SystemErr)
+				if len(junitTests[0].SystemOut) != 0 {
+					t.Errorf("This should've been a pass, but got %s", junitTests[0].SystemErr)
 				}
 			case "fail":
 				// At this time, we always want this case to be a flake; so, this will always flake
 				// since failureThreshold is maxInt.
-				if len(junit_tests) != 2 {
-					t.Errorf("This should've been a two tests as flake, but got %d tests", len(junit_tests))
+				if len(junitTests) != 2 {
+					t.Errorf("This should've been a two tests as flake, but got %d tests", len(junitTests))
 				}
 			case "flake":
-				if len(junit_tests) != 2 {
-					t.Errorf("This should've been a two tests as flake, but got %d tests", len(junit_tests))
+				if len(junitTests) != 2 {
+					t.Errorf("This should've been a two tests as flake, but got %d tests", len(junitTests))
 				}
 			default:
 				t.Errorf("Unknown test kind")


### PR DESCRIPTION
See [TRT-201](https://issues.redhat.com/browse/TRT-201).

Example of what we want to separate out:

```


: [sig-arch] events should not repeat pathologically

2 events happened too frequently

event happened 56 times, something is wrong: ns/openshift-cluster-csi-drivers pod/gcp-pd-csi-driver-controller-6747df4b84-bc96x node/ci-op-5nx16hrj-d3bee-4jzmr-master-1 - reason/BackOff Back-off restarting failed container
event happened 78 times, something is wrong: ns/openshift-cluster-csi-drivers pod/gcp-pd-csi-driver-controller-6747df4b84-qjf5g node/ci-op-5nx16hrj-d3bee-4jzmr-master-2 - reason/BackOff Back-off restarting failed container
```