### PR TITLE
Bug 2078528: bump cluster-node-tuning-operator apirequests upper bound for OpenStack

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -264,7 +264,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"cluster-baremetal-operator":             42.0,
 				"cluster-image-registry-operator":        112,
 				"cluster-monitoring-operator":            48,
-				"cluster-node-tuning-operator":           44.0,
+				"cluster-node-tuning-operator":           103.0,
 				"cluster-samples-operator":               26.0,
 				"cluster-storage-operator":               189,
 				"console-operator":                       109.0,


### PR DESCRIPTION
When deploying OCP on OpenStack with OVNKubernetes, we got this error
from the tests:

```
"Operator \"cluster-node-tuning-operator\" produces more watch requests than expected: watchrequestcount=143, upperbound=88, ratio=1.625"
```

Bumping the upperbound to 103 should solve this issue.
