### PR TITLE
hack/verify-generated: Replace --quiet with --exit-code

### DIFF
--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -11,7 +11,7 @@ trap "cleanup" EXIT
 
 os::test::junit::declare_suite_start "verify/generated"
 os::cmd::expect_success "${OS_ROOT}/hack/update-generated.sh"
-os::cmd::expect_success "git diff --quiet ${OS_ROOT}/test/extended/util/annotate/generated/"
-os::cmd::expect_success "git diff --quiet ${OS_ROOT}/test/extended/util/image/zz_generated.txt"
+os::cmd::expect_success "git diff --exit-code ${OS_ROOT}/test/extended/util/annotate/generated/"
+os::cmd::expect_success "git diff --exit-code ${OS_ROOT}/test/extended/util/image/zz_generated.txt"
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
`--quiet` implied `--exit-code`:

```console
$ git diff --help | grep -A1 -- --quiet
       --quiet
           Disable all output of the program. Implies --exit-code.
```

So with this change, the exit codes remain unaffected:

```console
$ git diff --help | grep -A1 '^       --exit-code'
       --exit-code
           Make the program exit with codes similar to diff(1). That is, it exits with 1 if there were differences and 0 means no differences.
```

But [the not-very-actionable output like][1]:

```
Running hack/verify-generated.sh:14: executing 'git diff --quiet /go/src/github.com/openshift/origin/test/extended/util/annotate/generated/' expecting success...
FAILURE after 1.223s: hack/verify-generated.sh:14: executing 'git diff --quiet /go/src/github.com/openshift/origin/test/extended/util/annotate/generated/' expecting success: the command returned the wrong error code
There was no output from the command.
```

will be replaced by diffs that the user can use with `git apply whatever.patch` to update their local branch with the content the
presubmit is hoping to see.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27054/pull-ci-openshift-origin-master-verify/1519113772063526912#1:build-log.txt%3A26-28