### PR TITLE
test/extended/scheduling/pods: Non-fatal different-nodes flake for 4.10 and earlier

### DIFF
--- a/pkg/synthetictests/platformidentification/types_test.go
+++ b/pkg/synthetictests/platformidentification/types_test.go
@@ -1,0 +1,60 @@
+package platformidentification
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestMostRecentlyCompletedVersionIsAtLeast(t *testing.T) {
+	jt := JobType{MostRecentCompletedRelease: "1.2"}
+	for _, testCase := range []struct {
+		name          string
+		version       string
+		expectedError *regexp.Regexp
+	}{
+		{
+			name:          "input patch version",
+			version:       "1.2.3",
+			expectedError: regexp.MustCompile(`^invalid MostRecentlyCompletedVersionIsAtLeast argument: "1[.]2[.]3" has 3 parts, but at most 2 parts are allowed$`),
+		},
+		{
+			name:          "input string minor",
+			version:       "1.notAnInteger",
+			expectedError: regexp.MustCompile(`^invalid MostRecentlyCompletedVersionIsAtLeast argument: "1[.]notAnInteger" has a non-integer minor version "notAnInteger": strconv.Atoi: parsing "notAnInteger": invalid syntax$`),
+		},
+		{
+			name:    "earlier major",
+			version: "0.2",
+		},
+		{
+			name:    "earlier minor",
+			version: "1.0",
+		},
+		{
+			name:    "same version",
+			version: "1.2",
+		},
+		{
+			name:          "later minor",
+			version:       "1.3",
+			expectedError: regexp.MustCompile(`^have completed 1[.]2, but not 1[.]3`),
+		},
+		{
+			name:          "later major",
+			version:       "2.0",
+			expectedError: regexp.MustCompile(`^have completed 1[.]2, but not 2[.]0`),
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := jt.MostRecentlyCompletedVersionIsAtLeast(testCase.version)
+
+			if err != nil && testCase.expectedError == nil {
+				t.Errorf("unexpected error: %v", err)
+			} else if testCase.expectedError != nil && err == nil {
+				t.Errorf("unexpected success, expected: %s", testCase.expectedError)
+			} else if testCase.expectedError != nil && !testCase.expectedError.MatchString(err.Error()) {
+				t.Errorf("expected error %s, not: %v", testCase.expectedError, err)
+			}
+		})
+	}
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2993,24 +2993,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests": "run Nvidia GPU Device Plugin tests [Disabled:SpecialConfig] [Suite:k8s]",
 
-	"[Top Level] [sig-scheduling][Early] The HAProxy router pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-scheduling][Early] The openshift-apiserver pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-scheduling][Early] The openshift-authentication pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-scheduling][Early] The openshift-console pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-scheduling][Early] The openshift-etcd pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-scheduling][Early] The openshift-image-registry pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-scheduling][Early] The openshift-monitoring pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-scheduling][Early] The openshift-oauth-apiserver pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-scheduling][Early] The openshift-operator-lifecycle-manager pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
-
 	"[Top Level] [sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: CSI Ephemeral-volume (default fs)] ephemeral should create read-only inline ephemeral volume": "should create read-only inline ephemeral volume [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: CSI Ephemeral-volume (default fs)] ephemeral should create read/write inline ephemeral volume": "should create read/write inline ephemeral volume [Suite:openshift/conformance/parallel] [Suite:k8s]",


### PR DESCRIPTION
The separation is only reliable on 4.11 and later.  Still test on earlier releases, but only report violations as non-fatal flakes for those older releases.

Like #27053, but with a new `JobType.HasCompleted` helper, more robust version comparison, and a flake instead of a silent success when run on versions where the test-cases are not expected to reliably succeed.