### PR TITLE
Bug 2081732: remove incorrect namespace check in static pod test

### DIFF
--- a/pkg/synthetictests/static_pod_test.go
+++ b/pkg/synthetictests/static_pod_test.go
@@ -19,7 +19,6 @@ func Test_staticPodFailureFromMessage(t *testing.T) {
 			name: "parser",
 			args: args{message: `static pod lifecycle failure - static pod: "etcd" in namespace: "openshift-etcd" for revision: 6 on node: "ovirt10-gh8t5-master-2" didn't show up, waited: 2m30s`},
 			want: &staticPodFailure{
-				namespace:      "openshift-etcd",
 				node:           "ovirt10-gh8t5-master-2",
 				revision:       6,
 				failureMessage: `static pod lifecycle failure - static pod: "etcd" in namespace: "openshift-etcd" for revision: 6 on node: "ovirt10-gh8t5-master-2" didn't show up, waited: 2m30s`,


### PR DESCRIPTION
NodeCurrentRevisionChanged message does not contain the namespace for the static pod. 