### PR TITLE
Revert "Bypass tests failing due to metal image rebuild on RHEL9"

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -435,10 +435,8 @@ func getCrdTypes(oc *exutil.CLI) []schema.GroupVersionResource {
 		switch capability {
 		case configv1.ClusterVersionCapabilityMarketplace:
 			crdTypes = append(crdTypes, marketplaceTypes...)
-			// FIXME(stbenjam): Baremetal disabled in 4.12 while they rebuild
-			// Ironic images for RHEL 9.
-			// case configv1.ClusterVersionCapabilityBaremetal:
-			// crdTypes = append(crdTypes, metal3Types...)
+		case configv1.ClusterVersionCapabilityBaremetal:
+			crdTypes = append(crdTypes, metal3Types...)
 		}
 	}
 

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -143,9 +143,6 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 
 		g.By("all cluster operators report an operator version in the first position equal to the cluster version")
 		for _, co := range coList.Items {
-			if co.Name == "baremetal" {
-				continue // Metal images are being rebuilt on RHEL9.
-			}
 			msg := fmt.Sprintf("unexpected operator status versions %s:\n%#v", co.Name, co.Status.Versions)
 			o.Expect(co.Status.Versions).NotTo(o.BeEmpty(), msg)
 			operator := findOperatorVersion(co.Status.Versions, "operator")


### PR DESCRIPTION
Reverts openshift/origin#27283, to be merged once metal images are being built again for 4.12.

/hold