### PR TITLE
Test we don't see substantial Secret/ConfigMap growth during upgrade.

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -77,6 +77,8 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testAPIQuotaEvents(events)...)
 	tests = append(tests, testMultipleSingleSecondAvailabilityFailure(events)...)
 	tests = append(tests, testNoDNSLookupErrorsInDisruptionSamplers(events)...)
+	tests = append(tests, testNoExcessiveSecretGrowthDuringUpgrade()...)
+	tests = append(tests, testNoExcessiveConfigMapGrowthDuringUpgrade()...)
 
 	return tests
 }

--- a/pkg/synthetictests/resource_growth.go
+++ b/pkg/synthetictests/resource_growth.go
@@ -1,0 +1,127 @@
+package synthetictests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"github.com/openshift/origin/test/e2e/upgrade"
+	exutil "github.com/openshift/origin/test/extended/util"
+	helper "github.com/openshift/origin/test/extended/util/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	// allowedResourceGrowth is the multiplier we'll allow before failing the test. (currently 40%)
+	allowedResourceGrowth = 1.4
+)
+
+func testNoExcessiveSecretGrowthDuringUpgrade() []*junitapi.JUnitTestCase {
+	const testName = "[sig-trt] Secret count should not have grown significantly during upgrade"
+	return comparePostUpgradeResourceCountFromMetrics(testName, "secrets")
+
+}
+
+func testNoExcessiveConfigMapGrowthDuringUpgrade() []*junitapi.JUnitTestCase {
+	const testName = "[sig-trt] ConfigMap count should not have grown significantly during upgrade"
+	return comparePostUpgradeResourceCountFromMetrics(testName, "configmaps")
+
+}
+
+// comparePostUpgradeResourceCountFromMetrics tests that some counts for certain resources we're most interested
+// in potentially leaking do not increase substantially during upgrade.
+// This is in response to a bug discovered where operators were leaking Secrets and ultimately taking down clusters.
+// The counts have to be recorded before upgrade which is done in test/e2e/upgrade/upgrade.go, stored in a package
+// variable, and then read here in invariant. This is to work around the problems where our normal ginko tests are
+// all run in separate processes by themselves.
+//
+// Values for comparison are a guess at what would have caught the leak we saw. (growth of about 60% during upgrade)
+//
+// resource should be all lowercase and plural such as "secrets".
+func comparePostUpgradeResourceCountFromMetrics(testName, resource string) []*junitapi.JUnitTestCase {
+	oc := exutil.NewCLI("resource-growth-test")
+	ctx := context.Background()
+
+	preUpgradeCount := upgrade.PreUpgradeResourceCounts[resource]
+	e2e.Logf("found %d %s prior to upgrade", preUpgradeCount, resource)
+
+	cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+	if err != nil {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Output: "Error getting ClusterVersion: " + err.Error(),
+				},
+			},
+		}
+
+	}
+	if len(cv.Status.History) == 0 {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Output: "ClusterVersion.Status has no History",
+				},
+			},
+		}
+	}
+	upgradeCompletion := cv.Status.History[0].CompletionTime
+
+	// Use prometheus to get the resource count at the moment we recorded upgrade complete. We can't do this
+	// for the starting count as prometheus metrics seem to get wiped during the upgrade. We also don't want to
+	// just list the resources right now, as we don't know what other tests might have created since.
+	e2e.Logf("querying metrics at: %s", upgradeCompletion.Time.UTC().Format(time.RFC3339))
+	resourceCountPromQuery := fmt.Sprintf(`cluster:usage:resources:sum{resource="%s"}`, resource)
+	promResultsCompletion, err := helper.RunQueryAtTime(ctx, oc.NewPrometheusClient(ctx),
+		resourceCountPromQuery, upgradeCompletion.Time)
+	if err != nil {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Output: "Error getting resource count from Prometheus at upgrade completion time: " + err.Error(),
+				},
+			},
+		}
+
+	}
+	e2e.Logf("got %d metrics after upgrade", len(promResultsCompletion.Data.Result))
+	if len(promResultsCompletion.Data.Result) == 0 {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Output: "Post-upgrade resource count metric data has no Result",
+				},
+			},
+		}
+	}
+	completedCount := int(promResultsCompletion.Data.Result[0].Value)
+	e2e.Logf("found %d %s after upgrade", completedCount, resource)
+
+	// Ensure that a resource count did not grow more than allowed:
+	maxAllowedCount := int(float64(preUpgradeCount) * allowedResourceGrowth)
+	output := fmt.Sprintf("%s count grew from %d to %d during upgrade (max allowed=%d). This test is experimental and may need adjusting in some cases.",
+		resource, preUpgradeCount, completedCount, maxAllowedCount)
+
+	if completedCount > maxAllowedCount {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Output: output,
+				},
+			},
+			// Add a success test to cause this to be a flake for now until we see how it behaves broadly.
+			{Name: testName},
+		}
+	}
+	return []*junitapi.JUnitTestCase{
+		{Name: testName},
+	}
+
+}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -270,6 +270,37 @@ func getUpgradeContext(c configv1client.Interface, upgradeImage string) (*upgrad
 
 var errControlledAbort = fmt.Errorf("beginning abort")
 
+// PreUpgradeResourceCounts stores a map of resource type to a count of the number of
+// resources of that type in the entire cluster, gathered prior to launching the upgrade.
+var PreUpgradeResourceCounts = map[string]int{}
+
+func GatherPreUpgradeResourceCounts() error {
+	config, err := framework.LoadConfig(true)
+	if err != nil {
+		return err
+	}
+	kubeClient := kubernetes.NewForConfigOrDie(config)
+	// Store resource counts we're interested in monitoring from before upgrade to after.
+	// Used to test for excessive resource growth during upgrade in the invariants.
+	ctx := context.Background()
+	secrets, err := kubeClient.CoreV1().Secrets("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	PreUpgradeResourceCounts["secrets"] = len(secrets.Items)
+	framework.Logf("found %d Secrets prior to upgrade at %s\n", len(secrets.Items),
+		time.Now().UTC().Format(time.RFC3339))
+
+	configMaps, err := kubeClient.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	PreUpgradeResourceCounts["configmaps"] = len(configMaps.Items)
+	framework.Logf("found %d ConfigMaps prior to upgrade at %s\n", len(configMaps.Items),
+		time.Now().UTC().Format(time.RFC3339))
+	return nil
+}
+
 func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynamic.Interface, config *rest.Config, version upgrades.VersionContext) error {
 	fmt.Fprintf(os.Stderr, "\n\n\n")
 	defer func() { fmt.Fprintf(os.Stderr, "\n\n\n") }()

--- a/test/extended/prometheus/upgrade.go
+++ b/test/extended/prometheus/upgrade.go
@@ -19,8 +19,7 @@ import (
 // MetricsAvailableAfterUpgradeTest tests that metrics from before an upgrade
 // are also available after the upgrade.
 type MetricsAvailableAfterUpgradeTest struct {
-	executionTimestamp      time.Time
-	persistentVolumeEnabled bool
+	executionTimestamp time.Time
 }
 
 func (t *MetricsAvailableAfterUpgradeTest) Name() string {


### PR DESCRIPTION
From a recent regression we looked into whether or not we could catch
what happened in a build cluster, in CI runs. I found that when this bug
was in play, Secret totals would grow by about 60% during upgrade
(roughly 600), and once the change was reverted this was not the case.

As such this test attempts to check for no more than a percentage of
growth for resources that are quite numerous. (i.e. we don't care if a
10 resource count grows to 20), but we do care if a 100 grows to
 800.

 We are unsure if this will be feasible across all upgrade jobs.

Test uses an early check prior to launching upgrade suite to grab the counts in the cluster and store in a global. We then use an invariant test as this is in the same process and can access the initial counts. The invariant test uses cluster version history completion time, and then checks the counts at that specific time via metrics. (as we don't want other tests to interfere in secret count) We could not use same approach for count at start of upgrade as the metrics are wiped during.
