### PR TITLE
WIP: Make chart with just image-registry,console,oauth

### DIFF
--- a/pkg/monitor/intervalcreation/rendering_per_namespace.go
+++ b/pkg/monitor/intervalcreation/rendering_per_namespace.go
@@ -40,6 +40,13 @@ func wellKnownNamespaceGroups() []relatedNamespaces {
 			),
 		},
 		{
+			// image-registry, console, oauth seem to break together so group them to help debugging
+			name: "openshift-ir-con-oauth",
+			namespaces: sets.NewString(
+				"openshift-authentication", "openshift-console", "openshift-image-registry", "openshift-ingress",
+			),
+		},
+		{
 			name: "openshift-machines",
 			namespaces: sets.NewString(
 				"openshift-cloud-controller-manager-operator", "openshift-cloud-controller-manager",


### PR DESCRIPTION
My goal: make it so that we can have a single chart with all these items in it (that tend to have disruption problems together) -- specifically, image-registry, console, oauth, router-default pods.

If this goes well, I will try to add in disruption events and node events so I don't have to make the charts manually.