### PR TITLE
Bug 2085997: explicit timeout for the etcd scaling test

### DIFF
--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd", func() {
 	// next it validates the size of etcd cluster and makes sure the new member is healthy.
 	// The test ends by removing the newly added machine and validating the size of the cluster
 	// and asserting the member was removed from the etcd cluster by contacting MemberList API.
-	g.It("is able to vertically scale up and down with a single node", func() {
+	g.It("is able to vertically scale up and down with a single node [Timeout:60m]", func() {
 		// set up
 		ctx := context.TODO()
 		etcdClientFactory := scalingtestinglibrary.NewEtcdClientFactory(oc.KubeClient())

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1995,7 +1995,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [Serial]",
 
-	"[Top Level] [sig-etcd][Serial] etcd is able to vertically scale up and down with a single node": "is able to vertically scale up and down with a single node [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-etcd][Serial] etcd is able to vertically scale up and down with a single node [Timeout:60m]": "is able to vertically scale up and down with a single node [Timeout:60m] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-imageregistry] Image registry should redirect on blob pull": "should redirect on blob pull [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
on `libvirt` the `etcd is able to vertically scale up and down with a single node` test seems to be interrupted after 15 minutes even though the global timeout for the suite is set (https://github.com/openshift/origin/blob/master/cmd/openshift-tests/e2e.go#L124). This PR sets the timeout explicitly for the test just in case something gets in the way and overwrites the global timeout for the suite.

for example:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-serial-remote-libvirt-ppc64le/1533524212742885376