### PR TITLE
 Bug 2079679: pkg/monitor: wait for Prometheus sidecars to be ready

### DIFF
--- a/pkg/monitor/alerts.go
+++ b/pkg/monitor/alerts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	prometheustypes "github.com/prometheus/common/model"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -81,6 +82,34 @@ func FetchEventIntervalsForAllAlerts(ctx context.Context, restConfig *rest.Confi
 	prometheusClient, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
 	if err != nil {
 		return nil, err
+	}
+
+	// Ensure that all Thanos queriers are connected to all Prometheus sidecars
+	// before fetching the alerts. This avoids retrieving partial data
+	// (possibly with gaps) when after an upgrade, one of the Prometheus
+	// sidecars hasn't been reconnected yet to the Thanos queriers.
+	if err = wait.PollImmediateWithContext(ctx, 5*time.Second, 5*time.Minute, func(context.Context) (bool, error) {
+		v, warningsForQuery, err := prometheusClient.Query(ctx, `min(count by(pod) (thanos_store_nodes_grpc_connections{store_type="sidecar"})) == min(kube_statefulset_replicas{statefulset="prometheus-k8s"})`, time.Time{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(warningsForQuery) > 0 {
+			fmt.Printf("#### warnings \n\t%v\n", strings.Join(warningsForQuery, "\n\t"))
+		}
+
+		if v.Type() != prometheustypes.ValVector {
+			return false, fmt.Errorf("expecting a vector type, got %q", v.Type().String())
+		}
+
+		if len(v.(prometheustypes.Vector)) == 0 {
+			fmt.Printf("#### at least one Prometheus sidecar isn't ready\n")
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		return nil, fmt.Errorf("Thanos queriers not connected to all Prometheus sidecars: %w", err)
 	}
 
 	timeRange := prometheusv1.Range{


### PR DESCRIPTION
When fetching alerts from Thanos Query, we should first ensure that the
queriers are connected to all Prometheus sidecars. Otherwise the
returned data could have gaps which would fail the tests verifying that
the Watchdog alert has been always firing.

This is a second try after #27201 failed all single node jobs.