### PR TITLE
Consider Prometheus maximum points in a time series for alert tests

### DIFF
--- a/pkg/monitor/alerts.go
+++ b/pkg/monitor/alerts.go
@@ -32,10 +32,15 @@ func whenWasAlertInState(ctx context.Context, prometheusClient prometheusv1.API,
 	if alertState != "pending" && alertState != "firing" {
 		return nil, fmt.Errorf("unrecognized alertState: %v", alertState)
 	}
+
+	// Prometheus has a hardcoded maximum resolution of 11,000 points per timeseries.  The "Step"
+	// used to be 1 second but if a query exceeded 3 hours, this query would fail.  A resolution of
+	// 2 seconds is fine because the query will work for up to 6 hours and ALERTS change every 30s
+	// at most.
 	timeRange := prometheusv1.Range{
 		Start: startTime,
 		End:   time.Now(),
-		Step:  1 * time.Second,
+		Step:  2 * time.Second,
 	}
 	query := ""
 	switch {


### PR DESCRIPTION
re: [TRT-412](https://issues.redhat.com//browse/TRT-412)

When the span exceeds about 3 hours (11,000 seconds), we can't use 1s interval for a range query because it will exceed the Prometheus max.

There's still the problem of a test running for a very long time but this change allows the alert tests to still run (by using an interval of at least 2 seconds).