### PR TITLE
Ignore tunbr NodeNetworkInterfaceFlapping alert

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -309,6 +309,11 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 				Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"}, // not sure how to do a job_name prefix
 				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2054426",
 			},
+			{
+				Selector: map[string]string{"alertname": "NodeNetworkInterfaceFlapping", "device": "tunbr", "job": "node-exporter"},
+				Text:     "tunbr is an ephemeral bridge interface that can go up an down depending on if the ephemeral network is created/deleted",
+				// https://issues.redhat.com/browse/SDN-3008
+			},
 		}
 		allowedFiringAlerts := helper.MetricConditions{
 			{


### PR DESCRIPTION
tunbr is an ephemeral bridge interface that can go up an down depending
on if the ephemeral network is created/deleted, we shouldnt care if that
happens. Same as we dont care if a veth interface goes up/down as that
is going to happen with CNI pod events.

Looking in to what it will take to have tunbr automatically ignored
in these alerts and not fire them. When that work is done we can
revert this commit.

https://issues.redhat.com/browse/SDN-3008

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>