### PR TITLE
Bug 2098053: Re-revert "Add networking test for invalid external gateway"

### DIFF
--- a/test/extended/networking/external_gateway.go
+++ b/test/extended/networking/external_gateway.go
@@ -5,10 +5,11 @@ import (
 	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = g.Describe("[sig-network] external gateway address", func() {
-	oc := exutil.NewCLI("ns-global")
+	oc := exutil.NewCLIWithPodSecurityLevel("ns-global", admissionapi.LevelPrivileged)
 
 	InOVNKubernetesContext(func() {
 		f := oc.KubeFramework()

--- a/test/extended/networking/external_gateway.go
+++ b/test/extended/networking/external_gateway.go
@@ -1,0 +1,62 @@
+package networking
+
+import (
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-network] external gateway address", func() {
+	oc := exutil.NewCLI("ns-global")
+
+	InOVNKubernetesContext(func() {
+		f := oc.KubeFramework()
+
+		g.It("should match the address family of the pod", func() {
+			podIPFamily := getIPFamilyForCluster(f)
+			o.Expect(podIPFamily).NotTo(o.Equal(Unknown))
+			// Set external gateway address into an IPv6 address and make sure
+			// pod ip address matches with IPv6 address family.
+			setNamespaceExternalGateway(f, "fd00:10:244:2::6")
+			podIPs, err := createPod(f.ClientSet, f.Namespace.Name, "test-ipv6-pod")
+			e2e.Logf("pod IPs are %v after setting external gw with IPv6 address", podIPs)
+			switch podIPFamily {
+			case DualStack:
+				expectNoError(err)
+				o.Expect(getIPFamily(podIPs)).To(o.Equal(DualStack))
+			case IPv4:
+				// This is an expected failure when pod network in IPv4 address family
+				// whereas external gateway is set with IPv6 address
+				expectError(err)
+			case IPv6:
+				expectNoError(err)
+				o.Expect(getIPFamily(podIPs)).To(o.Equal(IPv6))
+			}
+			// Set external gateway address into an IPv4 address and make sure
+			// pod ip address matches with IPv4 address family.
+			setNamespaceExternalGateway(f, "10.10.10.1")
+			podIPs, err = createPod(f.ClientSet, f.Namespace.Name, "test-ipv4-pod")
+			e2e.Logf("pod IPs are %v after setting external gw with IPv4 address", podIPs)
+			switch podIPFamily {
+			case DualStack:
+				expectNoError(err)
+				o.Expect(getIPFamily(podIPs)).To(o.Equal(DualStack))
+			case IPv4:
+				expectNoError(err)
+				o.Expect(getIPFamily(podIPs)).To(o.Equal(IPv4))
+			case IPv6:
+				// This is an expected failure when pod network in IPv6 address family
+				// whereas external gateway is set with IPv4 address
+				expectError(err)
+			}
+			// Set external gateway address supporting Dual Stack and make sure
+			// pod ip address(es) match with desired address family.
+			setNamespaceExternalGateway(f, "10.10.10.1,fd00:10:244:2::6")
+			podIPs, err = createPod(f.ClientSet, f.Namespace.Name, "test-dual-stack-pod")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			e2e.Logf("pod IPs are %v after setting external gw with Dual Stack address", podIPs)
+			o.Expect(getIPFamily(podIPs)).To(o.Equal(podIPFamily))
+		})
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2719,6 +2719,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] [Feature:Topology Hints] should distribute endpoints evenly": "should distribute endpoints evenly [Disabled:SpecialConfig] [Suite:k8s]",
 
+	"[Top Level] [sig-network] external gateway address when using openshift ovn-kubernetes should match the address family of the pod": "should match the address family of the pod [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network] multicast when using one of the OpenshiftSDN modes 'redhat/openshift-ovs-multitenant, redhat/openshift-ovs-networkpolicy' should allow multicast traffic in namespaces where it is enabled": "should allow multicast traffic in namespaces where it is enabled [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network] multicast when using one of the OpenshiftSDN modes 'redhat/openshift-ovs-multitenant, redhat/openshift-ovs-networkpolicy' should block multicast traffic in namespaces where it is disabled": "should block multicast traffic in namespaces where it is disabled [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Re-revert of https://github.com/openshift/origin/pull/26985 and fix the test for pod security level, ipv6 or dual stack clusters.

Signed-off-by: Periyasamy Palanisamy [pepalani@redhat.com](mailto:pepalani@redhat.com)