### PR TITLE
OTA-362: pkg/monitortests/clusterversionoperator: Fatal unless Available=False in allow-list

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -72,7 +72,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 				return "https://issues.redhat.com/browse/OCPBUGS-22364", nil
 			}
 		case "monitoring":
-			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "UpdatingPrometheusK8SFailed" {
+			if condition.Type == configv1.OperatorAvailable && (condition.Status == configv1.ConditionFalse && (condition.Reason == "PlatformTasksFailed" || condition.Reason == "UpdatingAlertmanagerFailed" || condition.Reason == "UpdatingConsolePluginComponentsFailed" || condition.Reason == "UpdatingPrometheusK8SFailed" || condition.Reason == "UpdatingPrometheusOperatorFailed")) || (condition.Status == configv1.ConditionUnknown && condition.Reason == "UpdatingPrometheusFailed") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23745", nil
 			}
 		case "openshift-apiserver":

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -75,6 +75,9 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "MachineConfigControllerFailed" && strings.Contains(condition.Message, "notAfter: Required value") {
 				return "https://issues.redhat.com/browse/OCPBUGS-22364", nil
 			}
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && strings.Contains(condition.Message, "missing HTTP content-type") {
+				return "https://issues.redhat.com/browse/OCPBUGS-24228", nil
+			}
 		case "monitoring":
 			if condition.Type == configv1.OperatorAvailable && (condition.Status == configv1.ConditionFalse && (condition.Reason == "PlatformTasksFailed" || condition.Reason == "UpdatingAlertmanagerFailed" || condition.Reason == "UpdatingConsolePluginComponentsFailed" || condition.Reason == "UpdatingPrometheusK8SFailed" || condition.Reason == "UpdatingPrometheusOperatorFailed")) || (condition.Status == configv1.ConditionUnknown && condition.Reason == "UpdatingPrometheusFailed") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23745", nil

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -31,8 +31,9 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 	exceptions := map[*regexp.Regexp]string{
 		regexp.MustCompile(".*condition/Degraded.*"): "We are not worried about Degraded=True blips yet.",
 
-		regexp.MustCompile(".*clusteroperator/authentication condition/Available reason/WellKnown_NotReady status/False[ :].*"):             "https://issues.redhat.com/browse/OCPBUGS-20056",
-		regexp.MustCompile(".*clusteroperator/control-plane-machine-set condition/Available reason/UnavailableReplicas status/False[ :].*"): "https://issues.redhat.com/browse/OCPBUGS-20061",
+		regexp.MustCompile(".*clusteroperator/authentication condition/Available reason/WellKnown_NotReady status/False[ :].*"):                                  "https://issues.redhat.com/browse/OCPBUGS-20056",
+		regexp.MustCompile(".*clusteroperator/control-plane-machine-set condition/Available reason/UnavailableReplicas status/False[ :].*"):                      "https://issues.redhat.com/browse/OCPBUGS-20061",
+		regexp.MustCompile(".*clusteroperator/kube-storage-version-migrator condition/Available reason/KubeStorageVersionMigrator_Deploying status/False[ :].*"): "https://issues.redhat.com/browse/OCPBUGS-20062",
 	}
 
 	var start, stop time.Time

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -56,7 +56,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 
 		switch operator {
 		case "authentication":
-			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && (condition.Reason == "APIServices_Error" || condition.Reason == "OAuthServerServiceEndpointAccessibleController_EndpointUnavailable" || condition.Reason == "APIServices_PreconditionNotReady" || condition.Reason == "OAuthServerRouteEndpointAccessibleController_EndpointUnavailable" || condition.Reason == "WellKnown_NotReady") {
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && (condition.Reason == "APIServices_Error" || condition.Reason == "APIServerDeployment_NoDeployment" || condition.Reason == "APIServerDeployment_NoPod" || condition.Reason == "APIServerDeployment_PreconditionNotFulfilled" || condition.Reason == "APIServices_PreconditionNotReady" || condition.Reason == "OAuthServerDeployment_NoDeployment" || condition.Reason == "OAuthServerRouteEndpointAccessibleController_EndpointUnavailable" || condition.Reason == "OAuthServerServiceEndpointAccessibleController_EndpointUnavailable" || condition.Reason == "WellKnown_NotReady") {
 				return "https://issues.redhat.com/browse/OCPBUGS-20056", nil
 			}
 		case "console":

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -67,6 +67,10 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-20062", nil
 			}
+		case "machine-config":
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "MachineConfigControllerFailed" && strings.Contains(condition.Message, "notAfter: Required value") {
+				return "https://issues.redhat.com/browse/OCPBUGS-22364", nil
+			}
 		}
 
 		return "", nil

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -31,7 +31,8 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 	exceptions := map[*regexp.Regexp]string{
 		regexp.MustCompile(".*condition/Degraded.*"): "We are not worried about Degraded=True blips yet.",
 
-		regexp.MustCompile(".*clusteroperator/authentication condition/Available reason/WellKnown_NotReady status/False[ :].*"): "https://issues.redhat.com/browse/OCPBUGS-20056",
+		regexp.MustCompile(".*clusteroperator/authentication condition/Available reason/WellKnown_NotReady status/False[ :].*"):             "https://issues.redhat.com/browse/OCPBUGS-20056",
+		regexp.MustCompile(".*clusteroperator/control-plane-machine-set condition/Available reason/UnavailableReplicas status/False[ :].*"): "https://issues.redhat.com/browse/OCPBUGS-20061",
 	}
 
 	var start, stop time.Time

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -167,10 +167,6 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 				}
 			}
 
-			if len(fatal) == 0 && len(excepted) == 0 {
-				continue // nothing to complain about
-			}
-
 			output := fmt.Sprintf("%d unexpected clusteroperator state transitions during e2e test run", len(fatal))
 			if len(fatal) > 0 {
 				output = fmt.Sprintf("%s.  These did not match any known exceptions, so they cause this test-case to fail:\n\n%v\n", output, strings.Join(fatal, "\n"))
@@ -184,17 +180,19 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 				output = fmt.Sprintf("%s, as desired.", output)
 			}
 
-			ret = append(ret, &junitapi.JUnitTestCase{
-				Name:      testName,
-				Duration:  duration,
-				SystemOut: output,
-				FailureOutput: &junitapi.FailureOutput{
-					Output: output,
-				},
-			})
+			if len(fatal) > 0 || len(excepted) > 0 {
+				ret = append(ret, &junitapi.JUnitTestCase{
+					Name:      testName,
+					Duration:  duration,
+					SystemOut: output,
+					FailureOutput: &junitapi.FailureOutput{
+						Output: output,
+					},
+				})
+			}
 
 			if len(fatal) == 0 {
-				// add a success so we flake and don't fail
+				// add a success so we flake (or pass) and don't fail
 				ret = append(ret, &junitapi.JUnitTestCase{Name: testName})
 			}
 		}

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -80,7 +80,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 				return "https://issues.redhat.com/browse/OCPBUGS-23745", nil
 			}
 		case "openshift-apiserver":
-			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "APIServices_Error" {
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && (condition.Reason == "APIServerDeployment_NoDeployment" || condition.Reason == "APIServerDeployment_NoPod" || condition.Reason == "APIServerDeployment_PreconditionNotFulfilled" || condition.Reason == "APIServices_Error") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23746", nil
 			}
 		case "operator-lifecycle-manager-packageserver":

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -56,7 +56,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 
 		switch operator {
 		case "authentication":
-			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "WellKnown_NotReady" {
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && (condition.Reason == "APIServices_Error" || condition.Reason == "OAuthServerServiceEndpointAccessibleController_EndpointUnavailable" || condition.Reason == "APIServices_PreconditionNotReady" || condition.Reason == "OAuthServerRouteEndpointAccessibleController_EndpointUnavailable" || condition.Reason == "WellKnown_NotReady") {
 				return "https://issues.redhat.com/browse/OCPBUGS-20056", nil
 			}
 		case "control-plane-machine-set":

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -59,6 +59,10 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && (condition.Reason == "APIServices_Error" || condition.Reason == "OAuthServerServiceEndpointAccessibleController_EndpointUnavailable" || condition.Reason == "APIServices_PreconditionNotReady" || condition.Reason == "OAuthServerRouteEndpointAccessibleController_EndpointUnavailable" || condition.Reason == "WellKnown_NotReady") {
 				return "https://issues.redhat.com/browse/OCPBUGS-20056", nil
 			}
+		case "console":
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && (condition.Reason == "RouteHealth_FailedGet" || condition.Reason == "RouteHealth_RouteNotAdmitted" || condition.Reason == "RouteHealth_StatusError") {
+				return "https://issues.redhat.com/browse/OCPBUGS-24041", nil
+			}
 		case "control-plane-machine-set":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "UnavailableReplicas" {
 				return "https://issues.redhat.com/browse/OCPBUGS-20061", nil

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -30,6 +30,8 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 	// map from allowed interval regexps to exceptions
 	exceptions := map[*regexp.Regexp]string{
 		regexp.MustCompile(".*condition/Degraded.*"): "We are not worried about Degraded=True blips yet.",
+
+		regexp.MustCompile(".*clusteroperator/authentication condition/Available reason/WellKnown_NotReady status/False[ :].*"): "https://issues.redhat.com/browse/OCPBUGS-20056",
 	}
 
 	var start, stop time.Time

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -75,6 +75,10 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "UpdatingPrometheusK8SFailed" {
 				return "https://issues.redhat.com/browse/OCPBUGS-23745", nil
 			}
+		case "openshift-apiserver":
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "APIServices_Error" {
+				return "https://issues.redhat.com/browse/OCPBUGS-23746", nil
+			}
 		case "operator-lifecycle-manager-packageserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "ClusterServiceVersionNotSucceeded" {
 				return "https://issues.redhat.com/browse/OCPBUGS-23744", nil

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -71,6 +71,10 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "MachineConfigControllerFailed" && strings.Contains(condition.Message, "notAfter: Required value") {
 				return "https://issues.redhat.com/browse/OCPBUGS-22364", nil
 			}
+		case "operator-lifecycle-manager-packageserver":
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "ClusterServiceVersionNotSucceeded" {
+				return "https://issues.redhat.com/browse/OCPBUGS-23744", nil
+			}
 		}
 
 		return "", nil

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -71,6 +71,10 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "MachineConfigControllerFailed" && strings.Contains(condition.Message, "notAfter: Required value") {
 				return "https://issues.redhat.com/browse/OCPBUGS-22364", nil
 			}
+		case "monitoring":
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "UpdatingPrometheusK8SFailed" {
+				return "https://issues.redhat.com/browse/OCPBUGS-23745", nil
+			}
 		case "operator-lifecycle-manager-packageserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "ClusterServiceVersionNotSucceeded" {
 				return "https://issues.redhat.com/browse/OCPBUGS-23744", nil


### PR DESCRIPTION
Filling in known bugs from [here][1] (~WIP: not actually full yet~).  This allows us to fail new regressions, and gradually ratchet tighter as we close out existing issues.

[1]: https://bugzilla.redhat.com/buglist.cgi?bug_status=__open__&f1=longdesc&f2=cf_environment&j_top=OR&known_name=ClusterOperator%20conditions&list_id=12649817&o1=casesubstring&o2=casesubstring&query_based_on=ClusterOperator%20conditions&query_format=advanced&v1=should%20not%20change%20condition%2F&v2=should%20not%20change%20condition%2F