### PR TITLE
Fix same test name being used twice for pods on different nodes check.

### DIFF
--- a/test/extended/scheduling/pods.go
+++ b/test/extended/scheduling/pods.go
@@ -164,13 +164,13 @@ var _ = g.Describe("[sig-scheduling][Early]", func() {
 		})
 	})
 
-	g.Describe("The openshift-console pods", func() {
+	g.Describe("The openshift-console console pods", func() {
 		g.It("should be scheduled on different nodes", func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-console", deployment: "console"}.run(oc)
 		})
 	})
 
-	g.Describe("The openshift-console pods", func() {
+	g.Describe("The openshift-console downloads pods", func() {
 		g.It("should be scheduled on different nodes", func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-console", deployment: "downloads"}.run(oc)
 		})
@@ -188,13 +188,13 @@ var _ = g.Describe("[sig-scheduling][Early]", func() {
 		})
 	})
 
-	g.Describe("The openshift-monitoring pods", func() {
+	g.Describe("The openshift-monitoring prometheus-adapter pods", func() {
 		g.It("should be scheduled on different nodes", func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-monitoring", deployment: "prometheus-adapter"}.run(oc)
 		})
 	})
 
-	g.Describe("The openshift-monitoring pods", func() {
+	g.Describe("The openshift-monitoring thanos-querier pods", func() {
 		g.It("should be scheduled on different nodes", func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-monitoring", deployment: "thanos-querier"}.run(oc)
 		})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -3273,13 +3273,17 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-scheduling][Early] The openshift-authentication pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-scheduling][Early] The openshift-console pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-scheduling][Early] The openshift-console console pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-scheduling][Early] The openshift-console downloads pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-scheduling][Early] The openshift-etcd pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-scheduling][Early] The openshift-image-registry pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-scheduling][Early] The openshift-monitoring pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-scheduling][Early] The openshift-monitoring prometheus-adapter pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-scheduling][Early] The openshift-monitoring thanos-querier pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-scheduling][Early] The openshift-oauth-apiserver pods should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
[TRT-395](https://issues.redhat.com//browse/TRT-395)

These two tests are showing as run twice always in testgrid, their name
was duplicated as they have two deployments we wanted to check.
