### PR TITLE
Bug 2085997: special configuration on barematal platform for the etcd vertical test is required

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -569,7 +569,7 @@ func newDuplicatedEventsAllowedWhenEtcdRevisionChange(ctx context.Context, opera
 		return nil, err
 	}
 	return &etcdRevisionChangeAllowance{
-		allowedGuardProbeFailurePattern:        regexp.MustCompile(`ns/openshift-etcd pod/etcd-guard-ip-.* node/[a-z0-9.-]+ - reason/(Unhealthy|ProbeError) Readiness probe.*`),
+		allowedGuardProbeFailurePattern:        regexp.MustCompile(`ns/openshift-etcd pod/etcd-guard-.* node/[a-z0-9.-]+ - reason/(Unhealthy|ProbeError) Readiness probe.*`),
 		maxAllowedGuardProbeFailurePerRevision: 60 / 5, // 60s for starting a new pod, divided by the probe interval
 		currentRevision:                        currentRevision,
 	}, nil

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -288,7 +288,6 @@ func SkipIfUnsupportedPlatform(ctx context.Context, oc *exutil.CLI) {
 	o.Expect(err).ToNot(o.HaveOccurred())
 	machineClient := machineClientSet.MachineV1beta1().Machines("openshift-machine-api")
 	skipUnlessFunctionalMachineAPI(ctx, machineClient)
-	skipIfBareMetal(oc)
 	skipIfAzure(oc)
 	skipIfSingleNode(oc)
 }
@@ -310,15 +309,6 @@ func skipUnlessFunctionalMachineAPI(ctx context.Context, machineClient machinev1
 	}
 	e2eskipper.Skipf("haven't found a machine in running state, this test can be run on a platform that supports functional MachineAPI")
 	return
-}
-
-func skipIfBareMetal(oc *exutil.CLI) {
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	if infra.Status.PlatformStatus.Type == configv1.BareMetalPlatformType {
-		e2eskipper.Skipf("this test is currently broken on the metal platform and needs to be fixed")
-	}
 }
 
 func skipIfAzure(oc *exutil.CLI) {

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -19,6 +19,16 @@ var _ = g.Describe("[sig-etcd][Serial] etcd", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-scaling").AsAdmin()
 
+	var cleanupPlatformSpecificConfiguration func()
+
+	g.BeforeEach(func() {
+		cleanupPlatformSpecificConfiguration = scalingtestinglibrary.InitPlatformSpecificConfiguration(oc)
+	})
+
+	g.AfterEach(func() {
+		cleanupPlatformSpecificConfiguration()
+	})
+
 	// The following test covers a basic vertical scaling scenario.
 	// It starts by adding a new master machine to the cluster
 	// next it validates the size of etcd cluster and makes sure the new member is healthy.


### PR DESCRIPTION
for baremetal platforms requires an extra worker to be previously deployed to allow scaling operations. Otherwise creating a new machine has no effect and is stuck on `No available BareMetalHost found`

requires https://github.com/openshift/origin/pull/27127