### PR TITLE
test/extended/prometheus/image_pulls: New "should be fast" test-case

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -77,6 +77,7 @@ func AllTests() []upgrades.Test {
 		&apps.DaemonSetUpgradeTest{},
 		imageregistry.NewImageRegistryAvailableWithNewConnectionsTest(),
 		imageregistry.NewImageRegistryAvailableWithReusedConnectionsTest(),
+		&prometheus.ImagePullsAreFast{},
 		&prometheus.MetricsAvailableAfterUpgradeTest{},
 		&dns.UpgradeTest{},
 	}

--- a/test/extended/prometheus/image_pulls.go
+++ b/test/extended/prometheus/image_pulls.go
@@ -1,0 +1,75 @@
+package prometheus
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	"github.com/openshift/origin/pkg/test/ginkgo/result"
+	exutil "github.com/openshift/origin/test/extended/util"
+	helper "github.com/openshift/origin/test/extended/util/prometheus"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+)
+
+// ImagePullsAreFast asserts that image pulls complete quickly.
+type ImagePullsAreFast struct {
+	threshold time.Duration
+}
+
+func (t *ImagePullsAreFast) Name() string {
+	return "image-pulls-are-fast"
+}
+
+func (t *ImagePullsAreFast) DisplayName() string {
+	return "[sig-node][Late] Image pulls are fast"
+}
+
+func (t *ImagePullsAreFast) Setup(_ *framework.Framework) {
+	if t.threshold.Seconds() == 0 {
+		t.threshold = 2 * time.Minute
+	}
+	return
+}
+
+func (t *ImagePullsAreFast) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	ctx := context.Background()
+	<-done
+
+	g.By(fmt.Sprintf("verifying that pull durations do not exceed %s", t.threshold))
+
+	oc := exutil.NewCLIWithFramework(f)
+
+	// we only consider samples since the beginning of the test
+	testDuration := exutil.DurationSinceStartInSeconds().String()
+
+	// checking with second-granularity over testDuration, count
+	// the number of times that the largest CRI-O pull was slower
+	// than threshold seconds.
+	query := fmt.Sprintf(`
+count_over_time((
+  max(container_runtime_crio_operations_latency_microseconds{operation_type="PullImage"})
+)[%[1]s:1s]) > %d * 1e6
+`, testDuration, int(t.threshold.Seconds()))
+	response, err := helper.RunQuery(ctx, oc.NewPrometheusClient(ctx), query)
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to retrieve CRI-O pull latencies")
+
+	if len(response.Data.Result) == 0 {
+		return
+	} else if len(response.Data.Result) > 1 {
+		framework.Failf("expected a single series, got %d: %v", len(response.Data.Result), response.Data.Result)
+	}
+
+	series := response.Data.Result[0]
+	result.Flakef("PullImage operations over %s for %s seconds", t.threshold, series.Value)
+}
+
+func (t ImagePullsAreFast) Teardown(_ *framework.Framework) {
+	return
+}
+
+func (t *ImagePullsAreFast) Skip(_ upgrades.UpgradeContext) bool {
+	return false
+}


### PR DESCRIPTION
To help make things [like][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-aws-ovn-upgrade/1518821292038426624/artifacts/e2e-aws-ovn-upgrade/gather-extra/artifacts/events.json | jq -r '[.items[] | select(.reason == "Pulled" and (.message | match("[0-9]m[0-9.]+s")))] | sort_by(.metadata.creationTimestamp)[] | .metadata.creationTimestamp + " " + (.involvedObject | (.namespace + " " + .name)) + " " + .reason + ": " + .message'
2022-04-26T06:11:43Z openshift-cluster-version version--xpvbz-zldzn Pulled: Successfully pulled image "registry.build04.ci.openshift.org/ci-op-9k22xqj3/release@sha256:8b4a46a564186bc9738732c573ca317b2b9d897fd8456a7dea0ed4c87f64db83" in 10m55.944899635s
```

easier to detect.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-aws-ovn-upgrade/1518821292038426624