### PR TITLE
sig-api-machinery: remove project from authenticated browser APIServe…

### DIFF
--- a/test/extended/apiserver/root_403.go
+++ b/test/extended/apiserver/root_403.go
@@ -23,7 +23,7 @@ import (
 var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLI("apiserver")
+	oc := exutil.NewCLIWithoutNamespace("apiserver")
 
 	g.It("anonymous browsers should get a 403 from /", func() {
 		transport, err := anonymousHttpTransport(oc.AdminConfig())


### PR DESCRIPTION
…r tests

Lose the project namespace for tests that dont require it.