### PR TITLE
Bug 2097713: Extend the allowance for etcdHighNumberOfLeaderChanges.

### DIFF
--- a/pkg/synthetictests/allowedalerts/allow_on_revision_change.go
+++ b/pkg/synthetictests/allowedalerts/allow_on_revision_change.go
@@ -39,7 +39,7 @@ func (d *etcdRevisionChangeAllowance) FailAfter(alertName string, jobType platfo
 	// in the future, we could make this function more dynamic
 	// we will leave it simple for now
 	if d.numberOfRevisionDuringTest > 2 {
-		return time.Duration(d.numberOfRevisionDuringTest) * 10 * time.Minute, nil
+		return time.Duration(d.numberOfRevisionDuringTest) * 15 * time.Minute, nil
 
 	}
 	allowed, _, _ := getClosestPercentilesValues(alertName, jobType)


### PR DESCRIPTION
This can fire on AWS in rare circumstances where we allow 20 minutes,
but we get 5s - 1min more than allowed, or very rarely up to 5 min more
than allowed.

The problem resolves itself and tests start passing again, indicating
the current limit is valuable, but a little higher will still be
valuable and cause less false positives for problems.

See: https://issues.redhat.com/browse/TRT-305
