### PR TITLE
Bug 2086519: AUTH-133: test/extended/util: set restricted pod security profile by default

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -309,8 +309,7 @@ func (c *CLI) SetupProject() string {
 		}
 
 		if len(c.kubeFramework.NamespacePodSecurityEnforceLevel) == 0 {
-			// TODO(sur): set to restricted in a separate PR and fix failing tests
-			c.kubeFramework.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+			c.kubeFramework.NamespacePodSecurityEnforceLevel = admissionapi.LevelRestricted
 		}
 		if ns.Labels == nil {
 			ns.Labels = make(map[string]string)


### PR DESCRIPTION
This sets restricted pod security profile restricted by default for e2e tests.

/cc @deads2k @stlaz 