### PR TITLE
Add tooling to track Timeout tags

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -1,6 +1,6 @@
 package extended
 
-//go:generate go run -mod vendor ./util/annotate -- ./util/annotate/generated/zz_generated.annotations.go
+//go:generate go run -mod vendor ./util/annotate ./util/annotate/generated/zz_generated.annotations.go ./util/annotate/generated/timeout/zz_generated.timeout
 
 import (
 	// openshift/kubernetes defines the set of kube tests that should be included

--- a/test/extended/util/annotate/generated/timeout/OWNERS
+++ b/test/extended/util/annotate/generated/timeout/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- deads2k
+- soltysh
+
+options:
+  no_parent_owners: true

--- a/test/extended/util/annotate/generated/timeout/zz_generated.timeout
+++ b/test/extended/util/annotate/generated/timeout/zz_generated.timeout
@@ -1,0 +1,1 @@
+"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:30m]": "grow and decrease when scaling different machineSets simultaneously [Timeout:30m] [Suite:openshift/conformance/serial]"


### PR DESCRIPTION
Requires https://github.com/openshift/kubernetes/pull/1284 and https://github.com/openshift/origin/pull/27181 to land
/hold
/assign @deads2k 