### PR TITLE
add a wait between each serial test to ensure the cluster reaches a stable state

### DIFF
--- a/test/extended/util/operator.go
+++ b/test/extended/util/operator.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"sync"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -138,7 +140,31 @@ func waitForOperatorProgressingToBe(ctx context.Context, configClient configv1cl
 	_, err := watchtools.UntilWithSync(ctx,
 		cache.NewListWatchFromClient(configClient.ConfigV1().RESTClient(), "clusteroperators", "", fields.Everything()),
 		&configv1.ClusterOperator{},
-		nil,
+		func(store cache.Store) (bool, error) {
+			obj, exists, err := store.Get(&metav1.ObjectMeta{Namespace: "", Name: operatorName})
+			if err != nil {
+				return true, err
+			}
+			if !exists {
+				return false, kerrors.NewNotFound(schema.GroupResource{
+					Group:    "config.openshift.io/v1",
+					Resource: "ClusterOperator",
+				}, operatorName)
+			}
+			operator := obj.(*configv1.ClusterOperator)
+			if desiredProgressing {
+				if v1helpers.IsStatusConditionTrue(operator.Status.Conditions, configv1.OperatorProgressing) {
+					return true, nil
+				}
+				return false, nil
+			}
+
+			if v1helpers.IsStatusConditionFalse(operator.Status.Conditions, configv1.OperatorProgressing) {
+				return true, nil
+			}
+			return false, nil
+		},
+
 		func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Added, watch.Modified:


### PR DESCRIPTION
This makes serial tests wait after each test until the clusteroperators are all progressing=false.  This should help in cases where a test leaves the cluster dirty.  We still prefer for the tests themselves to properly wait until the cluster is stable instead of hitting this backstop.

/hold


/assign @neisw @stbenjam 