### PR TITLE
Bug 2086086: image_ecosystem: remove deprecated imagestreams

### DIFF
--- a/test/extended/image_ecosystem/s2i_images.go
+++ b/test/extended/image_ecosystem/s2i_images.go
@@ -56,20 +56,6 @@ var s2iImages = map[string][]tc{
 			Arches:   []string{"amd64", "ppc64le", "s390x"},
 		},
 		{
-			Version:  "26",
-			Cmd:      "ruby --version",
-			Expected: "ruby 2.6",
-			Tag:      "2.6-ubi8",
-			Arches:   []string{"amd64", "arm64", "ppc64le", "s390x"},
-		},
-		{
-			Version:  "26",
-			Cmd:      "ruby --version",
-			Expected: "ruby 2.6",
-			Tag:      "2.6-ubi7",
-			Arches:   []string{"amd64", "ppc64le", "s390x"},
-		},
-		{
 			Version:  "25",
 			Cmd:      "ruby --version",
 			Expected: "ruby 2.5",
@@ -84,13 +70,6 @@ var s2iImages = map[string][]tc{
 			Expected: "Python 2.7",
 			Tag:      "2.7-ubi8",
 			Arches:   []string{"amd64", "arm64", "ppc64le", "s390x"},
-		},
-		{
-			Version:  "27",
-			Cmd:      "python --version",
-			Expected: "Python 2.7",
-			Tag:      "2.7-ubi7",
-			Arches:   []string{"amd64", "ppc64le", "s390x"},
 		},
 		{
 			Version:  "36",
@@ -220,13 +199,6 @@ var s2iImages = map[string][]tc{
 			Expected: "6.0",
 			Tag:      "6.0-ubi8",
 			Arches:   []string{"amd64", "arm64", "s390x"},
-		},
-		{
-			Version:  "50",
-			Cmd:      "dotnet --version",
-			Expected: "5.0",
-			Tag:      "5.0-ubi8",
-			Arches:   []string{"amd64"},
 		},
 		{
 			Version:  "31",

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1579,8 +1579,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-ubi8\" should print the usage",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:5.0-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:5.0-ubi8\" should print the usage",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:6.0-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:6.0-ubi8\" should print the usage",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.18-ubi7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.18-ubi7\" should print the usage",
@@ -1607,8 +1605,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/php:7.4-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/php:7.4-ubi8\" should print the usage",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/python:2.7-ubi7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/python:2.7-ubi7\" should print the usage",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/python:2.7-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/python:2.7-ubi8\" should print the usage",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.6-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/python:3.6-ubi8\" should print the usage",
@@ -1621,10 +1617,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5-ubi8\" should print the usage",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.6-ubi7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.6-ubi7\" should print the usage",
-
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.6-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.6-ubi8\" should print the usage",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi7\" should print the usage",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8\" should print the usage",
@@ -1636,8 +1628,6 @@ var annotations = map[string]string{
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-ubi8\" should be SCL enabled",
-
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:5.0-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:5.0-ubi8\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:6.0-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:6.0-ubi8\" should be SCL enabled",
 
@@ -1665,8 +1655,6 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/php:7.4-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/php:7.4-ubi8\" should be SCL enabled",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/python:2.7-ubi7\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/python:2.7-ubi7\" should be SCL enabled",
-
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/python:2.7-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/python:2.7-ubi8\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.6-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/python:3.6-ubi8\" should be SCL enabled",
@@ -1678,10 +1666,6 @@ var annotations = map[string]string{
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.9-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/python:3.9-ubi8\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5-ubi8\" should be SCL enabled",
-
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.6-ubi7\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.6-ubi7\" should be SCL enabled",
-
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.6-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.6-ubi8\" should be SCL enabled",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi7\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi7\" should be SCL enabled",
 


### PR DESCRIPTION
RHEL 8 Ruby 2.6 retirement: March 2022
RHEL 7 Ruby 2.6 retirement: May 2022
RHEL 8 .NET 5 retirement: May 2022
RHEL 7 Python 2.7 retirement: July 2022

https://access.redhat.com/support/policy/updates/rhscl-rhel7
https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle
