### PR TITLE
WIP: fix(olm): remove dependency on marketplace-provided content

### DIFF
--- a/test/extended/olm/olm.go
+++ b/test/extended/olm/olm.go
@@ -240,26 +240,34 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 		oc = exutil.NewCLI("olm-23440")
 
 		buildPruningBaseDir = exutil.FixturePath("testdata", "olm")
-		operatorGroup       = filepath.Join(buildPruningBaseDir, "operatorgroup.yaml")
-		sub                 = filepath.Join(buildPruningBaseDir, "subscription.yaml")
+		ogPath              = filepath.Join(buildPruningBaseDir, "operatorgroup.yaml")
+		subPath             = filepath.Join(buildPruningBaseDir, "subscription.yaml")
+		catalogPath         = filepath.Join(buildPruningBaseDir, "catalogsource.yaml")
 	)
 
-	files := []string{sub}
 	g.It("can subscribe to the operator", func() {
 		g.By("Cluster-admin user subscribe the operator resource")
 
-		// skip test if redhat-operators is not present or disabled
-		ok, err := hasRedHatOperatorsSource(oc)
+		// Configure OperatorGroup before tests
+		og, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", ogPath, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace())).OutputToFile("og.json")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		if !ok {
-			g.Skip("redhat-operators source not found in enabled sources")
-		}
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", og).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		// configure OperatorGroup before tests
-		configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", operatorGroup, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace())).OutputToFile("config.json")
+		// Configure CatalogSource before tests
+		const image = "registry.redhat.io/redhat/redhat-operator-index:v4.10"
+		catalog, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", catalogPath, "-p", "NAME=test-catalog", fmt.Sprintf("NAMESPACE=%s", oc.Namespace()), fmt.Sprintf("IMAGE=%s", image)).OutputToFile("catalog.json")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", catalog).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Eventually(func() string {
+			state, err := oc.AsAdmin().Run("get").Args("-n", oc.Namespace(), "catsrc", "test-catalog", "-o=jsonpath={.status.connectionState.lastObservedState}").Output()
+			if err != nil {
+				e2e.Logf("Could not get CatalogSource state, error:%v, trying again", err)
+			}
+			return state
+		}, 5*time.Minute, time.Second).Should(o.Equal("READY"))
 
 		o.Eventually(func() []string {
 			// Using json output instead of jsonpath - oc/jsonpath bug seems to improperly decode `[""]` as `[]`
@@ -286,12 +294,10 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 			return parsed.Status.Namespaces
 		}, 5*time.Minute, time.Second).Should(o.Equal([]string{""}))
 
-		for _, v := range files {
-			configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", v, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace()), "SOURCENAME=redhat-operators", "SOURCENAMESPACE=openshift-marketplace", "PACKAGE=cluster-logging", "CHANNEL=stable").OutputToFile("config.json")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-		}
+		sub, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", subPath, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace()), "SOURCENAME=test-catalog", fmt.Sprintf("SOURCENAMESPACE=%s", oc.Namespace()), "PACKAGE=cluster-logging", "CHANNEL=stable").OutputToFile("sub.json")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", sub).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		var current string
 		o.Eventually(func() string {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -433,6 +433,7 @@
 // test/extended/testdata/oauthserver/oauth-network.yaml
 // test/extended/testdata/oauthserver/oauth-pod.yaml
 // test/extended/testdata/oauthserver/oauth-sa.yaml
+// test/extended/testdata/olm/catalogsource.yaml
 // test/extended/testdata/olm/operatorgroup.yaml
 // test/extended/testdata/olm/subscription.yaml
 // test/extended/testdata/releases/payload-1/etcd-operator/image-references
@@ -47705,6 +47706,40 @@ func testExtendedTestdataOauthserverOauthSaYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataOlmCatalogsourceYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: catalogsource-template
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: CatalogSource
+  metadata:
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    sourceType: grpc
+    image: "${IMAGE}"
+parameters:
+- name: NAME
+- name: NAMESPACE
+- name: IMAGE
+`)
+
+func testExtendedTestdataOlmCatalogsourceYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmCatalogsourceYaml, nil
+}
+
+func testExtendedTestdataOlmCatalogsourceYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmCatalogsourceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olm/catalogsource.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataOlmOperatorgroupYaml = []byte(`apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -53544,6 +53579,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/oauthserver/oauth-network.yaml":                                                  testExtendedTestdataOauthserverOauthNetworkYaml,
 	"test/extended/testdata/oauthserver/oauth-pod.yaml":                                                      testExtendedTestdataOauthserverOauthPodYaml,
 	"test/extended/testdata/oauthserver/oauth-sa.yaml":                                                       testExtendedTestdataOauthserverOauthSaYaml,
+	"test/extended/testdata/olm/catalogsource.yaml":                                                          testExtendedTestdataOlmCatalogsourceYaml,
 	"test/extended/testdata/olm/operatorgroup.yaml":                                                          testExtendedTestdataOlmOperatorgroupYaml,
 	"test/extended/testdata/olm/subscription.yaml":                                                           testExtendedTestdataOlmSubscriptionYaml,
 	"test/extended/testdata/releases/payload-1/etcd-operator/image-references":                               testExtendedTestdataReleasesPayload1EtcdOperatorImageReferences,
@@ -54287,6 +54323,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"oauth-sa.yaml":      {testExtendedTestdataOauthserverOauthSaYaml, map[string]*bintree{}},
 				}},
 				"olm": {nil, map[string]*bintree{
+					"catalogsource.yaml": {testExtendedTestdataOlmCatalogsourceYaml, map[string]*bintree{}},
 					"operatorgroup.yaml": {testExtendedTestdataOlmOperatorgroupYaml, map[string]*bintree{}},
 					"subscription.yaml":  {testExtendedTestdataOlmSubscriptionYaml, map[string]*bintree{}},
 				}},

--- a/test/extended/testdata/olm/catalogsource.yaml
+++ b/test/extended/testdata/olm/catalogsource.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: catalogsource-template
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: CatalogSource
+  metadata:
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    sourceType: grpc
+    image: "${IMAGE}"
+parameters:
+- name: NAME
+- name: NAMESPACE
+- name: IMAGE


### PR DESCRIPTION
Remove a test dependency on the marketplace-provided redhat-operators
catalog by introducing a new catalog test fixture, pinning to content released
during 4.10. This makes less assumptions about future content allowing for a
more stable test. This also allows us to run the test when when the marketplace
capability is disabled.