### PR TITLE
NE-626: Re-introduce the DNS CI coverage for golang and glibc resolver libraries

### DIFF
--- a/test/extended/dns/dns_libraries.go
+++ b/test/extended/dns/dns_libraries.go
@@ -1,0 +1,134 @@
+package dns
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	watchtools "k8s.io/client-go/tools/watch"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+// checkForPodLogFailures goes through the pod logs and determines if there was a failure
+// by looking for "fail" keyword in the logs.
+func checkForPodLogFailures(f *e2e.Framework, pod *kapiv1.Pod) {
+	By("submitting the pod to kubernetes")
+	podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
+	updated, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		e2e.Failf("Failed to create %s pod: %v", pod.Name, err)
+	}
+
+	w, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Watch(context.Background(), metav1.SingleObject(metav1.ObjectMeta{Name: pod.Name, ResourceVersion: updated.ResourceVersion}))
+	if err != nil {
+		e2e.Failf("Failed to watch pods: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), e2e.PodStartTimeout)
+	defer cancel()
+	if _, err = watchtools.UntilWithoutRetry(ctx, w, PodSucceeded); err != nil {
+		e2e.Failf("Failed: %v", err)
+	}
+
+	By("retrieving the pod logs")
+	r, err := podClient.GetLogs(pod.Name, &kapiv1.PodLogOptions{Container: "querier"}).Stream(context.Background())
+	if err != nil {
+		e2e.Failf("Failed to get pod logs %s: %v", pod.Name, err)
+	}
+
+	scan := bufio.NewScanner(r)
+	for scan.Scan() {
+		line := scan.Text()
+		if strings.Contains(line, "fail") {
+			e2e.Failf("DNS resolution failed: %s", line)
+		}
+	}
+}
+
+var _ = Describe("[sig-network-edge] DNS lookup", func() {
+	f := e2e.NewDefaultFramework("dns-libraries")
+	oc := exutil.NewCLI("dns-libraries")
+
+	// creates a simple Pod that is using the image under /testdata/dns, which performs a DNS query to make sure Go's DNS resolver works fine with OpenShift DNS.
+	It("using Go's DNS resolver", func() {
+		configClient, err := configclient.NewForConfig(f.ClientConfig())
+		if err != nil {
+			e2e.Failf("Failed to get config client: %v", err)
+		}
+		infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		if err != nil {
+			e2e.Failf("Failed to get cluster config: %v", err)
+		}
+		if infra.Status.PlatformStatus.Type == configv1.BareMetalPlatformType {
+			Skip("Skip DNS lookup using Go's DNS resolver on BareMetal as there is no external connection to pull the base image.")
+		}
+
+		dnsService, err := f.ClientSet.CoreV1().Services("openshift-dns").Get(context.Background(), "dns-default", metav1.GetOptions{})
+		if err != nil {
+			e2e.Failf("Failed to get default DNS service: %v", err)
+		}
+
+		goVersions := []string{"go-v1-16", "go-v1-17"}
+		for _, version := range goVersions {
+			By(fmt.Sprintf("creating build and deployment config for dns-libraries-%s", version))
+			err = oc.Run("create").Args("-f", exutil.FixturePath("testdata", "dns", version, "dns_libraries_go.yaml")).Execute()
+			if err != nil {
+				e2e.Failf("Failed to create build configs and deployment config for dns-libraries-go: %v", err)
+			}
+
+			By("starting the builder image build with a directory")
+			err = oc.Run("start-build").Args(fmt.Sprintf("dns-libraries-%s", version), fmt.Sprintf("--from-dir=%s", exutil.FixturePath("testdata", "dns", version))).Execute()
+			if err != nil {
+				e2e.Failf("Failed to start the builder image build: %v", err)
+			}
+
+			labels := exutil.ParseLabelsOrDie(fmt.Sprintf("app=dns-libraries-%s", version))
+
+			By(fmt.Sprintf("expect the builds to complete successfully and deploy a dns-libraries-%s pod", version))
+			pods, err := exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), labels, exutil.CheckPodIsRunning, 1, 5*time.Minute)
+			if err != nil {
+				e2e.Failf("Failed to start the dns-libraries-go pod: %v", err)
+			}
+			if len(pods) != 1 {
+				e2e.Failf("Got %d pods with labels %v, expected 1", len(pods), labels)
+			}
+
+			By("expect the go application to successfully resolve DNS")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), pods[0], metav1.GetOptions{})
+			if err != nil {
+				e2e.Failf("Failed to get dns-libraries-go pod: %v", err)
+			}
+			//execute "go run /go/dns_libraries.go -cluster-ip={CLUSTER_IP}" command inside the pod
+			args := []string{pod.Name, "-c", pod.Spec.Containers[0].Name, "--", "bash", "-c", fmt.Sprintf("go run /go/dns_libraries.go -cluster-ip=%q", dnsService.Spec.ClusterIP)}
+			output, err := oc.Run("exec").Args(args...).Output()
+			if err != nil {
+				e2e.Failf("Failed to exec dns-libraries-go pod: %v", err)
+			}
+			if !strings.Contains(output, "Successfully") {
+				e2e.Failf("DNS resolution failed: %s", output)
+			}
+		}
+	})
+
+	// creates a simple Pod that is using getent to perform DNS queries, to make sure glibc's DNS resolver works fine with OpenShift DNS.
+	It("using glibc's DNS resolver", func() {
+		// using www.redhat.com just as a sample host for dns queries
+		const host = "www.redhat.com"
+
+		// running getent command 10 times to see if it can resolve the dns steadily
+		cmd := repeatCommand(
+			10,
+			fmt.Sprintf("getent -s dns ahosts %s || echo $(date) fail", host),
+		)
+		pod := createDNSPod(f.Namespace.Name, cmd)
+		checkForPodLogFailures(f, pod)
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -301,6 +301,12 @@
 // test/extended/testdata/deployments/tag-images-deployment.yaml
 // test/extended/testdata/deployments/test-deployment-broken.yaml
 // test/extended/testdata/deployments/test-deployment-test.yaml
+// test/extended/testdata/dns/go-v1-16/Dockerfile
+// test/extended/testdata/dns/go-v1-16/dns_libraries_go
+// test/extended/testdata/dns/go-v1-16/dns_libraries_go.yaml
+// test/extended/testdata/dns/go-v1-17/Dockerfile
+// test/extended/testdata/dns/go-v1-17/dns_libraries_go
+// test/extended/testdata/dns/go-v1-17/dns_libraries_go.yaml
 // test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
 // test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
 // test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml
@@ -41204,6 +41210,306 @@ func testExtendedTestdataDeploymentsTestDeploymentTestYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataDnsGoV116Dockerfile = []byte(`FROM registry.redhat.io/ubi8/go-toolset:1.16.12
+
+ENV GOCACHE=/tmp/
+
+COPY dns_libraries_go /go/dns_libraries.go
+
+CMD ["/bin/sh", "-c", "sleep 9999999"]
+`)
+
+func testExtendedTestdataDnsGoV116DockerfileBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsGoV116Dockerfile, nil
+}
+
+func testExtendedTestdataDnsGoV116Dockerfile() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsGoV116DockerfileBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/go-v1-16/Dockerfile", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataDnsGoV116Dns_libraries_go = []byte(`package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"time"
+)
+
+func main() {
+	clusterIP := flag.String("cluster-ip", "", "clusterIP for CoreDNS service")
+	flag.Parse()
+	if *clusterIP == "" {
+		log.Fatal("cluster-ip must be set")
+	}
+
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 10 * time.Second,
+			}
+			return d.DialContext(ctx, network, net.JoinHostPort(*clusterIP, "53"))
+		},
+	}
+	addrs, err := r.LookupHost(context.Background(), "www.redhat.com")
+	if err != nil {
+		log.Fatalf("Failed to look up host: %v", err)
+	}
+
+	log.Printf("Successfully resolved: %q", addrs)
+}
+`)
+
+func testExtendedTestdataDnsGoV116Dns_libraries_goBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsGoV116Dns_libraries_go, nil
+}
+
+func testExtendedTestdataDnsGoV116Dns_libraries_go() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsGoV116Dns_libraries_goBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/go-v1-16/dns_libraries_go", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataDnsGoV116Dns_libraries_goYaml = []byte(`apiVersion: v1
+kind: List
+metadata: {}
+items:
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      labels:
+        build: dns-libraries-go-v1-16
+      name: dns-libraries-go-v1-16
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: dns-libraries-go-v1-16:latest
+      source:
+        binary: {}
+        type: Binary
+      strategy:
+        dockerStrategy: {}
+        type: Docker
+      triggers: []
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      labels:
+        build: dns-libraries-go-v1-16
+      name: dns-libraries-go-v1-16
+    spec: { }
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: dns-libraries-go-v1-16
+      name: dns-libraries-go-v1-16
+    spec:
+      replicas: 1
+      selector:
+        app: dns-libraries-go-v1-16
+        deploymentconfig: dns-libraries-go-v1-16
+      template:
+        metadata:
+          labels:
+            app: dns-libraries-go-v1-16
+            deploymentconfig: dns-libraries-go-v1-16
+        spec:
+          containers:
+            - image: dns-libraries-go-v1-16
+              imagePullPolicy: Always
+              name: dns-libraries-go-v1-16
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - dns-libraries-go-v1-16
+            from:
+              kind: ImageStreamTag
+              name: dns-libraries-go-v1-16:latest
+          type: ImageChange
+`)
+
+func testExtendedTestdataDnsGoV116Dns_libraries_goYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsGoV116Dns_libraries_goYaml, nil
+}
+
+func testExtendedTestdataDnsGoV116Dns_libraries_goYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsGoV116Dns_libraries_goYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/go-v1-16/dns_libraries_go.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataDnsGoV117Dockerfile = []byte(`FROM registry.redhat.io/ubi8/go-toolset:1.17.10
+
+ENV GOCACHE=/tmp/
+
+COPY dns_libraries_go /go/dns_libraries.go
+
+CMD ["/bin/sh", "-c", "sleep 9999999"]
+`)
+
+func testExtendedTestdataDnsGoV117DockerfileBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsGoV117Dockerfile, nil
+}
+
+func testExtendedTestdataDnsGoV117Dockerfile() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsGoV117DockerfileBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/go-v1-17/Dockerfile", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataDnsGoV117Dns_libraries_go = []byte(`package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"time"
+)
+
+func main() {
+	clusterIP := flag.String("cluster-ip", "", "clusterIP for CoreDNS service")
+	flag.Parse()
+	if *clusterIP == "" {
+		log.Fatal("cluster-ip must be set")
+	}
+
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 10 * time.Second,
+			}
+			return d.DialContext(ctx, network, net.JoinHostPort(*clusterIP, "53"))
+		},
+	}
+	addrs, err := r.LookupHost(context.Background(), "www.redhat.com")
+	if err != nil {
+		log.Fatalf("Failed to look up host: %v", err)
+	}
+
+	log.Printf("Successfully resolved: %q", addrs)
+}
+`)
+
+func testExtendedTestdataDnsGoV117Dns_libraries_goBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsGoV117Dns_libraries_go, nil
+}
+
+func testExtendedTestdataDnsGoV117Dns_libraries_go() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsGoV117Dns_libraries_goBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/go-v1-17/dns_libraries_go", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataDnsGoV117Dns_libraries_goYaml = []byte(`apiVersion: v1
+kind: List
+metadata: {}
+items:
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      labels:
+        build: dns-libraries-go-v1-17
+      name: dns-libraries-go-v1-17
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: dns-libraries-go-v1-17:latest
+      source:
+        binary: {}
+        type: Binary
+      strategy:
+        dockerStrategy: {}
+        type: Docker
+      triggers: []
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      labels:
+        build: dns-libraries-go-v1-17
+      name: dns-libraries-go-v1-17
+    spec: { }
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: dns-libraries-go-v1-17
+      name: dns-libraries-go-v1-17
+    spec:
+      replicas: 1
+      selector:
+        app: dns-libraries-go-v1-17
+        deploymentconfig: dns-libraries-go-v1-17
+      template:
+        metadata:
+          labels:
+            app: dns-libraries-go-v1-17
+            deploymentconfig: dns-libraries-go-v1-17
+        spec:
+          containers:
+            - image: dns-libraries-go-v1-17
+              imagePullPolicy: Always
+              name: dns-libraries-go-v1-17
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - dns-libraries-go-v1-17
+            from:
+              kind: ImageStreamTag
+              name: dns-libraries-go-v1-17:latest
+          type: ImageChange
+`)
+
+func testExtendedTestdataDnsGoV117Dns_libraries_goYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataDnsGoV117Dns_libraries_goYaml, nil
+}
+
+func testExtendedTestdataDnsGoV117Dns_libraries_goYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataDnsGoV117Dns_libraries_goYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/dns/go-v1-17/dns_libraries_go.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml = []byte(`apiVersion: k8s.ovn.org/v1
 kind: EgressFirewall
 metadata:
@@ -52907,6 +53213,12 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/deployments/tag-images-deployment.yaml":                                          testExtendedTestdataDeploymentsTagImagesDeploymentYaml,
 	"test/extended/testdata/deployments/test-deployment-broken.yaml":                                         testExtendedTestdataDeploymentsTestDeploymentBrokenYaml,
 	"test/extended/testdata/deployments/test-deployment-test.yaml":                                           testExtendedTestdataDeploymentsTestDeploymentTestYaml,
+	"test/extended/testdata/dns/go-v1-16/Dockerfile":                                                         testExtendedTestdataDnsGoV116Dockerfile,
+	"test/extended/testdata/dns/go-v1-16/dns_libraries_go":                                                   testExtendedTestdataDnsGoV116Dns_libraries_go,
+	"test/extended/testdata/dns/go-v1-16/dns_libraries_go.yaml":                                              testExtendedTestdataDnsGoV116Dns_libraries_goYaml,
+	"test/extended/testdata/dns/go-v1-17/Dockerfile":                                                         testExtendedTestdataDnsGoV117Dockerfile,
+	"test/extended/testdata/dns/go-v1-17/dns_libraries_go":                                                   testExtendedTestdataDnsGoV117Dns_libraries_go,
+	"test/extended/testdata/dns/go-v1-17/dns_libraries_go.yaml":                                              testExtendedTestdataDnsGoV117Dns_libraries_goYaml,
 	"test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml":                                   testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml,
 	"test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml":                               testExtendedTestdataEgressFirewallSdnEgressnetworkpolicyTestYaml,
 	"test/extended/testdata/egress-router-cni/egress-router-cni-v4-cr.yaml":                                  testExtendedTestdataEgressRouterCniEgressRouterCniV4CrYaml,
@@ -53573,6 +53885,18 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"tag-images-deployment.yaml":          {testExtendedTestdataDeploymentsTagImagesDeploymentYaml, map[string]*bintree{}},
 					"test-deployment-broken.yaml":         {testExtendedTestdataDeploymentsTestDeploymentBrokenYaml, map[string]*bintree{}},
 					"test-deployment-test.yaml":           {testExtendedTestdataDeploymentsTestDeploymentTestYaml, map[string]*bintree{}},
+				}},
+				"dns": {nil, map[string]*bintree{
+					"go-v1-16": {nil, map[string]*bintree{
+						"Dockerfile":            {testExtendedTestdataDnsGoV116Dockerfile, map[string]*bintree{}},
+						"dns_libraries_go":      {testExtendedTestdataDnsGoV116Dns_libraries_go, map[string]*bintree{}},
+						"dns_libraries_go.yaml": {testExtendedTestdataDnsGoV116Dns_libraries_goYaml, map[string]*bintree{}},
+					}},
+					"go-v1-17": {nil, map[string]*bintree{
+						"Dockerfile":            {testExtendedTestdataDnsGoV117Dockerfile, map[string]*bintree{}},
+						"dns_libraries_go":      {testExtendedTestdataDnsGoV117Dns_libraries_go, map[string]*bintree{}},
+						"dns_libraries_go.yaml": {testExtendedTestdataDnsGoV117Dns_libraries_goYaml, map[string]*bintree{}},
+					}},
 				}},
 				"egress-firewall": {nil, map[string]*bintree{
 					"ovnk-egressfirewall-test.yaml":     {testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYaml, map[string]*bintree{}},

--- a/test/extended/testdata/dns/go-v1-16/Dockerfile
+++ b/test/extended/testdata/dns/go-v1-16/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.redhat.io/ubi8/go-toolset:1.16.12
+
+ENV GOCACHE=/tmp/
+
+COPY dns_libraries_go /go/dns_libraries.go
+
+CMD ["/bin/sh", "-c", "sleep 9999999"]

--- a/test/extended/testdata/dns/go-v1-16/dns_libraries_go
+++ b/test/extended/testdata/dns/go-v1-16/dns_libraries_go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"time"
+)
+
+func main() {
+	clusterIP := flag.String("cluster-ip", "", "clusterIP for CoreDNS service")
+	flag.Parse()
+	if *clusterIP == "" {
+		log.Fatal("cluster-ip must be set")
+	}
+
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 10 * time.Second,
+			}
+			return d.DialContext(ctx, network, net.JoinHostPort(*clusterIP, "53"))
+		},
+	}
+	addrs, err := r.LookupHost(context.Background(), "www.redhat.com")
+	if err != nil {
+		log.Fatalf("Failed to look up host: %v", err)
+	}
+
+	log.Printf("Successfully resolved: %q", addrs)
+}

--- a/test/extended/testdata/dns/go-v1-16/dns_libraries_go.yaml
+++ b/test/extended/testdata/dns/go-v1-16/dns_libraries_go.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      labels:
+        build: dns-libraries-go-v1-16
+      name: dns-libraries-go-v1-16
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: dns-libraries-go-v1-16:latest
+      source:
+        binary: {}
+        type: Binary
+      strategy:
+        dockerStrategy: {}
+        type: Docker
+      triggers: []
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      labels:
+        build: dns-libraries-go-v1-16
+      name: dns-libraries-go-v1-16
+    spec: { }
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: dns-libraries-go-v1-16
+      name: dns-libraries-go-v1-16
+    spec:
+      replicas: 1
+      selector:
+        app: dns-libraries-go-v1-16
+        deploymentconfig: dns-libraries-go-v1-16
+      template:
+        metadata:
+          labels:
+            app: dns-libraries-go-v1-16
+            deploymentconfig: dns-libraries-go-v1-16
+        spec:
+          containers:
+            - image: dns-libraries-go-v1-16
+              imagePullPolicy: Always
+              name: dns-libraries-go-v1-16
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - dns-libraries-go-v1-16
+            from:
+              kind: ImageStreamTag
+              name: dns-libraries-go-v1-16:latest
+          type: ImageChange

--- a/test/extended/testdata/dns/go-v1-17/Dockerfile
+++ b/test/extended/testdata/dns/go-v1-17/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.redhat.io/ubi8/go-toolset:1.17.10
+
+ENV GOCACHE=/tmp/
+
+COPY dns_libraries_go /go/dns_libraries.go
+
+CMD ["/bin/sh", "-c", "sleep 9999999"]

--- a/test/extended/testdata/dns/go-v1-17/dns_libraries_go
+++ b/test/extended/testdata/dns/go-v1-17/dns_libraries_go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"time"
+)
+
+func main() {
+	clusterIP := flag.String("cluster-ip", "", "clusterIP for CoreDNS service")
+	flag.Parse()
+	if *clusterIP == "" {
+		log.Fatal("cluster-ip must be set")
+	}
+
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 10 * time.Second,
+			}
+			return d.DialContext(ctx, network, net.JoinHostPort(*clusterIP, "53"))
+		},
+	}
+	addrs, err := r.LookupHost(context.Background(), "www.redhat.com")
+	if err != nil {
+		log.Fatalf("Failed to look up host: %v", err)
+	}
+
+	log.Printf("Successfully resolved: %q", addrs)
+}

--- a/test/extended/testdata/dns/go-v1-17/dns_libraries_go.yaml
+++ b/test/extended/testdata/dns/go-v1-17/dns_libraries_go.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      labels:
+        build: dns-libraries-go-v1-17
+      name: dns-libraries-go-v1-17
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: dns-libraries-go-v1-17:latest
+      source:
+        binary: {}
+        type: Binary
+      strategy:
+        dockerStrategy: {}
+        type: Docker
+      triggers: []
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      labels:
+        build: dns-libraries-go-v1-17
+      name: dns-libraries-go-v1-17
+    spec: { }
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: dns-libraries-go-v1-17
+      name: dns-libraries-go-v1-17
+    spec:
+      replicas: 1
+      selector:
+        app: dns-libraries-go-v1-17
+        deploymentconfig: dns-libraries-go-v1-17
+      template:
+        metadata:
+          labels:
+            app: dns-libraries-go-v1-17
+            deploymentconfig: dns-libraries-go-v1-17
+        spec:
+          containers:
+            - image: dns-libraries-go-v1-17
+              imagePullPolicy: Always
+              name: dns-libraries-go-v1-17
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - dns-libraries-go-v1-17
+            from:
+              kind: ImageStreamTag
+              name: dns-libraries-go-v1-17:latest
+          type: ImageChange

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2223,6 +2223,10 @@ var Annotations = map[string]string{
 
 	"[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [apigroup:config.openshift.io][apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-network-edge] DNS lookup using Go's DNS resolver": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network-edge] DNS lookup using glibc's DNS resolver": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": " [Disabled:Broken]",


### PR DESCRIPTION
This PR re-introduces the DNS CI coverage for golang and glibc resolver libraries by reverting 4a1e80297759a22a4cae03c3deb6171c0fd382eb. 

Modifications to the previous PR: 
- Base image for Go test was changed from `golang` in Docker Hub to `registry.redhat.io/ubi8/go-toolset`.
- A test for Go 1.16 and 1.17 were added, 1.18 was removed as the `go-toolset` image does not yet support 1.18.
- A check for BareMetal environment was added to skip the test, as this environment is disconnected and does not have any suitable images on the local registry to use for different Go versions.