### PR TITLE
Request Headers: Change wait logic, add more debugging data to post mortem

### DIFF
--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -56,14 +56,7 @@ var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [I
 	var oc = exutil.NewCLI("request-headers")
 
 	g.It("test RequestHeaders IdP", func() {
-
-		// In some rare cases, CAO might be damaged when entering this test. If it is - the results
-		// of this test might flaky. This check ensures that we capture such situation early and
-		// investigate why it wasn't ready before this test.
-		e2e.Logf("Ensuring CAO is available==True, progressing==False, degraded==False")
-
-		ctx := context.Background()
-		ctx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 		defer cancel()
 
 		authenticationRollout := exutil.WaitForOperatorToRollout(ctx, oc.AdminConfigClient(), "authentication")
@@ -107,8 +100,7 @@ var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [I
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// clean up after ourselves
 		defer func() {
-			ctx := context.Background()
-			ctx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 			defer cancel()
 
 			authenticationRollout := exutil.WaitForOperatorToRollout(ctx, oc.AdminConfigClient(), "authentication")

--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -105,12 +105,6 @@ var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [I
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// clean up after ourselves
 		defer func() {
-			g.By("clean up - wait for stability")
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
-			defer cancel()
-			authenticationRollout := exutil.WaitForOperatorToRollout(ctx, oc.AdminConfigClient(), "authentication")
-			<-authenticationRollout.StableBeforeStarting() // wait for the initial state to be stable
-
 			g.By("clean up - remove test environment")
 			userclient := oc.AdminUserClient().UserV1()
 			userclient.Identities().Delete(context.Background(), fmt.Sprintf("%s:%s", idpName, testUserName), metav1.DeleteOptions{})
@@ -125,10 +119,6 @@ var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [I
 			if err != nil {
 				g.Fail(fmt.Sprintf("Failed to update oauth/cluster, unable to turn it into its original state: %v", err))
 			}
-
-			g.By("clean up - wait for clean up to be done")
-			<-authenticationRollout.Done()
-			o.Expect(authenticationRollout.Err()).NotTo(o.HaveOccurred())
 		}()
 
 		g.By("setup  - wait for setup to be done")

--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -256,42 +256,6 @@ func gatherPostMortem(oc *exutil.CLI) {
 	}
 	e2e.Logf("Authentication %v\n", authn)
 
-	deploymentName := "oauth-openshift"
-	oauthServerNamespace := "openshift-authentication"
-	deployment, err := oc.AdminKubeClient().
-		AppsV1().
-		Deployments(oauthServerNamespace).
-		Get(context.Background(), deploymentName, metav1.GetOptions{})
-	if err != nil {
-		e2e.Logf("get deployment from %s in %s: %w", deploymentName, oauthServerNamespace, err)
-	}
-	e2e.Logf("deployment for %s in %s: %s", deploymentName, oauthServerNamespace, deployment)
-
-	configmapName := "v4-0-config-system-cliconfig"
-	configmap, err := oc.AdminKubeClient().
-		CoreV1().
-		ConfigMaps(oauthServerNamespace).
-		Get(context.Background(), configmapName, metav1.GetOptions{})
-	if err != nil {
-		e2e.Logf("get configmap from %s in %s: %w", configmapName, oauthServerNamespace, err)
-	}
-	e2e.Logf("configmap for %s in %s: %s", configmapName, oauthServerNamespace, configmap)
-
-	pods, err := oc.AdminKubeClient().
-		CoreV1().
-		Pods(oauthServerNamespace).
-		List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		e2e.Logf("get pods from %s: %w", oauthServerNamespace, err)
-	}
-	for _, pod := range pods.Items {
-		logs, err := oc.Run("logs").Args(pod.Name, "-n", oauthServerNamespace).Output()
-		if err != nil {
-			e2e.Logf("get logs from %s in %s: %w", pod.Name, oauthServerNamespace, err)
-		}
-		e2e.Logf("log from %s in %s: %s", pod.Name, oauthServerNamespace, logs)
-	}
-
 	operator, err := oc.AdminOperatorClient().
 		OperatorV1().
 		Authentications().
@@ -341,6 +305,42 @@ func gatherPostMortem(oc *exutil.CLI) {
 			conditionOutput.WriteString("\n")
 		}
 		e2e.Logf("authentication operator status condition %s:\n%s", conditionType, conditionOutput.String())
+	}
+
+	deploymentName := "oauth-openshift"
+	oauthServerNamespace := "openshift-authentication"
+	deployment, err := oc.AdminKubeClient().
+		AppsV1().
+		Deployments(oauthServerNamespace).
+		Get(context.Background(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		e2e.Logf("get deployment from %s in %s: %w", deploymentName, oauthServerNamespace, err)
+	}
+	e2e.Logf("deployment for %s in %s: %s", deploymentName, oauthServerNamespace, deployment)
+
+	configmapName := "v4-0-config-system-cliconfig"
+	configmap, err := oc.AdminKubeClient().
+		CoreV1().
+		ConfigMaps(oauthServerNamespace).
+		Get(context.Background(), configmapName, metav1.GetOptions{})
+	if err != nil {
+		e2e.Logf("get configmap from %s in %s: %w", configmapName, oauthServerNamespace, err)
+	}
+	e2e.Logf("configmap for %s in %s: %s", configmapName, oauthServerNamespace, configmap)
+
+	pods, err := oc.AdminKubeClient().
+		CoreV1().
+		Pods(oauthServerNamespace).
+		List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		e2e.Logf("get pods from %s: %w", oauthServerNamespace, err)
+	}
+	for _, pod := range pods.Items {
+		logs, err := oc.Run("logs").Args(pod.Name, "-n", oauthServerNamespace).Output()
+		if err != nil {
+			e2e.Logf("get logs from %s in %s: %w", pod.Name, oauthServerNamespace, err)
+		}
+		e2e.Logf("log from %s in %s: %s", pod.Name, oauthServerNamespace, logs)
 	}
 }
 


### PR DESCRIPTION
## What

- Reuse util solution, rather than custom logic
- Add more information to state-of-the-cluster during test run and especially on failure

## Why

We are trying to identify the reason for the flakiness of the request headers idp test suite.

## Ref

https://github.com/openshift/origin/pull/27194
