### PR TITLE
Bug 2093122: synthetictests: Event struct's Related field is optional

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -481,7 +481,8 @@ func isEventDuringInstallation(monitorEvent monitorapi.EventInterval, kubeClient
 		return true, nil
 	}
 	for _, event := range kubeEvents.Items {
-		if event.Related.Name != pod ||
+		if event.Related == nil ||
+			event.Related.Name != pod ||
 			event.Reason != reason ||
 			!strings.Contains(event.Message, msg) {
 			continue


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x47791db]

goroutine 1 [running]:
github.com/openshift/origin/pkg/synthetictests.isEventDuringInstallation({{0x1, {0xc0064240e0, 0x62}, {0xc006b74840, 0x34}}, {0x0, 0xeda2b470d, 0xbfae940}, {0x0, 0xeda2b470d, ...}}, ...)
	github.com/openshift/origin/pkg/synthetictests/duplicated_events.go:484 +0x2db
github.com/openshift/origin/pkg/synthetictests.testOvnNodeReadinessProbe({0xc00f6dc000, 0x6ee1, 0x745d?}, 0xc01adbe820?)
	github.com/openshift/origin/pkg/synthetictests/networking.go:253 +0x408
github.com/openshift/origin/pkg/synthetictests.SystemUpgradeEventInvariants({0xc00f6dc000, 0x6ee1, 0x745d}, 0x0?, 0xc014480000?, {0x7e617a9, 0x3})
	github.com/openshift/origin/pkg/synthetictests/event_junits.go:60 +0x60a
github.com/openshift/origin/pkg/test/ginkgo.JUnitForEventsFunc.JUnitsForEvents(0x6cf3020?, {0xc00f6dc000?, 0xc01451c000?, 0xc00274c3a8?}, 0xc01442e390?, 0x6ecd4c0?, {0x7e617a9?, 0x6ed4a40?})
	github.com/openshift/origin/pkg/test/ginkgo/synthentic_tests.go:30 +0x3c
github.com/openshift/origin/pkg/test/ginkgo.JUnitsForAllEvents.JUnitsForEvents({0xc0181db3e0?, 0x2, 0xc00f6dc000?}, {0xc00f6dc000, 0x6ee1, 0x745d}, 0x10?, 0x1?, {0x7e617a9, 0x3})
	github.com/openshift/origin/pkg/test/ginkgo/synthentic_tests.go:43 +0xf1
github.com/openshift/origin/pkg/test/ginkgo.(*Options).Run(0xc001c8e160, 0xbb9aaa0, {0x7ecbc72, 0x17})
	github.com/openshift/origin/pkg/test/ginkgo/cmd_runsuite.go:442 +0x2d25
main.newRunUpgradeCommand.func1.1()
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:385 +0x2fd
main.mirrorToFile(0xc001c8e160, 0xc0024bfbc8)
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:472 +0x653
main.newRunUpgradeCommand.func1(0xc000fc8000?, {0xc0021c0580?, 0xb?, 0xb?})
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:362 +0x5b
github.com/spf13/cobra.(*Command).execute(0xc000fc8000, {0xc0021c04d0, 0xb, 0xb})
	github.com/spf13/cobra@v1.2.1/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000fa3900)
	github.com/spf13/cobra@v1.2.1/command.go:974 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.2.1/command.go:902
main.main.func1(0xc002092700?)
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:94 +0x8a
main.main()
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:95 +0x476
```

@jluhrsen @deads2k @p0lyn0mial 