### PR TITLE
bug 2093051: use the node update finished as a backup completion time for OSStaged

### DIFF
--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -73,7 +73,7 @@ func (r ContainerReference) ToLocator() string {
 	return fmt.Sprintf("ns/%s pod/%s uid/%s container/%s", r.Pod.Namespace, r.Pod.Name, r.Pod.UID, r.ContainerName)
 }
 
-func ReasonFrom(message string) string {
+func AnnotationsFromMessage(message string) map[string]string {
 	tokens := strings.Split(message, " ")
 	annotations := map[string]string{}
 	for _, curr := range tokens {
@@ -83,7 +83,17 @@ func ReasonFrom(message string) string {
 		annotationTokens := strings.Split(curr, "/")
 		annotations[annotationTokens[0]] = annotationTokens[1]
 	}
+	return annotations
+}
+
+func ReasonFrom(message string) string {
+	annotations := AnnotationsFromMessage(message)
 	return annotations["reason"]
+}
+
+func PhaseFrom(message string) string {
+	annotations := AnnotationsFromMessage(message)
+	return annotations["phase"]
 }
 
 func ReasonedMessage(reason string, message ...string) string {


### PR DESCRIPTION
While chasing problems with `[bz-Machine Config Operator] Nodes should reach OSUpdateStaged in a timely fashion` like in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upgrade/1532346119462326272, I found that we don't have a backstop value for osupdatestaged.  If we complete the upgrade, then at some point we were OSUpdateStaged even if we didn't observe that event.

/assign @dgoodwin 