### PR TITLE
Bug 2099611: Increase etcd-operator watch channels upperbound for BareMetal Platform

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -212,7 +212,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"console-operator":                       166.0,
 				"csi-snapshot-controller-operator":       82.0,
 				"dns-operator":                           69.0,
-				"etcd-operator":                          203.0,
+				"etcd-operator":                          220.0,
 				"ingress-operator":                       440.0,
 				"kube-apiserver-operator":                315.0,
 				"kube-controller-manager-operator":       220.0,


### PR DESCRIPTION
Small increase in the upperbound limit of watch channels for etcd-operator
to avoid frequent failures in ipv6 jobs.

We usually see jobs fail for a small amount of watch channels, for example:
watchrequestcount=431, upperbound=406