### PR TITLE
Bump net.ipv6.neigh.IFNAME.retrans_time_ms for Multiarch

### DIFF
--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -37,8 +37,9 @@ var whitelistedSysctls = []SysctlVariant{
 	{Sysctl: "net.ipv4.conf.IFNAME.accept_redirects", Value: "1", Path: "/proc/sys/net/ipv4/conf/net1/accept_redirects"},
 	{Sysctl: "net.ipv6.conf.IFNAME.accept_redirects", Value: "1", Path: "/proc/sys/net/ipv6/conf/net1/accept_redirects"},
 	{Sysctl: "net.ipv4.conf.IFNAME.secure_redirects", Value: "1", Path: "/proc/sys/net/ipv4/conf/net1/secure_redirects"},
+	// Bumping the net.ipv6 values for Multiarch until https://bugzilla.redhat.com/show_bug.cgi?id=2082239 is fixed in RHEL
 	{Sysctl: "net.ipv6.neigh.IFNAME.base_reachable_time_ms", Value: "30010", Path: "/proc/sys/net/ipv6/neigh/net1/base_reachable_time_ms"},
-	{Sysctl: "net.ipv6.neigh.IFNAME.retrans_time_ms", Value: "1005", Path: "/proc/sys/net/ipv6/neigh/net1/retrans_time_ms"},
+	{Sysctl: "net.ipv6.neigh.IFNAME.retrans_time_ms", Value: "1010", Path: "/proc/sys/net/ipv6/neigh/net1/retrans_time_ms"},
 }
 
 var _ = g.Describe("[sig-network][Feature:tuning]", func() {


### PR DESCRIPTION
Follow up for https://github.com/openshift/origin/pull/27101/files 

/cc @mmirecki 