### PR TITLE
include storage and must-gather tests in expectedTestCount

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -301,7 +301,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 			mustGatherTests = append(mustGatherTests, copyTests(originalMustGather)...)
 		}
 	}
-	expectedTestCount += len(openshiftTests) + len(kubeTests)
+	expectedTestCount += len(openshiftTests) + len(kubeTests) + len(storageTests) + len(mustGatherTests)
 
 	status := newTestStatus(opt.Out, includeSuccess, expectedTestCount, timeout, monitorEventRecorder, opt.AsEnv())
 	testCtx := ctx


### PR DESCRIPTION
This pull request is intends to address https://github.com/openshift/origin/issues/27350 .  It appears that when https://github.com/openshift/origin/commit/a42d174f9f93110da7b1863d58ab7a21fd056513 was introduced, the storage and must-gather test counts were omitted from the expected test count.