### PR TITLE
Bypass tests failing due to metal image rebuild on RHEL9

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -435,8 +435,10 @@ func getCrdTypes(oc *exutil.CLI) []schema.GroupVersionResource {
 		switch capability {
 		case configv1.ClusterVersionCapabilityMarketplace:
 			crdTypes = append(crdTypes, marketplaceTypes...)
-		case configv1.ClusterVersionCapabilityBaremetal:
-			crdTypes = append(crdTypes, metal3Types...)
+			// FIXME(stbenjam): Baremetal disabled in 4.12 while they rebuild
+			// Ironic images for RHEL 9.
+			// case configv1.ClusterVersionCapabilityBaremetal:
+			// crdTypes = append(crdTypes, metal3Types...)
 		}
 	}
 

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -143,6 +143,9 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 
 		g.By("all cluster operators report an operator version in the first position equal to the cluster version")
 		for _, co := range coList.Items {
+			if co.Name == "baremetal" {
+				continue // Metal images are being rebuilt on RHEL9.
+			}
 			msg := fmt.Sprintf("unexpected operator status versions %s:\n%#v", co.Name, co.Status.Versions)
 			o.Expect(co.Status.Versions).NotTo(o.BeEmpty(), msg)
 			operator := findOperatorVersion(co.Status.Versions, "operator")


### PR DESCRIPTION
[TRT-371](https://issues.redhat.com//browse/TRT-371)

Several tests are failing because the metal images are being rebuilt on RHEL9. As soon as this merges, I'll open a revert so we don't forget to turn these back on.


`Managed cluster should have operators on the cluster version` fails since we have CBO from 4.11.

`oc explain should contain proper spec+status for CRDs` is failing on
4.12 jobs with errors like this:

```
{  fail [github.com/openshift/origin/test/extended/cli/explain.go:518]: Unexpected error:
    <*errors.errorString | 0xc00201ef30>: {
        s: "exit status 1: the server doesn't have a resource type \"provisionings\"",
    }
    exit status 1: the server doesn't have a resource type "provisionings"
occurred
Ginkgo exit error 1: exit with code 1}
```

This is because ART is not presently building any Ironic images, while
they work on getting RHEL 9 versions.