### PR TITLE
Bug 2082239: Bump net.ipv6.neigh.IFNAME from 30005 to 30010 for Multiarch

### DIFF
--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -37,7 +37,7 @@ var whitelistedSysctls = []SysctlVariant{
 	{Sysctl: "net.ipv4.conf.IFNAME.accept_redirects", Value: "1", Path: "/proc/sys/net/ipv4/conf/net1/accept_redirects"},
 	{Sysctl: "net.ipv6.conf.IFNAME.accept_redirects", Value: "1", Path: "/proc/sys/net/ipv6/conf/net1/accept_redirects"},
 	{Sysctl: "net.ipv4.conf.IFNAME.secure_redirects", Value: "1", Path: "/proc/sys/net/ipv4/conf/net1/secure_redirects"},
-	{Sysctl: "net.ipv6.neigh.IFNAME.base_reachable_time_ms", Value: "30005", Path: "/proc/sys/net/ipv6/neigh/net1/base_reachable_time_ms"},
+	{Sysctl: "net.ipv6.neigh.IFNAME.base_reachable_time_ms", Value: "30010", Path: "/proc/sys/net/ipv6/neigh/net1/base_reachable_time_ms"},
 	{Sysctl: "net.ipv6.neigh.IFNAME.retrans_time_ms", Value: "1005", Path: "/proc/sys/net/ipv6/neigh/net1/retrans_time_ms"},
 }
 


### PR DESCRIPTION
Using sysctl to set values for net.ipv6.neigh.lo.base_reachable_time_ms=30001
is inconsistent between amd64 and aarch64/s390x/ppc64le.

amd64 seems to honor 1ms increments while other architectures round up to 10ms

`[sig-network][Feature:tuning] pod should start with all sysctl on whitelist [Suite:openshift/conformance/parallel] ` is failing for Multiarch 

https://bugzilla.redhat.com/show_bug.cgi?id=2082239 
