### PR TITLE
Include timestamp when reporting observed ReusedPodIP events.

### DIFF
--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -278,7 +278,7 @@ func testPodIPReuse(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 		if reason := monitorapi.ReasonFrom(event.Message); reason != monitorapi.PodIPReused {
 			continue
 		}
-		failures = append(failures, event.Message)
+		failures = append(failures, event.From.Format(time.RFC3339)+" "+event.Message)
 	}
 
 	if len(failures) == 0 {


### PR DESCRIPTION
Important to see this when we start correlating which pods got which
IPs and when.
