### PR TITLE
restrict the per-namespace invariant alert check

### DIFF
--- a/pkg/monitor/alerts.go
+++ b/pkg/monitor/alerts.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
 
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
@@ -62,10 +60,9 @@ func whenWasAlertInState(ctx context.Context, prometheusClient prometheusv1.API,
 	}
 
 	if namespace == platformidentification.NamespaceOther {
-		knownNamespaces := sets.StringKeySet(platformidentification.GetNamespacesToBugzillaComponents())
 		ret = monitorapi.Intervals(ret).Filter(func(eventInterval monitorapi.EventInterval) bool {
 			namespace := monitorapi.NamespaceFromLocator(eventInterval.Locator)
-			return !knownNamespaces.Has(namespace)
+			return !platformidentification.KnownNamespaces.Has(namespace)
 		})
 	}
 

--- a/pkg/synthetictests/allowedalerts/basic_alert.go
+++ b/pkg/synthetictests/allowedalerts/basic_alert.go
@@ -271,32 +271,53 @@ func (a *basicAlertTest) failOrFlake(ctx context.Context, restConfig *rest.Confi
 	return pass, ""
 }
 
+func monitorEventMatchesNamespace(namespace string) func(event monitorapi.EventInterval) bool {
+	return func(event monitorapi.EventInterval) bool {
+		switch {
+		case len(namespace) == 0:
+			return true
+		case namespace == platformidentification.NamespaceOther:
+			eventNamespace := monitorapi.NamespaceFromLocator(event.Locator)
+			return !platformidentification.KnownNamespaces.Has(eventNamespace)
+		default:
+			eventNamespace := monitorapi.NamespaceFromLocator(event.Locator)
+			return eventNamespace == namespace
+		}
+	}
+}
+
 func (a *basicAlertTest) InvariantCheck(ctx context.Context, restConfig *rest.Config, alertIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
 	pendingIntervals := alertIntervals.Filter(
-		func(eventInterval monitorapi.EventInterval) bool {
-			locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
-			alertName := monitorapi.AlertFrom(locatorParts)
-			if alertName != a.alertName {
+		monitorapi.And(
+			func(eventInterval monitorapi.EventInterval) bool {
+				locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
+				alertName := monitorapi.AlertFrom(locatorParts)
+				if alertName != a.alertName {
+					return false
+				}
+				if strings.Contains(eventInterval.Message, `alertstate="pending"`) {
+					return true
+				}
 				return false
-			}
-			if strings.Contains(eventInterval.Message, `alertstate="pending"`) {
-				return true
-			}
-			return false
-		},
+			},
+			monitorEventMatchesNamespace(a.namespace),
+		),
 	)
 	firingIntervals := alertIntervals.Filter(
-		func(eventInterval monitorapi.EventInterval) bool {
-			locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
-			alertName := monitorapi.AlertFrom(locatorParts)
-			if alertName != a.alertName {
+		monitorapi.And(
+			func(eventInterval monitorapi.EventInterval) bool {
+				locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
+				alertName := monitorapi.AlertFrom(locatorParts)
+				if alertName != a.alertName {
+					return false
+				}
+				if strings.Contains(eventInterval.Message, `alertstate="firing"`) {
+					return true
+				}
 				return false
-			}
-			if strings.Contains(eventInterval.Message, `alertstate="firing"`) {
-				return true
-			}
-			return false
-		},
+			},
+			monitorEventMatchesNamespace(a.namespace),
+		),
 	)
 
 	state, message := a.failOrFlake(ctx, restConfig, firingIntervals, pendingIntervals)

--- a/pkg/synthetictests/platformidentification/operator_mapping.go
+++ b/pkg/synthetictests/platformidentification/operator_mapping.go
@@ -120,7 +120,8 @@ var (
 		"storage",
 	)
 
-	NamespaceOther = "all the other namespaces"
+	NamespaceOther  = "all the other namespaces"
+	KnownNamespaces = sets.String{}
 
 	operatorToBugzillaComponent  = map[string]string{}
 	namespaceToBugzillaComponent = map[string]string{}
@@ -229,6 +230,7 @@ func init() {
 	utilruntime.Must(addNamespaceMapping("openshift-user-workload-monitoring", "Unknown"))
 	utilruntime.Must(addNamespaceMapping("openshift-vsphere-infra", "Unknown"))
 
+	KnownNamespaces = sets.StringKeySet(namespaceToBugzillaComponent)
 }
 
 func GetBugzillaComponentForOperator(operator string) string {


### PR DESCRIPTION
found in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-aws-ovn-upgrade/1530066656057888770 , but that still looks broken.