### PR TITLE
bug 2093051: use reflects to drive node status monitor to improve reliability

### DIFF
--- a/pkg/monitor/pod.go
+++ b/pkg/monitor/pod.go
@@ -518,9 +518,9 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 	listWatch := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), "pods", "", fields.Everything())
 	customStore := newMonitoringStore(
 		"pods",
-		toCreateFns(podCreatedFns),
-		toUpdateFns(podChangeFns),
-		toDeleteFns(podDeleteFns),
+		toPodCreateFns(podCreatedFns),
+		toPodUpdateFns(podChangeFns),
+		toPodDeleteFns(podDeleteFns),
 		m,
 		m,
 	)
@@ -535,7 +535,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 
 }
 
-func toCreateFns(podCreateFns []func(pod *corev1.Pod) []monitorapi.Condition) []objCreateFunc {
+func toPodCreateFns(podCreateFns []func(pod *corev1.Pod) []monitorapi.Condition) []objCreateFunc {
 	ret := []objCreateFunc{}
 
 	for i := range podCreateFns {
@@ -548,7 +548,7 @@ func toCreateFns(podCreateFns []func(pod *corev1.Pod) []monitorapi.Condition) []
 	return ret
 }
 
-func toDeleteFns(podDeleteFns []func(pod *corev1.Pod) []monitorapi.Condition) []objDeleteFunc {
+func toPodDeleteFns(podDeleteFns []func(pod *corev1.Pod) []monitorapi.Condition) []objDeleteFunc {
 	ret := []objDeleteFunc{}
 
 	for i := range podDeleteFns {
@@ -561,7 +561,7 @@ func toDeleteFns(podDeleteFns []func(pod *corev1.Pod) []monitorapi.Condition) []
 	return ret
 }
 
-func toUpdateFns(podUpdateFns []func(pod, oldPod *corev1.Pod) []monitorapi.Condition) []objUpdateFunc {
+func toPodUpdateFns(podUpdateFns []func(pod, oldPod *corev1.Pod) []monitorapi.Condition) []objUpdateFunc {
 	ret := []objUpdateFunc{}
 
 	for i := range podUpdateFns {

--- a/vendor/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/client-go/tools/cache/reflector.go
@@ -177,8 +177,8 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 		// We used to make the call every 1sec (1 QPS), the goal here is to achieve ~98% traffic reduction when
 		// API server is not healthy. With these parameters, backoff will stop at [30,60) sec interval which is
 		// 0.22 QPS. If we don't backoff for 2min, assume API server is healthy and we reset the backoff.
-		backoffManager:         wait.NewExponentialBackoffManager(800*time.Millisecond, 30*time.Second, 2*time.Minute, 2.0, 1.0, realClock),
-		initConnBackoffManager: wait.NewExponentialBackoffManager(800*time.Millisecond, 30*time.Second, 2*time.Minute, 2.0, 1.0, realClock),
+		backoffManager:         wait.NewJitteredBackoffManager(800*time.Millisecond, 0, realClock),
+		initConnBackoffManager: wait.NewJitteredBackoffManager(800*time.Millisecond, 0, realClock),
 		resyncPeriod:           resyncPeriod,
 		clock:                  realClock,
 		watchErrorHandler:      WatchErrorHandler(DefaultWatchErrorHandler),


### PR DESCRIPTION
While chasing problems with `[bz-Machine Config Operator] Nodes should reach OSUpdateStaged in a timely fashion ` like in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upgrade/1532346119462326272, I found the informer versus reflector issue we changed for events and pods.  This makes it match pods.

I suggest doing a sweep eventually.

/assign @dgoodwin 