### PR TITLE
Bug 2114506: test/extended/olm: Handle unset enabledCapabilities in marketplaceEnabled

### DIFF
--- a/test/extended/olm/olm.go
+++ b/test/extended/olm/olm.go
@@ -204,6 +204,9 @@ func marketplaceEnabled(oc *exutil.CLI) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if len(output) == 0 {
+		return false, nil
+	}
 	capabilities := []string{}
 	if err = json.Unmarshal([]byte(output), &capabilities); err != nil {
 		return false, err


### PR DESCRIPTION
[Avoid][1]:

```
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-e2e-aws-sdn-no-capabilities/1554248054456979456

: [sig-operator] an end user can use OLM can subscribe to the operator [Skipped:Disconnected] [Suite:openshift/conformance/parallel] expand_more

{  fail [github.com/openshift/origin/test/extended/olm/olm.go:270]: Unexpected error:
    <*json.SyntaxError | 0xc002396318>: {
        msg: "unexpected end of JSON input",
        Offset: 0,
    }
    unexpected end of JSON input
occurred
Ginkgo exit error 1: exit with code 1}
```

because the call returns an empty string, and not valid JSON, when the `enabledCapabilities` property is unset:

```console
$ oc get clusterversion version '-o=jsonpath={.status.capabilities}'
{"knownCapabilities":["baremetal","marketplace","openshift-samples"]}
$ oc get clusterversion version '-o=jsonpath={.status.capabilities.enabledCapabilities}' | wc
      0       0       0
```

Fixing a corner case from f0b3b0a346 (#27302).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2114506#c0