### PR TITLE
WIP Single node OVN: skip disruption tests for minor upgrades

### DIFF
--- a/pkg/synthetictests/historicaldata/next_best_guess.go
+++ b/pkg/synthetictests/historicaldata/next_best_guess.go
@@ -50,6 +50,7 @@ var nextBestGuessers = []NextBestKey{
 	combine(ForTopology("single"), OnSDN),
 	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade),
 	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade, MicroReleaseUpgrade),
+	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade, MicroReleaseUpgrade, MinorReleaseUpgrade),
 }
 
 // NextBestKey returns the next best key in the query_results.json generated from BigQuery and a bool indicating whether this guesser has an opinion.


### PR DESCRIPTION
Make sure minor upgrades on SNO minor upgrades have less strict disruption test settings. 

This should fix pass rates for SNO minor upgrade job - [example](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-single-node/1531604102998396928)

Cluster-bot tests: 
* [workflow-upgrade openshift-upgrade-aws-single-node 4.10 4.11,https://github.com/openshift/origin/pull/27199 TEST_TYPE=upgrade-conformance](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1531917949860843520)
* [workflow-upgrade openshift-upgrade-azure-single-node 4.10 4.11,https://github.com/openshift/origin/pull/27199 TEST_TYPE=upgrade-conformance](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-azure-modern/1531918283236708352)

UPD: cluster-bot tests are useless, as the release was mutated to include this PR and changed release name to "0.0" so it no longer matches the expected releases