### PR TITLE
Add required pod security admission annotations into cmd/namespace

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -27893,6 +27893,10 @@ export KUBECONFIG=/kubeconfig
 
 namespace="cmd-${TEST_NAME}"
 oc new-project "${namespace}"
+
+oc label namespace ${namespace} --overwrite \
+  pod-security.kubernetes.io/enforce=baseline \
+  security.openshift.io/scc.podSecurityLabelSync=false
 `)
 
 func testExtendedTestdataCmdHackLibInitShBytes() ([]byte, error) {

--- a/test/extended/testdata/cmd/hack/lib/init.sh
+++ b/test/extended/testdata/cmd/hack/lib/init.sh
@@ -80,3 +80,7 @@ export KUBECONFIG=/kubeconfig
 
 namespace="cmd-${TEST_NAME}"
 oc new-project "${namespace}"
+
+oc label namespace ${namespace} --overwrite \
+  pod-security.kubernetes.io/enforce=baseline \
+  security.openshift.io/scc.podSecurityLabelSync=false


### PR DESCRIPTION
Currently `e2e-agnostic-cmd` jobs are failing due to pod security admission violation
error message. This PR adds required annotations into the namespace that tests run
to fix the error.