### PR TITLE
test: allow -f to match tests for any test suite (redux)

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -103,26 +103,12 @@ func (opt *Options) AsEnv() []string {
 func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite, error) {
 	var suite *TestSuite
 
-	if len(opt.TestFile) > 0 {
-		var in []byte
-		var err error
-		if opt.TestFile == "-" {
-			in, err = ioutil.ReadAll(os.Stdin)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			in, err = ioutil.ReadFile(opt.TestFile)
-		}
-		if err != nil {
-			return nil, err
-		}
-		suite, err = newSuiteFromFile("files", in)
-		if err != nil {
-			return nil, fmt.Errorf("could not read test suite from input: %v", err)
+	// If a test file was provided with no suite, use the "files" suite.
+	if len(opt.TestFile) > 0 && len(args) == 0 {
+		suite = &TestSuite{
+			Name: "files",
 		}
 	}
-
 	if suite == nil && len(args) == 0 {
 		fmt.Fprintf(opt.ErrOut, SuitesString(suites, "Select a test suite to run against the server:\n\n"))
 		return nil, fmt.Errorf("specify a test suite to run, for example: %s run %s", filepath.Base(os.Args[0]), suites[0].Name)
@@ -138,6 +124,27 @@ func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite,
 	if suite == nil {
 		fmt.Fprintf(opt.ErrOut, SuitesString(suites, "Select a test suite to run against the server:\n\n"))
 		return nil, fmt.Errorf("suite %q does not exist", args[0])
+	}
+	// If a test file was provided, override the Matches function
+	// to match the tests from both the suite and the file.
+	if len(opt.TestFile) > 0 {
+		var in []byte
+		var err error
+		if opt.TestFile == "-" {
+			in, err = ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			in, err = ioutil.ReadFile(opt.TestFile)
+		}
+		if err != nil {
+			return nil, err
+		}
+		err = matchTestsFromFile(suite, in)
+		if err != nil {
+			return nil, fmt.Errorf("could not read test suite from input: %v", err)
+		}
 	}
 	return suite, nil
 }

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -103,10 +103,7 @@ func (s *TestSuite) Filter(tests []*testCase) []*testCase {
 	return matches
 }
 
-func newSuiteFromFile(name string, contents []byte) (*TestSuite, error) {
-	suite := &TestSuite{
-		Name: name,
-	}
+func matchTestsFromFile(suite *TestSuite, contents []byte) error {
 	tests := make(map[string]int)
 	for _, line := range strings.Split(string(contents), "\n") {
 		line = strings.TrimSpace(line)
@@ -114,16 +111,23 @@ func newSuiteFromFile(name string, contents []byte) (*TestSuite, error) {
 			var err error
 			line, err = strconv.Unquote(line)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			tests[line]++
 		}
 	}
+	match := suite.Matches
 	suite.Matches = func(name string) bool {
+		// If there is an existing Matches function for the suite,
+		// require the test to pass the existing match and also
+		// be in the file contents.
+		if match != nil && !match(name) {
+			return false
+		}
 		_, ok := tests[name]
 		return ok
 	}
-	return suite, nil
+	return nil
 }
 
 func filterWithRegex(suite *TestSuite, regex string) error {


### PR DESCRIPTION
This allows the -f option for openshift-tests to work with specific
test suites instead of assuming the "files" test suite.

Background:
This change was first merged in this PR: https://github.com/openshift/origin/pull/27091
But that resulted in an issue where providing -f (or --file) without a test suite called `matchTestsFromFile` twice, which means the test file was getting parsed and matched twice. This may have contributed to [OOM errors in e2e-metal-ipi](https://search.ci.openshift.org/?search=Container+test+exited+with+code+1%2C+reason+OOMKilled&maxAge=48h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job).
The change was reverted here: https://github.com/openshift/origin/pull/27095

This PR reintroduces the original fix, with some refactoring to avoid calling `matchTestsFromFile` more than once.
We also had to bump the memory limit for the test in https://github.com/openshift/release/pull/29795 because it was already [approaching the 2Gi limit](https://resources.ci.openshift.org/usage/steps?branch=master&container=test&org=openshift&repo=baremetal-operator&step=baremetalds-e2e-test&target=e2e-metal-ipi-ovn-ipv6&variant) in some cases.
The only thing I see now in this PR that would explain additional memory consumption is: 1) we now initiailze the provided test suite instead of ignoring it, and 2) we match the tests based on the provided file and on the test suite Matches function.

Examples:
```
$ ./openshift-tests run --dry-run -f offline.txt
error: suite "files" does not contain any tests

$ ./openshift-tests run all --dry-run | head -2 | ./openshift-tests run --dry-run -f -
"[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-ext.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]"
"[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-int.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]"

$ ./openshift-tests run openshift/csi --dry-run -f offline.txt
May  4 09:00:42.518: INFO: Driver loaded from path [/home/jon/workspace/ibm-vpc-block-csi-driver-operator/test/e2e/manifest.yaml]: &{DriverInfo:{Name:vpc.block.csi.ibm.io InTreePluginName: FeatureTag: MaxFileSize:0 SupportedSizeRange:{Max:2Ti Min:10Gi} SupportedFsType:map[:{} ext4:{} xfs:{}] SupportedMountOption:map[dirsync:{}] RequiredMountOption:map[] Capabilities:map[RWX:false block:true controllerExpansion:true exec:true fsGroup:false multipods:false nodeExpansion:true onlineExpansion:true persistence:true pvcDataSource:false snapshotDataSource:false topology:false volumeLimits:false] RequiredAccessModes:[] TopologyKeys:[failure-domain.beta.kubernetes.io/zone] NumAllowedTopologies:0 StressTestOptions:<nil> VolumeSnapshotStressTestOptions:<nil> PerformanceTestOptions:<nil>} StorageClass:{FromName:false FromFile: FromExistingClassName:ibmc-vpc-block-10iops-tier} SnapshotClass:{FromName:true FromFile: FromExistingClassName:} InlineVolumes:[] ClientNodeName: Timeouts:map[]}
"External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (block volmode)(allowExpansion)] volume-expand Verify if offline PVC expansion works"
"External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (default fs)(allowExpansion)] volume-expand Verify if offline PVC expansion works"
"External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (ntfs)(allowExpansion)][Feature:Windows] volume-expand Verify if offline PVC expansion works"

Storage Capabilities (guaranteed only on full CSI test suite with 0 fails)
==========================================================================
Driver short name:                         ibm-vpc-block
Driver name:                               vpc.block.csi.ibm.io
Storage class:
Supported OpenShift / CSI features:
  Persistent volumes:                      true
  Raw block mode:                          true
  FSGroup:                                 false
  Executable files on a volume:            true
  Volume snapshots:                        false
  Volume cloning:                          false
  Use volume from multiple pods on a node: false
  ReadWriteMany access mode:               false
  Volume expansion for controller:         true
  Volume expansion for node:               true
  Volume limits:                           false
  Volume can run on single node:           false
  Topology:                                false
Supported OpenShift Virtualization features:
  Raw block VM disks:                      true
  Live migration:                          false
  VM snapshots:                            false
  Storage-assisted cloning:                false

$ ./openshift-tests run openshift/csi --dry-run | grep -v "Verify if offline PVC expansion works" | ./openshift-tests run openshift/csi --dry-run -f - | grep offline
$ 
```

/cc @openshift/storage @derekhiggins @elfosardo @stbenjam @deads2k
/hold for testing
/test e2e-metal-ipi
/test e2e-metal-ipi-ovn-ipv6