### PR TITLE
Bug 2091110: Skip ErrImagePull for expected failures

### DIFF
--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -409,6 +409,18 @@ func testSystemDTimeout(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 
 var errImagePullTimeoutRE = regexp.MustCompile("ErrImagePull.*read: connection timed out")
 var errImagePullGenericRE = regexp.MustCompile("ErrImagePull")
+var invalidImagesRE = []*regexp.Regexp{
+
+	// See this test: "should not be able to pull image from invalid registry [NodeConformance]"
+	regexp.MustCompile("invalid.com"),
+
+	// See this test: "should not be able to pull from private registry without secret [NodeConformance]"
+	regexp.MustCompile("3.7 in gcr.io/authenticated-image-pulling/alpine"),
+
+	// See this test: "deployment should support proportional scaling"
+	// and "Updating deployment %q with a non-existent image" where they use webserver:404
+	regexp.MustCompile("404 in docker.io/library/webserver"),
+}
 
 // namespaceRestriction is an enum for clearly indicating if were only interested in events in openshift- namespaces,
 // or those that are not.
@@ -421,26 +433,26 @@ const (
 
 func testErrImagePullConnTimeoutOpenShiftNamespaces(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] should not encounter ErrImagePull read connection timeout in openshift namespace pods"
-	return buildTestsFailIfRegexMatch(testName, errImagePullTimeoutRE, nil, InOpenShiftNS, events)
+	return buildTestsFailIfRegexMatch(testName, errImagePullTimeoutRE, nil, InOpenShiftNS, []*regexp.Regexp{}, events)
 }
 
 func testErrImagePullConnTimeout(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] should not encounter ErrImagePull read connection timeout in non-openshift namespace pods"
-	return buildTestsFailIfRegexMatch(testName, errImagePullTimeoutRE, nil, NotInOpenshiftNS, events)
+	return buildTestsFailIfRegexMatch(testName, errImagePullTimeoutRE, nil, NotInOpenshiftNS, []*regexp.Regexp{}, events)
 }
 
 func testErrImagePullGenericOpenShiftNamespaces(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] should not encounter ErrImagePull in openshift namespace pods"
-	return buildTestsFailIfRegexMatch(testName, errImagePullGenericRE, errImagePullTimeoutRE, InOpenShiftNS, events)
+	return buildTestsFailIfRegexMatch(testName, errImagePullGenericRE, errImagePullTimeoutRE, InOpenShiftNS, invalidImagesRE, events)
 }
 
 func testErrImagePullGeneric(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] should not encounter ErrImagePull in non-openshift namespace pods"
-	return buildTestsFailIfRegexMatch(testName, errImagePullGenericRE, errImagePullTimeoutRE, NotInOpenshiftNS, events)
+	return buildTestsFailIfRegexMatch(testName, errImagePullGenericRE, errImagePullTimeoutRE, NotInOpenshiftNS, invalidImagesRE, events)
 }
 
 func buildTestsFailIfRegexMatch(testName string, matchRE, dontMatchRE *regexp.Regexp,
-	nsRestriction namespaceRestriction, events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	nsRestriction namespaceRestriction, expectedErrPatterns []*regexp.Regexp, events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 
 	var matchedIntervals monitorapi.Intervals
 	for _, event := range events {
@@ -459,6 +471,21 @@ func buildTestsFailIfRegexMatch(testName string, matchRE, dontMatchRE *regexp.Re
 
 		// Skip if we *do* match the don't match regex:
 		if dontMatchRE != nil && dontMatchRE.MatchString(estr) {
+			continue
+		}
+
+		// Skip if this ErrImagePull problem is part of a negative test (i.e., if any of these
+		// patterns match the event string, it is an expected ErrImagePull failure).
+		found := false
+		for i := 0; i < len(expectedErrPatterns); i++ {
+			if expectedErrPatterns[i].MatchString(estr) {
+				found = true
+				break
+			}
+		}
+		if found {
+			// ErrImagePull was found but also one of the expected error patters was found so don't
+			// count this as an ErrImagePull failure.
 			continue
 		}
 


### PR DESCRIPTION
There are certain [documented exceptions](https://github.com/openshift/origin/blob/f88be40a20026986abd239bfb161f21dce283986/test/extended/util/image/README.md#kube-exceptions) where the ErrImagePull event is expected as part of a negative test.  This PR skips those so they are not counted as failures.

See the [Example CI job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27202/pull-ci-openshift-origin-master-e2e-gcp/1532383286834237440) that ran with these changes.  Look for the `: [sig-node] should not encounter ErrImagePull in non-openshift namespace pods` failure and notice the ErrImagePull failures associated with the 3 regexes in the PR are no longer present.

Look for the same failure in the [another CI job](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-gcp-ovn-upgrade/1532093641084899328) that did not run with these changes and you can see what's different.

ref: [TRT-266](https://issues.redhat.com//browse/TRT-266)