### PR TITLE
Increase determinism when searching for prom service secret token

### DIFF
--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -78,7 +78,7 @@ func LocatePrometheus(oc *exutil.CLI) (queryURL, prometheusURL, bearerToken stri
 			if secret.Type != v1.SecretTypeServiceAccountToken {
 				continue
 			}
-			if !strings.HasPrefix(secret.Name, "prometheus-") {
+			if !strings.HasPrefix(secret.Name, "prometheus-k8s-token") {
 				continue
 			}
 			bearerToken = string(secret.Data[v1.ServiceAccountTokenKey])


### PR DESCRIPTION
Prior to this chance, we may pick up a service account token that
isn't the one we require. This is causing rare flakes in CI runs.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

Sample CI run where flake occurred:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-ovn/1514867591028412416

/cc @openshift/openshift-team-monitoring 