### PR TITLE
Bug 2093049: test/extended/networking: fix [pod sysctls should not affect node] to use known host interfaces

### DIFF
--- a/test/extended/security/sysctl.go
+++ b/test/extended/security/sysctl.go
@@ -33,6 +33,11 @@ var _ = g.Describe("[sig-arch] [Conformance] sysctl", func() {
 			o.Expect(err).NotTo(o.HaveOccurred(), "unable to check sysctl value")
 			previousPodSysctlValue, err = oc.AsAdmin().Run("exec").Args(preexistingPod.Name, "--", "cat", path).Output()
 			o.Expect(err).NotTo(o.HaveOccurred(), "unable to check sysctl value")
+
+			// Retrieve created pod so we can use the same NodeName
+			preexistingPod, err = f.ClientSet.CoreV1().Pods(preexistingPod.Namespace).Get(context.TODO(), preexistingPod.Name, metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred(), "unable get running pod")
+			o.Expect(preexistingPod.Spec.NodeName).NotTo(o.BeEmpty(), "expected scheduled pod but found empty Spec.NodeName")
 		})
 
 		g.By("creating a pod with a sysctl", func() {


### PR DESCRIPTION
This test was listing all interfaces on the host with 'ls /sys/class/net'
which does not return a stable order of interfaces. Thus it was sometimes
reading host-side veths of pods, which would be gone (because we run
tests in parallel and pods are starting/stopping all the time) by the time
the test wanted to read the interface's sysctls.

```
Jun  2 16:13:38.827: INFO: Error running /usr/bin/oc --namespace=e2e-test-tuning-vz9kr --kubeconfig=/tmp/secret/kubeconfig exec nodeaccess-pod-lmbdb -- cat /host/proc/sys/net/ipv4/conf/090399bc34a8bcf/send_redirects:
StdOut>
cat: can't open '/host/proc/sys/net/ipv4/conf/090399bc34a8bcf/send_redirects': No such file or directory
command terminated with exit code 1
StdErr>
cat: can't open '/host/proc/sys/net/ipv4/conf/090399bc34a8bcf/send_redirects': No such file or directory
command terminated with exit code 1
```

Instead of grabbing random interfaces from the host that may or may not
exist when the rest of the test runs, make the test own all the interfaces
it uses by creating it's own host interface via a second Network Attachment
Definition.

Rework of https://github.com/openshift/origin/pull/27203 to fix instances where the host interface is named `eth0` like the default pod interface.

@danwinship 