### PR TITLE
track pod IP re-use

### DIFF
--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -95,6 +95,9 @@ func ReasonedMessagef(reason, messageFormat string, a ...interface{}) string {
 }
 
 const (
+	// PodIPReused means the same pod IP is in use by two pods at the same time.
+	PodIPReused = "ReusedPodIP"
+
 	PodReasonCreated   = "Created"
 	PodReasonDeleted   = "Deleted"
 	PodReasonScheduled = "Scheduled"

--- a/pkg/monitor/pod.go
+++ b/pkg/monitor/pod.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -50,6 +52,11 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 		}
 		return conditions
 	})
+
+	podIPTracker := &podNetworkIPCache{
+		podIPsToCurrentPodLocators: map[string]sets.String{},
+	}
+	trackPodIPReuseFn := podIPTracker.updatePod
 
 	podScheduledFn := func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
 		oldPodHasNode := oldPod != nil && len(oldPod.Spec.NodeName) > 0
@@ -293,6 +300,9 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 			}
 		},
 		func(pod *corev1.Pod) []monitorapi.Condition {
+			return trackPodIPReuseFn(pod, nil)
+		},
+		func(pod *corev1.Pod) []monitorapi.Condition {
 			return podScheduledFn(pod, nil)
 		},
 		func(pod *corev1.Pod) []monitorapi.Condition {
@@ -306,6 +316,8 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 	podChangeFns := []func(pod, oldPod *corev1.Pod) []monitorapi.Condition{
 		// check if the pod was scheduled
 		podScheduledFn,
+		// check if the pod was assigned an IP address already in use
+		trackPodIPReuseFn,
 		// check if container lifecycle state changed
 		containerLifecycleStateFn,
 		// check if readiness for containers changed
@@ -460,6 +472,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 		},
 	}
 	podDeleteFns := []func(pod *corev1.Pod) []monitorapi.Condition{
+		podIPTracker.deletePod,
 		// check for transitions to being deleted
 		func(pod *corev1.Pod) []monitorapi.Condition {
 			conditions := []monitorapi.Condition{
@@ -532,10 +545,6 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 	)
 
 	go podInformer.Run(ctx.Done())
-}
-
-func containerHasPreviousState(c *corev1.ContainerStatus) bool {
-	return c.LastTerminationState != corev1.ContainerState{}
 }
 
 func podContainerPhaseStartTime(pod *corev1.Pod, init bool) time.Time {
@@ -618,4 +627,90 @@ func conditionsForTransitioningContainer(pod *corev1.Pod, current, previous *cor
 
 func isMirrorPod(pod *corev1.Pod) bool {
 	return len(pod.Annotations["kubernetes.io/config.mirror"]) > 0
+}
+
+type podNetworkIPCache struct {
+	lock sync.Mutex
+
+	// podIPsToCurrentPodLocators contains the name of the pods currently using a given pod IP.
+	// This only tracks the current state, because we will emit monitor error events on any overlaps.
+	podIPsToCurrentPodLocators map[string]sets.String
+}
+
+func (p *podNetworkIPCache) updatePod(pod, _ *corev1.Pod) []monitorapi.Condition {
+	var conditions []monitorapi.Condition
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	// only consider pod network pods because host network pods will have duplicated IPs
+	if pod.Spec.HostNetwork {
+		return conditions
+	}
+
+	podLocator := monitorapi.LocatePod(pod)
+
+	if isPodIPReleased(pod) {
+		for _, podIP := range pod.Status.PodIPs {
+			ip := podIP.IP
+			if _, ok := p.podIPsToCurrentPodLocators[ip]; !ok {
+				continue
+			}
+			p.podIPsToCurrentPodLocators[ip].Delete(podLocator)
+			if len(p.podIPsToCurrentPodLocators[ip]) == 0 {
+				delete(p.podIPsToCurrentPodLocators, ip)
+			}
+		}
+
+		return conditions
+	}
+
+	for _, podIP := range pod.Status.PodIPs {
+		ip := podIP.IP
+		podNames, existing := p.podIPsToCurrentPodLocators[ip]
+		if !existing {
+			p.podIPsToCurrentPodLocators[ip] = sets.NewString(podLocator)
+			continue
+		}
+		// pods get updated a lot, we'll see the same one many times.
+		if podNames.Has(podLocator) {
+			continue
+		}
+
+		// if we have an existing entry AND we do not already contain this pod name, then have a duplicate.
+		// we'll add the new pod and then fail
+		podNames.Insert(podLocator)
+		p.podIPsToCurrentPodLocators[ip] = podNames
+
+		conditions = append(conditions, monitorapi.Condition{
+			Level:   monitorapi.Error,
+			Locator: podLocator,
+			Message: monitorapi.ReasonedMessagef(monitorapi.PodIPReused, "podIP %v is currently assigned to multiple pods: %v", ip, strings.Join(podNames.List(), ";")),
+		})
+	}
+
+	return conditions
+}
+
+func (p *podNetworkIPCache) deletePod(pod *corev1.Pod) []monitorapi.Condition {
+	podCopy := pod.DeepCopy()
+	if podCopy.DeletionTimestamp == nil {
+		t := metav1.Now()
+		podCopy.DeletionTimestamp = &t
+	}
+	return p.updatePod(podCopy, nil)
+}
+
+// isPodIPReleased returns true if the podIP can be reused.
+// This happens on pod deletion and when the pod will not start any more containers
+func isPodIPReleased(pod *corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		return true
+	}
+
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return true
+	}
+
+	return false
 }

--- a/pkg/monitor/pod_test.go
+++ b/pkg/monitor/pod_test.go
@@ -1,0 +1,277 @@
+package monitor
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func newPod(namespace, name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func addIP(in *corev1.Pod, ip string) *corev1.Pod {
+	out := in.DeepCopy()
+	out.Status.PodIPs = append(out.Status.PodIPs, corev1.PodIP{IP: ip})
+	return out
+}
+
+func setDeletionTimestamp(in *corev1.Pod, deletionTime time.Time) *corev1.Pod {
+	out := in.DeepCopy()
+	out.DeletionTimestamp = &metav1.Time{Time: deletionTime}
+	return out
+}
+
+func Test_podNetworkIPCache_updatePod(t *testing.T) {
+
+	type fields struct {
+		podIPsToCurrentPodLocators map[string]sets.String
+	}
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     []monitorapi.Condition
+		finalMap map[string]sets.String
+	}{
+		{
+			name: "newly-created",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{},
+			},
+			args: args{
+				pod: addIP(newPod("alfa", "zulu"), "10.28.0.96"),
+			},
+			want: nil,
+			finalMap: map[string]sets.String{
+				"10.28.0.96": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "zulu")),
+				),
+			},
+		},
+		{
+			name: "deleted-not-present",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{},
+			},
+			args: args{
+				pod: setDeletionTimestamp(addIP(newPod("alfa", "zulu"), "10.28.0.96"), time.Now()),
+			},
+			want:     nil,
+			finalMap: map[string]sets.String{},
+		},
+		{
+			name: "deleted-ip-present-not-with-pod",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{
+					"10.28.0.96": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "yankee")),
+					),
+				},
+			},
+			args: args{
+				pod: setDeletionTimestamp(addIP(newPod("alfa", "zulu"), "10.28.0.96"), time.Now()),
+			},
+			want: nil,
+			finalMap: map[string]sets.String{
+				"10.28.0.96": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "yankee")),
+				),
+			},
+		},
+		{
+			name: "deleted-ip-present-with-pod",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{
+					"10.28.0.96": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "zulu")),
+					),
+				},
+			},
+			args: args{
+				pod: setDeletionTimestamp(addIP(newPod("alfa", "zulu"), "10.28.0.96"), time.Now()),
+			},
+			want:     nil,
+			finalMap: map[string]sets.String{},
+		},
+		{
+			name: "deleted-ip-present-with-two-pods",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{
+					"10.28.0.96": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "yankee")),
+						monitorapi.LocatePod(newPod("alfa", "zulu")),
+					),
+				},
+			},
+			args: args{
+				pod: setDeletionTimestamp(addIP(newPod("alfa", "zulu"), "10.28.0.96"), time.Now()),
+			},
+			want: nil,
+			finalMap: map[string]sets.String{
+				"10.28.0.96": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "yankee")),
+				),
+			},
+		},
+		{
+			name: "update-of-existing-pod",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{
+					"10.28.0.96": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "zulu")),
+					),
+				},
+			},
+			args: args{
+				pod: addIP(newPod("alfa", "zulu"), "10.28.0.96"),
+			},
+			want: nil,
+			finalMap: map[string]sets.String{
+				"10.28.0.96": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "zulu")),
+				),
+			},
+		},
+		{
+			name: "update-of-existing-pod-already-duplicated",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{
+					"10.28.0.96": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "yankee")),
+						monitorapi.LocatePod(newPod("alfa", "zulu")),
+					),
+				},
+			},
+			args: args{
+				pod: addIP(newPod("alfa", "zulu"), "10.28.0.96"),
+			},
+			want: nil,
+			finalMap: map[string]sets.String{
+				"10.28.0.96": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "yankee")),
+					monitorapi.LocatePod(newPod("alfa", "zulu")),
+				),
+			},
+		},
+		{
+			name: "add-conflicting-pod",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{
+					"10.28.0.96": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "yankee")),
+					),
+				},
+			},
+			args: args{
+				pod: addIP(newPod("alfa", "zulu"), "10.28.0.96"),
+			},
+			want: []monitorapi.Condition{
+				{
+					Level:   monitorapi.Error,
+					Locator: monitorapi.LocatePod(newPod("alfa", "zulu")),
+					Message: `reason/ReusedPodIP podIP 10.28.0.96 is currently assigned to multiple pods: ns/alfa pod/yankee node/ uid/;ns/alfa pod/zulu node/ uid/`,
+				},
+			},
+			finalMap: map[string]sets.String{
+				"10.28.0.96": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "yankee")),
+					monitorapi.LocatePod(newPod("alfa", "zulu")),
+				),
+			},
+		},
+		{
+			name: "add-conflicting-pod-second-ip",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{
+					"10.28.0.96": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "yankee")),
+					),
+				},
+			},
+			args: args{
+				pod: addIP(addIP(newPod("alfa", "zulu"), "2001:0db8:85a3:0000:0000:8a2e:0370:7334"), "10.28.0.96"),
+			},
+			want: []monitorapi.Condition{
+				{
+					Level:   monitorapi.Error,
+					Locator: monitorapi.LocatePod(newPod("alfa", "zulu")),
+					Message: `reason/ReusedPodIP podIP 10.28.0.96 is currently assigned to multiple pods: ns/alfa pod/yankee node/ uid/;ns/alfa pod/zulu node/ uid/`,
+				},
+			},
+			finalMap: map[string]sets.String{
+				"10.28.0.96": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "yankee")),
+					monitorapi.LocatePod(newPod("alfa", "zulu")),
+				),
+				"2001:0db8:85a3:0000:0000:8a2e:0370:7334": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "zulu")),
+				),
+			},
+		},
+		{
+			name: "add-two-conflicts",
+			fields: fields{
+				podIPsToCurrentPodLocators: map[string]sets.String{
+					"10.28.0.96": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "yankee")),
+					),
+					"2001:0db8:85a3:0000:0000:8a2e:0370:7334": sets.NewString(
+						monitorapi.LocatePod(newPod("alfa", "x-ray")),
+					),
+				},
+			},
+			args: args{
+				pod: addIP(addIP(newPod("alfa", "zulu"), "2001:0db8:85a3:0000:0000:8a2e:0370:7334"), "10.28.0.96"),
+			},
+			want: []monitorapi.Condition{
+				{
+					Level:   monitorapi.Error,
+					Locator: monitorapi.LocatePod(newPod("alfa", "zulu")),
+					Message: `reason/ReusedPodIP podIP 2001:0db8:85a3:0000:0000:8a2e:0370:7334 is currently assigned to multiple pods: ns/alfa pod/x-ray node/ uid/;ns/alfa pod/zulu node/ uid/`,
+				},
+				{
+					Level:   monitorapi.Error,
+					Locator: monitorapi.LocatePod(newPod("alfa", "zulu")),
+					Message: `reason/ReusedPodIP podIP 10.28.0.96 is currently assigned to multiple pods: ns/alfa pod/yankee node/ uid/;ns/alfa pod/zulu node/ uid/`,
+				},
+			},
+			finalMap: map[string]sets.String{
+				"10.28.0.96": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "yankee")),
+					monitorapi.LocatePod(newPod("alfa", "zulu")),
+				),
+				"2001:0db8:85a3:0000:0000:8a2e:0370:7334": sets.NewString(
+					monitorapi.LocatePod(newPod("alfa", "x-ray")),
+					monitorapi.LocatePod(newPod("alfa", "zulu")),
+				),
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &podNetworkIPCache{
+				podIPsToCurrentPodLocators: tt.fields.podIPsToCurrentPodLocators,
+			}
+			if got := p.updatePod(tt.args.pod, nil); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("updatePod() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(p.podIPsToCurrentPodLocators, tt.finalMap) {
+				t.Errorf("map = %v, want %v", p.podIPsToCurrentPodLocators, tt.finalMap)
+			}
+		})
+	}
+}

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -81,5 +81,6 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 // machine, even if the machine crashes.
 func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*junitapi.JUnitTestCase) {
 	tests = append(tests, testSystemDTimeout(events)...)
+	tests = append(tests, testPodIPReuse(events)...)
 	return tests
 }


### PR DESCRIPTION
This should let us catch cases where the networking for the cluster assigns the same IP to multiple pods at the same time.