### PR TITLE
Flake on Endpoint Slice Error events

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -182,6 +182,11 @@ var knownEventsBugs = []knownProblem{
 		BZ:        "https://bugzilla.redhat.com/show_bug.cgi?id=2034984",
 		TestSuite: stringPointer("openshift/build"),
 	},
+	{
+		Regexp:    regexp.MustCompile(`ns/openshift-ovn-kubernetes service/ovn.*reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices for Service openshift-ovn-kubernetes/ovn.*node.*not found`),
+		BZ:        "https://issues.redhat.com/browse/SDN-3087",
+		TestSuite: stringPointer("openshift/conformance/serial"),
+	},
 	//{ TODO this should only be skipped for single-node
 	//	name:    "single=node-storage",
 	//  BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1990662


### PR DESCRIPTION
https://issues.redhat.com/browse/SDN-3087

This failure is common in the ovn-serial jobs and is
being addressed in upstream k8s [0]. Eventually, when
that fix is available in openshift, we can revert
this.

[0] https://github.com/kubernetes/kubernetes/pull/110115

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>