### PR TITLE
coreos/kdump: Add kdump e2e test using mco

### DIFF
--- a/test/extended/coreos/common.go
+++ b/test/extended/coreos/common.go
@@ -1,0 +1,73 @@
+package coreos
+
+import (
+	"context"
+	"os/exec"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+
+	"github.com/openshift/origin/test/e2e/upgrade"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	o "github.com/onsi/gomega"
+)
+
+func runCommandAndRetry(command string) string {
+	const (
+		maxRetries = 10
+		pause      = 10
+	)
+	var (
+		retryCount = 0
+		out        []byte
+		err        error
+	)
+	for retryCount = 0; retryCount <= maxRetries; retryCount++ {
+		out, err = exec.Command("bash", "-c", command).CombinedOutput()
+		e2elog.Logf("output:\n%s", out)
+		if err == nil {
+			break
+		}
+		e2elog.Logf("%v", err)
+		time.Sleep(time.Second * pause)
+	}
+	o.Expect(retryCount).NotTo(o.Equal(maxRetries + 1))
+	return string(out)
+}
+
+func clusterNodes(oc *exutil.CLI) (masters, workers []*corev1.Node) {
+	nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok {
+			masters = append(masters, node)
+		} else {
+			workers = append(workers, node)
+		}
+	}
+	return
+}
+
+func waitForInfraToUpdate(oc *exutil.CLI, mcps dynamic.NamespaceableResourceInterface) {
+	e2elog.Logf("Waiting for updates to be finished on infra pool")
+	err := wait.Poll(30*time.Second, 15*time.Minute, func() (done bool, err error) {
+		done, _ = upgrade.IsPoolUpdated(mcps, "infra")
+		return done, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func waitForWorkerToUpdate(oc *exutil.CLI, mcps dynamic.NamespaceableResourceInterface) {
+	e2elog.Logf("Waiting for updates to be finished on worker pool")
+	err := wait.Poll(30*time.Second, 15*time.Minute, func() (done bool, err error) {
+		done, _ = upgrade.IsPoolUpdated(mcps, "worker")
+		return done, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}

--- a/test/extended/coreos/kdump.go
+++ b/test/extended/coreos/kdump.go
@@ -1,0 +1,107 @@
+package coreos
+
+import (
+	"math/rand"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = g.Describe("[sig-coreos] [Feature:machine-config-operator] [Conformance] [Slow] [Disruptive] kdump", func() {
+	defer g.GinkgoRecover()
+	var (
+		infraMCPYaml         = exutil.FixturePath("testdata", "coreos", "infra.mcp.yaml")
+		infraKdumpConfigYaml = exutil.FixturePath("testdata", "coreos", "99-infra-kdump-configuration.yaml")
+	)
+
+	oc := exutil.NewCLIWithPodSecurityLevel("kdump-enablement", admissionapi.LevelPrivileged)
+	g.It("TestKdump", func() {
+		_, workers := clusterNodes(oc)
+		workerNode := workers[rand.Intn(len(workers))]
+
+		config, err := framework.LoadConfig()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		dynamicClient := dynamic.NewForConfigOrDie(config)
+
+		mcps := dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "machineconfiguration.openshift.io",
+			Version:  "v1",
+			Resource: "machineconfigpools",
+		})
+
+		err = kdumpSetup(oc, workerNode, mcps, infraMCPYaml, infraKdumpConfigYaml)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = kernelCrash(oc, workerNode, mcps)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = cleanup(oc, workerNode, mcps, infraMCPYaml, infraKdumpConfigYaml)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})
+
+func kdumpSetup(oc *exutil.CLI, node *corev1.Node, mcps dynamic.NamespaceableResourceInterface, infraMCPYaml string, infraKdumpConfigYaml string) error {
+	// Label a worker node to infra and create infra pool to roll out MC changes
+	err := oc.AsAdmin().Run("label").Args("node/"+node.Name, "node-role.kubernetes.io/infra=").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	err = oc.AsAdmin().Run("create").Args("-f", infraMCPYaml).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Apply MC to enable kdump.service and reserve memory for kdump
+	err = oc.AsAdmin().Run("create").Args("-f", infraKdumpConfigYaml).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	waitForInfraToUpdate(oc, mcps)
+	framework.Logf("infra.mcp and 99-infra-kdump-configuration config rendered")
+
+	kargs, err := oc.AsAdmin().Run("debug").Args("node/"+node.Name, "--", "chroot", "/host", "/bin/bash", "-c", "cat /proc/cmdline").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(kargs).Should(o.ContainSubstring("crashkernel=256M"))
+	framework.Logf("The infra node has crashkernel kargs")
+
+	activeKdump, err := oc.AsAdmin().Run("debug").Args("node/"+node.Name, "--", "chroot", "/host", "/bin/bash", "-c", "systemctl is-active kdump").Output()
+	o.Expect(activeKdump).ShouldNot(o.ContainSubstring("inactive"))
+	o.Expect(err).NotTo(o.HaveOccurred())
+	framework.Logf("kdump.service is active")
+
+	return nil
+}
+
+func kernelCrash(oc *exutil.CLI, node *corev1.Node, mcps dynamic.NamespaceableResourceInterface) error {
+	// Triggering crash
+	framework.Logf("Triggering kernel crash")
+	err := oc.AsAdmin().Run("debug").Args("node/"+node.Name, "--", "chroot", "/host", "/bin/bash", "-c", string("echo 1 > /proc/sys/kernel/sysrq")).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	err = oc.AsAdmin().Run("debug").Args("node/"+node.Name, "--", "chroot", "/host", "/bin/bash", "-c", string("(sleep 2; echo c > /proc/sysrq-trigger)")).Execute()
+	waitForInfraToUpdate(oc, mcps)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Test the existence of vmcore file in /var/crash/
+	kcore, err := oc.AsAdmin().Run("debug").Args("node/"+node.Name, "--", "chroot", "/host", "/bin/bash", "-c", "find /var/crash -type f -name vmcore").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(kcore).Should(o.ContainSubstring("/vmcore"))
+	framework.Logf("kcore found in /var/crash")
+
+	return nil
+}
+
+func cleanup(oc *exutil.CLI, node *corev1.Node, mcps dynamic.NamespaceableResourceInterface, infraMCPYaml string, infraKdumpConfigYaml string) error {
+	// Remove the infra label from the node
+	err := oc.AsAdmin().Run("label").Args("node/"+node.Name, "node-role.kubernetes.io/infra-").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	waitForWorkerToUpdate(oc, mcps)
+
+	// Delete the respective mc and mcp
+	err = oc.AsAdmin().Run("delete").Args("mc", "99-infra-kdump-configuration").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	err = oc.AsAdmin().Run("delete").Args("mcp", "infra").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return nil
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -290,6 +290,8 @@
 // test/extended/testdata/cmd/test/cmd/triggers.sh
 // test/extended/testdata/cmd/test/cmd/volumes.sh
 // test/extended/testdata/cmd/test/cmd/whoami.sh
+// test/extended/testdata/coreos/99-infra-kdump-configuration.yaml
+// test/extended/testdata/coreos/infra.mcp.yaml
 // test/extended/testdata/custom-secret-builder/Dockerfile
 // test/extended/testdata/custom-secret-builder/build.sh
 // test/extended/testdata/deployments/custom-deployment.yaml
@@ -40624,6 +40626,67 @@ func testExtendedTestdataCmdTestCmdWhoamiSh() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataCoreos99InfraKdumpConfigurationYaml = []byte(`apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: infra
+  name: 99-infra-kdump-configuration
+spec:
+  kernelArguments:
+    - 'crashkernel=256M'
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - enabled: true
+          name: kdump.service
+`)
+
+func testExtendedTestdataCoreos99InfraKdumpConfigurationYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataCoreos99InfraKdumpConfigurationYaml, nil
+}
+
+func testExtendedTestdataCoreos99InfraKdumpConfigurationYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataCoreos99InfraKdumpConfigurationYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/coreos/99-infra-kdump-configuration.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataCoreosInfraMcpYaml = []byte(`apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: infra
+spec:
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ""
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,infra]}
+`)
+
+func testExtendedTestdataCoreosInfraMcpYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataCoreosInfraMcpYaml, nil
+}
+
+func testExtendedTestdataCoreosInfraMcpYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataCoreosInfraMcpYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/coreos/infra.mcp.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataCustomSecretBuilderDockerfile = []byte(`FROM openshift/origin-custom-docker-builder
 # Override the default build script
 ADD build.sh /tmp/build.sh
@@ -53246,6 +53309,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/cmd/test/cmd/triggers.sh":                                                        testExtendedTestdataCmdTestCmdTriggersSh,
 	"test/extended/testdata/cmd/test/cmd/volumes.sh":                                                         testExtendedTestdataCmdTestCmdVolumesSh,
 	"test/extended/testdata/cmd/test/cmd/whoami.sh":                                                          testExtendedTestdataCmdTestCmdWhoamiSh,
+	"test/extended/testdata/coreos/99-infra-kdump-configuration.yaml":                                        testExtendedTestdataCoreos99InfraKdumpConfigurationYaml,
+	"test/extended/testdata/coreos/infra.mcp.yaml":                                                           testExtendedTestdataCoreosInfraMcpYaml,
 	"test/extended/testdata/custom-secret-builder/Dockerfile":                                                testExtendedTestdataCustomSecretBuilderDockerfile,
 	"test/extended/testdata/custom-secret-builder/build.sh":                                                  testExtendedTestdataCustomSecretBuilderBuildSh,
 	"test/extended/testdata/deployments/custom-deployment.yaml":                                              testExtendedTestdataDeploymentsCustomDeploymentYaml,
@@ -53916,6 +53981,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 							"whoami.sh":   {testExtendedTestdataCmdTestCmdWhoamiSh, map[string]*bintree{}},
 						}},
 					}},
+				}},
+				"coreos": {nil, map[string]*bintree{
+					"99-infra-kdump-configuration.yaml": {testExtendedTestdataCoreos99InfraKdumpConfigurationYaml, map[string]*bintree{}},
+					"infra.mcp.yaml":                    {testExtendedTestdataCoreosInfraMcpYaml, map[string]*bintree{}},
 				}},
 				"custom-secret-builder": {nil, map[string]*bintree{
 					"Dockerfile": {testExtendedTestdataCustomSecretBuilderDockerfile, map[string]*bintree{}},

--- a/test/extended/testdata/coreos/99-infra-kdump-configuration.yaml
+++ b/test/extended/testdata/coreos/99-infra-kdump-configuration.yaml
@@ -1,0 +1,16 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: infra
+  name: 99-infra-kdump-configuration
+spec:
+  kernelArguments:
+    - 'crashkernel=256M'
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - enabled: true
+          name: kdump.service

--- a/test/extended/testdata/coreos/infra.mcp.yaml
+++ b/test/extended/testdata/coreos/infra.mcp.yaml
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: infra
+spec:
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/infra: ""
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,infra]}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1573,6 +1573,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-coreos] [Conformance] CoreOS bootimages TestBootimagesPresent": "TestBootimagesPresent [Suite:openshift/conformance/parallel/minimal]",
 
+	"[Top Level] [sig-coreos] [Feature:machine-config-operator] [Conformance] [Slow] [Disruptive] kdump TestKdump": "TestKdump [Serial]",
+
 	"[Top Level] [sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations": "run sample related validations [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should print the usage",


### PR DESCRIPTION
Add e2e test for OCP CI that validates enabling kdump and generating kernel core via machine config successfully. This is one of the steps to to enhance the kdump feature.