### PR TITLE
BUG 2067323: test/extended/router: Drop host lookup for gRPC HTTP/2 h2spec tests

### DIFF
--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -142,23 +142,6 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 				routev1.TLSTerminationReencrypt,
 				routev1.TLSTerminationPassthrough,
 			} {
-				var addrs []string
-
-				if len(shardService.Status.LoadBalancer.Ingress[0].Hostname) > 0 {
-					g.By("Waiting for LB hostname to register in DNS")
-					addrs, err = resolveHost(oc, time.Minute, 15*time.Minute, shardService.Status.LoadBalancer.Ingress[0].Hostname)
-					o.Expect(err).NotTo(o.HaveOccurred())
-					o.Expect(addrs).NotTo(o.BeEmpty())
-				} else {
-					addrs = append(addrs, shardService.Status.LoadBalancer.Ingress[0].IP)
-				}
-
-				g.By("Waiting for route hostname to register in DNS")
-				host := fmt.Sprintf("grpc-interop-%s.%s", routeType, shardFQDN)
-				addrs, err = resolveHostAsAddress(oc, time.Minute, 15*time.Minute, host, addrs[0])
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(addrs).NotTo(o.BeEmpty())
-
 				err := grpcExecTestCases(oc, routeType, 5*time.Minute, testCases...)
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -140,22 +140,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			o.Expect(shardService).NotTo(o.BeNil())
 			o.Expect(shardService.Status.LoadBalancer.Ingress).ShouldNot(o.BeEmpty())
 
-			var addrs []string
-
-			if len(shardService.Status.LoadBalancer.Ingress[0].Hostname) > 0 {
-				g.By("Waiting for LB hostname to register in DNS")
-				addrs, err = resolveHost(oc, time.Minute, 15*time.Minute, shardService.Status.LoadBalancer.Ingress[0].Hostname)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(addrs).NotTo(o.BeEmpty())
-			} else {
-				addrs = append(addrs, shardService.Status.LoadBalancer.Ingress[0].IP)
-			}
-
-			g.By("Waiting for route hostname to register in DNS")
 			host := "h2spec-passthrough." + shardFQDN
-			addrs, err = resolveHostAsAddress(oc, time.Minute, 15*time.Minute, host, addrs[0])
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(addrs).NotTo(o.BeEmpty())
 
 			// ROUTER_H2SPEC_SAMPLE when set runs the
 			// conformance tests for N iterations to

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -228,22 +228,6 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			o.Expect(shardService).NotTo(o.BeNil())
 			o.Expect(shardService.Status.LoadBalancer.Ingress).To(o.Not(o.BeEmpty()))
 
-			var addrs []string
-
-			if len(shardService.Status.LoadBalancer.Ingress[0].Hostname) > 0 {
-				g.By("Waiting for LB hostname to register in DNS")
-				addrs, err = resolveHost(oc, time.Minute, 15*time.Minute, shardService.Status.LoadBalancer.Ingress[0].Hostname)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(addrs).NotTo(o.BeEmpty())
-			} else {
-				addrs = append(addrs, shardService.Status.LoadBalancer.Ingress[0].IP)
-			}
-
-			g.By("Waiting for route hostname to register in DNS")
-			addrs, err = resolveHostAsAddress(oc, time.Minute, 15*time.Minute, testCases[0].route+"."+shardFQDN, addrs[0])
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(addrs).NotTo(o.BeEmpty())
-
 			for i, tc := range testCases {
 				testConfig := fmt.Sprintf("%+v", tc)
 				var resp *http.Response
@@ -352,32 +336,6 @@ func resolveHost(oc *exutil.CLI, interval, timeout time.Duration, host string) (
 		}
 		result = addrs
 		return true, nil
-	}); err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
-func resolveHostAsAddress(oc *exutil.CLI, interval, timeout time.Duration, host, expectedAddr string) ([]string, error) {
-	var result []string
-
-	if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		addrs, err := net.LookupHost(host)
-		if err != nil {
-			e2e.Logf("error: %v, retrying in %s...", err, interval.String())
-			return false, nil
-		}
-
-		for i := range addrs {
-			if addrs[i] == expectedAddr {
-				e2e.Logf("host %q now resolves as %+v", host, addrs)
-				result = addrs
-				return true, nil
-			}
-		}
-		e2e.Logf("host %q resolves as %+v, expecting %v, retrying in %s...", host, addrs, expectedAddr, interval.String())
-		return false, nil
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Each of the tests go on to call Dial() or http.Get() and retry on
failure. By removing host lookup we also remove the association that
there's only 1 IP address returned--and that was failing for
Azure/UPI. For example:

Apr 18 20:21:37.899: INFO: host
   "http2-custom-cert-edge.e2e-test-router-http2-25wkr.apps.ci-op-00l27v7z-c3806.ci.azure.devcluster.openshift.com"
 resolves as
   [52.234.42.30]
 expecting 13.64.142.91, retrying in 1m0s...
