### PR TITLE
[release-4.10] Bug 2077995: Best matcher single node OVN

### DIFF
--- a/pkg/synthetictests/allowedbackenddisruption/matches_test.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches_test.go
@@ -58,6 +58,36 @@ func TestGetClosestP95Value(t *testing.T) {
 			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"ingress-to-oauth-server-reused-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.11", Platform:"azure", Network:"sdn", Topology:"ha"}}, fell back to historicaldata.DataKey{Name:"ingress-to-oauth-server-reused-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.10", Platform:"azure", Network:"sdn", Topology:"ha"}})`,
 		},
 		{
+			name: "fuzzy-match-single-ovn-on-sdn",
+			args: args{
+				backendName: "image-registry-reused-connections",
+				jobType: platformidentification.JobType{
+					Release:     "4.10",
+					FromRelease: "4.10",
+					Platform:    "aws",
+					Network:     "ovn",
+					Topology:    "single",
+				},
+			},
+			expectedDuration: mustDuration("211.86s"),
+			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"image-registry-reused-connections", JobType:platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"aws", Network:"ovn", Topology:"single"}}, fell back to historicaldata.DataKey{Name:"image-registry-reused-connections", JobType:platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"aws", Network:"sdn", Topology:"single"}})`,
+		},
+		{
+			name: "fuzzy-match-single-ovn-on-sdn-previous",
+			args: args{
+				backendName: "image-registry-new-connections",
+				jobType: platformidentification.JobType{
+					Release:     "4.11",
+					FromRelease: "4.11",
+					Platform:    "aws",
+					Network:     "ovn",
+					Topology:    "single",
+				},
+			},
+			expectedDuration: mustDuration("210.86s"),
+			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"image-registry-new-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.11", Platform:"aws", Network:"ovn", Topology:"single"}}, fell back to historicaldata.DataKey{Name:"image-registry-new-connections", JobType:platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"aws", Network:"sdn", Topology:"single"}})`,
+		},
+		{
 			name: "missing",
 			args: args{
 				backendName: "kube-api-reused-connections",

--- a/pkg/synthetictests/historicaldata/next_best_guess.go
+++ b/pkg/synthetictests/historicaldata/next_best_guess.go
@@ -15,6 +15,9 @@ var nextBestGuessers = []NextBestKey{
 	PreviousReleaseUpgrade,
 	combine(PreviousReleaseUpgrade, MicroReleaseUpgrade),
 	combine(PreviousReleaseUpgrade, MinorReleaseUpgrade),
+
+	combine(ForTopology("single"), OnSDN),
+	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade),
 }
 
 // NextBestKey returns the next best key in the query_results.json generated from BigQuery and a bool indicating whether this guesser has an opinion.
@@ -113,6 +116,16 @@ func OnSDN(in platformidentification.JobType) (platformidentification.JobType, b
 	ret := platformidentification.CloneJobType(in)
 	ret.Network = "sdn"
 	return ret, true
+}
+
+// ForTopology we match on exact topology
+func ForTopology(topology string) func(in platformidentification.JobType) (platformidentification.JobType, bool) {
+	return func(in platformidentification.JobType) (platformidentification.JobType, bool) {
+		if in.Topology != topology {
+			return platformidentification.JobType{}, false
+		}
+		return in, true
+	}
 }
 
 // combine will start with the input and call each guess in order.  It uses the output of the previous NextBestKeyFn


### PR DESCRIPTION
Back porting [PR](https://github.com/openshift/origin/pull/26929), This would allow fuzzy matching for SNO and OVN and should fix the identified tests: [Filtered Tests on 4.10 TestGrid](https://testgrid.k8s.io/redhat-openshift-ocp-release-4.10-informing#periodic-ci-openshift-release-master-ci-4.10-e2e-aws-upgrade-single-node&include-filter-by-regex=remains%3F%20available(.*)(with%7Cusing%7Cfor)%20(reused%7Cnew)%20connections&exclude-non-failed-tests=)
