### PR TITLE
Revert "Bug 2089831: Temporarily disable telemetry token test."

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -521,9 +521,6 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 				e2eskipper.Skipf("Telemetry is disabled")
 			}
 
-			// TODO: temporarily disabled
-			e2eskipper.Skipf("test is currently broken due to problems with a pull secret: https://bugzilla.redhat.com/show_bug.cgi?id=2089831")
-
 			tests := map[string]bool{}
 			if hasTelemeterClient(oc.AdminKubeClient()) {
 				e2e.Logf("Found telemeter-client pod")


### PR DESCRIPTION
Reverts openshift/origin#27165

On this [payload run](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.11.0-0.nightly/release/4.11.0-0.nightly-2022-05-24-163302), this [aggregated job](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-aws-sdn-upgrade-4.11-micro-release-openshift-release-analysis-aggregator/1529139076328853504) ran.

That job has 10 jobs in it and I see that the `: [sig-instrumentation] Prometheus when installed on the cluster should report telemetry if a cloud.openshift.com token is present [Late] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]` test shows up in the "Tests Passed" list on a handful of those 10 jobs.

We can wait until more jobs pass before merging.