### PR TITLE
Add test that checks CI job name matches platform and network type

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -1,0 +1,75 @@
+package ci
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	v1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+
+	"github.com/openshift/origin/pkg/test/ginkgo/result"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLI("job-names")
+
+	g.It("should match platform type", func() {
+		jobName := os.Getenv("JOB_NAME")
+		if jobName == "" {
+			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
+		} else if strings.Contains(jobName, "agnostic") {
+			e2eskipper.Skipf("JOB_NAME contains agnostic, not expecting platform in name")
+		}
+
+		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		hasPlatform := true
+		platform := infra.Status.PlatformStatus.Type
+		switch platform {
+		case v1.AlibabaCloudPlatformType:
+			if !strings.Contains(jobName, "alibaba") {
+				hasPlatform = false
+			}
+		case v1.EquinixMetalPlatformType, v1.BareMetalPlatformType:
+			if !strings.Contains(jobName, "metal") {
+				hasPlatform = false
+			}
+		default:
+			if !strings.Contains(jobName, strings.ToLower(string(platform))) {
+				hasPlatform = false
+			}
+		}
+
+		if !hasPlatform {
+			result.Flakef("job name %q does not contain platform type in name (%s)", jobName, platform)
+		}
+
+	})
+
+	g.It("should match network type", func() {
+		jobName := os.Getenv("JOB_NAME")
+		if jobName == "" {
+			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
+		}
+
+		network, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		switch network.Status.NetworkType {
+		case "OpenShiftSDN":
+			if !strings.Contains(jobName, "sdn") {
+				result.Flakef("job name %q does not have network type in name (expected `sdn`)", jobName)
+			}
+		case "OVNKubernetes":
+			if !strings.Contains(jobName, "ovn") {
+				result.Flakef("job name %q does not have network type in name (expected `ovn`)", jobName)
+			}
+		}
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/baremetal"
 	_ "github.com/openshift/origin/test/extended/bootstrap_user"
 	_ "github.com/openshift/origin/test/extended/builds"
+	_ "github.com/openshift/origin/test/extended/ci"
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/cluster"
 	_ "github.com/openshift/origin/test/extended/cmd"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1511,6 +1511,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-builds][Feature:JenkinsRHELImagesOnly][Feature:Jenkins][Feature:Builds][sig-devex][Slow] openshift pipeline build  jenkins pipeline build config strategy using a jenkins instance launched with the ephemeral template": "using a jenkins instance launched with the ephemeral template",
 
+	"[Top Level] [sig-ci] [Early] prow job name should match network type": "should match network type [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-ci] [Early] prow job name should match platform type": "should match platform type [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 should support forwarding over websockets": "should support forwarding over websockets [Skipped:Proxy] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
 	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 that expects NO client request should support a client that connects, sends DATA, and disconnects": "should support a client that connects, sends DATA, and disconnects [Suite:openshift/conformance/parallel] [Suite:k8s]",


### PR DESCRIPTION
[TRT-391](https://issues.redhat.com//browse/TRT-391)

We want to make sure that all jobs indicate both their platform (unless
agnostic) and network type. This adds a flaking test case to help us
identify misconfigured jobs.