### PR TITLE
Bug 2086092: skip tests to facilitate rebase

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -19,7 +19,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP": "test RequestHeaders IdP [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial]": "should be stored at the correct location and version for all resources [Serial] [SkippedUntil:05272022:blocker-bz/2081021] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial]": "should be stored at the correct location and version for all resources [Serial] [SkippedUntil:06072022:blocker-bz/2081021] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-api-machinery] API priority and fairness should ensure that requests can be classified by adding FlowSchema and PriorityLevelConfiguration": "should ensure that requests can be classified by adding FlowSchema and PriorityLevelConfiguration [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -959,7 +959,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth] ServiceAccounts ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer [Conformance]": "ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]": "should allow opting out of API token automount  [Conformance] [SkippedUntil:05272022:blocker-bz/2081087] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[Top Level] [sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]": "should allow opting out of API token automount  [Conformance] [SkippedUntil:06072022:blocker-bz/2081087] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-auth] ServiceAccounts should ensure a single API token exists": "should ensure a single API token exists [Disabled:Broken] [Suite:k8s]",
 
@@ -2105,7 +2105,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation] Events API should delete a collection of events [Conformance]": "should delete a collection of events [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
-	"[Top Level] [sig-instrumentation] Events API should ensure that an event can be fetched, patched, deleted, and listed [Conformance]": "should ensure that an event can be fetched, patched, deleted, and listed [Conformance] [SkippedUntil:05272022:blocker-bz/2081084] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
+	"[Top Level] [sig-instrumentation] Events API should ensure that an event can be fetched, patched, deleted, and listed [Conformance]": "should ensure that an event can be fetched, patched, deleted, and listed [Conformance] [SkippedUntil:06072022:blocker-bz/2081084] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-instrumentation] Events should delete a collection of events [Conformance]": "should delete a collection of events [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -335,19 +335,19 @@ var (
 			`\[Feature:Platform\] Managed cluster should ensure control plane operators do not make themselves unevictable`,
 		},
 
-		// TODO: to facilitate v.14 rebase, skip the following tests until May 27 2022,
+		// TODO: to facilitate v.14 rebase, skip the following tests until June 07 2022,
 		//  the following key should be removed after the rebase PR lands
 		//  BZs to keep track of these issues:
 		//   - [sig-api-machinery] API data in etcd should be: https://bugzilla.redhat.com/show_bug.cgi?id=2081021
 		//   - [sig-instrumentation] Events API should ensure that: https://bugzilla.redhat.com/show_bug.cgi?id=2081084
 		//   - [sig-auth] ServiceAccounts : https//bugzilla.redhat.com/show_bug.cgi?id=2081087
-		"[SkippedUntil:05272022:blocker-bz/2081087]": {
+		"[SkippedUntil:06072022:blocker-bz/2081087]": {
 			`\[sig-auth\] ServiceAccounts should allow opting out of API token automount`,
 		},
-		"[SkippedUntil:05272022:blocker-bz/2081084]": {
+		"[SkippedUntil:06072022:blocker-bz/2081084]": {
 			`\[sig-instrumentation\] Events API should ensure that an event can be fetched, patched, deleted, and listed`,
 		},
-		"[SkippedUntil:05272022:blocker-bz/2081021]": {
+		"[SkippedUntil:06072022:blocker-bz/2081021]": {
 			`\[sig-api-machinery\] API data in etcd should be stored at the correct location and version for all resources`,
 		},
 	}


### PR DESCRIPTION
kube v1.24 update https://github.com/openshift/kubernetes/pull/1252 has landed, we need to skip these tests until we have a good clear signal with new kubelet


