### PR TITLE
Bug 2085997: the machine API can be unavailable resulting in a 404 or an empty list

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -569,7 +569,7 @@ func newDuplicatedEventsAllowedWhenEtcdRevisionChange(ctx context.Context, opera
 		return nil, err
 	}
 	return &etcdRevisionChangeAllowance{
-		allowedGuardProbeFailurePattern:        regexp.MustCompile(`ns/openshift-etcd pod/etcd-guard-ip-.* node/[a-z0-9.-]+ - reason/(Unhealthy|ProbeError) Readiness probe.*`),
+		allowedGuardProbeFailurePattern:        regexp.MustCompile(`ns/openshift-etcd pod/etcd-guard-.* node/[a-z0-9.-]+ - reason/(Unhealthy|ProbeError) Readiness probe.*`),
 		maxAllowedGuardProbeFailurePerRevision: 60 / 5, // 60s for starting a new pod, divided by the probe interval
 		currentRevision:                        currentRevision,
 	}, nil

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -70,7 +70,7 @@ func CreateNewMasterMachine(ctx context.Context, t TestingT, machineClient machi
 
 func EnsureMasterMachine(ctx context.Context, t TestingT, machineName string, machineClient machinev1beta1client.MachineInterface) error {
 	waitPollInterval := 15 * time.Second
-	waitPollTimeout := 5 * time.Minute
+	waitPollTimeout := 10 * time.Minute
 	t.Logf("Waiting up to %s for %q machine to be in the Running state", waitPollTimeout.String(), machineName)
 
 	return wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {


### PR DESCRIPTION
on some platforms, machine API can be totally off resulting in a 404 response, and on some, we might get an empty list.
this PR changes the etcd scaling test to take into account both scenarios.