### PR TITLE
test: allow -f to match tests for any test suite

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -102,9 +102,9 @@ func (opt *Options) AsEnv() []string {
 
 func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite, error) {
 	var suite *TestSuite
+	var in []byte
 
 	if len(opt.TestFile) > 0 {
-		var in []byte
 		var err error
 		if opt.TestFile == "-" {
 			in, err = ioutil.ReadAll(os.Stdin)
@@ -117,9 +117,12 @@ func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite,
 		if err != nil {
 			return nil, err
 		}
-		suite, err = newSuiteFromFile("files", in)
-		if err != nil {
-			return nil, fmt.Errorf("could not read test suite from input: %v", err)
+		// If a test file was provided with no suite, use the "files" suite.
+		if len(args) == 0 {
+			suite, err = newSuiteFromFile("files", in)
+			if err != nil {
+				return nil, fmt.Errorf("could not read test suite from input: %v", err)
+			}
 		}
 	}
 
@@ -138,6 +141,14 @@ func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite,
 	if suite == nil {
 		fmt.Fprintf(opt.ErrOut, SuitesString(suites, "Select a test suite to run against the server:\n\n"))
 		return nil, fmt.Errorf("suite %q does not exist", args[0])
+	}
+	// If suite and test file were both provided, override the Matches
+	// function to match the tests from both the suite and the file.
+	if len(opt.TestFile) > 0 {
+		err := matchTestsFromFile(suite, in)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return suite, nil
 }


### PR DESCRIPTION
This allows the -f option for openshift-tests to work with specific
test suites instead of assuming the "files" test suite.

Examples:
```
$ ./openshift-tests run --dry-run -f offline.txt 
error: suite "files" does not contain any tests

$ ./openshift-tests run all --dry-run | head -2 | ./openshift-tests run --dry-run -f -
"[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-ext.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]"
"[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-int.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]"

$ ./openshift-tests run openshift/csi --dry-run -f offline.txt
May  2 19:57:25.156: INFO: Driver loaded from path [/home/jon/workspace/ibm-vpc-block-csi-driver-operator/test/e2e/manifest.yaml]: &{DriverInfo:{Name:vpc.block.csi.ibm.io InTreePluginName: FeatureTag: MaxFileSize:0 SupportedSizeRange:{Max:2Ti Min:10Gi} SupportedFsType:map[:{} ext4:{} xfs:{}] SupportedMountOption:map[dirsync:{}] RequiredMountOption:map[] Capabilities:map[RWX:false block:true controllerExpansion:true exec:true fsGroup:false multipods:false nodeExpansion:true onlineExpansion:true persistence:true pvcDataSource:false snapshotDataSource:false topology:false volumeLimits:false] RequiredAccessModes:[] TopologyKeys:[failure-domain.beta.kubernetes.io/zone] NumAllowedTopologies:0 StressTestOptions:<nil> VolumeSnapshotStressTestOptions:<nil> PerformanceTestOptions:<nil>} StorageClass:{FromName:false FromFile: FromExistingClassName:ibmc-vpc-block-10iops-tier} SnapshotClass:{FromName:true FromFile: FromExistingClassName:} InlineVolumes:[] ClientNodeName: Timeouts:map[]}
"External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (block volmode)(allowExpansion)] volume-expand Verify if offline PVC expansion works"
"External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (default fs)(allowExpansion)] volume-expand Verify if offline PVC expansion works"
"External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (ntfs)(allowExpansion)][Feature:Windows] volume-expand Verify if offline PVC expansion works"

Storage Capabilities (guaranteed only on full CSI test suite with 0 fails)
==========================================================================
Driver short name:                         ibm-vpc-block
Driver name:                               vpc.block.csi.ibm.io
Storage class:
Supported OpenShift / CSI features:
  Persistent volumes:                      true
  Raw block mode:                          true
  FSGroup:                                 false
  Executable files on a volume:            true
  Volume snapshots:                        false
  Volume cloning:                          false
  Use volume from multiple pods on a node: false
  ReadWriteMany access mode:               false
  Volume expansion for controller:         true
  Volume expansion for node:               true
  Volume limits:                           false
  Volume can run on single node:           false
  Topology:                                false
Supported OpenShift Virtualization features:
  Raw block VM disks:                      true
  Live migration:                          false
  VM snapshots:                            false
  Storage-assisted cloning:                false
```

/cc @openshift/storage @bertinatto @EmilienM
