### PR TITLE
don't wait for SA token secrets

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1034,23 +1034,17 @@ func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string) 
 			return false, fmt.Errorf("Failed to get service account %q: %v", name, err)
 		}
 		secretNames := []string{}
-		var hasDockercfg, hasToken bool
-		for _, s := range sc.Secrets {
-			if strings.Contains(s.Name, "-token-") {
-				hasToken = true
-			}
-			secretNames = append(secretNames, s.Name)
-		}
+		var hasDockercfg bool
 		for _, s := range sc.ImagePullSecrets {
 			if strings.Contains(s.Name, "-dockercfg-") {
 				hasDockercfg = true
 			}
 			secretNames = append(secretNames, s.Name)
 		}
-		if hasDockercfg && hasToken {
+		if hasDockercfg {
 			return true, nil
 		}
-		e2e.Logf("Waiting for service account %q secrets (%s) to include dockercfg/token ...", name, strings.Join(secretNames, ","))
+		e2e.Logf("Waiting for service account %q secrets (%s) to include dockercfg ...", name, strings.Join(secretNames, ","))
 		return false, nil
 	}
 	return wait.Poll(100*time.Millisecond, 3*time.Minute, waitFn)


### PR DESCRIPTION
kube 1.24 stops autogenerating SA tokens in secrets in behalf
of the projected SA tokens.

/assign @tkashem 