### PR TITLE
Bug 2093992: Bump timeout for cvo ugprade check to 10 minutes for Baremetal jobs

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -392,7 +392,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			switch infra.Status.PlatformStatus.Type {
 			// Timeout was previously 2min, bumped for metal/openstack while work underway on https://bugzilla.redhat.com/show_bug.cgi?id=2071998
 			case configv1.BareMetalPlatformType:
-				cvoAckTimeout = 4 * time.Minute
+				cvoAckTimeout = 10 * time.Minute
 			case configv1.OpenStackPlatformType:
 				cvoAckTimeout = 4 * time.Minute
 			default:


### PR DESCRIPTION
In the baremetal environment, especially on ipv6 configuration, it
often happens that the current 4 minutes timeout is not enough to
let the cvo verify the upgrade.
Bumping the timeout value to a ridiculous 10 minutes to try and
improve the situation.