### PR TITLE
Add --from-date and --to-date to get events falling between dates

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -198,6 +198,18 @@ func IsInNamespaces(namespaces sets.String) EventIntervalMatchesFunc {
 	}
 }
 
+// IsBetween returns a function that returns true of the given eventInterval
+// falls between from/to range.
+//
+func IsBetween(from, to time.Time) EventIntervalMatchesFunc {
+	return func(eventInterval EventInterval) bool {
+		if eventInterval.From.After(from) && eventInterval.To.Before(to) {
+			return true
+		}
+		return false
+	}
+}
+
 // ContainsAllParts ensures that all listed key match at least one of the values.
 func ContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatchesFunc {
 	return func(eventInterval EventInterval) bool {


### PR DESCRIPTION
To include events that fall between 2022-06-10T15:56:12Z and 2022-06-10T15:59:17Z do this:
```
./openshift-tests timeline -f e2e-timelines_everything_20220610-152657.json \
                           --type everything \
                           --from-date 2022-06-10T15:56:12Z \
                           --to-date 2022-06-10T15:59:17Z > out.html
```
