### PR TITLE
Bug 2104641: Add tests for CloudPrivateIPConfig to the EgressIP tests

### DIFF
--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	cloudnetworkv1 "github.com/openshift/api/cloudnetwork/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	networkv1 "github.com/openshift/api/network/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -1665,6 +1666,25 @@ func cloudPrivateIpConfigExists(oc *exutil.CLI, cloudNetworkClientset cloudnetwo
 	}
 
 	return true, false, nil
+}
+
+// createCloudPrivateIPConfig creates an object of type CloudPrivateIPConfig with the given IP address.
+func createCloudPrivateIPConfig(cloudNetworkClientset cloudnetwork.Interface, ip, nodeName string) error {
+	cpic := cloudnetworkv1.CloudPrivateIPConfig{}
+	cpic.Name = ip
+	cpic.Spec.Node = nodeName
+	_, err := cloudNetworkClientset.CloudV1().CloudPrivateIPConfigs().Create(context.Background(), &cpic, metav1.CreateOptions{})
+	return err
+}
+
+// deleteCloudPrivateIPConfig deletes an object of type CloudPrivateIPConfig with the given IP address.
+func deleteCloudPrivateIPConfig(cloudNetworkClientset cloudnetwork.Interface, ip string) error {
+	return cloudNetworkClientset.CloudV1().CloudPrivateIPConfigs().Delete(context.Background(), ip, metav1.DeleteOptions{})
+}
+
+// listCloudPrivateIPConfigs lists objects of type CloudPrivateIPConfig.
+func listCloudPrivateIPConfigs(cloudNetworkClientset cloudnetwork.Interface) (*cloudnetworkv1.CloudPrivateIPConfigList, error) {
+	return cloudNetworkClientset.CloudV1().CloudPrivateIPConfigs().List(context.Background(), metav1.ListOptions{})
 }
 
 // egressIPStatusHasIP returns if a given ip was found in a given EgressIP object's status field.

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2769,6 +2769,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift-sdn should ensure egressnetworkpolicy is created": "should ensure egressnetworkpolicy is created [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network][Feature:EgressIP] [cloud-private-ip-config] CloudPrivateIPConfig objects can be created and deleted repeatedly": "CloudPrivateIPConfig objects can be created and deleted repeatedly [Serial] [Suite:openshift/conformance/serial]",
+
+	"[Top Level] [sig-network][Feature:EgressIP] [cloud-private-ip-config] Invalid CloudPrivateIPConfig objects are handled correctly": "Invalid CloudPrivateIPConfig objects are handled correctly [Serial] [Suite:openshift/conformance/serial]",
+
 	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes]": "EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes] [Serial] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN]": "only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",


### PR DESCRIPTION
How to test:
~~~
./openshift-tests run-test "[sig-network][Feature:EgressIP] [cloud-private-ip-config] Invalid CloudPrivateIPConfig objects are handled correctly [Serial] [Suite:openshift/conformance/serial]"
./openshift-tests run-test "[sig-network][Feature:EgressIP] [cloud-private-ip-config] CloudPrivateIPConfig objects can be created and deleted repeatedly [Serial] [Suite:openshift/conformance/serial]"
~~~

Tested:
AWS/OVNKubernetes