### PR TITLE
Add regex matching, regex inverse matching, and default end date option for intervals

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -2,6 +2,7 @@ package monitorapi
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -198,7 +199,7 @@ func IsInNamespaces(namespaces sets.String) EventIntervalMatchesFunc {
 }
 
 // ContainsAllParts ensures that all listed key match at least one of the values.
-func ContainsAllParts(matchers map[string][]string) EventIntervalMatchesFunc {
+func ContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatchesFunc {
 	return func(eventInterval EventInterval) bool {
 		actualParts := LocatorParts(eventInterval.Locator)
 		for key, possibleValues := range matchers {
@@ -206,7 +207,7 @@ func ContainsAllParts(matchers map[string][]string) EventIntervalMatchesFunc {
 
 			found := false
 			for _, possibleValue := range possibleValues {
-				if actualValue == possibleValue {
+				if possibleValue.MatchString(actualValue) {
 					found = true
 					break
 				}
@@ -216,6 +217,23 @@ func ContainsAllParts(matchers map[string][]string) EventIntervalMatchesFunc {
 			}
 		}
 
+		return true
+	}
+}
+
+// NotContainsAllParts returns a function that returns false if any key matches.
+func NotContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatchesFunc {
+	return func(eventInterval EventInterval) bool {
+		actualParts := LocatorParts(eventInterval.Locator)
+		for key, possibleValues := range matchers {
+			actualValue := actualParts[key]
+
+			for _, possibleValue := range possibleValues {
+				if possibleValue.MatchString(actualValue) {
+					return false
+				}
+			}
+		}
 		return true
 	}
 }

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52870,7 +52870,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     zQualitative(true).
     enableAnimations(false).
     leftMargin(240).
-    rightMargin(550).
+    rightMargin(1550).
     maxLineHeight(20).
     maxHeight(10000).
     zColorScale(ordinalScale).
@@ -52879,7 +52879,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
 
     // force a minimum width for smaller devices (which otherwise get an unusable display)
-    setTimeout(() => { if (myChart.width() < 1300) { myChart.width(1300) }}, 1)
+    setTimeout(() => { if (myChart.width() < 3000) { myChart.width(3000) }}, 1)
 </script>
 </body>
 </html>


### PR DESCRIPTION
For matching, we use a regex (e.g., to match all multus pods using `-lpod=multus` or `-lpod=multus-.*`).

For inverse matching, if any item matches, it is removed (hence the option is called `--remove`) like `grep -v`.

The default end date (either by not specifying `--end-date` or `--end-date=default`) is set to 1 hour after the latest event (using the `To` field).  This will make it so that older charts don't have a long bar with the rest of the bars being very short.  You can also specify an actual date.

Also tweak the right margin so you can see more of the text (in case you want to search for it in the browser with the `...`).  Increase the width to accommodate the new margin.