### PR TITLE
WIP: try to get resourceMaps later in upgrade

### DIFF
--- a/pkg/monitor/monitor_cmd/command.go
+++ b/pkg/monitor/monitor_cmd/command.go
@@ -211,7 +211,7 @@ func (o *Timeline) Run() error {
 
 	recordedResources := monitorapi.ResourcesMap{}
 	if len(o.PodResourceFilename) > 0 {
-		recordedResources, err = loadKnownPods(o.PodResourceFilename)
+		recordedResources, err = LoadKnownPods(o.PodResourceFilename)
 		if err != nil {
 			return err
 		}
@@ -279,7 +279,7 @@ func renderHTML(events monitorapi.Intervals) ([]byte, error) {
 	return e2eChartHTML, nil
 }
 
-func loadKnownPods(filename string) (monitorapi.ResourcesMap, error) {
+func LoadKnownPods(filename string) (monitorapi.ResourcesMap, error) {
 
 	zipReader, err := zip.OpenReader(filename)
 	if err != nil {

--- a/pkg/monitor/write_job_run_data.go
+++ b/pkg/monitor/write_job_run_data.go
@@ -33,6 +33,22 @@ func WriteTrackedResourcesForJobRun(artifactDir string, monitor *Monitor, events
 	return utilerrors.NewAggregate(errors)
 }
 
+// Just like WriteTrackedResourcesForJobRun but to write state for use in another test.
+func WriteTrackedResourcesForJobRunState(artifactDir string, monitor *Monitor, timeSuffix string) error {
+	errors := []error{}
+
+	// write out the current state of resources that we explicitly tracked.
+	resourcesMap := monitor.CurrentResourceState()
+	for resourceType, instanceMap := range resourcesMap {
+		targetFile := fmt.Sprintf("resource-tmp-%s%s.zip", resourceType, timeSuffix)
+		if err := monitorserialization.InstanceMapToFile(filepath.Join(artifactDir, targetFile), resourceType, instanceMap); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
+}
+
 func WriteBackendDisruptionForJobRun(artifactDir string, monitor *Monitor, events monitorapi.Intervals, timeSuffix string) error {
 	backendDisruption := computeDisruptionData(events)
 	return writeDisruptionData(filepath.Join(artifactDir, fmt.Sprintf("backend-disruption%s.json", timeSuffix)), backendDisruption)

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -375,6 +375,14 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 	q.Execute(testCtx, late, parallelism, status.Run)
 	tests = append(tests, late...)
 
+	timeSuffix := fmt.Sprintf("_%s", start.UTC().Format("20060102-150405"))
+	if len(opt.JUnitDir) > 0 {
+		if err := monitor.WriteTrackedResourcesForJobRunState(opt.JUnitDir, m, timeSuffix); err != nil {
+			fmt.Fprintf(opt.ErrOut, "error: Failed to write current resource state: %v\n", err)
+		} else {
+			fmt.Printf("DP-DEBUG: wrote resource state to %s\n", opt.JUnitDir)
+		}
+	}
 	// TODO: will move to the monitor
 	if len(opt.JUnitDir) > 0 {
 		pc.ComputePodTransitions()
@@ -406,7 +414,6 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 	// monitor the cluster while the tests are running and report any detected anomalies
 	var syntheticTestResults []*junitapi.JUnitTestCase
 	var syntheticFailure bool
-	timeSuffix := fmt.Sprintf("_%s", start.UTC().Format("20060102-150405"))
 	events := m.Intervals(time.Time{}, time.Time{})
 
 	if len(opt.JUnitDir) > 0 {

--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -58,13 +58,15 @@ func loadResourcesMaps(junitDir string) []monitorapi.ResourcesMap {
 	}
 	ret := make([]monitorapi.ResourcesMap, 0)
 	for _, file := range files {
-		if strings.HasPrefix(file.Name(), "resource-pods") {
+		if strings.HasPrefix(file.Name(), "resource-tmp-pods") {
 			resMap, err := monitor_cmd.LoadKnownPods(file.Name())
 			if err != nil {
 				framework.Logf("Unable to read %s", file.Name())
 				continue
 			}
 			ret = append(ret, resMap)
+		} else {
+			framework.Logf("Found file but skipped: %s", file.Name())
 		}
 	}
 	return ret

--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -47,28 +47,28 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 
 func loadResourcesMaps(junitDir string) []monitorapi.ResourcesMap {
 	if len(junitDir) == 0 {
-		framework.Logf("TEST_JUNIT_DIR is not set")
+		framework.Logf("DP-DEBUG: TEST_JUNIT_DIR is not set")
 		return nil
 	}
-	framework.Logf("TEST_JUNIT_DIR is set to: %s", junitDir)
+	framework.Logf("DP-DEBUG: TEST_JUNIT_DIR is set to: %s", junitDir)
 	files, err := ioutil.ReadDir(junitDir)
 	if err != nil {
-		framework.Logf("Unable to read %s", junitDir)
+		framework.Logf("DP-DEBUG: Unable to read %s", junitDir)
 		return nil
 	}
 	ret := make([]monitorapi.ResourcesMap, 0)
 
-	framework.Logf("Length of files: %d", len(files))
+	framework.Logf("DP-DEBUG: Length of files: %d", len(files))
 	for _, file := range files {
 		if strings.HasPrefix(file.Name(), "resource-tmp-pods") {
 			resMap, err := monitor_cmd.LoadKnownPods(file.Name())
 			if err != nil {
-				framework.Logf("Unable to read %s", file.Name())
+				framework.Logf("DP-DEBUG: Unable to read %s", file.Name())
 				continue
 			}
 			ret = append(ret, resMap)
 		} else {
-			framework.Logf("Found file but skipped: %s", file.Name())
+			framework.Logf("DP-DEBUG: Found file but skipped: %s", file.Name())
 		}
 	}
 	return ret
@@ -246,7 +246,7 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 				lenWait <- len(resourcesMaps)
 				break
 			}
-			fmt.Printf("%s: No resourceMaps yet, sleeping ...\n", time.Now().String())
+			fmt.Printf("%s: DP-DEBUG: No resourceMaps yet, sleeping ...\n", time.Now().String())
 			time.Sleep(2 * time.Minute)
 		}
 	}()


### PR DESCRIPTION
I believe pod resource maps are saved by this time when we look at alerts.  Let's prove or disprove it.