### PR TITLE
WIP: Add tests for the EgressIP on OpenStack

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -107,6 +107,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 			configv1.AWSPlatformType,
 			configv1.GCPPlatformType,
 			configv1.AzurePlatformType,
+			configv1.OpenStackPlatformType,
 		}
 		for _, supportedPlatform := range supportedPlatforms {
 			if cloudType == supportedPlatform {

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1042,6 +1042,18 @@ func getFirstFreeIPs(ipnetStr string, reservedIPs []string, cloudType configv1.P
 			return []string{}, fmt.Errorf("Cloud type is GCP, but there are less than 3 IPs available in the IP network %s", ipnetStr)
 		}
 		ipList = ipList[2 : len(ipList)-1]
+	case configv1.OpenStackPlatformType:
+		// OpenStack network's should have plenty of addresses available. Assume that the network is large
+		// and has plenty of space for IP address allocations.
+		if len(ipList) < 128 {
+			return []string{}, fmt.Errorf("Cloud type is OpenStack, but there are less than 128 IPs available in the IP network %s", ipnetStr)
+		}
+		// For OpenStack, use the upper half of the machine network as a heuristic. This
+		// should help us avoid any important IP addresses such as the API address.
+		// The allocations should be here, but let's play it safe nevertheless.
+		// https://github.com/openshift/installer/blob/1884f8bda4ffbde7bc808900400aa62a7806fa21/pkg/types/openstack/defaults/platform.go#L30
+		// https://github.com/openshift/installer/blob/1884f8bda4ffbde7bc808900400aa62a7806fa21/pkg/types/openstack/defaults/platform.go#L40
+		ipList = ipList[len(ipList)/2+1 : len(ipList)-1]
 	default:
 		// Skip the network address and the broadcast address
 		ipList = ipList[1 : len(ipList)-1]


### PR DESCRIPTION
Now that we support EgressIP on OpenStack, enable tests for that
platform.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>