### PR TITLE
add openshift-tests timeline

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -13,6 +13,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitor_cmd"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
 	"github.com/onsi/ginkgo"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/library-go/pkg/serviceability"
@@ -71,6 +75,11 @@ func main() {
 		newRunTestCommand(),
 		newRunMonitorCommand(),
 		cmd.NewRunResourceWatchCommand(),
+		monitor_cmd.NewTimelineCommand(genericclioptions.IOStreams{
+			In:     os.Stdin,
+			Out:    os.Stdout,
+			ErrOut: os.Stderr,
+		}),
 	)
 
 	f := flag.CommandLine.Lookup("v")

--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -30,6 +30,17 @@ func GetMonitorRESTConfig() (*rest.Config, error) {
 	return clusterConfig, nil
 }
 
+func DefaultIntervalCreationFns() []IntervalCreationFunc {
+	return []IntervalCreationFunc{
+		intervalcreation.IntervalsFromEvents_OperatorAvailable,
+		intervalcreation.IntervalsFromEvents_OperatorProgressing,
+		intervalcreation.IntervalsFromEvents_OperatorDegraded,
+		intervalcreation.IntervalsFromEvents_E2ETests,
+		intervalcreation.IntervalsFromEvents_NodeChanges,
+		intervalcreation.CreatePodIntervalsFromInstants,
+	}
+}
+
 // Start begins monitoring the cluster referenced by the default kube configuration until
 // context is finished.
 func Start(ctx context.Context, restConfig *rest.Config, additionalEventIntervalRecorders []StartEventIntervalRecorderFunc) (*Monitor, error) {
@@ -55,15 +66,7 @@ func Start(ctx context.Context, restConfig *rest.Config, additionalEventInterval
 
 	// add interval creation at the same point where we add the monitors
 	startClusterOperatorMonitoring(ctx, m, configClient)
-	m.intervalCreationFns = append(
-		m.intervalCreationFns,
-		intervalcreation.IntervalsFromEvents_OperatorAvailable,
-		intervalcreation.IntervalsFromEvents_OperatorProgressing,
-		intervalcreation.IntervalsFromEvents_OperatorDegraded,
-		intervalcreation.IntervalsFromEvents_E2ETests,
-		intervalcreation.IntervalsFromEvents_NodeChanges,
-		intervalcreation.CreatePodIntervalsFromInstants,
-	)
+	m.intervalCreationFns = append(m.intervalCreationFns, DefaultIntervalCreationFns()...)
 
 	m.StartSampling(ctx)
 	return m, nil

--- a/pkg/monitor/intervalcreation/rendering.go
+++ b/pkg/monitor/intervalcreation/rendering.go
@@ -74,7 +74,7 @@ func (r eventIntervalRenderer) writeEventData(artifactDir, filenameBase string, 
 }
 
 func BelongsInEverything(eventInterval monitorapi.EventInterval) bool {
-	if isPodLifecycle(eventInterval) { // there are just too many
+	if IsPodLifecycle(eventInterval) { // there are just too many
 		return false
 	}
 	return true
@@ -84,7 +84,7 @@ func BelongsInSpyglass(eventInterval monitorapi.EventInterval) bool {
 	if isLessInterestingAlert(eventInterval) {
 		return false
 	}
-	if isPodLifecycle(eventInterval) {
+	if IsPodLifecycle(eventInterval) {
 		return false
 	}
 
@@ -95,7 +95,7 @@ func BelongsInOperatorRollout(eventInterval monitorapi.EventInterval) bool {
 	if monitorapi.IsE2ETest(eventInterval.Locator) {
 		return false
 	}
-	if isPodLifecycle(eventInterval) {
+	if IsPodLifecycle(eventInterval) {
 		if isPlatformPodEvent(eventInterval) {
 			return true
 		}
@@ -112,7 +112,7 @@ func BelongsInKubeAPIServer(eventInterval monitorapi.EventInterval) bool {
 	if isLessInterestingAlert(eventInterval) {
 		return false
 	}
-	if isPodLifecycle(eventInterval) {
+	if IsPodLifecycle(eventInterval) {
 		if isPlatformPodEvent(eventInterval) && isInterestingNamespace(eventInterval, kubeAPIServerDependentNamespaces) {
 			return true
 		}
@@ -125,8 +125,16 @@ func BelongsInKubeAPIServer(eventInterval monitorapi.EventInterval) bool {
 	return true
 }
 
-func isPodLifecycle(eventInterval monitorapi.EventInterval) bool {
+func IsPodLifecycle(eventInterval monitorapi.EventInterval) bool {
 	return strings.Contains(eventInterval.Message, "constructed/true")
+}
+
+func IsOriginalPodEvent(eventInterval monitorapi.EventInterval) bool {
+	// constructed events are not original
+	if strings.Contains(eventInterval.Message, "constructed/true") {
+		return false
+	}
+	return strings.Contains(eventInterval.Locator, "pod/")
 }
 
 func isPlatformPodEvent(eventInterval monitorapi.EventInterval) bool {

--- a/pkg/monitor/intervalcreation/rendering_per_namespace.go
+++ b/pkg/monitor/intervalcreation/rendering_per_namespace.go
@@ -133,7 +133,7 @@ func (r podRendering) WriteEventData(artifactDir string, events monitorapi.Inter
 	for _, namespaceGroup := range namespaceGroups {
 		writer := NewNonSpyglassEventIntervalRenderer(namespaceGroup.name,
 			func(eventInterval monitorapi.EventInterval) bool {
-				if !isPodLifecycle(eventInterval) {
+				if !IsPodLifecycle(eventInterval) {
 					return false
 				}
 				if isInterestingNamespace(eventInterval, namespaceGroup.namespaces) {

--- a/pkg/monitor/monitor_cmd/command.go
+++ b/pkg/monitor/monitor_cmd/command.go
@@ -1,0 +1,243 @@
+package monitor_cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/origin/pkg/monitor"
+
+	"github.com/openshift/origin/pkg/monitor/intervalcreation"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+	"github.com/openshift/origin/test/extended/testdata"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type TimelineOptions struct {
+	MonitorEventFilename string
+	PodResourceFilename  string
+	TimelineType         string
+
+	Namespaces []string
+	OutputType string
+
+	KnownRenderers map[string]RenderFunc
+	KnownTimelines map[string]monitorapi.EventIntervalMatchesFunc
+	IOStreams      genericclioptions.IOStreams
+}
+
+type RenderFunc func(intervals monitorapi.Intervals) ([]byte, error)
+
+func NewTimelineOptions(ioStreams genericclioptions.IOStreams) *TimelineOptions {
+	return &TimelineOptions{
+		TimelineType: "spyglass",
+
+		OutputType: "html",
+
+		IOStreams: ioStreams,
+		KnownRenderers: map[string]RenderFunc{
+			"json": monitorserialization.EventsIntervalsToJSON,
+			"html": renderHTML,
+		},
+		KnownTimelines: map[string]monitorapi.EventIntervalMatchesFunc{
+			"everything":    intervalcreation.BelongsInEverything,
+			"operators":     intervalcreation.BelongsInOperatorRollout,
+			"apiserver":     intervalcreation.BelongsInKubeAPIServer,
+			"spyglass":      intervalcreation.BelongsInSpyglass,
+			"pod-lifecycle": intervalcreation.IsOriginalPodEvent,
+		},
+	}
+}
+
+func NewTimelineCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := NewTimelineOptions(ioStreams)
+
+	cmd := &cobra.Command{
+		Use:   "timeline",
+		Short: "Run an upgrade suite",
+		Long: `
+		Create a timeline html page based on the provided monitor events.
+
+		openshift-tests timeline --type=pod -f raw-monitor-events.json --namespace=openshift-kube-apiserver --namespace=openshift-kube-apiserver-operator -ojson 
+		`,
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	o.Bind(cmd.Flags())
+
+	return cmd
+}
+
+func (o *TimelineOptions) Bind(flagset *pflag.FlagSet) error {
+	flagset.StringVarP(&o.MonitorEventFilename, "filename", "f", o.MonitorEventFilename, "raw-monitor-events.json file")
+	flagset.StringSliceVar(&o.Namespaces, "namespace", o.Namespaces, "namespaces to filter.  No entry is no filtering.")
+	flagset.StringVarP(&o.OutputType, "output", "o", o.OutputType, fmt.Sprintf("type of output: [%s]", strings.Join(sets.StringKeySet(o.KnownRenderers).List(), ",")))
+	flagset.StringVar(&o.TimelineType, "type", o.TimelineType, "type of timeline to produce: "+strings.Join(sets.StringKeySet(o.KnownTimelines).List(), ","))
+	flagset.StringVar(&o.PodResourceFilename, "known-pods", o.PodResourceFilename, "resource-pods_<timestamp>.zip filename from openshift-tests.")
+
+	return nil
+}
+
+func (o *TimelineOptions) Complete() error {
+	return nil
+}
+
+func (o *TimelineOptions) Validate() error {
+	if len(o.MonitorEventFilename) == 0 {
+		return fmt.Errorf("missing -f")
+	}
+	if len(o.OutputType) == 0 {
+		return fmt.Errorf("missing -o")
+	}
+	if len(o.TimelineType) == 0 {
+		return fmt.Errorf("missing --type")
+	}
+
+	if o.KnownRenderers[o.OutputType] == nil {
+		return fmt.Errorf("unknown --type")
+	}
+	if o.KnownTimelines[o.TimelineType] == nil {
+		return fmt.Errorf("unknown --type")
+	}
+
+	return nil
+}
+
+func (o *TimelineOptions) Run() error {
+	consumedEvents, err := monitorserialization.EventsFromFile(o.MonitorEventFilename)
+	if err != nil {
+		return err
+	}
+
+	recordedResources := monitorapi.ResourcesMap{}
+	if len(o.PodResourceFilename) > 0 {
+		recordedResources, err = loadKnownPods(o.PodResourceFilename)
+		if err != nil {
+			return err
+		}
+	}
+
+	filteredEvents := consumedEvents.Filter(o.KnownTimelines[o.TimelineType])
+	if len(o.Namespaces) > 0 {
+		filteredEvents = filteredEvents.Filter(monitorapi.IsInNamespaces(sets.NewString(o.Namespaces...)))
+	}
+
+	// compute intervals from raw
+	from := time.Time{}
+	to := time.Time{}
+	computedIntervalFns := monitor.DefaultIntervalCreationFns()
+	for _, createIntervals := range computedIntervalFns {
+		filteredEvents = append(filteredEvents, createIntervals(filteredEvents, recordedResources, from, to)...)
+	}
+	sort.Sort(filteredEvents)
+
+	output, err := o.KnownRenderers[o.OutputType](filteredEvents)
+	if err != nil {
+		return err
+	}
+
+	if _, err := o.IOStreams.Out.Write(output); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func renderHTML(events monitorapi.Intervals) ([]byte, error) {
+	eventIntervalsJSON, err := monitorserialization.EventsIntervalsToJSON(events)
+	if err != nil {
+		return nil, err
+
+	}
+	e2eChartTemplate := testdata.MustAsset("e2echart/e2e-chart-template.html")
+	e2eChartTitle := "Timeline"
+	e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_TITLE_GOES_HERE"), []byte(e2eChartTitle))
+	e2eChartHTML = bytes.ReplaceAll(e2eChartHTML, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)
+
+	return e2eChartHTML, nil
+}
+
+func loadKnownPods(filename string) (monitorapi.ResourcesMap, error) {
+
+	zipReader, err := zip.OpenReader(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer zipReader.Close()
+
+	pods := monitorapi.InstanceMap{}
+	for _, f := range zipReader.File {
+		rc, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		currBytes, err := ioutil.ReadAll(rc)
+		if err != nil {
+			return nil, err
+		}
+		_ = rc.Close()
+
+		// there has to be a better way, but this functions, ugly as it is.
+		unstructuredObject := map[string]interface{}{}
+		if err := json.Unmarshal(currBytes, &unstructuredObject); err != nil {
+			return nil, fmt.Errorf("error unmarshalling list: %w", err)
+		}
+		unstructuredObj := &unstructured.Unstructured{
+			Object: unstructuredObject,
+		}
+		unstructuredList, err := unstructuredObj.ToList()
+		if err != nil {
+			return nil, err
+		}
+		//nsList := &unstructured.UnstructuredList{}
+
+		for _, item := range unstructuredList.Items {
+			item.SetKind("Pod")
+			item.SetAPIVersion("v1")
+
+			pod := &corev1.Pod{}
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, pod)
+			if err != nil {
+				return nil, err
+			}
+			podKey, err := cache.MetaNamespaceKeyFunc(pod)
+			if err != nil {
+				return nil, err
+			}
+			pods[podKey] = pod
+		}
+	}
+
+	return monitorapi.ResourcesMap{
+		"pods": pods,
+	}, nil
+}

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -186,6 +188,13 @@ func IsInE2ENamespace(eventInterval EventInterval) bool {
 		return true
 	}
 	return false
+}
+
+func IsInNamespaces(namespaces sets.String) EventIntervalMatchesFunc {
+	return func(eventInterval EventInterval) bool {
+		ns := NamespaceFromLocator(eventInterval.Locator)
+		return namespaces.Has(ns)
+	}
 }
 
 func And(filters ...EventIntervalMatchesFunc) EventIntervalMatchesFunc {


### PR DESCRIPTION
`openshift-tests timeline --type=pod-lifecycle -f '/home/deads/Downloads/e2e-events_20220502-220022 (2).json' --known-pods='/home/deads/Downloads/resource-pods_20220502-220022.zip'  --namespace=openshift-etcd > ../timeline.html`

for example.  You need the e2e events and the resource-pods to make it work.

