### PR TITLE
separate interval gathering from interval calculation

### DIFF
--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
-	"github.com/openshift/origin/pkg/monitor/intervalcreation"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,17 +27,6 @@ func GetMonitorRESTConfig() (*rest.Config, error) {
 	}
 
 	return clusterConfig, nil
-}
-
-func DefaultIntervalCreationFns() []IntervalCreationFunc {
-	return []IntervalCreationFunc{
-		intervalcreation.IntervalsFromEvents_OperatorAvailable,
-		intervalcreation.IntervalsFromEvents_OperatorProgressing,
-		intervalcreation.IntervalsFromEvents_OperatorDegraded,
-		intervalcreation.IntervalsFromEvents_E2ETests,
-		intervalcreation.IntervalsFromEvents_NodeChanges,
-		intervalcreation.CreatePodIntervalsFromInstants,
-	}
 }
 
 // Start begins monitoring the cluster referenced by the default kube configuration until
@@ -66,7 +54,6 @@ func Start(ctx context.Context, restConfig *rest.Config, additionalEventInterval
 
 	// add interval creation at the same point where we add the monitors
 	startClusterOperatorMonitoring(ctx, m, configClient)
-	m.intervalCreationFns = append(m.intervalCreationFns, DefaultIntervalCreationFns()...)
 
 	m.StartSampling(ctx)
 	return m, nil

--- a/pkg/monitor/intervalcreation/types.go
+++ b/pkg/monitor/intervalcreation/types.go
@@ -1,0 +1,38 @@
+package intervalcreation
+
+import (
+	"sort"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+type simpleIntervalCreationFunc func(intervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) monitorapi.Intervals
+
+func defaultIntervalCreationFns() []simpleIntervalCreationFunc {
+	return []simpleIntervalCreationFunc{
+		IntervalsFromEvents_OperatorAvailable,
+		IntervalsFromEvents_OperatorProgressing,
+		IntervalsFromEvents_OperatorDegraded,
+		IntervalsFromEvents_E2ETests,
+		IntervalsFromEvents_NodeChanges,
+		CreatePodIntervalsFromInstants,
+	}
+}
+
+// InsertCalculatedIntervals calculates intervals from the currently known interval set and saves them into the same list
+func InsertCalculatedIntervals(startingIntervals []monitorapi.EventInterval, recordedResources monitorapi.ResourcesMap, from, to time.Time) monitorapi.Intervals {
+	ret := make([]monitorapi.EventInterval, 0, len(startingIntervals))
+	copy(ret, startingIntervals)
+
+	intervalCreationFns := defaultIntervalCreationFns()
+	// create additional intervals from events
+	for _, createIntervals := range intervalCreationFns {
+		ret = append(ret, createIntervals(startingIntervals, recordedResources, from, to)...)
+	}
+
+	// we must sort the result
+	sort.Sort(monitorapi.Intervals(ret))
+
+	return ret
+}

--- a/pkg/monitor/monitor_cmd/command.go
+++ b/pkg/monitor/monitor_cmd/command.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -15,8 +14,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/openshift/origin/pkg/monitor"
 
 	"github.com/openshift/origin/pkg/monitor/intervalcreation"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -247,11 +244,8 @@ func (o *Timeline) Run() error {
 	} else {
 		to = *o.EndDate
 	}
-	computedIntervalFns := monitor.DefaultIntervalCreationFns()
-	for _, createIntervals := range computedIntervalFns {
-		filteredEvents = append(filteredEvents, createIntervals(filteredEvents, recordedResources, from, to)...)
-	}
-	sort.Sort(filteredEvents)
+
+	filteredEvents = intervalcreation.InsertCalculatedIntervals(filteredEvents, recordedResources, from, to)
 
 	output, err := o.Renderer(filteredEvents)
 	if err != nil {

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -27,6 +27,7 @@ func TestMonitor_Events(t *testing.T) {
 		want    monitorapi.Intervals
 	}{
 		{
+			name: "one",
 			events: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
@@ -37,6 +38,7 @@ func TestMonitor_Events(t *testing.T) {
 			},
 		},
 		{
+			name: "two",
 			events: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
@@ -47,6 +49,7 @@ func TestMonitor_Events(t *testing.T) {
 			},
 		},
 		{
+			name: "three",
 			events: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
@@ -58,6 +61,7 @@ func TestMonitor_Events(t *testing.T) {
 			},
 		},
 		{
+			name: "four",
 			events: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
@@ -66,6 +70,7 @@ func TestMonitor_Events(t *testing.T) {
 			want: monitorapi.Intervals{},
 		},
 		{
+			name: "five",
 			samples: []*sample{
 				{at: time.Unix(1, 0), conditions: []*monitorapi.Condition{{Message: "1"}, {Message: "A"}}},
 				{at: time.Unix(2, 0), conditions: []*monitorapi.Condition{{Message: "2"}}},
@@ -74,20 +79,21 @@ func TestMonitor_Events(t *testing.T) {
 			from: time.Unix(1, 0),
 			want: monitorapi.Intervals{
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
-				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
+				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(4, 0)},
 			},
 		},
 		{
+			name: "six",
 			samples: []*sample{
 				{at: time.Unix(1, 0), conditions: []*monitorapi.Condition{{Message: "1"}, {Message: "A"}}},
 				{at: time.Unix(2, 0), conditions: []*monitorapi.Condition{{Message: "2"}}},
 				{at: time.Unix(3, 0), conditions: []*monitorapi.Condition{{Message: "2"}, {Message: "A"}}},
 			},
 			want: monitorapi.Intervals{
-				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(2, 0)},
+				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(1, 0), To: time.Unix(2, 0)},
 				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(3, 0)},
-				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(3, 0)},
+				{Condition: monitorapi.Condition{Message: "A"}, From: time.Unix(3, 0), To: time.Unix(4, 0)},
 			},
 		},
 	}

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -10,8 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-type IntervalCreationFunc func(intervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) monitorapi.Intervals
-
 type SamplerFunc func(time.Time) []*monitorapi.Condition
 
 type Interface interface {

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -414,7 +414,9 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 	var syntheticTestResults []*junitapi.JUnitTestCase
 	var syntheticFailure bool
 	timeSuffix := fmt.Sprintf("_%s", start.UTC().Format("20060102-150405"))
-	events := m.Intervals(time.Time{}, time.Time{})
+	fromTime, endTime := time.Time{}, time.Time{}
+	events := m.Intervals(fromTime, endTime)
+	events = intervalcreation.InsertCalculatedIntervals(events, m.CurrentResourceState(), fromTime, endTime)
 
 	if len(opt.JUnitDir) > 0 {
 		var additionalEvents monitorapi.Intervals

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -178,12 +178,14 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 	allowedDisruption, disruptionDetails, err := t.getAllowedDisruption(f)
 	framework.ExpectNoError(err)
 
+	fromTime, endTime := time.Time{}, time.Time{}
+	events := m.Intervals(fromTime, endTime)
 	ginkgo.By(fmt.Sprintf("writing results: %s", t.backend.GetLocator()))
 	ExpectNoDisruptionForDuration(
 		f,
 		*allowedDisruption,
 		end.Sub(start),
-		m.Intervals(time.Time{}, time.Time{}),
+		events,
 		fmt.Sprintf("%s was unreachable during disruption: %v", t.backend.GetLocator(), disruptionDetails),
 	)
 


### PR DESCRIPTION
separating the creation of the raw events from the calculated intervals allows us to later add more complicated interval collection without increasing the cost of getting just the raw events.

/assign @DennisPeriquet 