### PR TITLE
Increase API requests limit for monitoring operator on openstack

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -263,7 +263,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"cluster-autoscaler-operator":            53.0,
 				"cluster-baremetal-operator":             42.0,
 				"cluster-image-registry-operator":        112,
-				"cluster-monitoring-operator":            48,
+				"cluster-monitoring-operator":            72,
 				"cluster-node-tuning-operator":           103.0,
 				"cluster-samples-operator":               26.0,
 				"cluster-storage-operator":               189,


### PR DESCRIPTION
We are seeing this fail quite a bit in CI at the moment, for example like in [this job](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-shiftstack-shiftstack-ci-main-periodic-4.12-e2e-openstack-techpreview-serial/1551916732883406848).

This is happening on both [stable](https://search.ci.openshift.org/?search=operators+should+not+create+watch+channels+very+often&maxAge=336h&context=1&type=junit&name=openstack&excludeName=openstack-techpreview&maxMatches=5&maxBytes=20971520&groupBy=job) jobs and [tech preview](https://search.ci.openshift.org/?search=operators+should+not+create+watch+channels+very+often&maxAge=336h&context=1&type=junit&name=openstack-techpreview&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) jobs.

I've had a look at the Cluster Monitoring operator and they currently create 12 informers with a watch period of 15 minutes. This means over an hour, they are going to create a minimum of 48 watches. Should there be any interruption to the connection between the pod and the API server, this number will increase in multiples of 12.

Because OpenStack uses Keepalived for the VIP for the API server, there is guaranteed to be at least 1 failure through the life of the cluster as the bootstrap node goes away (it will hold the VIP during bootstrap). The leadership may change again during the tests which would lead to the number being increased again.

To allow for leadship changes, I've increased the number from 48 to 72, which allows up to 4 leadership changes through the lifetime of the test (the figure we configure is per hour, tests run for 2 hours). I think this should be ample to prevent this test failing again in the near future.

I have seen some jobs fail with more requests than this, but in these jobs, there are other larger issues and much wider spread failures so I think there were legitimate issues in these cases.