### PR TITLE
Fixes OVN ACL audit log parsing

### DIFF
--- a/test/extended/networking/acl_audit_log.go
+++ b/test/extended/networking/acl_audit_log.go
@@ -206,7 +206,8 @@ func verifyAuditLogs(out string, ns []string, ips []string, ipv6 bool) (bool, bo
 			allowLogFound = true
 			continue
 		}
-		if strings.Contains(logLine, ns[0]+"_allow-from-same-ns\", verdict=drop") && strings.Contains(logLine, ipMatchSrc+ips[2]) &&
+		if (strings.Contains(logLine, ns[0]+"_allow-from-same-ns\", verdict=drop") && strings.Contains(logLine, ipMatchSrc+ips[2]) ||
+			strings.Contains(logLine, ns[0]+"_ingressDefaultDeny\", verdict=drop") && strings.Contains(logLine, ipMatchSrc+ips[2])) &&
 			strings.Contains(logLine, ipMatchDst+ips[0]) {
 			denyLogFound = true
 			continue


### PR DESCRIPTION
In OVN the default deny ACL naming was changed and thus the log line
will be different for the ACL name. This changes allows for both cases.

Signed-off-by: Tim Rozet <trozet@redhat.com>