### PR TITLE
[TRT-430] Update all agnhost references to 2.39

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -34797,7 +34797,7 @@ var _testExtendedTestdataCmdTestCmdTestdataHelloOpenshiftHelloPodJson = []byte(`
     "containers": [
       {
         "name": "hello-openshift",
-        "image": "k8s.gcr.io/e2e-test-images/agnhost:2.36",
+        "image": "k8s.gcr.io/e2e-test-images/agnhost:2.39",
         "args": ["netexec"],
         "ports": [
           {
@@ -38926,7 +38926,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       - kind: Route
         apiVersion: route.openshift.io/v1
         metadata:
@@ -43162,7 +43162,7 @@ items:
           replicationcontroller: idling-echo
       spec:
         containers:
-        - image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.39
           name: idling-echo-server
           args: [ "netexec", "--http-port", "8675" ]
           ports:
@@ -43228,7 +43228,7 @@ items:
           deploymentconfig: idling-echo
       spec:
         containers:
-        - image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.39
           name: idling-echo-server
           args: [ "netexec", "--http-port", "8675", "--udp-port", "3090" ]
           ports:
@@ -48215,7 +48215,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -48233,7 +48233,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -48472,7 +48472,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -48634,7 +48634,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -49687,7 +49687,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -49705,7 +49705,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -50308,7 +50308,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -50326,7 +50326,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -50344,7 +50344,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -51747,7 +51747,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.39
 `)
 
 func testExtendedTestdataTemplatesTemplateinstance_badobjectYamlBytes() ([]byte, error) {
@@ -51807,7 +51807,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       - kind: Route
         apiVersion: route.openshift.io/v1
         metadata:

--- a/test/extended/testdata/cmd/test/cmd/testdata/hello-openshift/hello-pod.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/hello-openshift/hello-pod.json
@@ -12,7 +12,7 @@
     "containers": [
       {
         "name": "hello-openshift",
-        "image": "k8s.gcr.io/e2e-test-images/agnhost:2.36",
+        "image": "k8s.gcr.io/e2e-test-images/agnhost:2.39",
         "args": ["netexec"],
         "ports": [
           {

--- a/test/extended/testdata/cmd/test/cmd/testdata/templateinstance_objectkinds.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/templateinstance_objectkinds.yaml
@@ -40,7 +40,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       - kind: Route
         apiVersion: route.openshift.io/v1
         metadata:

--- a/test/extended/testdata/idling-echo-server-rc.yaml
+++ b/test/extended/testdata/idling-echo-server-rc.yaml
@@ -17,7 +17,7 @@ items:
           replicationcontroller: idling-echo
       spec:
         containers:
-        - image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.39
           name: idling-echo-server
           args: [ "netexec", "--http-port", "8675" ]
           ports:

--- a/test/extended/testdata/idling-echo-server.yaml
+++ b/test/extended/testdata/idling-echo-server.yaml
@@ -20,7 +20,7 @@ items:
           deploymentconfig: idling-echo
       spec:
         containers:
-        - image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+        - image: k8s.gcr.io/e2e-test-images/agnhost:2.39
           name: idling-echo-server
           args: [ "netexec", "--http-port", "8675", "--udp-port", "3090" ]
           ports:

--- a/test/extended/testdata/router/ingress.yaml
+++ b/test/extended/testdata/router/ingress.yaml
@@ -91,7 +91,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -109,7 +109,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/router/router-common.yaml
+++ b/test/extended/testdata/router/router-common.yaml
@@ -105,7 +105,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/router/router-config-manager.yaml
+++ b/test/extended/testdata/router/router-config-manager.yaml
@@ -136,7 +136,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/router/router-metrics.yaml
+++ b/test/extended/testdata/router/router-metrics.yaml
@@ -78,7 +78,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -96,7 +96,7 @@ items:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/router/weighted-router.yaml
+++ b/test/extended/testdata/router/weighted-router.yaml
@@ -177,7 +177,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -195,7 +195,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080
@@ -213,7 +213,7 @@ objects:
     terminationGracePeriodSeconds: 1
     containers:
     - name: test
-      image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+      image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       args: ["netexec"]
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/templates/templateinstance_badobject.yaml
+++ b/test/extended/testdata/templates/templateinstance_badobject.yaml
@@ -28,4 +28,4 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.39

--- a/test/extended/testdata/templates/templateinstance_objectkinds.yaml
+++ b/test/extended/testdata/templates/templateinstance_objectkinds.yaml
@@ -40,7 +40,7 @@ items:
             spec:
               containers:
               - name: hello-openshift
-                image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+                image: k8s.gcr.io/e2e-test-images/agnhost:2.39
       - kind: Route
         apiVersion: route.openshift.io/v1
         metadata:


### PR DESCRIPTION
This was missed as part of the k8s 1.24.1 bump in #27323, and should drop the need to revert it via #27328.

https://issues.redhat.com/browse/TRT-430
https://coreos.slack.com/archives/CFP6ST0A3/p1659093112135979
