### PR TITLE
Bug 2082598: Updated disruption times with higher tolerations for single node

### DIFF
--- a/test/extended/single_node/topology.go
+++ b/test/extended/single_node/topology.go
@@ -119,6 +119,11 @@ func isAllowedToFail(deployment appsv1.Deployment) bool {
 	return false
 }
 
+func IsSingleNodeInfra(f *e2e.Framework) bool {
+	_, infra := getTopologies(f)
+	return infra == v1.SingleReplicaTopologyMode
+}
+
 var _ = Describe("[sig-arch] Cluster topology single node tests", func() {
 	f := e2e.NewDefaultFramework("single-node")
 

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -123,6 +123,7 @@ func (t *availableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 			toleratedDisruption = 0
 		}
 	}
+	toleratedDisruption = disruption.GetSingleNodeDistributionWithDefault(t.Name(), toleratedDisruption, f)
 	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), fmt.Sprintf("API %q was unreachable during disruption (AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804)", t.name))
 }
 

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -79,6 +79,7 @@ func (t *AvailableTest) Setup(f *framework.Framework) {
 func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	client, err := framework.LoadClientset()
 	framework.ExpectNoError(err)
+	toleratedDisruption := disruption.GetSingleNodeDistributionWithDefault(t.Name(), 0.20, f)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -105,7 +106,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Frontends were unreachable during disruption")
+	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Frontends were unreachable during disruption")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/extended/util/disruption/imageregistry/imageregistry.go
+++ b/test/extended/util/disruption/imageregistry/imageregistry.go
@@ -97,6 +97,7 @@ func (t *AvailableTest) Setup(f *framework.Framework) {
 func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	client, err := framework.LoadClientset()
 	framework.ExpectNoError(err)
+	toleratedDisruption := disruption.GetSingleNodeDistributionWithDefault(t.Name(), 0.20, f)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -122,7 +123,7 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	cancel()
 	end := time.Now()
 
-	disruption.ExpectNoDisruption(f, 0.20, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Image registry was unreachable during disruption")
+	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Image registry was unreachable during disruption")
 }
 
 // Teardown cleans up any remaining resources.


### PR DESCRIPTION
For typical single node topologies the current disruption values in 4.8 fail during upgrades, this PR adds some more generous disruption rates for only for a single node topology on `aws` and `azure`.

The values were retrieved from `ci-search` and buffered by 5.

[Filtered testgrid data for the tests below](https://testgrid.k8s.io/redhat-openshift-ocp-release-4.8-informing#periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade-single-node&include-filter-by-regex=remains%3F%20available(.*)(with%7Cusing%7Cfor)%20(reused%7Cnew)%20connections&exclude-non-failed-tests=)
