### PR TITLE
Update authenticated users RBAC e2e test

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -67,6 +67,9 @@ const (
 
 	// Provided as CRD via cluster-csi-snapshot-controller-operator
 	snapshotGroup = "snapshot.storage.k8s.io"
+
+	// Provided as CRD via operator-lifecycle-manager
+	operatorsCoreOSGroup = "operators.coreos.com"
 )
 
 // Do not change any of these lists without approval from the auth and master teams
@@ -154,6 +157,7 @@ var (
 		kuser.AllAuthenticated: {
 			"openshift": {
 				rbacv1helpers.NewRule(read...).Groups(templateGroup, legacyTemplateGroup).Resources("templates").RuleOrDie(),
+				rbacv1helpers.NewRule(read...).Groups(operatorsCoreOSGroup).Resources("clusterserviceversions").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(imageGroup, legacyImageGroup).Resources("imagestreams", "imagestreamtags", "imagestreamimages", "imagetags").RuleOrDie(),
 				rbacv1helpers.NewRule("get").Groups(imageGroup, legacyImageGroup).Resources("imagestreams/layers").RuleOrDie(),
 				rbacv1helpers.NewRule("get").Groups("").Resources("configmaps").RuleOrDie(),


### PR DESCRIPTION
Problem: OLM has historically communicated to users which operators
are available in a given namespace by creating a copy of an operator
CSV in each namespace that it is scoped to. This has caused performance
issues on large clusters with many namespaces. OLM provided users with
the means to disable Copied CSVs for operators scoped to all namespaces,
but console was unable to communicate which operators were available
globally. Console will look for csvs in the openshift namespace to
identify which operators are available globally for authenticated users.

The authenticated user group needs read permissions to view the
CSVs in the openshift namespace. The extended e2e origin test suite has
a test that ensures that authenticated users do not have unanticipated
RBAC.

Solution: This commit updates the test so that it expects the authenticated
user group to have get, list, and watch permissions on CSVs in the openshift
namespace.