### PR TITLE
Revert "Add e2e tests for ExternalIP Policy and AutoAssignCIDRs"

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -85,8 +85,6 @@ var staticSuites = testSuites{
 				}
 				return strings.Contains(name, "[Suite:openshift/conformance/serial") || isStandardEarlyOrLateTest(name)
 			},
-			// doubling default test timeout (15 mins) which is needed for external ip configuration related serial tests.
-			TestTimeout:         30 * time.Minute,
 			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.StableSystemEventInvariants),
 		},
 		PreSuite: suiteWithProviderPreSuite,

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -3,17 +3,11 @@ package networking
 import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
-	"context"
-	"strings"
-	"time"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("[sig-network] services", func() {
@@ -81,127 +75,6 @@ var _ = Describe("[sig-network] services", func() {
 		It("should allow connections from pods in the default namespace to a service in another namespace on a different node", func() {
 			makeNamespaceGlobal(oc, f2.Namespace)
 			Expect(checkServiceConnectivity(f1, f2, DIFFERENT_NODE)).To(Succeed())
-		})
-	})
-
-	var retryInterval = 1 * time.Minute
-
-	Context("external ip", func() {
-		It("ensures policy is configured correctly on the cluster [Serial]", func() {
-			namespace := oc.Namespace()
-			adminConfigClient := oc.AdminConfigClient()
-			k8sClient := oc.KubeClient()
-			serviceClient := k8sClient.CoreV1().Services(namespace)
-			// Test a load balancer service with default cluster networks config
-			// In this case service creation must throw an error for non admin user
-			By("create service of type load balancer with default cluster networks config")
-			serviceName := "svc-without-ext-ip"
-			By("check load balance service creation fails")
-			err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
-			deleteService(serviceClient, serviceName)
-			Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
-
-			// Test external ip policy configured with allowedCIDRs. Make sure service
-			// is created if that is within allowedCIDRs range and service creation
-			// fails if its outside the allowed range.
-			By("update network config with allowed cidr for external ip")
-			modifyNetworkConfig(adminConfigClient, nil, []string{"192.168.132.10/32"}, nil)
-			serviceName = "svc-with-ext-ip"
-			By("check service is within external ip within allowed range")
-			for {
-				err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
-				deleteService(serviceClient, serviceName)
-				if err != nil && kapierrs.IsForbidden(err) {
-					time.Sleep(retryInterval)
-					continue
-				}
-				expectNoError(err)
-				break
-			}
-			By("check service creation fails when external ip outside the allowed range")
-			err = createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.20"}, nil)
-			deleteService(serviceClient, serviceName)
-			Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
-
-			// Revert cluster networks config into default settings and make sure
-			// service creation must fail with an error for non admin user.
-			By("update network config without external ip")
-			modifyNetworkConfig(adminConfigClient, []string{}, []string{}, []string{})
-			serviceName = "svc-without-ext-ip-2"
-			By("check load balance service creation fails")
-			for {
-				err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
-				deleteService(serviceClient, serviceName)
-				if err == nil {
-					e2e.Logf("error not occurred while creating %s/%s service", namespace, serviceName)
-					time.Sleep(retryInterval)
-					continue
-				}
-				e2e.Logf("error occurred while creating %s/%s service: %v", namespace, serviceName, err)
-				Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
-				break
-			}
-		})
-	})
-
-	InBareMetalClusterContext(oc, func() {
-		It("ensures external auto assign cidr is configured correctly on the cluster [Serial]", func() {
-			namespace := oc.Namespace()
-			adminConfigClient := oc.AdminConfigClient()
-			k8sClient := oc.KubeClient()
-			serviceClient := k8sClient.CoreV1().Services(namespace)
-			// Test a load balancer service with default cluster networks config
-			// In this case service creation must throw an error for non admin user.
-			By("create service of type load balancer with default cluster networks config")
-			serviceName := "svc-without-ext-ip-3"
-			By("check load balance service creation fails")
-			err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
-			Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
-
-			// Test external ip policy configured with both policy and auto assign cidr. Make sure service
-			// is assigned with an ip address from auto assign cidr.
-			By("update network config with auto assign cidr")
-			modifyNetworkConfig(adminConfigClient, []string{"192.168.132.254/29"}, []string{"192.168.132.0/29"}, []string{"192.168.132.8/29"})
-			serviceName = "svc-ext-ip-auto-assign"
-			By("check load balancer service having desired ingress ip prefix")
-			for {
-				err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{}, nil)
-				if err != nil && kapierrs.IsForbidden(err) {
-					deleteService(serviceClient, serviceName)
-					time.Sleep(retryInterval)
-					continue
-				}
-				expectNoError(err)
-				service, err := serviceClient.Get(context.Background(), serviceName, metav1.GetOptions{})
-				expectNoError(err)
-				var ingressIP string
-				if len(service.Status.LoadBalancer.Ingress) > 0 {
-					ingressIP = service.Status.LoadBalancer.Ingress[0].IP
-				}
-				deleteService(serviceClient, serviceName)
-				if !strings.HasPrefix(ingressIP, "192.168.132") {
-					time.Sleep(retryInterval)
-					continue
-				}
-				break
-			}
-
-			// Revert cluster networks config into default settings and make sure
-			// service creation must fail with an error for non admin user.
-			By("update network config without external ip")
-			modifyNetworkConfig(adminConfigClient, []string{}, []string{}, []string{})
-			serviceName = "svc-without-ext-ip-4"
-			By("check load balance service creation fails")
-			for {
-				err := createWebserverLBService(k8sClient, namespace, serviceName, "", []string{"192.168.132.10"}, nil)
-				deleteService(serviceClient, serviceName)
-				if err == nil {
-					time.Sleep(retryInterval)
-					continue
-				}
-				Expect(kapierrs.IsForbidden(err)).Should(Equal(true))
-				break
-			}
 		})
 	})
 })

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	networkclient "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
 	"github.com/openshift/library-go/pkg/network/networkutils"
@@ -25,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/util/retry"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -34,10 +32,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	configv1client "github.com/openshift/client-go/config/clientset/versioned"
-	k8sclient "k8s.io/client-go/kubernetes"
-	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 type NodeType int
@@ -87,10 +81,24 @@ func expectError(err error, explain ...interface{}) {
 	ExpectWithOffset(1, err).To(HaveOccurred(), explain...)
 }
 
-func launchWebserverService(client k8sclient.Interface, namespace, serviceName string, nodeName string) (serviceAddr string) {
-	labelSelector := make(map[string]string)
-	labelSelector["name"] = "web"
-	createPodForService(client, namespace, serviceName, nodeName, labelSelector)
+func launchWebserverService(f *e2e.Framework, serviceName string, nodeName string) (serviceAddr string) {
+	exutil.LaunchWebserverPod(f, serviceName, nodeName)
+
+	// FIXME: make e2e.LaunchWebserverPod() set the label when creating the pod
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
+		pod, err := podClient.Get(context.Background(), serviceName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if pod.ObjectMeta.Labels == nil {
+			pod.ObjectMeta.Labels = make(map[string]string)
+		}
+		pod.ObjectMeta.Labels["name"] = "web"
+		_, err = podClient.Update(context.Background(), pod, metav1.UpdateOptions{})
+		return err
+	})
+	expectNoError(err)
 
 	servicePort := 8080
 	service := &corev1.Service{
@@ -105,85 +113,20 @@ func launchWebserverService(client k8sclient.Interface, namespace, serviceName s
 					Port:     int32(servicePort),
 				},
 			},
-			Selector: labelSelector,
+			Selector: map[string]string{
+				"name": "web",
+			},
 		},
 	}
-	serviceClient := client.CoreV1().Services(namespace)
-	_, err := serviceClient.Create(context.Background(), service, metav1.CreateOptions{})
+	serviceClient := f.ClientSet.CoreV1().Services(f.Namespace.Name)
+	_, err = serviceClient.Create(context.Background(), service, metav1.CreateOptions{})
 	expectNoError(err)
-	expectNoError(exutil.WaitForEndpoint(client, namespace, serviceName))
+	expectNoError(exutil.WaitForEndpoint(f.ClientSet, f.Namespace.Name, serviceName))
 	createdService, err := serviceClient.Get(context.Background(), serviceName, metav1.GetOptions{})
 	expectNoError(err)
 	serviceAddr = net.JoinHostPort(createdService.Spec.ClusterIP, strconv.Itoa(servicePort))
 	e2e.Logf("Target service IP/port is %s", serviceAddr)
 	return
-}
-
-func createPodForService(client k8sclient.Interface, namespace, serviceName string, nodeName string, labelMap map[string]string) {
-	exutil.LaunchWebserverPod(client, namespace, serviceName, nodeName)
-	// FIXME: make e2e.LaunchWebserverPod() set the label when creating the pod
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		podClient := client.CoreV1().Pods(namespace)
-		pod, err := podClient.Get(context.Background(), serviceName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		if pod.ObjectMeta.Labels == nil {
-			pod.ObjectMeta.Labels = labelMap
-		} else {
-			for key, value := range labelMap {
-				pod.ObjectMeta.Labels[key] = value
-			}
-		}
-		_, err = podClient.Update(context.Background(), pod, metav1.UpdateOptions{})
-		return err
-	})
-	expectNoError(err)
-}
-
-func createWebserverLBService(client k8sclient.Interface, namespace, serviceName, nodeName string,
-	externalIPs []string, epSelector map[string]string) error {
-	servicePort := 8080
-	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: serviceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
-			Ports: []corev1.ServicePort{
-				{
-					Protocol: corev1.ProtocolTCP,
-					Port:     int32(servicePort),
-					TargetPort: intstr.IntOrString{Type: intstr.Int,
-						IntVal: 8080},
-				},
-			},
-			ExternalIPs: externalIPs,
-			Selector:    epSelector,
-		},
-	}
-	serviceClient := client.CoreV1().Services(namespace)
-	e2e.Logf("creating service %s/%s", namespace, serviceName)
-	_, err := serviceClient.Create(context.Background(), service, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-	e2e.Logf("service %s/%s is created", namespace, serviceName)
-	if len(epSelector) > 0 {
-		err = exutil.WaitForEndpoint(client, namespace, serviceName)
-		if err != nil {
-			return err
-		}
-		e2e.Logf("endpoints for service %s/%s is up", namespace, serviceName)
-	}
-	_, err = serviceClient.Get(context.Background(), serviceName, metav1.GetOptions{})
-	return err
-}
-
-func deleteService(serviceClient v1.ServiceInterface, serviceName string) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return serviceClient.Delete(context.Background(), serviceName, metav1.DeleteOptions{})
-	})
 }
 
 func checkConnectivityToHost(f *e2e.Framework, nodeName string, podName string, host string, timeout time.Duration) error {
@@ -235,14 +178,6 @@ func openshiftSDNMode() string {
 		cachedNetworkPluginName = &pluginName
 	}
 	return *cachedNetworkPluginName
-}
-
-func platformType(configClient configv1client.Interface) (configv1.PlatformType, error) {
-	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	return infrastructure.Status.PlatformStatus.Type, nil
 }
 
 func networkPluginName() string {
@@ -317,22 +252,6 @@ func makeNamespaceScheduleToAllNodes(f *e2e.Framework) {
 	}
 }
 
-func modifyNetworkConfig(configClient configv1client.Interface, autoAssignCIDRs, allowedCIDRs, rejectedCIDRs []string) {
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		network, err := configClient.ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
-		expectNoError(err)
-		extIPConfig := &configv1.ExternalIPConfig{Policy: &configv1.ExternalIPPolicy{}}
-		if len(allowedCIDRs) != 0 || len(rejectedCIDRs) != 0 || len(autoAssignCIDRs) != 0 {
-			extIPConfig = &configv1.ExternalIPConfig{Policy: &configv1.ExternalIPPolicy{AllowedCIDRs: allowedCIDRs,
-				RejectedCIDRs: rejectedCIDRs}, AutoAssignCIDRs: autoAssignCIDRs}
-		}
-		network.Spec.ExternalIP = extIPConfig
-		_, err = configClient.ConfigV1().Networks().Update(context.Background(), network, metav1.UpdateOptions{})
-		return err
-	})
-	expectNoError(err)
-}
-
 // findAppropriateNodes tries to find a source and destination for a type of node connectivity
 // test (same node, or different node).
 func findAppropriateNodes(f *e2e.Framework, nodeType NodeType) (*corev1.Node, *corev1.Node, error) {
@@ -398,7 +317,7 @@ func checkPodIsolation(f1, f2 *e2e.Framework, nodeType NodeType) error {
 	}
 	podName := "isolation-webserver"
 	defer f1.ClientSet.CoreV1().Pods(f1.Namespace.Name).Delete(context.Background(), podName, metav1.DeleteOptions{})
-	ip := exutil.LaunchWebserverPod(f1.ClientSet, f1.Namespace.Name, podName, serverNode.Name)
+	ip := exutil.LaunchWebserverPod(f1, podName, serverNode.Name)
 
 	return checkConnectivityToHost(f2, clientNode.Name, "isolation-wget", ip, 10*time.Second)
 }
@@ -413,7 +332,7 @@ func checkServiceConnectivity(serverFramework, clientFramework *e2e.Framework, n
 	podName := names.SimpleNameGenerator.GenerateName("service-")
 	defer serverFramework.ClientSet.CoreV1().Pods(serverFramework.Namespace.Name).Delete(context.Background(), podName, metav1.DeleteOptions{})
 	defer serverFramework.ClientSet.CoreV1().Services(serverFramework.Namespace.Name).Delete(context.Background(), podName, metav1.DeleteOptions{})
-	ip := launchWebserverService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverNode.Name)
+	ip := launchWebserverService(serverFramework, podName, serverNode.Name)
 
 	return checkConnectivityToHost(clientFramework, clientNode.Name, "service-wget", ip, 10*time.Second)
 }
@@ -481,22 +400,6 @@ func InOpenShiftSDNContext(body func()) {
 			BeforeEach(func() {
 				if networkPluginName() != openshiftSDNPluginName {
 					e2eskipper.Skipf("Not using openshift-sdn")
-				}
-			})
-
-			body()
-		},
-	)
-}
-
-func InBareMetalClusterContext(oc *exutil.CLI, body func()) {
-	Context("when running openshift cluster on bare metal",
-		func() {
-			BeforeEach(func() {
-				pType, err := platformType(oc.AdminConfigClient())
-				expectNoError(err)
-				if pType != configv1.BareMetalPlatformType {
-					e2eskipper.Skipf("Not running in bare metal platform")
 				}
 			})
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2495,10 +2495,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services basic functionality should allow connections to another pod on the same node via a service IP": "should allow connections to another pod on the same node via a service IP [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network] services external ip ensures policy is configured correctly on the cluster [Serial]": "ensures policy is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
-
-	"[Top Level] [sig-network] services when running openshift cluster on bare metal ensures external auto assign cidr is configured correctly on the cluster [Serial]": "ensures external auto assign cidr is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
-
 	"[Top Level] [sig-network] services when using OpenshiftSDN in a mode that does not isolate namespaces by default should allow connections to pods in different namespaces on different nodes via service IPs": "should allow connections to pods in different namespaces on different nodes via service IPs [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network] services when using OpenshiftSDN in a mode that does not isolate namespaces by default should allow connections to pods in different namespaces on the same node via service IPs": "should allow connections to pods in different namespaces on the same node via service IPs [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -60,7 +60,6 @@ import (
 	"github.com/openshift/library-go/pkg/image/imageutil"
 	"github.com/openshift/origin/test/extended/testdata"
 	utilimage "github.com/openshift/origin/test/extended/util/image"
-	k8sclient "k8s.io/client-go/kubernetes"
 )
 
 // WaitForInternalRegistryHostname waits for the internal registry hostname to be made available to the cluster.
@@ -1613,7 +1612,7 @@ func ParseLabelsOrDie(str string) labels.Selector {
 // as the target for networking connectivity checks.  The ip address
 // of the created pod will be returned if the pod is launched
 // successfully.
-func LaunchWebserverPod(client k8sclient.Interface, namespace, podName, nodeName string) (ip string) {
+func LaunchWebserverPod(f *e2e.Framework, podName, nodeName string) (ip string) {
 	containerName := fmt.Sprintf("%s-container", podName)
 	port := 8080
 	pod := &corev1.Pod{
@@ -1633,10 +1632,10 @@ func LaunchWebserverPod(client k8sclient.Interface, namespace, podName, nodeName
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
-	podClient := client.CoreV1().Pods(namespace)
+	podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
 	_, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{})
 	e2e.ExpectNoError(err)
-	e2e.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(client, podName, namespace))
+	e2e.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, podName, f.Namespace.Name))
 	createdPod, err := podClient.Get(context.Background(), podName, metav1.GetOptions{})
 	e2e.ExpectNoError(err)
 	ip = net.JoinHostPort(createdPod.Status.PodIP, strconv.Itoa(port))


### PR DESCRIPTION
Reverts openshift/origin#26894

Apologies but this PR had to be reverted. The test is failing about 30% of the time particularly on serial jobs: https://sippy.dptools.openshift.org/sippy-ng/tests/4.11/analysis?test=[sig-network]%20services%20external%20ip%20ensures%20policy%20is%20configured%20correctly%20on%20the%20cluster%20[Serial]%20[Suite:openshift/conformance/serial]

And subsequently is it killing payload promotion and preventing code from flowing to the greater openshift org: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-serial/1519658962591420416

