### PR TITLE
Add config for golangci-lint no-sprintf-host-port

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+linters:
+  disable-all: true
+  enable:
+    - nosprintfhostport
+  presets: []
+  fast: true


### PR DESCRIPTION
This enables a single linter for now, eventually we could turn on more but a quick
check of this code base is that the typical linters need some work to pass. 

Once this merges,  I'll setup the lint job.



---

This enables the [no-sprintf-host-port](https://github.com/stbenjam/no-sprintf-host-port) linter to prevent URL
constructions that are incompatible with IPv6. These breakages
are common in this repo.

The Go linter no-sprintf-host-port checks that sprintf is not used to
construct a host:port combination in a URL. A frequent pattern is for a
developer to construct a URL like this:

```go
fmt.Sprintf("http://%s:%d/foo", host, port)
```

However, if "host" is an IPv6 address like `2001:4860:4860::8888`, the
URL constructed will be invalid. IPv6 addresses must be bracketed, like this:

```
http://[2001:4860:4860::8888]:9443
```