### PR TITLE
Make margin wider to see more in spyglass charts

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -429,7 +429,7 @@
         zQualitative(true).
         enableAnimations(false).
         leftMargin(240).
-        rightMargin(550).
+        rightMargin(1550).
         maxLineHeight(20).
         maxHeight(10000).
         zColorScale(ordinalScale).
@@ -439,7 +439,7 @@
 
 
         // force a minimum width for smaller devices (which otherwise get an unusable display)
-        setTimeout(() => { if (myChart.width() < 1300) { myChart.width(1300) }}, 1)
+        setTimeout(() => { if (myChart.width() < 3100) { myChart.width(3100) }}, 1)
     }
 
     renderChart(null)

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53043,7 +53043,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         zQualitative(true).
         enableAnimations(false).
         leftMargin(240).
-        rightMargin(550).
+        rightMargin(1550).
         maxLineHeight(20).
         maxHeight(10000).
         zColorScale(ordinalScale).
@@ -53053,7 +53053,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
 
         // force a minimum width for smaller devices (which otherwise get an unusable display)
-        setTimeout(() => { if (myChart.width() < 1300) { myChart.width(1300) }}, 1)
+        setTimeout(() => { if (myChart.width() < 3100) { myChart.width(3100) }}, 1)
     }
 
     renderChart(null)


### PR DESCRIPTION
These settings allow you to see more info on the right side of the charts vs. seeing the text squeezed with `...`.

View artifacts in the junit subdir for recent CI runs to see the results.  Note that there is no horizontal scroll bar so you have to widen your browser screen or shrink your font to see all the text in the right margin.

bindata.go is updated via "make update-bindata".