### PR TITLE
WIP: (DNM) Trigger release-3.11 CI

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package node
@@ -150,7 +151,7 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		// Not an OpenShift plugin
 		return nil, nil
 	}
-	glog.Infof("Initializing SDN node of type %q with configured hostname %q (IP %q)", c.PluginName, c.Hostname, c.SelfIP)
+	glog.Infof("(trivial change to trigger release-3.11 CI) Initializing SDN node of type %q with configured hostname %q (IP %q)", c.PluginName, c.Hostname, c.SelfIP)
 
 	if useConnTrack && c.ProxyMode != kubeproxyconfig.ProxyModeIPTables {
 		return nil, fmt.Errorf("%q plugin is not compatible with proxy-mode %q", c.PluginName, c.ProxyMode)


### PR DESCRIPTION
I'd like to see how e2e-gcp test is running and have a PR that will test the changes of [PR26155](https://github.com/openshift/release/pull/26155) when I get the e2e-aws to run (which uses the old template style).

Specifically, I'm interested in the behavior related to the `RPM_REPO_OPENSHIFT_ORIGIN` variable on the e2e-gcp test.

Since the [rehearse isn't working on PR26155](https://issues.redhat.com/browse/DPTP-2905), a simple way to test would be to get PR26155 in shape, force merge it, trigger CI with this PR, and see if the test does what we're expecting.