### PR TITLE
Revert "Enable EgressIP tests for internal targets"

### DIFF
--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -911,6 +911,7 @@ func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetw
 
 	// Build the list of reserved IPs. To do so, look at the currently used cloudprivateipconfigs
 	// and egressips as well as nodes.
+	var reservedIPs []string
 	reservedIPs, err := buildReservedEgressIPList(oc, clientset, cloudNetworkClientset)
 	if err != nil {
 		return nil, err
@@ -939,19 +940,24 @@ func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetw
 		}
 		nodeEgressIPs[node.Name] = freeIPs
 		// Most cloud environments such as GCP report a single, common CIDR for
-		// EgressIPs. Therefore, just add the IPs for this node to the reservedPool.
+		// EgresiIPs. Therefore, just add the IPs for this node to the reservedPool.
 		for _, freeIP := range freeIPs {
-			reservedIPs[freeIP] = struct{}{}
+			reservedIPs = append(reservedIPs, freeIP)
 		}
 	}
 
 	return nodeEgressIPs, nil
 }
 
-// buildReservedEgressIPList builds the list of reserved IPs. To do so, look at the currently used cloudprivateipconfigs, egressips,
-// hostsubnets, netnamespaces as well as the node IP addresses.
-func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetworkClientset cloudnetwork.Interface) (map[string]struct{}, error) {
-	reservedIPs := make(map[string]struct{})
+// buildReservedEgressIPList builds the list of reserved IPs. To do so, look at the currently used cloudprivateipconfigs
+// and egressips as well as the node IP addresses.
+// Warning: Some cloud environments have a common CIDR for EgressIPs. In those environments, it is not possible to attribute
+// a specific EgressIP to a specific node so this is just a "best effort" allocation and should be kept in mind when writing
+// tests.
+// TODO: add an internal reservation system based on a singleton to avoid race conditions during
+// concurrent tests.
+func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetworkClientset cloudnetwork.Interface) ([]string, error) {
+	var reservedIPs []string
 
 	// cloudprivateipconfigs
 	cloudPrivateIPConfigs, err := cloudNetworkClientset.CloudV1().CloudPrivateIPConfigs().List(context.Background(), metav1.ListOptions{})
@@ -959,7 +965,7 @@ func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface, c
 		return nil, err
 	}
 	for _, cloudPrivateIPConfig := range cloudPrivateIPConfigs.Items {
-		reservedIPs[cloudPrivateIPConfig.Name] = struct{}{}
+		reservedIPs = append(reservedIPs, cloudPrivateIPConfig.Name)
 	}
 
 	// egressip for OVNKubernetes - if we receive a failure here, it may simply be because
@@ -968,11 +974,10 @@ func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface, c
 	if err == nil {
 		for _, egressip := range egressipList.Items {
 			for _, ip := range egressip.Spec.EgressIPs {
-				reservedIPs[ip] = struct{}{}
+				reservedIPs = append(reservedIPs, ip)
 			}
 		}
 	}
-	// Find EgressIP in HostSubnet configuration.
 	// egressip for OpenShiftSDN - if we receive a failure here, it may simply be because
 	// we are on OVNKubernetes, so ignore the error.
 	networkClient := networkclient.NewForConfigOrDie(oc.AdminConfig())
@@ -980,18 +985,7 @@ func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface, c
 	if err == nil {
 		for _, hostSubnet := range hostSubnets.Items {
 			for _, eip := range hostSubnet.EgressIPs {
-				reservedIPs[string(eip)] = struct{}{}
-			}
-		}
-	}
-	// Find EgressIPs in NetNamespace configuration.
-	// egressip for OpenShiftSDN - if we receive a failure here, it may simply be because
-	// we are on OVNKubernetes, so ignore the error.
-	netNamespaces, err := networkClient.NetNamespaces().List(context.Background(), metav1.ListOptions{})
-	if err == nil {
-		for _, netNamespace := range netNamespaces.Items {
-			for _, eip := range netNamespace.EgressIPs {
-				reservedIPs[string(eip)] = struct{}{}
+				reservedIPs = append(reservedIPs, string(eip))
 			}
 		}
 	}
@@ -1006,7 +1000,7 @@ func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface, c
 	for _, node := range nodes.Items {
 		for _, addr := range node.Status.Addresses {
 			if addr.Type == corev1.NodeInternalIP {
-				reservedIPs[addr.Address] = struct{}{}
+				reservedIPs = append(reservedIPs, addr.Address)
 			}
 		}
 	}
@@ -1016,7 +1010,7 @@ func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface, c
 
 // getFirstFreeIPs returns the first available IP addresses from the IP network (CIDR notation). reservedIPs are
 // eliminated from the choice and the cloudType is taken into account.
-func getFirstFreeIPs(ipnetStr string, reservedIPs map[string]struct{}, cloudType configv1.PlatformType, egressIPsPerNode int) ([]string, error) {
+func getFirstFreeIPs(ipnetStr string, reservedIPs []string, cloudType configv1.PlatformType, egressIPsPerNode int) ([]string, error) {
 	// Parse the CIDR notation and enumerate all IPs inside the subnet.
 	_, ipnet, err := net.ParseCIDR(ipnetStr)
 	if err != nil {
@@ -1057,7 +1051,7 @@ func getFirstFreeIPs(ipnetStr string, reservedIPs map[string]struct{}, cloudType
 	var freeIPList []string
 outer:
 	for _, ip := range ipList {
-		for rip := range reservedIPs {
+		for _, rip := range reservedIPs {
 			if ip.String() == rip {
 				continue outer
 			}
@@ -1551,42 +1545,60 @@ func getDaemonSetPodIPs(clientset kubernetes.Interface, namespace, daemonsetName
 // probeForClientIPs spawns a prober pod inside the prober namespace. It then runs curl against http://%s/dial?host=%s&port=%d&request=/clientip
 // for the specified number of iterations and returns a set of the clientIP addresses that were returned.
 // At the end of the test, the prober pod is deleted again.
-func probeForClientIPs(oc *exutil.CLI, proberPodNamespace, proberPodName, url, targetIP string, targetPort, iterations int) (map[string]int, []error, error) {
+func probeForClientIPs(oc *exutil.CLI, proberPodNamespace, proberPodName, url, targetIP string, targetPort, iterations int) (map[string]struct{}, error) {
 	if oc == nil {
-		return nil, nil, fmt.Errorf("Nil pointer to exutil.CLI oc was provided in SendProbesToHostPort.")
+		return nil, fmt.Errorf("Nil pointer to exutil.CLI oc was provided in SendProbesToHostPort.")
 	}
 
-	clientIpSet := make(map[string]int)
+	f := oc.KubeFramework()
+	clientset := f.ClientSet
 
+	clientIpSet := make(map[string]struct{})
+
+	proberPod := frameworkpod.CreateExecPodOrFail(clientset, proberPodNamespace, probePodName, func(pod *corev1.Pod) {
+		// pod.ObjectMeta.Annotations = annotation
+	})
 	request := fmt.Sprintf("http://%s/dial?host=%s&port=%d&request=/clientip", url, targetIP, targetPort)
-	var warnings []error
+	maxTimeouts := 3
 	for i := 0; i < iterations; i++ {
-		output, err := runOcWithRetry(oc.AsAdmin(), "exec", "-n", proberPodNamespace, proberPodName, "--", "curl", "-s", request)
+		output, err := runOcWithRetry(oc.AsAdmin(), "exec", "--", "curl", "-s", request)
 		if err != nil {
-			return nil, warnings, fmt.Errorf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
+			// if we hit an i/o timeout, retry
+			if timeoutError, _ := regexp.Match("^Unable to connect to the server: dial tcp.*i/o timeout$", []byte(output)); timeoutError && maxTimeouts > 0 {
+				framework.Logf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
+				iterations++
+				maxTimeouts--
+				continue
+			}
+			return nil, fmt.Errorf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
 		}
 		dialResponse := &struct {
 			Responses []string
 		}{}
 		err = json.Unmarshal([]byte(output), dialResponse)
 		if err != nil {
-			warnings = append(warnings, err)
 			continue
 		}
 		if len(dialResponse.Responses) != 1 {
-			warnings = append(warnings, fmt.Errorf("Received invalid dial responses: %s", output))
 			continue
 		}
 		clientIpPort := strings.Split(dialResponse.Responses[0], ":")
 		if len(clientIpPort) != 2 {
-			warnings = append(warnings, fmt.Errorf("Received an invalid value for clientIP and port in dial responses: %s", output))
 			continue
 		}
 		clientIp := clientIpPort[0]
-		clientIpSet[clientIp]++
+		clientIpSet[clientIp] = struct{}{}
 	}
 
-	return clientIpSet, warnings, nil
+	// delete the exec pod again - in foreground, so that it blocks
+	deletePolicy := metav1.DeletePropagationForeground
+	if err := clientset.CoreV1().Pods(proberPod.Namespace).Delete(context.TODO(), proberPod.Name, metav1.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	}); err != nil {
+		return nil, err
+	}
+
+	return clientIpSet, nil
 }
 
 // getTargetProtocolHostPort gets targetProtocol, targetHost, targetPort.

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2779,7 +2779,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should keep the assigned EgressIPs when being rescheduled to another node": "pods should keep the assigned EgressIPs when being rescheduled to another node [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP] [internal-targets] EgressIP pods should reach hostNetwork pods on other nodes [Skipped:azure][Skipped:gce]": "EgressIP pods should reach hostNetwork pods on other nodes [Skipped:azure][Skipped:gce] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP] [internal-targets] EgressIP pods should query hostNetwork pods with the local node's SNAT": "EgressIP pods should query hostNetwork pods with the local node's SNAT [Disabled:Broken] [Serial]",
 
 	"[Top Level] [sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created": "should ensure ipv4 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -67,6 +67,9 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=2004074
 			`\[sig-network-edge\]\[Feature:Idling\] Unidling should work with TCP \(while idling\)`,
 
+			// https://bugzilla.redhat.com/show_bug.cgi?id=2070929
+			`\[sig-network\]\[Feature:EgressIP\] \[internal-targets\]`,
+
 			// https://bugzilla.redhat.com/show_bug.cgi?id=2093339
 			`\[sig-storage\].* provisioning should provision storage with any volume data source`,
 		},


### PR DESCRIPTION
Reverts openshift/origin#27262

This test is not reliable enough. BZ is logged with details: https://bugzilla.redhat.com/show_bug.cgi?id=2107260. 

Passing rate is less than %60: https://sippy.dptools.openshift.org/sippy-ng/tests/4.12/analysis?test=%5Bsig-network%5D%5BFeature%3AEgressIP%5D%20%5Binternal-targets%5D%20EgressIP%20pods%20should%20reach%20hostNetwork%20pods%20on%20other%20nodes%20%5BSkipped%3Aazure%5D%5BSkipped%3Agce%5D%20%5BSerial%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fserial%5D

We suggest fixing the issue described in the bug and reintroduce the test as flakes to collect some history before make it fail again. 