### PR TITLE
Bug 2106216: Reduce expected success rate to 98%

### DIFF
--- a/test/e2e/upgrade/dns/dns.go
+++ b/test/e2e/upgrade/dns/dns.go
@@ -130,8 +130,8 @@ func (t *UpgradeTest) validateDNSResults(f *framework.Framework) {
 			}
 		}
 
-		if successRate := (successCount / (successCount + failureCount)) * 100; successRate < 99 {
-			err = fmt.Errorf("success rate is less than 99%% on the node %s: [%0.2f]", pod.Spec.NodeName, successRate)
+		if successRate := (successCount / (successCount + failureCount)) * 100; successRate < 98 {
+			err = fmt.Errorf("success rate is less than 98%% on the node %s: [%0.2f]", pod.Spec.NodeName, successRate)
 		} else {
 			err = nil
 		}


### PR DESCRIPTION
We initially came up with 99% success rate expectancy as a guess as we didn't have any historical data to compare with. However, this test has been failing mostly with success rates greater than 98% but less than 99%: https://search.ci.openshift.org/?search=success+rate+is+less+than+99%25+on+the+node&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job 
So, changing the expected success rate in the test to >= 98% will reduce CI failures.
