### PR TITLE
runs the etcd vertical test on a platform that supports MachineAPI

### DIFF
--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -9,9 +9,11 @@ import (
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	testlibraryapi "github.com/openshift/library-go/test/library/apiserver"
 	scalingtestinglibrary "github.com/openshift/origin/test/extended/etcd/helpers"
+	machineapihelpers "github.com/openshift/origin/test/extended/machines"
 	exutil "github.com/openshift/origin/test/extended/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -25,6 +27,11 @@ var _ = g.Describe("[sig-etcd][Serial] etcd", func() {
 	// The test ends by removing the newly added machine and validating the size of the cluster
 	// and asserting the member was removed from the etcd cluster by contacting MemberList API.
 	g.It("is able to vertically scale up and down with a single node", func() {
+		// prerequisite, we do run the test only on a platform that supports functional MachineAPI
+		dc, err := dynamic.NewForConfig(oc.AdminConfig())
+		o.Expect(err).ToNot(o.HaveOccurred())
+		machineapihelpers.SkipUnlessMachineAPIOperator(dc, oc.KubeClient().CoreV1().Namespaces())
+
 		// set up
 		ctx := context.TODO()
 		etcdClientFactory := scalingtestinglibrary.NewEtcdClientFactory(oc.KubeClient())

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed clu
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
+		SkipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
 
 		g.By("getting MachineSet list")
 		machineSetClient := dc.Resource(schema.GroupVersionResource{Group: "machine.openshift.io", Resource: "machinesets", Version: "v1beta1"})

--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
+		SkipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
 
 		g.By("ensuring every node is linked to a machine api resource")
 		allNodes, err := c.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 	})
 })
 
-// skipUnlessMachineAPI is used to deterine if the Machine API is installed and running in a cluster.
+// SkipUnlessMachineAPI is used to deterine if the Machine API is installed and running in a cluster.
 // It is expected to skip the test if it determines that the Machine API is not installed/running.
 // Use this early in a test that relies on Machine API functionality.
 //
@@ -110,7 +110,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 // If machines are not installed it skips the test case.
 // It then checks to see if the `openshift-machine-api` namespace is installed.
 // If the namespace is not present it skips the test case.
-func skipUnlessMachineAPIOperator(dc dynamic.Interface, c coreclient.NamespaceInterface) {
+func SkipUnlessMachineAPIOperator(dc dynamic.Interface, c coreclient.NamespaceInterface) {
 	machineClient := dc.Resource(schema.GroupVersionResource{Group: "machine.openshift.io", Resource: "machines", Version: "v1beta1"})
 
 	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -243,7 +243,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
+		SkipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
 
 		g.By("fetching worker machineSets")
 		machineSets, err := listWorkerMachineSets(dc)

--- a/test/extended/machines/workers.go
+++ b/test/extended/machines/workers.go
@@ -140,7 +140,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Manage
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
+		SkipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
 
 		g.By("validating node and machine invariants")
 		// fetch all machines


### PR DESCRIPTION
the test fails on `metal` - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-baremetal-operator/245/pull-ci-openshift-cluster-baremetal-operator-master-e2e-metal-ipi-serial-ipv4/1524036156033863680