### PR TITLE
etcd vertical scaling test: add verbose timeout error messages and bump machine provisioning timeout for Azure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
 	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
 	github.com/pborman/uuid v1.2.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.32.1
@@ -195,7 +196,6 @@ require (
 	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -75,7 +75,9 @@ func CreateNewMasterMachine(ctx context.Context, t TestingT, machineClient machi
 
 func EnsureMasterMachine(ctx context.Context, t TestingT, machineName string, machineClient machinev1beta1client.MachineInterface) error {
 	waitPollInterval := 15 * time.Second
-	waitPollTimeout := 10 * time.Minute
+	// This timeout should be tuned for the platform that takes the longest to provision a node and result
+	// in a Running machine phase.
+	waitPollTimeout := 25 * time.Minute
 	t.Logf("Waiting up to %s for %q machine to be in the Running state", waitPollTimeout.String(), machineName)
 
 	return wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {


### PR DESCRIPTION
This PR increases the timeout for ensuring Machine phase is Running in the etcd vertical scaling test.
The node provisioning times observed on platforms like Azure range from 8-11 mins currently so this should help the test to not prematurely fail on those platforms.

<p><strong>Timeline for failed run:</strong><br /><a class="external-link" href="https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-e2e-azure-sdn-serial/1551552247274409984" target="_blank" rel="nofollow noopener">https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-e2e-azure-sdn-serial/1551552247274409984</a><br />&gt;&gt;&gt; Machine created</p>
<pre class="code panel" style="border-width: 1px;" data-language="code-java">2022-07-25T15:10:57.637648074Z I0725 15:10:57.637568 1 controller.go:179] ci-op-2gq9tc91-45a6f-z5fgn-master-0-clone: reconciling Machine </pre>
<p>&nbsp;<br />&gt;&gt;&gt; Machine going into phase Running:</p>
<pre class="code panel" style="border-width: 1px;" data-language="code-java">2022-07-25T15:21:11.985630907Z I0725 15:21:11.985571 1 controller.go:426] ci-op-2gq9tc91-45a6f-z5fgn-master-0-clone: going into phase <span class="code-quote">"Running"</span> </pre>
<p>&nbsp;<br />&gt;&gt; Master node gets provisioned after more than 10 mins and fails the test</p>
<div class="table-wrap">


15:21:11 (x2) | openshift-etcd-operator | openshift-cluster-etcd-operator-nodecontroller | etcd-operator | MasterNodeObserved | Observed new master node ci-op-2gq9tc91-45a6f-z5fgn-master-0-clone
-- | -- | -- | -- | -- | --


</div>

The verbose error messages for different timeouts will also help to surface those errors better in search.ci.openshift.org

/cc @dgoodwin @tjungblu 

