### PR TITLE
Bug 2091067: EgressIP: Make tests retry on API timeout errors 

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -137,8 +137,9 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 		g.By("Determining the target protocol, host and port")
 		targetProtocol, targetHost, targetPort, err = getTargetProtocolHostPort(oc, hasIPv4, hasIPv6, cloudType, networkPlugin)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		framework.Logf("Testing against: CloudType: %s, Protocol %s, TargetHost: %s, TargetPort: %d",
+		framework.Logf("Testing against: CloudType: %s, NetworkPlugin: %s, Protocol %s, TargetHost: %s, TargetPort: %d",
 			cloudType,
+			networkPlugin,
 			targetProtocol,
 			targetHost,
 			targetPort)


### PR DESCRIPTION
The EgressIP tests use the oc.Run() command a lot. Occasionally, these
commands seem to time out for some of the tests. Add retry logic so that
a single timeout calling the API won't make the entire test fail.

Tested on GCP OVNKubernetes (/):
~~~
./openshift-tests run-test "[sig-network][Feature:EgressIP] [external-targets] pods should keep the assigned EgressIPs when being rescheduled to another node [Serial] [Suite:openshift/conformance/serial]"
echo ==========================
./openshift-tests run-test "[sig-network][Feature:EgressIP] [external-targets] only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]"
echo ==========================
./openshift-tests run-test "[sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure] [Serial] [Suite:openshift/conformance/serial]"
echo ==========================
./openshift-tests run-test "[sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]"
~~~

Tested AWS with SDN(/):
~~~
./openshift-tests run-test "[sig-network][Feature:EgressIP] [external-targets] pods should keep the assigned EgressIPs when being rescheduled to another node [Serial] [Suite:openshift/conformance/serial]"
echo ================
./openshift-tests run-test "[sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure] [Serial] [Suite:openshift/conformance/serial]"
echo ================
./openshift-tests run-test "[sig-network][Feature:EgressIP] [external-targets] EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes] [Serial] [Suite:openshift/conformance/serial]"
~~~

Signed-off-by: Andreas Karis <ak.karis@gmail.com>