### PR TITLE
Bug 2085997: EnsureMemberRemoved tolerates some failures

### DIFF
--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -73,7 +73,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd", func() {
 		framework.Logf("successfully deleted the machine %q from the API", machineName)
 		err = scalingtestinglibrary.EnsureVotingMembersCount(g.GinkgoT(), etcdClientFactory, 3)
 		o.Expect(err).ToNot(o.HaveOccurred())
-		err = scalingtestinglibrary.EnsureMemberRemoved(etcdClientFactory, memberName)
+		err = scalingtestinglibrary.EnsureMemberRemoved(g.GinkgoT(), etcdClientFactory, memberName)
 		o.Expect(err).ToNot(o.HaveOccurred())
 		err = scalingtestinglibrary.EnsureMasterMachinesAndCount(ctx, g.GinkgoT(), machineClient)
 		o.Expect(err).ToNot(o.HaveOccurred())


### PR DESCRIPTION
The etcd client factory used by the method establishes a stream connection to an etcd pod.
Since a connection like this is considered a long-running connection
and isn't subjected to gracefully termination
and the fact it runs after deleting a machine gives a reason to tolerate some failures while getting a list of members.

Note that unavailability of the APIs and the etcd cluster will be reported by the monitor tool.