### PR TITLE
Bug 2097297: Show DNS lookup sampler problems on the disruption intervals chart.

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -147,7 +147,7 @@
     }
 
     function isEndpointConnectivity(eventInterval) {
-        if (!eventInterval.message.includes("stopped responding to GET requests")){
+        if (!eventInterval.message.includes("reason/DisruptionBegan") && !eventInterval.message.includes("reason/DisruptionSamplerOutageBegan")){
             return false
         }
         if (eventInterval.locator.includes("disruption/")) {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52743,7 +52743,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function isEndpointConnectivity(eventInterval) {
-        if (!eventInterval.message.includes("stopped responding to GET requests")){
+        if (!eventInterval.message.includes("reason/DisruptionBegan") && !eventInterval.message.includes("reason/DisruptionSamplerOutageBegan")){
             return false
         }
         if (eventInterval.locator.includes("disruption/")) {


### PR DESCRIPTION
In #27238 we began treating DNS lookup errors as disruption warnings not
errors, as they indicate a problem in the CI cluster not the cluster
under test.

I confirmed warnings would show in the graph, but did not realize this
was based on the message. When the message later was changed for these
warnings, they no longer appeared.

Update the message logic to use a slightly safer "reason" my original PR
added, and include the new reason.
