### PR TITLE
Bug 2092961: Use http for network endpoint test.

### DIFF
--- a/test/e2e/upgrade/cidisruptiontester/cidisruptiontester.go
+++ b/test/e2e/upgrade/cidisruptiontester/cidisruptiontester.go
@@ -35,7 +35,7 @@ const (
 func NewCIDisruptionWithNewConnectionsTest() upgrades.Test {
 	ciDisruptTest := &ciDisruptionUpgradeTest{}
 	backend := backenddisruption.NewSimpleBackend(
-		"https://static.redhat.com/test/rhel-networkmanager.txt",
+		"http://static.redhat.com/test/rhel-networkmanager.txt",
 		"ci-cluster-network-liveness",
 		"",
 		backenddisruption.NewConnectionType)
@@ -54,7 +54,7 @@ func NewCIDisruptionWithNewConnectionsTest() upgrades.Test {
 func NewCIDisruptionWithReusedConnectionsTest() upgrades.Test {
 	ciDisruptTest := &ciDisruptionUpgradeTest{}
 	backend := backenddisruption.NewSimpleBackend(
-		"https://static.redhat.com/test/rhel-networkmanager.txt",
+		"http://static.redhat.com/test/rhel-networkmanager.txt",
 		"ci-cluster-network-liveness",
 		"",
 		backenddisruption.ReusedConnectionType)


### PR DESCRIPTION
This is tripping about 20% of the time on a tls: internal error.
Trying http to see if that makes it more stable.
