### PR TITLE
Suppress failures if certain firing alerts happened with related event

### DIFF
--- a/cmd/openshift-tests/images.go
+++ b/cmd/openshift-tests/images.go
@@ -214,7 +214,7 @@ func pulledInvalidImages(fromRepository string) ginkgo.JUnitForEventsFunc {
 
 	// any image not in the allowed prefixes is considered a failure, as the user
 	// may have added a new test image without calling the appropriate helpers
-	return func(events monitorapi.Intervals, _ time.Duration, cfg *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
+	return func(events monitorapi.Intervals, _ time.Duration, cfg *rest.Config, testSuite string, _ *monitorapi.ResourcesMap) []*junitapi.JUnitTestCase {
 		imageStreamPrefixes, err := imagePrefixesFromNamespaceImageStreams("openshift")
 		if err != nil {
 			klog.Errorf("Unable to identify image prefixes from the openshift namespace: %v", err)

--- a/pkg/synthetictests/alerts.go
+++ b/pkg/synthetictests/alerts.go
@@ -12,14 +12,14 @@ import (
 	"github.com/openshift/origin/pkg/synthetictests/allowedalerts"
 )
 
-func testAlerts(events monitorapi.Intervals, restConfig *rest.Config, duration time.Duration) []*junitapi.JUnitTestCase {
+func testAlerts(events monitorapi.Intervals, restConfig *rest.Config, duration time.Duration, recordedResource *monitorapi.ResourcesMap) []*junitapi.JUnitTestCase {
 	ret := []*junitapi.JUnitTestCase{}
 
 	alertTests := allowedalerts.AllAlertTests(context.TODO(), restConfig, duration)
 	for i := range alertTests {
 		alertTest := alertTests[i]
 
-		junit, err := alertTest.InvariantCheck(context.TODO(), restConfig, events)
+		junit, err := alertTest.InvariantCheck(context.TODO(), restConfig, events, *recordedResource)
 		if err != nil {
 			ret = append(ret, &junitapi.JUnitTestCase{
 				Name: alertTest.InvariantTestName(),

--- a/pkg/synthetictests/allowedalerts/watchdog.go
+++ b/pkg/synthetictests/allowedalerts/watchdog.go
@@ -97,7 +97,7 @@ func isSNOUpgradeTest(ctx context.Context, restConfig *rest.Config) (bool, error
 	return len(clusterVersion.Status.History) > 1, nil
 }
 
-func (a *watchdogAlertTest) InvariantCheck(ctx context.Context, restConfig *rest.Config, alertIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+func (a *watchdogAlertTest) InvariantCheck(ctx context.Context, restConfig *rest.Config, alertIntervals monitorapi.Intervals, _ monitorapi.ResourcesMap) ([]*junitapi.JUnitTestCase, error) {
 
 	// Skip this test when SNO is being upgraded
 	isSNOUpgrade, err := isSNOUpgradeTest(ctx, restConfig)

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -13,8 +13,8 @@ import (
 // steady state (not being changed externally). Use these with suites that assume the
 // cluster is under no adversarial change (config changes, induced disruption to nodes,
 // etcd, or apis).
-func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*junitapi.JUnitTestCase) {
-	tests = SystemEventInvariants(events, duration, kubeClientConfig, testSuite)
+func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string, recordedResource *monitorapi.ResourcesMap) (tests []*junitapi.JUnitTestCase) {
+	tests = SystemEventInvariants(events, duration, kubeClientConfig, testSuite, recordedResource)
 	tests = append(tests, testContainerFailures(events)...)
 	tests = append(tests, testDeleteGracePeriodZero(events)...)
 	tests = append(tests, testKubeApiserverProcessOverlap(events)...)
@@ -33,7 +33,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testErrImagePullConnTimeout(events)...)
 	tests = append(tests, testErrImagePullGenericOpenShiftNamespaces(events)...)
 	tests = append(tests, testErrImagePullGeneric(events)...)
-	tests = append(tests, testAlerts(events, kubeClientConfig, duration)...)
+	tests = append(tests, testAlerts(events, kubeClientConfig, duration, recordedResource)...)
 	tests = append(tests, testOperatorOSUpdateStaged(events, kubeClientConfig)...)
 	tests = append(tests, testOperatorOSUpdateStartedEventRecorded(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
@@ -48,8 +48,8 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 
 // SystemUpgradeEventInvariants are invariants tested against events that should hold true in a cluster
 // that is being upgraded without induced disruption
-func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*junitapi.JUnitTestCase) {
-	tests = SystemEventInvariants(events, duration, kubeClientConfig, testSuite)
+func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string, recordedResource *monitorapi.ResourcesMap) (tests []*junitapi.JUnitTestCase) {
+	tests = SystemEventInvariants(events, duration, kubeClientConfig, testSuite, recordedResource)
 	tests = append(tests, testContainerFailures(events)...)
 	tests = append(tests, testDeleteGracePeriodZero(events)...)
 	tests = append(tests, testKubeApiserverProcessOverlap(events)...)
@@ -66,7 +66,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testErrImagePullConnTimeout(events)...)
 	tests = append(tests, testErrImagePullGenericOpenShiftNamespaces(events)...)
 	tests = append(tests, testErrImagePullGeneric(events)...)
-	tests = append(tests, testAlerts(events, kubeClientConfig, duration)...)
+	tests = append(tests, testAlerts(events, kubeClientConfig, duration, recordedResource)...)
 	tests = append(tests, testOperatorOSUpdateStaged(events, kubeClientConfig)...)
 	tests = append(tests, testOperatorOSUpdateStartedEventRecorded(events, kubeClientConfig)...)
 	tests = append(tests, testPodNodeNameIsImmutable(events)...)
@@ -84,7 +84,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 // SystemEventInvariants are invariants tested against events that should hold true in any cluster,
 // even one undergoing disruption. These are usually focused on things that must be true on a single
 // machine, even if the machine crashes.
-func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) (tests []*junitapi.JUnitTestCase) {
+func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string, _ *monitorapi.ResourcesMap) (tests []*junitapi.JUnitTestCase) {
 	tests = append(tests, testSystemDTimeout(events)...)
 	tests = append(tests, testPodIPReuse(events)...)
 	return tests

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -429,7 +429,8 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 	if events := opt.MonitorEventsOptions.GetEvents(); len(events) > 0 {
 		var buf *bytes.Buffer
 		syntheticTestResults, buf, _ = createSyntheticTestsFromMonitor(events, duration)
-		testCases := syntheticEventTests.JUnitsForEvents(events, duration, restConfig, suite.Name)
+		currResState := opt.MonitorEventsOptions.GetRecordedResources()
+		testCases := syntheticEventTests.JUnitsForEvents(events, duration, restConfig, suite.Name, &currResState)
 		syntheticTestResults = append(syntheticTestResults, testCases...)
 
 		if len(syntheticTestResults) > 0 {

--- a/pkg/test/ginkgo/options_monitor_events.go
+++ b/pkg/test/ginkgo/options_monitor_events.go
@@ -157,6 +157,10 @@ func (o *MonitorEventsOptions) GetEvents() monitorapi.Intervals {
 	return o.recordedEvents
 }
 
+func (o *MonitorEventsOptions) GetRecordedResources() monitorapi.ResourcesMap {
+	return o.recordedResources
+}
+
 // WriteRunDataToArtifactsDir attempts to write useful run data to the specified directory.
 func (o *MonitorEventsOptions) WriteRunDataToArtifactsDir(artifactDir string) error {
 	if o.endTime == nil {

--- a/pkg/test/ginkgo/synthentic_tests.go
+++ b/pkg/test/ginkgo/synthentic_tests.go
@@ -18,29 +18,29 @@ type JUnitsForEvents interface {
 	// JUnitsForEvents returns a set of additional test passes or failures implied by the
 	// events sent during the test suite run. If passed is false, the entire suite is failed.
 	// To set a test as flaky, return a passing and failing JUnitTestCase with the same name.
-	JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase
+	JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string, recordedResource *monitorapi.ResourcesMap) []*junitapi.JUnitTestCase
 }
 
 // JUnitForEventsFunc converts a function into the JUnitForEvents interface.
 // kubeClientConfig may or may not be present.  The JUnit evaluation needs to tolerate a missing *rest.Config
 // and an unavailable cluster without crashing.
-type JUnitForEventsFunc func(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase
+type JUnitForEventsFunc func(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string, recordedResource *monitorapi.ResourcesMap) []*junitapi.JUnitTestCase
 
-func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
-	return fn(events, duration, kubeClientConfig, testSuite)
+func (fn JUnitForEventsFunc) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string, recordedResource *monitorapi.ResourcesMap) []*junitapi.JUnitTestCase {
+	return fn(events, duration, kubeClientConfig, testSuite, recordedResource)
 }
 
 // JUnitsForAllEvents aggregates multiple JUnitsForEvent interfaces and returns
 // the result of all invocations. It ignores nil interfaces.
 type JUnitsForAllEvents []JUnitsForEvents
 
-func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
+func (a JUnitsForAllEvents) JUnitsForEvents(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string, recordedResource *monitorapi.ResourcesMap) []*junitapi.JUnitTestCase {
 	var all []*junitapi.JUnitTestCase
 	for _, obj := range a {
 		if obj == nil {
 			continue
 		}
-		results := obj.JUnitsForEvents(events, duration, kubeClientConfig, testSuite)
+		results := obj.JUnitsForEvents(events, duration, kubeClientConfig, testSuite, recordedResource)
 		all = append(all, results...)
 	}
 	return all


### PR DESCRIPTION
Related to [TRT-238](https://issues.redhat.com//browse/TRT-238)

We look at information from tracked resources (pods and events) that can be used to tell if we should suppress an alert related failure.

The main logic is in `basic_alert.go`.  The rest of the code is about extracting the recorded resources from the `MonitorEventsOptions.recordedResources` field and plumbing that through to the new functions in basic_alert.go.