### PR TITLE
Bug 2085997: gives the backend monitoring an identity

### DIFF
--- a/test/extended/util/disruption/controlplane/known_backends.go
+++ b/test/extended/util/disruption/controlplane/known_backends.go
@@ -115,6 +115,7 @@ func createAPIServerBackendSampler(clusterConfig *rest.Config, disruptionBackend
 	if err != nil {
 		return nil, err
 	}
+	backendSampler.WithUserAgent("openshift-origin-external-backend-sampler")
 
 	return backendSampler, nil
 }


### PR DESCRIPTION
the identity will ill be used to trace audit logs for requests that were sent by the monitor tool

the primary use case will be to find requests that arrived at an API server during its shutdown procedure.