### PR TITLE
Ensures operators use external cloud provider

### DIFF
--- a/test/extended/cloud_controller_manager/OWNERS
+++ b/test/extended/cloud_controller_manager/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - MaysaMacedo
+  - JoelSpeed
+approvers:
+  - MaysaMacedo
+  - JoelSpeed

--- a/test/extended/cloud_controller_manager/ccm.go
+++ b/test/extended/cloud_controller_manager/ccm.go
@@ -1,0 +1,67 @@
+package cloud_controller_manager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const cloudControllerNamespace = "openshift-cloud-controller-manager"
+const kuberControllerNamespace = "openshift-kube-controller-manager"
+
+var _ = g.Describe("[sig-cloud-provider][Feature:OpenShiftCloudControllerManager][Late]", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLI("ccm")
+
+	g.It("Deploy an external cloud provider", func() {
+		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if infra.Status.PlatformStatus.Type != configv1.OpenStackPlatformType {
+			g.Skip("Platform does not use external cloud provider")
+		}
+
+		g.By("Listing Pods on the openshift-cloud-controller-manager Namespace")
+		ccmPods, err := oc.AdminKubeClient().CoreV1().Pods(cloudControllerNamespace).List(context.Background(), metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Checking existance of any CCM Pod on the openshift-cloud-controller-manager Namespace")
+		o.Expect(len(ccmPods.Items) > 0).Should(o.BeTrue())
+
+		g.By("Getting configMap on the openshift-kube-controller-manager Namespace")
+		cm, err := oc.AdminKubeClient().CoreV1().ConfigMaps(kuberControllerNamespace).Get(context.TODO(), "config", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var observedConfig map[string]interface{}
+		err = yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &observedConfig)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Getting the value for the cloud-provider setting in the configMap")
+		cloudProvider, found, err := unstructured.NestedSlice(observedConfig, "extendedArguments", "cloud-provider")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Expecting Kube Controller Manager to not own cloud controller")
+		// When cloud-provider setting has "external" as value or it's just empty, KCM does not own Cloud Controllers
+		if found && (len(cloudProvider) != 1 || (cloudProvider[0] != "external" && cloudProvider[0] != "")) {
+			g.Fail(fmt.Sprintf("Expected cloud-provider %v setting to indicate KCM relinquished cloud ownership", cloudProvider))
+		}
+
+		g.By("Getting masters MachineConfig")
+		masterkubelet, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machineconfig/01-master-kubelet", "-o=jsonpath={.spec.config.systemd.units[0].contents}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Expecting masters MachineConfig to contain cloud-provider as external for kubelet")
+		o.Expect(masterkubelet).To(o.ContainSubstring("cloud-provider=external"))
+
+		g.By("Getting workers MachineConfig")
+		workerkubelet, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machineconfig/01-worker-kubelet", "-o=jsonpath={.spec.config.systemd.units[0].contents}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Expecting workers MachineConfig to contain cloud-provider as external for kubelet")
+		o.Expect(workerkubelet).To(o.ContainSubstring("cloud-provider=external"))
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/ci"
 	_ "github.com/openshift/origin/test/extended/cli"
+	_ "github.com/openshift/origin/test/extended/cloud_controller_manager"
 	_ "github.com/openshift/origin/test/extended/cluster"
 	_ "github.com/openshift/origin/test/extended/cmd"
 	_ "github.com/openshift/origin/test/extended/controller_manager"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1829,6 +1829,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods using a watch should watch for changes and rsync them": "should watch for changes and rsync them",
 
+	"[Top Level] [sig-cloud-provider][Feature:OpenShiftCloudControllerManager][Late] Deploy an external cloud provider": "Deploy an external cloud provider [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-cluster-lifecycle] CSRs from machines that are not recognized by the cloud provider are not approved": "CSRs from machines that are not recognized by the cloud provider are not approved [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cluster-lifecycle] Pods cannot access the /config/master API endpoint": "Pods cannot access the /config/master API endpoint [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
OpenStack platform is moving from in-tree cloud provider
to external one. The switch to external cloud provider has
to be done at the same time for the cluster cloud controller
manager operator and kube controller manager operator to avoid
the two providers being used in the cluster. Besides this the
machine config operator has to configure kubelet with external provider.
This commit includes a new test scenario to check that external provider
is properly configured for the needed operators.