### PR TITLE
prometheus helper: add helper to retrieve prometheus query token

### DIFF
--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -70,6 +70,13 @@ func LocatePrometheus(oc *exutil.CLI) (queryURL, prometheusURL, bearerToken stri
 		return "", "", "", false
 	}
 
+	bearerToken = GetPrometheusSABearerToken(oc)
+
+	return "https://thanos-querier.openshift-monitoring.svc:9091", "https://prometheus-k8s.openshift-monitoring.svc:9091", bearerToken, true
+}
+
+func GetPrometheusSABearerToken(oc *exutil.CLI) string {
+	var bearerToken string
 	waitForServiceAccountInNamespace(oc.AdminKubeClient(), "openshift-monitoring", "prometheus-k8s", 2*time.Minute)
 	for i := 0; i < 30; i++ {
 		secrets, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-monitoring").List(context.Background(), metav1.ListOptions{})
@@ -91,8 +98,7 @@ func LocatePrometheus(oc *exutil.CLI) (queryURL, prometheusURL, bearerToken stri
 		}
 	}
 	o.Expect(bearerToken).ToNot(o.BeEmpty())
-
-	return "https://thanos-querier.openshift-monitoring.svc:9091", "https://prometheus-k8s.openshift-monitoring.svc:9091", bearerToken, true
+	return bearerToken
 }
 
 type MetricCondition struct {


### PR DESCRIPTION
Problem: In https://github.com/openshift/origin/pull/27073 the token retrieval
was improved. the via_route client had the same issue and can in some
cases use the wrong token.

Solution: create a helper so token retrieval is handled in a single
location.

Issues: https://github.com/openshift/origin/pull/27073

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>