### PR TITLE
make a new category of pod sandbox failure

### DIFF
--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -38,6 +38,7 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 		{by: " by writing child", substring: "write child: broken pipe"},
 		{by: " by ovn default network ready", substring: "have you checked that your default network is ready? still waiting for readinessindicatorfile"},
 		{by: " by adding pod to network", substring: "failed (add)"},
+		{by: " by initializing docker source", substring: `can't talk to a V1 container registry`},
 		{by: " by other", substring: " "}, // always matches
 	}
 


### PR DESCRIPTION
separates out failures like https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-azure-ovn-upgrade/1535593831418826752 into their own category.  Doesn't fix the problem