### PR TITLE
[WIP] Improve output of machineset scale tests

### DIFF
--- a/test/extended/machines/util.go
+++ b/test/extended/machines/util.go
@@ -1,0 +1,57 @@
+package operators
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"time"
+)
+
+// BufferedLogger represents a logger interface which is buffered.
+// It only writes to the output when flushed.
+// It can be reset at any time by calling Reset().
+// This is useful if you want to log only the last iteration of an
+// asynchronous assertion.
+type BufferedLogger interface {
+	Reset()
+	Flush()
+	Logf(string, ...interface{})
+}
+
+// bufferedLogger keeps a track of whatever was written to it last, and writes that out
+// to the underlying writer when flushed.
+type bufferedLogger struct {
+	buffer *bytes.Buffer
+	output io.Writer
+}
+
+// NewBufferedLogger creates a new BufferedLogger which will flush to the output given.
+func NewBufferedLogger(out io.Writer) BufferedLogger {
+	return &bufferedLogger{
+		buffer: bytes.NewBuffer(nil),
+		output: out,
+	}
+}
+
+// Reset resets the contents of the buffer in the logger.
+func (l *bufferedLogger) Reset() {
+	l.buffer = bytes.NewBuffer(nil)
+}
+
+func (l *bufferedLogger) log(level string, format string, args ...interface{}) {
+	fmt.Fprintf(l.buffer, nowStamp()+": "+level+": "+format+"\n", args...)
+}
+
+// Logf logs the info.
+func (l *bufferedLogger) Logf(format string, args ...interface{}) {
+	l.log("INFO", format, args...)
+}
+
+// Flush writes the loggers buffer to the output.
+func (l *bufferedLogger) Flush() {
+	l.output.Write(l.buffer.Bytes())
+}
+
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}

--- a/test/extended/machines/workers.go
+++ b/test/extended/machines/workers.go
@@ -9,14 +9,14 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	"github.com/stretchr/objx"
 
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	machineclientset "github.com/openshift/client-go/machine/clientset/versioned"
+	machinev1beta1clientset "github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -31,45 +31,27 @@ const (
 )
 
 // machineClient returns a client for machines scoped to the proper namespace
-func machineClient(dc dynamic.Interface) dynamic.ResourceInterface {
-	machineClient := dc.Resource(schema.GroupVersionResource{Group: "machine.openshift.io", Resource: "machines", Version: "v1beta1"})
-	return machineClient.Namespace(machineAPINamespace)
+func machineClient(mc machineclientset.Interface) machinev1beta1clientset.MachineInterface {
+	return mc.MachineV1beta1().Machines(machineAPINamespace)
 }
 
 // listMachines list all machines scoped by selector
-func listMachines(dc dynamic.Interface, labelSelector string) ([]objx.Map, error) {
-	mc := machineClient(dc)
-	obj, err := mc.List(context.Background(), metav1.ListOptions{
+func listMachines(mc machineclientset.Interface, labelSelector string) (*machinev1beta1.MachineList, error) {
+	c := machineClient(mc)
+	machines, err := c.List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
 		return nil, err
 	}
-	machines := objx.Map(obj.UnstructuredContent())
-	items := objects(machines.Get("items"))
-	return items, nil
+
+	return machines, nil
 }
 
 // deleteMachine deletes the named machine
-func deleteMachine(dc dynamic.Interface, machineName string) error {
-	mc := machineClient(dc)
-	return mc.Delete(context.Background(), machineName, metav1.DeleteOptions{})
-}
-
-// machineName returns the machine name
-func machineName(item objx.Map) string {
-	return item.Get("metadata.name").String()
-}
-
-func creationTimestamp(item objx.Map) time.Time {
-	creationString := item.Get("metadata.creationTimestamp").String()
-	creation, err := time.Parse(time.RFC3339, creationString)
-	if err != nil {
-		// This should never happen as we always read creation timestamps
-		// set by the Kube API server which sets timestamps to the RFC3339 format.
-		panic(err)
-	}
-	return creation
+func deleteMachine(mc machineclientset.Interface, machineName string) error {
+	c := machineClient(mc)
+	return c.Delete(context.Background(), machineName, metav1.DeleteOptions{})
 }
 
 // nodeNames returns the names of nodes
@@ -81,18 +63,9 @@ func nodeNames(nodes []corev1.Node) sets.String {
 	return result
 }
 
-// nodeNames returns the names of nodes
-func machineNames(machines []objx.Map) sets.String {
-	result := sets.NewString()
-	for i := range machines {
-		result.Insert(machineName(machines[i]))
-	}
-	return result
-}
-
 // mapNodeNameToMachine returns a tuple (map node to machine by name, true if a match is found for every node)
-func mapNodeNameToMachine(nodes []corev1.Node, machines []objx.Map) (map[string]objx.Map, bool) {
-	result := map[string]objx.Map{}
+func mapNodeNameToMachine(nodes []corev1.Node, machines []machinev1beta1.Machine) (map[string]machinev1beta1.Machine, bool) {
+	result := map[string]machinev1beta1.Machine{}
 	for i := range nodes {
 		for j := range machines {
 			if nodes[i].Name == nodeNameFromNodeRef(machines[j]) {
@@ -105,12 +78,12 @@ func mapNodeNameToMachine(nodes []corev1.Node, machines []objx.Map) (map[string]
 }
 
 // mapMachineNameToNodeName returns a tuple (map node to machine by name, true if a match is found for every node)
-func mapMachineNameToNodeName(machines []objx.Map, nodes []corev1.Node) (map[string]string, bool) {
+func mapMachineNameToNodeName(machines []machinev1beta1.Machine, nodes []corev1.Node) (map[string]string, bool) {
 	result := map[string]string{}
 	for i := range machines {
 		for j := range nodes {
 			if nodes[j].Name == nodeNameFromNodeRef(machines[i]) {
-				result[machineName(machines[i])] = nodes[j].Name
+				result[machines[i].GetName()] = nodes[j].Name
 				break
 			}
 		}
@@ -135,21 +108,21 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Manage
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		dc, err := dynamic.NewForConfig(cfg)
+		mc, err := machineclientset.NewForConfig(cfg)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
+		skipUnlessMachineAPIOperator(mc, c.CoreV1().Namespaces())
 
 		g.By("validating node and machine invariants")
 		// fetch all machines
-		allMachines, err := listMachines(dc, "")
+		allMachines, err := listMachines(mc, "")
 		if err != nil {
 			e2e.Failf("unable to fetch worker machines: %v", err)
 		}
 
-		if len(allMachines) == 0 {
+		if len(allMachines.Items) == 0 {
 			e2e.Failf("cluster should have machines")
 		}
 
@@ -162,7 +135,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Manage
 			e2e.Failf("cluster should have nodes")
 		}
 		// map node -> machine
-		workerNodeToMachine, nodeMatch := mapNodeNameToMachine(workerNodes.Items, allMachines)
+		workerNodeToMachine, nodeMatch := mapNodeNameToMachine(workerNodes.Items, allMachines.Items)
 		if !nodeMatch {
 			e2e.Failf("unable to map every node to machine.  workerNodeToMachine: %v, nodeName: %v", workerNodeToMachine, nodeNames(workerNodes.Items))
 		}
@@ -170,14 +143,14 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Manage
 
 		g.By("deleting all worker nodes")
 		for _, machine := range workerNodeToMachine {
-			machineName := machine.Get("metadata.name").String()
-			if err := deleteMachine(dc, machineName); err != nil {
+			machineName := machine.GetName()
+			if err := deleteMachine(mc, machineName); err != nil {
 				e2e.Failf("Unable to delete machine %s/%s with error: %v", machineAPINamespace, machineName, err)
 			}
 		}
 		g.By("waiting for cluster to replace and recover workers")
 		if pollErr := wait.PollImmediate(3*time.Second, machineRepairWait, func() (bool, error) {
-			allMachines, err = listMachines(dc, "")
+			allMachines, err = listMachines(mc, "")
 			if err != nil {
 				return false, nil
 			}
@@ -189,7 +162,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Manage
 				return false, nil
 			}
 			// map both data sets for easy comparison now
-			workerNodeToMachine, nodeMatch = mapNodeNameToMachine(workerNodes.Items, allMachines)
+			workerNodeToMachine, nodeMatch = mapNodeNameToMachine(workerNodes.Items, allMachines.Items)
 			if numMachineWorkers != len(workerNodeToMachine) {
 				e2e.Logf("Waiting for %v machines, but only found: %v", numMachineWorkers, len(workerNodeToMachine))
 				return false, nil
@@ -212,8 +185,8 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Manage
 			w := tabwriter.NewWriter(buf, 0, 4, 1, ' ', 0)
 			fmt.Fprintf(w, "NAMESPACE\tNAME\tNODE NAME\n")
 			for _, machine := range workerNodeToMachine {
-				ns := machine.Get("metadata.namespace").String()
-				name := machine.Get("metadata.name").String()
+				ns := machine.GetNamespace()
+				name := machine.GetName()
 				nodeName := nodeNameFromNodeRef(machine)
 				fmt.Fprintf(w, "%s\t%s\t%s\n",
 					ns,


### PR DESCRIPTION
This is an attempt to clean up the output of the MachineSet scale tests to make it easier to determine what happens when the test fails.
Primarily, I've converted what was raw go struct output to YAML output, and, rather than printing all objects every 5 seconds, we dump only the last versions of each object to the log, which should make the log output a little less confusing