### PR TITLE
Bug 2083941: feat: add fuzzy match on micro release

### DIFF
--- a/pkg/synthetictests/allowedbackenddisruption/matches_test.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches_test.go
@@ -92,6 +92,22 @@ func TestGetClosestP95Value(t *testing.T) {
 			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"image-registry-new-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.11", Platform:"aws", Architecture:"amd64", Network:"ovn", Topology:"single"}}, fell back to historicaldata.DataKey{Name:"image-registry-new-connections", JobType:platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"aws", Architecture:"amd64", Network:"sdn", Topology:"single"}})`,
 		},
 		{
+			name: "fuzzy-match-single-ovn-on-sdn-previous-micro-release",
+			args: args{
+				backendName: "ingress-to-console-new-connections",
+				jobType: platformidentification.JobType{
+					Release:      "4.11",
+					FromRelease:  "4.10",
+					Platform:     "aws",
+					Network:      "ovn",
+					Architecture: "amd64",
+					Topology:     "single",
+				},
+			},
+			expectedDuration: mustDuration("2102.3s"),
+			expectedDetails:  `(no exact match for historicaldata.DataKey{Name:"ingress-to-console-new-connections", JobType:platformidentification.JobType{Release:"4.11", FromRelease:"4.10", Platform:"aws", Architecture:"amd64", Network:"ovn", Topology:"single"}}, fell back to historicaldata.DataKey{Name:"ingress-to-console-new-connections", JobType:platformidentification.JobType{Release:"4.10", FromRelease:"4.10", Platform:"aws", Architecture:"amd64", Network:"sdn", Topology:"single"}})`,
+		},
+		{
 			name: "missing",
 			args: args{
 				backendName: "kube-api-reused-connections",

--- a/pkg/synthetictests/historicaldata/next_best_guess.go
+++ b/pkg/synthetictests/historicaldata/next_best_guess.go
@@ -49,6 +49,7 @@ var nextBestGuessers = []NextBestKey{
 
 	combine(ForTopology("single"), OnSDN),
 	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade),
+	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade, MicroReleaseUpgrade),
 }
 
 // NextBestKey returns the next best key in the query_results.json generated from BigQuery and a bool indicating whether this guesser has an opinion.


### PR DESCRIPTION
This PR adds a fuzzy match on single node for previous micro upgrades when we lack data for single node minor upgrades