### PR TITLE
WIP: Revert "Bug 2101538: Remove etcd vertical scaling test."

### DIFF
--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -1,0 +1,96 @@
+package etcd
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
+	testlibraryapi "github.com/openshift/library-go/test/library/apiserver"
+	scalingtestinglibrary "github.com/openshift/origin/test/extended/etcd/helpers"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-etcd][Serial] etcd", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("etcd-scaling").AsAdmin()
+
+	cleanupPlatformSpecificConfiguration := func() { /*noop*/ }
+
+	g.BeforeEach(func() {
+		cleanupPlatformSpecificConfiguration = scalingtestinglibrary.InitPlatformSpecificConfiguration(oc)
+	})
+
+	g.AfterEach(func() {
+		cleanupPlatformSpecificConfiguration()
+	})
+
+	// The following test covers a basic vertical scaling scenario.
+	// It starts by adding a new master machine to the cluster
+	// next it validates the size of etcd cluster and makes sure the new member is healthy.
+	// The test ends by removing the newly added machine and validating the size of the cluster
+	// and asserting the member was removed from the etcd cluster by contacting MemberList API.
+	g.It("is able to vertically scale up and down with a single node [Timeout:60m]", func() {
+		// set up
+		ctx := context.TODO()
+		etcdClientFactory := scalingtestinglibrary.NewEtcdClientFactory(oc.KubeClient())
+		machineClientSet, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).ToNot(o.HaveOccurred())
+		machineClient := machineClientSet.MachineV1beta1().Machines("openshift-machine-api")
+		kubeClient := oc.KubeClient()
+
+		// make sure it can be run on the current platform
+		scalingtestinglibrary.SkipIfUnsupportedPlatform(ctx, oc)
+
+		// assert the cluster state before we run the test
+		err = scalingtestinglibrary.EnsureInitialClusterState(ctx, g.GinkgoT(), etcdClientFactory, machineClient, kubeClient)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 0: ensure clean state after the test
+		defer func() {
+			// since the deletion triggers a new rollout
+			// we need to make sure that the API is stable after the test
+			// so that other e2e test won't hit an API that undergoes a termination (write request might fail)
+			g.GinkgoT().Log("cleaning routine: ensuring initial cluster state and waiting for api servers to stabilize on the same revision")
+			err = scalingtestinglibrary.EnsureInitialClusterState(ctx, g.GinkgoT(), etcdClientFactory, machineClient, kubeClient)
+			o.Expect(err).ToNot(o.HaveOccurred())
+			err = testlibraryapi.WaitForAPIServerToStabilizeOnTheSameRevision(g.GinkgoT(), oc.KubeClient().CoreV1().Pods("openshift-kube-apiserver"))
+			o.Expect(err).ToNot(o.HaveOccurred())
+		}()
+
+		// step 1: add a new master node and wait until it is in Running state
+		machineName, err := scalingtestinglibrary.CreateNewMasterMachine(ctx, g.GinkgoT(), machineClient)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		err = scalingtestinglibrary.EnsureMasterMachine(ctx, g.GinkgoT(), machineName, machineClient)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 2: wait until a new member shows up and check if it is healthy
+		//         and until all kube-api servers have reached the same revision
+		//         this additional step is the best-effort of ensuring they
+		//         have observed the new member before disruption
+		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 4)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		memberName, err := scalingtestinglibrary.MachineNameToEtcdMemberName(ctx, oc.KubeClient(), machineClient, machineName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		err = scalingtestinglibrary.EnsureHealthyMember(g.GinkgoT(), etcdClientFactory, memberName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		g.GinkgoT().Log("waiting for api servers to stabilize on the same revision")
+		err = testlibraryapi.WaitForAPIServerToStabilizeOnTheSameRevision(g.GinkgoT(), oc.KubeClient().CoreV1().Pods("openshift-kube-apiserver"))
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 3: clean-up: delete the machine and wait until etcd member is removed from the etcd cluster
+		err = machineClient.Delete(ctx, machineName, metav1.DeleteOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+		framework.Logf("successfully deleted the machine %q from the API", machineName)
+		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 3)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		err = scalingtestinglibrary.EnsureMemberRemoved(g.GinkgoT(), etcdClientFactory, memberName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		err = scalingtestinglibrary.EnsureMasterMachinesAndCount(ctx, g.GinkgoT(), machineClient)
+		o.Expect(err).ToNot(o.HaveOccurred())
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2011,6 +2011,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [Serial]",
 
+	"[Top Level] [sig-etcd][Serial] etcd is able to vertically scale up and down with a single node [Timeout:60m]": "is able to vertically scale up and down with a single node [Timeout:60m] [Suite:openshift/conformance/serial]",
+
 	"[Top Level] [sig-imageregistry] Image registry should redirect on blob pull": "should redirect on blob pull [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-imageregistry][Feature:ImageAppend] Image append should create images by appending them": "should create images by appending them [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",

--- a/vendor/github.com/openshift/library-go/test/library/apiserver/apiserver.go
+++ b/vendor/github.com/openshift/library-go/test/library/apiserver/apiserver.go
@@ -1,0 +1,36 @@
+package apiserver
+
+import (
+	"time"
+
+	"github.com/openshift/library-go/test/library"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var (
+	// the following parameters specify for how long apis must
+	// stay on the same revision to be considered stable
+	waitForAPIRevisionSuccessThreshold = 6
+	waitForAPIRevisionSuccessInterval  = 1 * time.Minute
+
+	// the following parameters specify max timeout after which
+	// apis are considered to not converged
+	waitForAPIRevisionPollInterval = 30 * time.Second
+	waitForAPIRevisionTimeout      = 22 * time.Minute
+)
+
+// WaitForAPIServerToStabilizeOnTheSameRevision waits until all API Servers are running at the same revision.
+// The API Servers must stay on the same revision for at least waitForAPIRevisionSuccessThreshold * waitForAPIRevisionSuccessInterval.
+// Mainly because of the difference between the propagation time of triggering a new release and the actual roll-out.
+//
+// Observations:
+//  rolling out a new version is not instant you need to account for a propagation time (~1/2 minutes)
+//  for some API servers (KAS) rolling out a new version can take ~10 minutes
+//
+// Note:
+//  the number of instances is calculated based on the number of running pods in a namespace.
+//  only pods with apiserver=true label are considered
+//  only pods in the given namespace are considered (podClient)
+func WaitForAPIServerToStabilizeOnTheSameRevision(t library.LoggingT, podClient corev1client.PodInterface) error {
+	return library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "apiserver=true", waitForAPIRevisionSuccessThreshold, waitForAPIRevisionSuccessInterval, waitForAPIRevisionPollInterval, waitForAPIRevisionTimeout)
+}

--- a/vendor/github.com/openshift/library-go/test/library/client.go
+++ b/vendor/github.com/openshift/library-go/test/library/client.go
@@ -1,0 +1,19 @@
+package library
+
+import (
+	"fmt"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// NewClientConfigForTest returns a config configured to connect to the api server
+func NewClientConfigForTest() (*rest.Config, error) {
+	loader := clientcmd.NewDefaultClientConfigLoadingRules()
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, &clientcmd.ConfigOverrides{ClusterInfo: api.Cluster{InsecureSkipTLSVerify: true}})
+	config, err := clientConfig.ClientConfig()
+	if err == nil {
+		fmt.Printf("Found configuration for host %v.\n", config.Host)
+	}
+	return config, err
+}

--- a/vendor/github.com/openshift/library-go/test/library/library.go
+++ b/vendor/github.com/openshift/library-go/test/library/library.go
@@ -1,0 +1,38 @@
+package library
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math"
+	"math/big"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	WaitPollInterval = time.Second
+	WaitPollTimeout  = 10 * time.Minute
+)
+
+type LoggingT interface {
+	Logf(format string, args ...interface{})
+}
+
+// GenerateNameForTest generates a name of the form `prefix + test name + random string` that
+// can be used as a resource name. Convert the result to lowercase to use as a dns label.
+func GenerateNameForTest(t *testing.T, prefix string) string {
+	n, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	require.NoError(t, err)
+	name := []byte(fmt.Sprintf("%s%s-%016x", prefix, t.Name(), n.Int64()))
+	// make the name (almost) suitable for use as a dns label
+	// only a-z, 0-9, and '-' allowed
+	name = regexp.MustCompile("[^a-zA-Z0-9]+").ReplaceAll(name, []byte("-"))
+	// collapse multiple `-`
+	name = regexp.MustCompile("-+").ReplaceAll(name, []byte("-"))
+	// ensure no `-` at beginning or end
+	return strings.Trim(string(name), "-")
+}

--- a/vendor/github.com/openshift/library-go/test/library/pod_same_revision.go
+++ b/vendor/github.com/openshift/library-go/test/library/pod_same_revision.go
@@ -1,0 +1,107 @@
+package library
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// WaitForPodsToStabilizeOnTheSameRevision waits until all Pods with the given selector are running at the same revision.
+// The Pods must stay on the same revision for at least waitForRevisionSuccessThreshold * waitForRevisionSuccessInterval.
+// Mainly because of the difference between the propagation time of triggering a new release and the actual roll-out.
+//
+// Note:
+//  the number of instances is calculated based on the number of running pods in a namespace.
+//  only pods with the given label are considered
+//  only pods in the given namespace are considered (podClient)
+func WaitForPodsToStabilizeOnTheSameRevision(t LoggingT, podClient corev1client.PodInterface, podLabelSelector string, waitForRevisionSuccessThreshold int, waitForRevisionSuccessInterval, waitForRevisionPollInterval, waitForRevisionTimeout time.Duration) error {
+	return wait.Poll(waitForRevisionPollInterval, waitForRevisionTimeout, mustSucceedMultipleTimes(waitForRevisionSuccessThreshold, waitForRevisionSuccessInterval, func() (bool, error) {
+		return arePodsOnTheSameRevision(t, podClient, podLabelSelector)
+	}))
+}
+
+// arePodsOnTheSameRevision tries to find the current revision that the pods are running at.
+// The number of instances is calculated based on the number of running pods in a namespace.
+// This should be okay because this function is meant to be used by WaitForPodsToStabilizeOnTheSameRevision which will wait at least waitForRevisionSuccessThreshold * waitForRevisionSuccessInterval
+// The number of pods should stabilize in that period of time.
+func arePodsOnTheSameRevision(t LoggingT, podClient corev1client.PodInterface, podLabelSelector string) (bool, error) {
+	revisionLabel := "revision"
+
+	// do a live list so we never get confused about what revision we are on
+	apiServerPods, err := podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: podLabelSelector})
+	if err != nil {
+		// ignore the errors as we hope it will succeed next time
+		t.Logf("failed to list pods, err = %v (this error will be ignored)", err)
+		return false, nil
+	}
+
+	goodRevisions, failingRevisions, progressing, err := getRevisions(revisionLabel, apiServerPods.Items)
+	if err != nil || progressing || len(goodRevisions) != 1 {
+		return false, err
+	}
+
+	if revision, _ := goodRevisions.PopAny(); failingRevisions.Has(revision) {
+		return false, fmt.Errorf("api server revision %s has both running and failed pods", revision)
+	}
+
+	return true, nil
+}
+
+func getRevisions(revisionLabel string, pods []corev1.Pod) (sets.String, sets.String, bool, error) {
+	if len(pods) == 0 {
+		return nil, nil, true, nil
+	}
+
+	goodRevisions := sets.NewString()
+	badRevisions := sets.NewString()
+
+	for _, apiServerPod := range pods {
+		switch phase := apiServerPod.Status.Phase; phase {
+		case corev1.PodRunning:
+			if !podReady(apiServerPod) {
+				return nil, nil, true, nil // pods are not fully ready
+			}
+			goodRevisions.Insert(apiServerPod.Labels[revisionLabel])
+		case corev1.PodPending:
+			return nil, nil, true, nil // pods are not fully ready
+		case corev1.PodUnknown:
+			return nil, nil, false, fmt.Errorf("api server pod %s in unknown phase", apiServerPod.Name)
+		case corev1.PodSucceeded, corev1.PodFailed:
+			// handle failed pods carefully to make sure things are healthy
+			badRevisions.Insert(apiServerPod.Labels[revisionLabel])
+		default:
+			// error in case new unexpected phases get added
+			return nil, nil, false, fmt.Errorf("api server pod %s has unexpected phase %v", apiServerPod.Name, phase)
+		}
+	}
+	return goodRevisions, badRevisions, false, nil
+}
+
+func podReady(pod corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// mustSucceedMultipleTimes calls f multiple times sleeping before each invocation, it only returns true if all invocations are successful.
+func mustSucceedMultipleTimes(n int, sleep time.Duration, f func() (bool, error)) func() (bool, error) {
+	return func() (bool, error) {
+		for i := 0; i < n; i++ {
+			time.Sleep(sleep)
+			ok, err := f()
+			if err != nil || !ok {
+				return ok, err
+			}
+		}
+		return true, nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -868,6 +868,8 @@ github.com/openshift/library-go/pkg/security/ldaputil
 github.com/openshift/library-go/pkg/security/uid
 github.com/openshift/library-go/pkg/serviceability
 github.com/openshift/library-go/pkg/template/templateprocessingclient
+github.com/openshift/library-go/test/library
+github.com/openshift/library-go/test/library/apiserver
 github.com/openshift/library-go/test/library/metrics
 # github.com/pborman/uuid v1.2.0
 ## explicit


### PR DESCRIPTION
Follow up on: https://issues.redhat.com/browse/TRT-358 and https://issues.redhat.com/browse/ETCD-296

Reopening to investigate why the vertical scaling test was occasionally failing on various jobs, e.g:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-serial-aws-heterogeneous/1544699934450651136

https://sippy.dptools.openshift.org/sippy-ng/tests/4.11/analysis?test=%5Bsig-etcd%5D%5BSerial%5D%20etcd%20is%20able%20to%20vertically%20scale%20up%20and%20down%20with%20a%20single%20node%20%5BTimeout%3A60m%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fserial%5D

/hold