### PR TITLE
[OCPNODE-1034] WIP: Reject extreme latency profile test

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
+	_ "github.com/openshift/origin/test/extended/node"
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/olm"
 	_ "github.com/openshift/origin/test/extended/operators"

--- a/test/extended/node/reject_extreme_latency_profile.go
+++ b/test/extended/node/reject_extreme_latency_profile.go
@@ -1,0 +1,34 @@
+package node
+
+import (
+	"os/exec"
+
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-node][Feature:WorkerLatencyProfiles]", func() {
+	g.It("should reject extreme latency profile", func() {
+		latencyProfile := workerLatencyProfile()
+		o.Expect(latencyProfile).To(o.Equal(""))
+	})
+})
+
+func workerLatencyProfile() string {
+	// We don't use exutil.NewCLI() here because it can't be called from BeforeEach()
+	out, err := exec.Command(
+		"oc", "--kubeconfig="+exutil.KubeConfigPath(),
+		"get", "nodes.config.openshift.io", "cluster",
+		"--template={{.spec.workerLatencyProfile}}",
+	).CombinedOutput()
+	latencyProfile := string(out)
+	if err != nil {
+		e2e.Logf("Could not check network plugin name: %v. Assuming a non-OpenShift plugin", err)
+		latencyProfile = ""
+	}
+	return latencyProfile
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -3193,6 +3193,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [Local]": "should propagate requested groups to the container [Local]",
 
+	"[Top Level] [sig-node][Feature:WorkerLatencyProfiles] should reject extreme latency profile": "should reject extreme latency profile [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-node][Late] should not have pod creation failures due to systemd timeouts": "should not have pod creation failures due to systemd timeouts [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL": "Implement packages API server and list packagemanifest info with namespace not NULL [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
E2E test to block transition between Default <-> Low worker latency profiles.
This is a follow-up on config node custom resource validation: https://github.com/openshift/kubernetes/pull/1287

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>