### PR TITLE
Bug 2077167: disable unidling test failing under ovn-k

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1725,7 +1725,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Idling with a single service and ReplicationController should idle the service and ReplicationController properly": "should idle the service and ReplicationController properly [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should handle many TCP connections by possibly dropping those over a certain bound [Serial]": "should handle many TCP connections by possibly dropping those over a certain bound [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should handle many TCP connections by possibly dropping those over a certain bound [Serial]": "should handle many TCP connections by possibly dropping those over a certain bound [Serial] [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Unidling should handle many UDP senders (by continuing to drop all packets on the floor) [Serial]": "should handle many UDP senders (by continuing to drop all packets on the floor) [Serial] [Suite:openshift/conformance/serial]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -272,6 +272,9 @@ var (
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1989169: unidling tests are flaky under ovn-kubernetes
 			`Unidling should work with TCP`,
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=2077167: unidling TCP tests fail in ovn-kubernetes
+			`Unidling should handle many TCP connections`,
 		},
 		"[Skipped:ibmcloud]": {
 			// skip Gluster tests (not supported on ROKS worker nodes)


### PR DESCRIPTION
Some but not all unidling tests were disabled when running on ovn-kubernetes.  This one was overlooked.