### PR TITLE
Hypershift KubeVirt platform network tests

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2743,6 +2743,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services basic functionality should allow connections to another pod on the same node via a service IP": "should allow connections to another pod on the same node via a service IP [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-network] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from guest hostNetwork pod via NodePort across different guest nodes": "should allow connections to pods from guest hostNetwork pod via NodePort across different guest nodes [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-network] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from infra cluster pod via NodePort across different infra nodes": "should allow connections to pods from infra cluster pod via NodePort across different infra nodes [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-network] services when running openshift ipv4 cluster ensures external ip policy is configured correctly on the cluster [Serial]": "ensures external ip policy is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-network] services when running openshift ipv4 cluster on bare metal ensures external auto assign cidr is configured correctly on the cluster [Serial]": "ensures external auto assign cidr is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",


### PR DESCRIPTION
The Hypershift KubeVirt platform involves running a nested OCP cluster (guest cluster) within KubeVirt VMs on an OCP infrastructure cluster (typically baremetal). Due to the nested nature of this configuration, it's important that we validate not only the ability for pods within the guest cluster to contact one another via services, but also pods within the infra cluster to be able to contact pods within the guest cluster via services.

For example, ingress into the nested KubeVirt guest cluster involves routing traffic through the infra cluster into the guest cluster.

Two new test cases have been introduced specifically to account for this nested use case.

`should allow connections to pods from infra cluster pod via NodePort across different infra nodes` verifies that pods in the infra cluster can contact pods in the guest cluster via a NodePort in the guest cluster. This is important as it exercises the method used to pass ingress through the infra cluster to the guest cluster

`should allow connections to pods from guest hostNetwork pod via NodePort across different guest nodes` Verifies that a pod on the hostNetwork of the guest cluster can contact pods via a NodePort within the guest cluster across guest nodes. This verifies that the nested OVN layers are routing correctly.

