### PR TITLE
Bug 2093049: test/extended/networking: fix [pod sysctls should not affect node] to use host interfaces

### DIFF
--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -104,12 +105,15 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 		})
 
 		g.By("retrieving node interface name to create sysctl pod with interface of the same name")
-		nodeInterfaceNames, err := oc.AsAdmin().Run("exec").Args(nodePod.Name, "--", "ls", "/host/net").Output()
+		linkInfo, err := oc.AsAdmin().Run("exec").Args(nodePod.Name, "--", "bash", "-c", "ip -o link show | grep -v LOOPBACK | head -1").Output()
 		o.Expect(err).NotTo(o.HaveOccurred(), "unable to get interface names")
-		nodeInterfaceName := strings.Fields(nodeInterfaceNames)[0]
-		if nodeInterfaceName == "lo" {
-			nodeInterfaceName = strings.Fields(nodeInterfaceNames)[1]
-		}
+		fields := strings.Split(linkInfo, ": ")
+		o.Expect(len(fields)).To(o.BeNumerically(">", 2), "unexpected ip link output")
+		ifindex, err := strconv.ParseInt(fields[0], 10, 32)
+		o.Expect(err).NotTo(o.HaveOccurred(), "unable to parse interface ifindex")
+		o.Expect(ifindex).To(o.BeNumerically(">", 1), "invalid ifindex")
+		nodeInterfaceName := fields[1]
+		o.Expect(nodeInterfaceName).NotTo(o.BeEmpty(), "unable to find interface name")
 
 		g.By("getting the value of the node sysctl")
 		nodeSysctlValue, err := oc.AsAdmin().Run("exec").Args(nodePod.Name, "--", "cat", "/host"+fmt.Sprintf(sysctlPath, nodeInterfaceName)).Output()


### PR DESCRIPTION
This test was listing all interfaces on the host with 'ls /sys/class/net'
which does not return a stable order of interfaces. Thus it was sometimes
reading host-side veths of pods, which would be gone (because we run
tests in parallel and pods are starting/stopping all the time) by the time
the test wanted to read the interface's sysctls.

```
Jun  2 16:13:38.827: INFO: Error running /usr/bin/oc --namespace=e2e-test-tuning-vz9kr --kubeconfig=/tmp/secret/kubeconfig exec nodeaccess-pod-lmbdb -- cat /host/proc/sys/net/ipv4/conf/090399bc34a8bcf/send_redirects:
StdOut>
cat: can't open '/host/proc/sys/net/ipv4/conf/090399bc34a8bcf/send_redirects': No such file or directory
command terminated with exit code 1
StdErr>
cat: can't open '/host/proc/sys/net/ipv4/conf/090399bc34a8bcf/send_redirects': No such file or directory
command terminated with exit code 1
```