### PR TITLE
Poll disruption backends every 5s instead of 1s.

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -406,7 +406,7 @@ func (b *BackendSampler) RunEndpointMonitoring(ctx context.Context, monitorRecor
 		eventRecorder = fakeEventRecorder
 	}
 
-	interval := 1 * time.Second
+	interval := 5 * time.Second
 	disruptionSampler := newDisruptionSampler(b)
 	go disruptionSampler.produceSamples(producerContext, interval)
 	go disruptionSampler.consumeSamples(consumerContext, interval, monitorRecorder, eventRecorder)


### PR DESCRIPTION
Possibly just a temporary change, but we're attempting to determine if
we're overloading DNS on the build clusters.

5x is chosen because we want to see a dramatic impact if there will be
one. This implies we'll miss more single second disruptions, but if we
find one we'll register 5s as much. Data will be less accurate but
perhaps more sustainable to investigate.
