### PR TITLE
Bug 2086519: AUTH-133: test/extended/security/scc: comply to pod security admission

### DIFF
--- a/test/extended/apiserver/kubeconfigs.go
+++ b/test/extended/apiserver/kubeconfigs.go
@@ -9,18 +9,20 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	configv1 "github.com/openshift/api/config/v1"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("apiserver")
+	oc := exutil.NewCLIWithPodSecurityLevel("apiserver", admissionapi.LevelPrivileged)
 
 	for _, kc := range []string{
 		"localhost.kubeconfig",

--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -11,8 +11,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -27,7 +29,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 		failedBuildConfig     = filepath.Join(buildPruningBaseDir, "failed-build-config.yaml")
 		erroredBuildConfig    = filepath.Join(buildPruningBaseDir, "errored-build-config.yaml")
 		groupBuildConfig      = filepath.Join(buildPruningBaseDir, "default-group-build-config.yaml")
-		oc                    = exutil.NewCLI("build-pruning")
+		oc                    = exutil.NewCLIWithPodSecurityLevel("build-pruning", admissionapi.LevelBaseline)
 		pollingInterval       = time.Second
 		timeout               = time.Minute
 	)

--- a/test/extended/builds/build_timing.go
+++ b/test/extended/builds/build_timing.go
@@ -7,7 +7,10 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	buildv1 "github.com/openshift/api/build/v1"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -36,7 +39,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][timing] capture build stages an
 		dockerBuildDockerfile = filepath.Join(buildTimingBaseDir, "Dockerfile")
 		sourceBuildFixture    = filepath.Join(buildTimingBaseDir, "test-s2i-build.json")
 		sourceBuildBinDir     = filepath.Join(buildTimingBaseDir, "s2i-binary-dir")
-		oc                    = exutil.NewCLI("build-timing")
+		oc                    = exutil.NewCLIWithPodSecurityLevel("build-timing", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -12,13 +12,14 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds with a context directory", func() {
 	defer g.GinkgoRecover()
 	var (
 		appFixture            = exutil.FixturePath("testdata", "builds", "test-context-build.json")
-		oc                    = exutil.NewCLI("contextdir")
+		oc                    = exutil.NewCLIWithPodSecurityLevel("contextdir", admissionapi.LevelBaseline)
 		s2iBuildConfigName    = "s2icontext"
 		s2iBuildName          = "s2icontext-1"
 		dcName                = "frontend"

--- a/test/extended/builds/custom_build.go
+++ b/test/extended/builds/custom_build.go
@@ -5,13 +5,16 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-builds][Feature:Builds] custom build with buildah", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                 = exutil.NewCLI("custom-build")
+		oc                 = exutil.NewCLIWithPodSecurityLevel("custom-build", admissionapi.LevelBaseline)
 		customBuildAdd     = exutil.FixturePath("testdata", "builds", "custom-build")
 		customBuildFixture = exutil.FixturePath("testdata", "builds", "test-custom-build.yaml")
 	)

--- a/test/extended/builds/docker_pullsearch.go
+++ b/test/extended/builds/docker_pullsearch.go
@@ -4,6 +4,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	"k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -11,7 +13,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][pullsearch] docker build where 
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-build-search-registries.yaml")
-		oc           = exutil.NewCLI("docker-build-pullsearch")
+		oc           = exutil.NewCLIWithPodSecurityLevel("docker-build-pullsearch", api.LevelPrivileged)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/docker_pullsecret.go
+++ b/test/extended/builds/docker_pullsecret.go
@@ -6,6 +6,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -18,7 +20,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][pullsecret] docker build using 
 
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-docker-build-pullsecret.json")
-		oc           = exutil.NewCLI("docker-build-pullsecret")
+		oc           = exutil.NewCLIWithPodSecurityLevel("docker-build-pullsecret", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/hooks.go
+++ b/test/extended/builds/hooks.go
@@ -12,6 +12,7 @@ import (
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = g.Describe("[sig-builds][Feature:Builds][Slow] testing build configuration hooks", func() {
@@ -20,7 +21,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] testing build configurati
 		dockerBuildFixture = exutil.FixturePath("testdata", "builds", "build-postcommit", "docker.yaml")
 		s2iBuildFixture    = exutil.FixturePath("testdata", "builds", "build-postcommit", "sti.yaml")
 		imagestreamFixture = exutil.FixturePath("testdata", "builds", "build-postcommit", "imagestreams.yaml")
-		oc                 = exutil.NewCLI("cli-test-hooks")
+		oc                 = exutil.NewCLIWithPodSecurityLevel("cli-test-hooks", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -46,7 +47,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 		s2iBuildFixture    = exutil.FixturePath("testdata", "builds", "test-imageresolution-s2i-build.yaml")
 		dockerBuildFixture = exutil.FixturePath("testdata", "builds", "test-imageresolution-docker-build.yaml")
 		customBuildFixture = exutil.FixturePath("testdata", "builds", "test-imageresolution-custom-build.yaml")
-		oc                 = exutil.NewCLI("build-image-source")
+		oc                 = exutil.NewCLIWithPodSecurityLevel("build-image-source", admissionapi.LevelBaseline)
 		imageSourceLabel   = exutil.ParseLabelsOrDie("app=imagesourceapp")
 		imageDockerLabel   = exutil.ParseLabelsOrDie("app=imagedockerapp")
 		sourceBuildLabel   = exutil.ParseLabelsOrDie("openshift.io/build.name=imagesourcebuild")

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -7,6 +7,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	eximages "github.com/openshift/origin/test/extended/images"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -17,7 +19,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] result image should have proper
 		imageStreamFixture = exutil.FixturePath("testdata", "builds", "test-image-stream.json")
 		stiBuildFixture    = exutil.FixturePath("testdata", "builds", "test-s2i-build.json")
 		dockerBuildFixture = exutil.FixturePath("testdata", "builds", "test-docker-build.json")
-		oc                 = exutil.NewCLI("build-sti-labels")
+		oc                 = exutil.NewCLIWithPodSecurityLevel("build-sti-labels", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -11,8 +11,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
+
 	eximages "github.com/openshift/origin/test/extended/images"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
@@ -21,7 +23,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] Multi-stage image builds", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc             = exutil.NewCLI("build-multistage")
+		oc             = exutil.NewCLIWithPodSecurityLevel("build-multistage", admissionapi.LevelBaseline)
 		testDockerfile = fmt.Sprintf(`
 FROM scratch as test
 USER 1001

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -9,6 +9,7 @@ import (
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kdeployutil "k8s.io/kubernetes/test/e2e/framework/deployment"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	deployutil "github.com/openshift/origin/test/extended/deployments"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -25,7 +26,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 	// whose name itself includes the app name.  Ensure we can create and fully
 	// deploy an app with a 58 character name [63 maximum - len('-9999' suffix)].
 
-	oc := exutil.NewCLI("new-app")
+	oc := exutil.NewCLIWithPodSecurityLevel("new-app", admissionapi.LevelBaseline)
 
 	g.Context("", func() {
 

--- a/test/extended/builds/no_outputname.go
+++ b/test/extended/builds/no_outputname.go
@@ -6,6 +6,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -14,7 +16,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build without output image", fu
 	var (
 		dockerImageFixture = exutil.FixturePath("testdata", "builds", "test-docker-no-outputname.json")
 		s2iImageFixture    = exutil.FixturePath("testdata", "builds", "test-s2i-no-outputname.json")
-		oc                 = exutil.NewCLI("build-no-outputname")
+		oc                 = exutil.NewCLIWithPodSecurityLevel("build-no-outputname", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/nosrc.go
+++ b/test/extended/builds/nosrc.go
@@ -8,6 +8,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -16,7 +17,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build with empty source", func(
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-nosrc-build.json")
-		oc           = exutil.NewCLI("cli-build-nosrc")
+		oc           = exutil.NewCLIWithPodSecurityLevel("cli-build-nosrc", admissionapi.LevelBaseline)
 		exampleBuild = exutil.FixturePath("testdata", "builds", "test-build-app")
 	)
 

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -11,8 +11,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
 )
@@ -20,7 +22,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] Optimized image builds", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc             = exutil.NewCLI("build-dockerfile-env")
+		oc             = exutil.NewCLIWithPodSecurityLevel("build-dockerfile-env", admissionapi.LevelBaseline)
 		skipLayers     = buildv1.ImageOptimizationSkipLayers
 		testDockerfile = fmt.Sprintf(`
 FROM %s

--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -7,6 +7,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/jenkins"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -16,7 +18,7 @@ var _ = g.Describe("[sig-builds][Feature:JenkinsRHELImagesOnly][Feature:Jenkins]
 	defer g.GinkgoRecover()
 
 	var (
-		oc               = exutil.NewCLI("jenkins-pipeline")
+		oc               = exutil.NewCLIWithPodSecurityLevel("jenkins-pipeline", admissionapi.LevelBaseline)
 		j                *jenkins.JenkinsRef
 		simplePipelineBC = exutil.FixturePath("testdata", "builds", "simple-pipeline-bc.yaml")
 

--- a/test/extended/builds/revision.go
+++ b/test/extended/builds/revision.go
@@ -8,6 +8,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -16,7 +17,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build have source revision meta
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-build-revision.json")
-		oc           = exutil.NewCLI("cli-build-revision")
+		oc           = exutil.NewCLIWithPodSecurityLevel("cli-build-revision", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/run_fs_verification.go
+++ b/test/extended/builds/run_fs_verification.go
@@ -7,6 +7,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
 )
@@ -14,7 +16,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] verify /run filesystem contents", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                                      = exutil.NewCLI("verify-run-fs")
+		oc                                      = exutil.NewCLIWithPodSecurityLevel("verify-run-fs", admissionapi.LevelBaseline)
 		testVerityRunFSWriteableBuildConfigYaml = fmt.Sprintf(`
 apiVersion: build.openshift.io/v1
 kind: BuildConfig

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/pod"
 
@@ -25,7 +27,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] s2i build with environmen
 		imageStreamFixture   = exutil.FixturePath("testdata", "builds", "test-image-stream.json")
 		stiEnvBuildFixture   = exutil.FixturePath("testdata", "builds", "test-env-build.json")
 		podAndServiceFixture = exutil.FixturePath("testdata", "builds", "test-build-podsvc.json")
-		oc                   = exutil.NewCLI("build-sti-env")
+		oc                   = exutil.NewCLIWithPodSecurityLevel("build-sti-env", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -8,6 +8,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/pod"
 
@@ -25,7 +27,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] incremental s2i build", f
 	var (
 		templateFixture      = exutil.FixturePath("testdata", "builds", "incremental-auth-build.json")
 		podAndServiceFixture = exutil.FixturePath("testdata", "builds", "test-build-podsvc.json")
-		oc                   = exutil.NewCLI("build-sti-inc")
+		oc                   = exutil.NewCLIWithPodSecurityLevel("build-sti-inc", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -2,6 +2,7 @@ package builds
 
 import (
 	"fmt"
+	"k8s.io/pod-security-admission/api"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -21,7 +22,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a quota", func()
 
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-s2i-build-quota.json")
-		oc           = exutil.NewCLI("s2i-build-quota")
+		oc           = exutil.NewCLIWithPodSecurityLevel("s2i-build-quota", api.LevelPrivileged)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -10,8 +10,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
 )
@@ -30,7 +32,7 @@ func After(oc *exutil.CLI) {
 
 var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user image", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("s2i-build-root")
+	oc := exutil.NewCLIWithPodSecurityLevel("s2i-build-root", admissionapi.LevelBaseline)
 
 	g.It("should create a root build and fail without a privileged SCC", func() {
 		g.Skip("TODO: figure out why we aren't properly denying this, also consider whether we still need to deny it")

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -7,6 +7,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -24,7 +25,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use build secrets", f
 		dockerBuildDockerfile  = filepath.Join(buildSecretBaseDir, "Dockerfile")
 		sourceBuildFixture     = filepath.Join(buildSecretBaseDir, "test-s2i-build.json")
 		sourceBuildBinDir      = filepath.Join(buildSecretBaseDir, "s2i-binary-dir")
-		oc                     = exutil.NewCLI("build-secrets")
+		oc                     = exutil.NewCLIWithPodSecurityLevel("build-secrets", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/service.go
+++ b/test/extended/builds/service.go
@@ -10,6 +10,7 @@ import (
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kdeployutil "k8s.io/kubernetes/test/e2e/framework/deployment"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
@@ -18,7 +19,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] build can reference a cluster service", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc             = exutil.NewCLI("build-service")
+		oc             = exutil.NewCLIWithPodSecurityLevel("build-service", admissionapi.LevelBaseline)
 		testDockerfile = fmt.Sprintf(`
 FROM %s
 RUN cat /etc/resolv.conf

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	"github.com/openshift/api/image/docker10"
@@ -35,7 +36,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 		symlinkFixture     = exutil.FixturePath("testdata", "builds", "test-symlink-build.yaml")
 		exampleGemfileURL  = "https://raw.githubusercontent.com/openshift/ruby-hello-world/master/Gemfile"
 		exampleArchiveURL  = "https://github.com/openshift/ruby-hello-world/archive/master.zip"
-		oc                 = exutil.NewCLI("cli-start-build")
+		oc                 = exutil.NewCLIWithPodSecurityLevel("cli-start-build", admissionapi.LevelBaseline)
 		verifyNodeSelector = func(oc *exutil.CLI, name string) {
 			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), name+"-build", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/valuefrom.go
+++ b/test/extended/builds/valuefrom.go
@@ -7,6 +7,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -20,7 +22,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 		successfulDockerBuildValueFrom = filepath.Join(valueFromBaseDir, "successful-docker-build-value-from-config.yaml")
 		failedSTIBuildValueFrom        = filepath.Join(valueFromBaseDir, "failed-sti-build-value-from-config.yaml")
 		failedDockerBuildValueFrom     = filepath.Join(valueFromBaseDir, "failed-docker-build-value-from-config.yaml")
-		oc                             = exutil.NewCLI("build-valuefrom")
+		oc                             = exutil.NewCLIWithPodSecurityLevel("build-valuefrom", admissionapi.LevelBaseline)
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/volumes.go
+++ b/test/extended/builds/volumes.go
@@ -8,9 +8,11 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -21,7 +23,7 @@ import (
 
 var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func() {
 	var (
-		oc                     = exutil.NewCLI("build-volumes")
+		oc                     = exutil.NewCLIWithPodSecurityLevel("build-volumes", admissionapi.LevelBaseline)
 		baseDir                = exutil.FixturePath("testdata", "builds", "volumes")
 		secret                 = filepath.Join(baseDir, "secret.yaml")
 		configmap              = filepath.Join(baseDir, "configmap.yaml")
@@ -211,7 +213,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                     = exutil.NewCLI("build-volumes-csi")
+		oc                     = exutil.NewCLIWithPodSecurityLevel("build-volumes-csi", admissionapi.LevelBaseline)
 		baseDir                = exutil.FixturePath("testdata", "builds", "volumes")
 		secret                 = filepath.Join(baseDir, "secret.yaml")
 		s2iDeploymentConfig    = filepath.Join(baseDir, "s2i-deploymentconfig.yaml")

--- a/test/extended/builds/webhook.go
+++ b/test/extended/builds/webhook.go
@@ -9,20 +9,23 @@ import (
 	"net/http"
 	"time"
 
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	admissionapi "k8s.io/pod-security-admission/api"
 
-	g "github.com/onsi/ginkgo"
-	o "github.com/onsi/gomega"
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-builds][Feature:Builds][webhook]", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("build-webhooks")
+	oc := exutil.NewCLIWithPodSecurityLevel("build-webhooks", admissionapi.LevelBaseline)
 
 	g.It("TestWebhook", func() {
 		TestWebhook(g.GinkgoT(), oc)

--- a/test/extended/cli/annotation.go
+++ b/test/extended/cli/annotation.go
@@ -6,6 +6,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -16,7 +18,7 @@ var _ = g.Describe("[sig-cli] oc annotate", func() {
 		podAnnotationTemplate = `{{index .metadata.annotations "new-anno"}}`
 	)
 
-	var oc = exutil.NewCLI("oc-annotation")
+	var oc = exutil.NewCLIWithPodSecurityLevel("oc-annotation", admissionapi.LevelBaseline)
 
 	g.It("pod", func() {
 		g.By("creating hello-openshift pod")

--- a/test/extended/cli/basics.go
+++ b/test/extended/cli/basics.go
@@ -12,15 +12,18 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	exutil "github.com/openshift/origin/test/extended/util"
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	k8simage "k8s.io/kubernetes/test/utils/image"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-cli] oc basics", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc                   = exutil.NewCLI("oc-basics")
+		oc                   = exutil.NewCLIWithPodSecurityLevel("oc-basics", admissionapi.LevelBaseline)
 		cmdTestData          = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata")
 		mixedAPIVersionsFile = exutil.FixturePath("testdata", "mixed-api-versions.yaml")
 		oauthAccessTokenFile = filepath.Join(cmdTestData, "oauthaccesstoken.yaml")

--- a/test/extended/cli/compat.go
+++ b/test/extended/cli/compat.go
@@ -10,6 +10,7 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -26,7 +27,7 @@ var _ = g.Describe("[sig-cli] oc", func() {
 		}
 	})
 
-	oc = exutil.NewCLI("cli")
+	oc = exutil.NewCLIWithPodSecurityLevel("cli", admissionapi.LevelBaseline)
 
 	g.It("can run inside of a busybox container", func() {
 		ns = oc.Namespace()

--- a/test/extended/cli/debug.go
+++ b/test/extended/cli/debug.go
@@ -8,6 +8,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -20,7 +21,7 @@ var (
 var _ = g.Describe("[sig-cli] oc debug", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLI("oc-debug")
+	oc := exutil.NewCLIWithPodSecurityLevel("oc-debug", admissionapi.LevelBaseline)
 	testCLIDebug := exutil.FixturePath("testdata", "test-cli-debug.yaml")
 	testDeploymentConfig := exutil.FixturePath("testdata", "test-deployment-config.yaml")
 	testReplicationController := exutil.FixturePath("testdata", "test-replication-controller.yaml")

--- a/test/extended/cli/label.go
+++ b/test/extended/cli/label.go
@@ -6,6 +6,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -16,7 +18,7 @@ const (
 var _ = g.Describe("[sig-cli] oc label", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLI("oc-label")
+	var oc = exutil.NewCLIWithPodSecurityLevel("oc-label", admissionapi.LevelBaseline)
 
 	g.It("pod", func() {
 		g.By("creating hello-openshift pod")

--- a/test/extended/cli/probe.go
+++ b/test/extended/cli/probe.go
@@ -6,6 +6,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -14,7 +16,7 @@ var _ = g.Describe("[sig-cli] oc probe", func() {
 
 	var (
 		deploymentConfig = exutil.FixturePath("testdata", "test-deployment-config.yaml")
-		oc               = exutil.NewCLI("oc-probe")
+		oc               = exutil.NewCLIWithPodSecurityLevel("oc-probe", admissionapi.LevelBaseline)
 	)
 
 	g.It("can ensure the probe command is functioning as expected on pods", func() {

--- a/test/extended/cli/rsh.go
+++ b/test/extended/cli/rsh.go
@@ -6,6 +6,8 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -13,7 +15,7 @@ var _ = g.Describe("[sig-cli] oc rsh", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc                     = exutil.NewCLI("oc-rsh")
+		oc                     = exutil.NewCLIWithPodSecurityLevel("oc-rsh", admissionapi.LevelBaseline)
 		multiContainersFixture = exutil.FixturePath("testdata", "cli", "pod-with-two-containers.yaml")
 		podsLabel              = exutil.ParseLabelsOrDie("name=hello-centos")
 	)

--- a/test/extended/cli/statefulset.go
+++ b/test/extended/cli/statefulset.go
@@ -7,13 +7,15 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-cli] oc statefulset", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLI("oc-statefulset")
+	var oc = exutil.NewCLIWithPodSecurityLevel("oc-statefulset", admissionapi.LevelBaseline)
 
 	g.It("creates and deletes statefulsets", func() {
 		g.By("creating a new service for the statefulset")

--- a/test/extended/cmd/cmd.go
+++ b/test/extended/cmd/cmd.go
@@ -9,16 +9,15 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -37,7 +36,7 @@ var _ = g.Describe("[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] te
 	hacklibDir := exutil.FixturePath("testdata", "cmd", "hack")
 	keys := exutil.FixturePaths("testdata", "cmd", "test", "cmd")
 
-	oc := exutil.NewCLI("test-cmd")
+	oc := exutil.NewCLIWithPodSecurityLevel("test-cmd", admissionapi.LevelBaseline)
 
 	for _, filename := range keys {
 		// only make tests for the bash files

--- a/test/extended/csrapprover/csrapprover.go
+++ b/test/extended/csrapprover/csrapprover.go
@@ -26,6 +26,7 @@ import (
 	kubeclient "k8s.io/client-go/kubernetes"
 	certclientv1 "k8s.io/client-go/kubernetes/typed/certificates/v1"
 	restclient "k8s.io/client-go/rest"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	configv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -33,7 +34,7 @@ import (
 )
 
 var _ = g.Describe("[sig-cluster-lifecycle]", func() {
-	oc := exutil.NewCLI("cluster-client-cert")
+	oc := exutil.NewCLIWithPodSecurityLevel("cluster-client-cert", admissionapi.LevelBaseline)
 	defer g.GinkgoRecover()
 
 	g.It("Pods cannot access the /config/master API endpoint", func() {

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -84,7 +85,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 		entry.dic.Wait()
 	})
 
-	oc = exutil.NewCLI("cli-deployment")
+	oc = exutil.NewCLIWithPodSecurityLevel("cli-deployment", admissionapi.LevelBaseline)
 
 	var (
 		deploymentFixture               = exutil.FixturePath("testdata", "deployments", "test-deployment-test.yaml")

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -17,6 +17,7 @@ import (
 
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -161,7 +162,7 @@ func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]s
 var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                  = exutil.NewCLI("cli-idling").Verbose()
+		oc                  = exutil.NewCLIWithPodSecurityLevel("cli-idling", admissionapi.LevelBaseline).Verbose()
 		echoServerFixture   = exutil.FixturePath("testdata", "idling-echo-server.yaml")
 		echoServerRcFixture = exutil.FixturePath("testdata", "idling-echo-server-rc.yaml")
 		framework           = oc.KubeFramework()

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -10,6 +10,7 @@ import (
 
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/openshift/api/image/docker10"
 	"github.com/openshift/library-go/pkg/image/imageutil"
@@ -78,7 +79,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageAppend] Image append", func
 		}
 	})
 
-	oc = exutil.NewCLI("image-append")
+	oc = exutil.NewCLIWithPodSecurityLevel("image-append", admissionapi.LevelBaseline)
 
 	g.It("should create images by appending them", func() {
 		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})

--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -12,6 +12,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8simage "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	imageapi "github.com/openshift/api/image/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned"
@@ -30,7 +31,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 		}
 	})
 
-	oc = exutil.NewCLI("image-extract")
+	oc = exutil.NewCLIWithPodSecurityLevel("image-extract", admissionapi.LevelBaseline)
 
 	g.It("should extract content from an image", func() {
 		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})

--- a/test/extended/images/imagestreamimport.go
+++ b/test/extended/images/imagestreamimport.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -33,7 +34,7 @@ import (
 
 var _ = g.Describe("[sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("imagestream-api")
+	oc := exutil.NewCLIWithPodSecurityLevel("imagestream-api", admissionapi.LevelBaseline)
 	g.BeforeEach(func() {
 		if err := deployEphemeralImageRegistry(oc); err != nil {
 			g.GinkgoT().Fatalf("error deploying ephemeral registry: %s", err)

--- a/test/extended/images/info.go
+++ b/test/extended/images/info.go
@@ -4,6 +4,8 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	g "github.com/onsi/ginkgo"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -19,7 +21,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageInfo] Image info", func() {
 		}
 	})
 
-	oc = exutil.NewCLI("image-info")
+	oc = exutil.NewCLIWithPodSecurityLevel("image-info", admissionapi.LevelBaseline)
 
 	g.It("should display information about images", func() {
 		ns = oc.Namespace()

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -14,11 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	k8simage "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	buildv1client "github.com/openshift/client-go/build/clientset/versioned"
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
 )
@@ -37,7 +39,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 		}
 	})
 
-	oc = exutil.NewCLI("image-layers")
+	oc = exutil.NewCLIWithPodSecurityLevel("image-layers", admissionapi.LevelBaseline)
 
 	g.It("should identify a deleted image as missing", func() {
 		client := imagev1client.NewForConfigOrDie(oc.AdminConfig()).ImageV1()

--- a/test/extended/images/mirror.go
+++ b/test/extended/images/mirror.go
@@ -19,6 +19,7 @@ import (
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
@@ -277,7 +278,7 @@ RUN echo %[3]s > /3
 var _ = g.Describe("[sig-imageregistry][Feature:ImageMirror][Slow] Image mirror", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLI("image-mirror")
+	var oc = exutil.NewCLIWithPodSecurityLevel("image-mirror", admissionapi.LevelBaseline)
 
 	g.It("mirror image from integrated registry to external registry", func() {
 		g.By("get user credentials")

--- a/test/extended/images/oc_tag.go
+++ b/test/extended/images/oc_tag.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	k8simage "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	authorizationv1 "github.com/openshift/api/authorization/v1"
 
@@ -20,7 +21,7 @@ import (
 
 var _ = g.Describe("[sig-imageregistry][Feature:Image] oc tag", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("image-oc-tag")
+	oc := exutil.NewCLIWithPodSecurityLevel("image-oc-tag", admissionapi.LevelBaseline)
 	ctx := context.Background()
 
 	g.It("should preserve image reference for external images", func() {

--- a/test/extended/images/resolve.go
+++ b/test/extended/images/resolve.go
@@ -16,13 +16,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8simage "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-imageregistry][Feature:ImageLookup] Image policy", func() {
 	defer g.GinkgoRecover()
-	var oc = exutil.NewCLI("resolve-local-names")
+	var oc = exutil.NewCLIWithPodSecurityLevel("resolve-local-names", admissionapi.LevelBaseline)
 	one := int64(0)
 	ctx := context.Background()
 

--- a/test/extended/images/signatures.go
+++ b/test/extended/images/signatures.go
@@ -8,6 +8,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -16,7 +17,7 @@ var _ = g.Describe("[sig-imageregistry][Serial][Suite:openshift/registry/serial]
 	defer g.GinkgoRecover()
 
 	var (
-		oc                 = exutil.NewCLI("registry-signing")
+		oc                 = exutil.NewCLIWithPodSecurityLevel("registry-signing", admissionapi.LevelBaseline)
 		signerBuildFixture = exutil.FixturePath("testdata", "signer-buildconfig.yaml")
 	)
 

--- a/test/extended/jobs/jobs.go
+++ b/test/extended/jobs/jobs.go
@@ -11,11 +11,12 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = g.Describe("[sig-apps][Feature:Jobs]", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("job-controller")
+	oc := exutil.NewCLIWithPodSecurityLevel("job-controller", admissionapi.LevelBaseline)
 
 	g.It("Users should be able to create and run a job in a user project", func() {
 		for _, ver := range []string{"v1"} {

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -28,7 +29,7 @@ const (
 
 var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 
-	egFwoc := exutil.NewCLI(egressFWE2E)
+	egFwoc := exutil.NewCLIWithPodSecurityLevel(egressFWE2E, admissionapi.LevelPrivileged)
 	egFwf := egFwoc.KubeFramework()
 
 	// The OVNKubernetes subnet plugin supports EgressFirewall objects.
@@ -47,7 +48,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 			})
 		},
 	)
-	noegFwoc := exutil.NewCLI(noEgressFWE2E)
+	noegFwoc := exutil.NewCLIWithPodSecurityLevel(noEgressFWE2E, admissionapi.LevelBaseline)
 	noegFwf := noegFwoc.KubeFramework()
 	g.It("egressFirewall should have no impact outside its namespace", func() {
 		g.By("creating test pod")

--- a/test/extended/networking/egress_router_cni.go
+++ b/test/extended/networking/egress_router_cni.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 	"time"
 
-	exutil "github.com/openshift/origin/test/extended/util"
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
+	admissionapi "k8s.io/pod-security-admission/api"
 
-	g "github.com/onsi/ginkgo"
-	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 const (
@@ -33,7 +34,7 @@ const (
 )
 
 var _ = g.Describe("[sig-network][Feature:EgressRouterCNI]", func() {
-	oc := exutil.NewCLI(egressRouterCNIE2E)
+	oc := exutil.NewCLIWithPodSecurityLevel(egressRouterCNIE2E, admissionapi.LevelPrivileged)
 
 	g.It("should ensure ipv4 egressrouter cni resources are created", func() {
 		doEgressRouterCNI(egressRouterCNIV4Manifest, oc, ipv4MatchPattern)

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -12,14 +12,18 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
-	exutil "github.com/openshift/origin/test/extended/util"
+
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/skipper"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 const (
@@ -40,7 +44,7 @@ const (
 )
 
 var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
-	oc := exutil.NewCLI(namespacePrefix)
+	oc := exutil.NewCLIWithPodSecurityLevel(namespacePrefix, admissionapi.LevelPrivileged)
 	portAllocator := NewPortAllocator(egressIPTargetHostPortMin, egressIPTargetHostPortMax)
 
 	var (

--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -18,13 +18,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("[sig-network] multicast", func() {
-	oc := exutil.NewCLI("multicast")
+	oc := exutil.NewCLIWithPodSecurityLevel("multicast", admissionapi.LevelBaseline)
 
 	// The subnet plugin should block all multicast. The multitenant and networkpolicy
 	// plugins should implement multicast in the way that we test. For third-party

--- a/test/extended/networking/multus.go
+++ b/test/extended/networking/multus.go
@@ -5,16 +5,19 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	exutil "github.com/openshift/origin/test/extended/util"
+
 	v1 "k8s.io/api/core/v1"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-network][Feature:Multus]", func() {
 	var oc *exutil.CLI
 	var ns string // namespace
 
-	oc = exutil.NewCLI("multus-e2e")
+	oc = exutil.NewCLIWithPodSecurityLevel("multus-e2e", admissionapi.LevelBaseline)
 
 	f := oc.KubeFramework()
 	podName := "multus-test-pod-"

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -1,20 +1,20 @@
 package networking
 
 import (
-	"k8s.io/apiserver/pkg/storage/names"
-	admissionapi "k8s.io/pod-security-admission/api"
-
 	"context"
 	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	exutil "github.com/openshift/origin/test/extended/util"
+
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = Describe("[sig-network] services", func() {
@@ -49,7 +49,7 @@ var _ = Describe("[sig-network] services", func() {
 		})
 	})
 
-	oc := exutil.NewCLI("ns-global")
+	oc := exutil.NewCLIWithPodSecurityLevel("ns-global", admissionapi.LevelBaseline)
 
 	InIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-services1")

--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -3,16 +3,20 @@ package networking
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	g "github.com/onsi/ginkgo"
 	t "github.com/onsi/ginkgo/extensions/table"
 	o "github.com/onsi/gomega"
-	exutil "github.com/openshift/origin/test/extended/util"
+
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
-	"strings"
-	"time"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 const (
@@ -44,7 +48,7 @@ var whitelistedSysctls = []SysctlVariant{
 }
 
 var _ = g.Describe("[sig-network][Feature:tuning]", func() {
-	oc := exutil.NewCLI("tuning")
+	oc := exutil.NewCLIWithPodSecurityLevel("tuning", admissionapi.LevelPrivileged)
 	f := oc.KubeFramework()
 
 	g.It("pod should start with all sysctl on whitelist", func() {

--- a/test/extended/networking/whereabouts.go
+++ b/test/extended/networking/whereabouts.go
@@ -8,16 +8,19 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
 var _ = g.Describe("[sig-network][Feature:Whereabouts]", func() {
 
-	oc := exutil.NewCLI("whereabouts-e2e")
+	oc := exutil.NewCLIWithPodSecurityLevel("whereabouts-e2e", admissionapi.LevelBaseline)
 
 	// Whereabouts is already installed in Origin. These tests aims to verify the integrity of the installation.
 

--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -14,6 +14,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
@@ -23,7 +24,7 @@ import (
 )
 
 var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() {
-	var oc = exutil.NewCLI("oauth-expiration")
+	var oc = exutil.NewCLIWithPodSecurityLevel("oauth-expiration", admissionapi.LevelBaseline)
 	var newRequestTokenOptions oauthserver.NewRequestTokenOptionsFunc
 	var oauthServerCleanup func()
 

--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -14,12 +14,13 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	"gopkg.in/ldap.v2"
-	"sigs.k8s.io/yaml"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kdiff "k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/kube-openapi/pkg/util/sets"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+	"sigs.k8s.io/yaml"
 
 	userv1 "github.com/openshift/api/user/v1"
 	userclient "github.com/openshift/client-go/user/clientset/versioned"
@@ -32,7 +33,7 @@ import (
 var _ = g.Describe("[sig-auth][Feature:LDAP][Serial] ldap group sync", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLI("ldap-group-sync").AsAdmin()
+		oc = exutil.NewCLIWithPodSecurityLevel("ldap-group-sync", admissionapi.LevelPrivileged).AsAdmin()
 	)
 
 	g.It("can sync groups from ldap", func() {

--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	osinv1 "github.com/openshift/api/osin/v1"
 
@@ -29,7 +30,7 @@ func init() {
 }
 
 var _ = g.Describe("[sig-auth][Feature:HTPasswdAuth] HTPasswd IDP", func() {
-	var oc = exutil.NewCLI("htpasswd-idp")
+	var oc = exutil.NewCLIWithPodSecurityLevel("htpasswd-idp", admissionapi.LevelBaseline)
 
 	g.It("should successfully configure htpasswd and be responsive", func() {
 		newTokenReqOpts, cleanup, err := deployOAuthServer(oc)

--- a/test/extended/oauth/ldap.go
+++ b/test/extended/oauth/ldap.go
@@ -4,13 +4,15 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLI("oauth-ldap")
+		oc = exutil.NewCLIWithPodSecurityLevel("oauth-ldap", admissionapi.LevelPrivileged)
 	)
 
 	g.It("should start an OpenLDAP test server", func() {

--- a/test/extended/oauth/oauth_ldap.go
+++ b/test/extended/oauth/oauth_ldap.go
@@ -12,10 +12,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	configv1 "github.com/openshift/api/config/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
 	oauthutil "github.com/openshift/origin/test/extended/util/oauthserver"
@@ -24,7 +26,7 @@ import (
 var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP IDP", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLI("oauth-ldap-idp")
+		oc = exutil.NewCLIWithPodSecurityLevel("oauth-ldap-idp", admissionapi.LevelPrivileged)
 
 		bindDN         = "cn=Manager,dc=example,dc=com"
 		bindPassword   = "admin"

--- a/test/extended/oauth/server_headers.go
+++ b/test/extended/oauth/server_headers.go
@@ -11,13 +11,14 @@ import (
 
 	"k8s.io/client-go/rest"
 	"k8s.io/kube-openapi/pkg/util/sets"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/oauthserver"
 )
 
 var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers]", func() {
-	var oc = exutil.NewCLI("oauth-server-headers")
+	var oc = exutil.NewCLIWithPodSecurityLevel("oauth-server-headers", admissionapi.LevelBaseline)
 	var transport http.RoundTripper
 	var oauthServerAddr string
 	var oauthServerCleanup func()

--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	exurl "github.com/openshift/origin/test/extended/util/url"
@@ -22,7 +23,7 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc = exutil.NewCLI("operators-routable")
+		oc = exutil.NewCLIWithPodSecurityLevel("operators-routable", admissionapi.LevelBaseline)
 
 		// routeHostWait is how long to wait for routes to be assigned a host
 		routeHostWait = 30 * time.Second

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -8,9 +8,11 @@ import (
 	o "github.com/onsi/gomega"
 
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	configv1 "github.com/openshift/api/config/v1"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	helper "github.com/openshift/origin/test/extended/util/prometheus"
 )
@@ -18,7 +20,7 @@ import (
 var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithoutNamespace("prometheus")
+		oc = exutil.NewCLIWithPodSecurityLevel("prometheus", admissionapi.LevelBaseline)
 	)
 
 	g.AfterEach(func() {
@@ -40,7 +42,6 @@ var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus
 					"Remove this skip when https://issues.redhat.com/browse/CO-895 is implemented.")
 			}
 
-			oc.SetupProject()
 			appTemplate := exutil.FixturePath("testdata", "builds", "build-pruning", "successful-build-config.yaml")
 
 			br := startOpenShiftBuild(oc, appTemplate)

--- a/test/extended/router/certs.go
+++ b/test/extended/router/certs.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 
@@ -81,7 +82,7 @@ u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
 		}
 	})
 
-	oc = exutil.NewCLI("router-certs")
+	oc = exutil.NewCLIWithPodSecurityLevel("router-certs", admissionapi.LevelBaseline)
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -7,17 +7,19 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/openshift/origin/test/extended/router/certgen"
 	grpcinterop "github.com/openshift/origin/test/extended/router/grpc-interop"
 	"github.com/openshift/origin/test/extended/router/shard"
 	exutil "github.com/openshift/origin/test/extended/util"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
-	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
 var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
@@ -27,7 +29,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 		grpcServiceConfigPath     = exutil.FixturePath("testdata", "router", "router-grpc-interop.yaml")
 		grpcRoutesConfigPath      = exutil.FixturePath("testdata", "router", "router-grpc-interop-routes.yaml")
 		grpcRouterShardConfigPath = exutil.FixturePath("testdata", "router", "router-shard.yaml")
-		oc                        = exutil.NewCLI("grpc-interop")
+		oc                        = exutil.NewCLIWithPodSecurityLevel("grpc-interop", admissionapi.LevelBaseline)
 		shardConfigPath           string // computed
 	)
 

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -17,9 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	securityv1 "github.com/openshift/api/security/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
+
 	"github.com/openshift/origin/test/extended/router/h2spec"
 	"github.com/openshift/origin/test/extended/router/shard"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -40,7 +42,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 		h2specRoutesConfigPath      = exutil.FixturePath("testdata", "router", "router-h2spec-routes.yaml")
 		h2specRouterShardConfigPath = exutil.FixturePath("testdata", "router", "router-shard.yaml")
 
-		oc              = exutil.NewCLI("router-h2spec")
+		oc              = exutil.NewCLIWithPodSecurityLevel("router-h2spec", admissionapi.LevelBaseline)
 		shardConfigPath string // computed
 	)
 

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -26,7 +27,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "router-http-echo-server.yaml")
-		oc         = exutil.NewCLI("router-headers")
+		oc         = exutil.NewCLIWithPodSecurityLevel("router-headers", admissionapi.LevelBaseline)
 
 		routerIP  string
 		metricsIP string

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -19,13 +19,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/pod-security-admission/api"
 
 	configv1 "github.com/openshift/api/config/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
-	exutil "github.com/openshift/origin/test/extended/util"
 
 	"github.com/openshift/origin/test/extended/router/certgen"
 	"github.com/openshift/origin/test/extended/router/shard"
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 const (
@@ -63,7 +64,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 		http2RoutesConfigPath      = exutil.FixturePath("testdata", "router", "router-http2-routes.yaml")
 		http2RouterShardConfigPath = exutil.FixturePath("testdata", "router", "router-shard.yaml")
 
-		oc = exutil.NewCLI("router-http2")
+		oc = exutil.NewCLIWithPodSecurityLevel("router-http2", api.LevelBaseline)
 
 		shardConfigPath string // computed
 	)

--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -28,7 +29,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "router-idle.yaml")
-		oc         = exutil.NewCLI("router-idling")
+		oc         = exutil.NewCLIWithPodSecurityLevel("router-idling", admissionapi.LevelBaseline)
 	)
 
 	// this hook must be registered before the framework namespace teardown

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -21,6 +21,7 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubernetes/pkg/client/conditions"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -39,7 +40,7 @@ import (
 var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLI("router-metrics")
+		oc = exutil.NewCLIWithPodSecurityLevel("router-metrics", admissionapi.LevelBaseline)
 
 		username, password, bearerToken string
 		metricsPort                     int32

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -10,6 +10,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -36,7 +37,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		}
 	})
 
-	oc = exutil.NewCLI("router-reencrypt")
+	oc = exutil.NewCLIWithPodSecurityLevel("router-reencrypt", admissionapi.LevelBaseline)
 
 	g.BeforeEach(func() {
 		var err error

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -46,7 +47,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		}
 	})
 
-	oc = exutil.NewCLI("router-stress")
+	oc = exutil.NewCLIWithPodSecurityLevel("router-stress", admissionapi.LevelBaseline)
 
 	g.BeforeEach(func() {
 		var err error

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	routev1 "github.com/openshift/api/route/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
@@ -45,7 +46,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		}
 	})
 
-	oc = exutil.NewCLI("router-scoped")
+	oc = exutil.NewCLIWithPodSecurityLevel("router-scoped", admissionapi.LevelBaseline)
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	routev1 "github.com/openshift/api/route/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
@@ -47,7 +48,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		}
 	})
 
-	oc = exutil.NewCLI("router-stress")
+	oc = exutil.NewCLIWithPodSecurityLevel("router-stress", admissionapi.LevelBaseline)
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/subdomain.go
+++ b/test/extended/router/subdomain.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	routev1 "github.com/openshift/api/route/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
@@ -42,7 +43,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		}
 	})
 
-	oc = exutil.NewCLI("router-subdomain")
+	oc = exutil.NewCLIWithPodSecurityLevel("router-subdomain", admissionapi.LevelBaseline)
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -12,6 +12,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 
@@ -38,7 +39,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		}
 	})
 
-	oc = exutil.NewCLI("unprivileged-router")
+	oc = exutil.NewCLIWithPodSecurityLevel("unprivileged-router", admissionapi.LevelBaseline)
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -12,12 +12,13 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	"k8s.io/kubernetes/test/e2e/framework/pod"
 
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -26,7 +27,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "weighted-router.yaml")
-		oc         = exutil.NewCLI("weighted-router")
+		oc         = exutil.NewCLIWithPodSecurityLevel("weighted-router", admissionapi.LevelBaseline)
 	)
 
 	g.BeforeEach(func() {

--- a/test/extended/security/fips.go
+++ b/test/extended/security/fips.go
@@ -8,10 +8,14 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
-	exutil "github.com/openshift/origin/test/extended/util"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 const (
@@ -46,7 +50,7 @@ func validateFIPSOnNode(oc *exutil.CLI, fipsExpected bool, node *corev1.Node) er
 
 var _ = g.Describe("[sig-arch] [Conformance] FIPS", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("fips")
+	oc := exutil.NewCLIWithPodSecurityLevel("fips", admissionapi.LevelPrivileged)
 
 	g.It("TestFIPS", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)

--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -7,11 +7,6 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	securityv1 "github.com/openshift/api/security/v1"
-	securityv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
-	"github.com/openshift/origin/test/extended/authorization"
-	exutil "github.com/openshift/origin/test/extended/util"
-	"github.com/openshift/origin/test/extended/util/image"
 	kubeauthorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -21,11 +16,18 @@ import (
 	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	securityv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
+
+	"github.com/openshift/origin/test/extended/authorization"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
 )
 
 var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("scc")
+	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
 	ctx := context.Background()
 
 	g.It("TestPodUpdateSCCEnforcement", func() {
@@ -88,7 +90,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 
 	defer g.GinkgoRecover()
 	// pods running as root are being started here
-	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelBaseline)
+	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
 
 	g.It("TestAllowedSCCViaRBAC", func() {
 		t := g.GinkgoT()
@@ -265,7 +267,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 
 var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("ssc")
+	oc := exutil.NewCLIWithPodSecurityLevel("ssc", admissionapi.LevelBaseline)
 
 	g.It("TestPodDefaultCapabilities", func() {
 		g.By("Running a restricted pod and getting it's inherited capabilities")

--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
@@ -86,7 +87,8 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	ctx := context.Background()
 
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLI("scc")
+	// pods running as root are being started here
+	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelBaseline)
 
 	g.It("TestAllowedSCCViaRBAC", func() {
 		t := g.GinkgoT()

--- a/test/extended/security/sysctl.go
+++ b/test/extended/security/sysctl.go
@@ -2,20 +2,23 @@ package security
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"time"
 
 	g "github.com/onsi/ginkgo"
 	t "github.com/onsi/ginkgo/extensions/table"
 	o "github.com/onsi/gomega"
-	exutil "github.com/openshift/origin/test/extended/util"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-arch] [Conformance] sysctl", func() {
-	oc := exutil.NewCLI("sysctl")
+	oc := exutil.NewCLIWithPodSecurityLevel("sysctl", admissionapi.LevelPrivileged)
 	t.DescribeTable("whitelists", func(sysctl, value, path, defaultSysctlValue string) {
 		f := oc.KubeFramework()
 		var preexistingPod *v1.Pod

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -14,11 +14,13 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/openshift/library-go/pkg/apps/appsutil"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -27,7 +29,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 	defer g.GinkgoRecover()
 
 	var (
-		cli              = exutil.NewCLI("templates")
+		cli              = exutil.NewCLIWithPodSecurityLevel("templates", admissionapi.LevelBaseline)
 		template         *templatev1.Template
 		templateinstance *templatev1.TemplateInstance
 		templatefixture  = exutil.FixturePath("testdata", "templates", "templateinstance_readiness.yaml")

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -428,8 +428,7 @@ func (c *CLI) setupNamespacePodSecurity(ns string) error {
 		}
 
 		if len(c.kubeFramework.NamespacePodSecurityEnforceLevel) == 0 {
-			// TODO(sur): set to restricted in a separate PR and fix failing tests
-			c.kubeFramework.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+			c.kubeFramework.NamespacePodSecurityEnforceLevel = admissionapi.LevelRestricted
 		}
 		if ns.Labels == nil {
 			ns.Labels = make(map[string]string)

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -301,30 +301,7 @@ func (c *CLI) SetupProject() string {
 	})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// once permissions are settled the underlying namespace must have been created.
-		ns, err := c.AdminKubeClient().CoreV1().Namespaces().Get(context.Background(), newNamespace, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		if len(c.kubeFramework.NamespacePodSecurityEnforceLevel) == 0 {
-			// TODO(sur): set to restricted in a separate PR and fix failing tests
-			c.kubeFramework.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
-		}
-		if ns.Labels == nil {
-			ns.Labels = make(map[string]string)
-		}
-		ns.Labels[admissionapi.EnforceLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
-		// In contrast to upstream, OpenShift sets a global default on warn and audit pod security levels.
-		// Since this would cause unwanted audit log and warning entries, we are setting the same level as for enforcement.
-		ns.Labels[admissionapi.WarnLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
-		ns.Labels[admissionapi.AuditLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
-		ns.Labels["security.openshift.io/scc.podSecurityLabelSync"] = "false"
-
-		_, err = c.AdminKubeClient().CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
-		return err
-	})
+	err = c.setupNamespacePodSecurity(newNamespace)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	// Wait for SAs and default dockercfg Secret to be injected
@@ -435,7 +412,38 @@ func (c *CLI) CreateProject() string {
 		},
 	})
 	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = c.setupNamespacePodSecurity(newNamespace)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
 	return newNamespace
+}
+
+func (c *CLI) setupNamespacePodSecurity(ns string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// once permissions are settled the underlying namespace must have been created.
+		ns, err := c.AdminKubeClient().CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if len(c.kubeFramework.NamespacePodSecurityEnforceLevel) == 0 {
+			// TODO(sur): set to restricted in a separate PR and fix failing tests
+			c.kubeFramework.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		}
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		ns.Labels[admissionapi.EnforceLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
+		// In contrast to upstream, OpenShift sets a global default on warn and audit pod security levels.
+		// Since this would cause unwanted audit log and warning entries, we are setting the same level as for enforcement.
+		ns.Labels[admissionapi.WarnLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
+		ns.Labels[admissionapi.AuditLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
+		ns.Labels["security.openshift.io/scc.podSecurityLabelSync"] = "false"
+
+		_, err = c.AdminKubeClient().CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 // TeardownProject removes projects created by this test.


### PR DESCRIPTION
Currently, namespaces created via `CLI#CreateProject()` don't respect the configured pod security profile. This fixes it.

Further, this lets pass i.e. the e2e test: `[sig-auth][Feature:SecurityContextConstraints]  TestAllowedSCCViaRBAC [Suite:openshift/conformance/parallel]` as part of https://github.com/openshift/cluster-kube-apiserver-operator/pull/1339.

/cc @stlaz 