### PR TITLE
Bug 2086519: authorization: add a test checking that the restricted-v2 SCC mutates securityContext to match restricted PSa

### DIFF
--- a/test/extended/authorization/podsecurity_admission.go
+++ b/test/extended/authorization/podsecurity_admission.go
@@ -1,0 +1,39 @@
+package authorization
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/pod-security-admission/api"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-auth][Feature:PodSecurity]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithPodSecurityLevel("pod-security", api.LevelRestricted)
+	g.It("restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile", func() {
+		pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(context.Background(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "psa-testpod",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "sleeper",
+						Image:   "fedora:latest",
+						Command: []string{"sleep"},
+						Args:    []string{"infinity"},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())                                                     // the pod passed admission
+		o.Expect(pod.Annotations[securityv1.ValidatedSCCAnnotation]).To(o.Equal("restricted-v2")) // and the mutating SCC is restricted-v2
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1079,6 +1079,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization][Serial] authorization  TestAuthorizationResourceAccessReview should succeed": "should succeed [Suite:openshift/conformance/serial]",
 
+	"[Top Level] [sig-auth][Feature:PodSecurity] restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile": "restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestInvalidRoleRefs should succeed": "should succeed [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectIsNamespace should succeed": "should succeed [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This is a test to check that our SCC system by default mutates container and pod security context so that they can run with the restricted security profile

/assign @deads2k 