### PR TITLE
USHIFT-285: MicroShift: allow CLI creation without OpenShift APIs

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -52,7 +52,6 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	buildv1clienttyped "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 	imagev1typedclient "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
-	projectv1typedclient "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	"github.com/openshift/library-go/pkg/build/naming"
 	"github.com/openshift/library-go/pkg/git"
 	"github.com/openshift/library-go/pkg/image/imageutil"
@@ -1018,38 +1017,19 @@ func CheckBuildCancelled(b *buildv1.Build) bool {
 	return b.Status.Phase == buildv1.BuildPhaseCancelled
 }
 
-func getServiceAccount(c corev1client.ServiceAccountInterface, name string) (*corev1.ServiceAccount, error) {
-	sc, err := c.Get(context.Background(), name, metav1.GetOptions{})
-	if err != nil {
-		if kapierrs.IsNotFound(err) || kapierrs.IsForbidden(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return sc, nil
-}
-
-func serviceAccountContainsPullSecret(sa *corev1.ServiceAccount) bool {
-	hasDockerCfg := false
-	for _, s := range sa.ImagePullSecrets {
-		if strings.Contains(s.Name, "-dockercfg-") {
-			hasDockerCfg = true
-		}
-	}
-	return hasDockerCfg
-}
-
-// WaitForServiceAccountWithSecret waits until the named service account gets fully
-// provisioned. without dockercfg secrets
+// WaitForServiceAccount waits until the named service account gets fully
+// provisioned. Does not wait for dockercfg secrets
 func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string) error {
 	waitFn := func() (bool, error) {
-		sa, err := getServiceAccount(c, name)
+		_, err := c.Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
+			// If we can't access the service accounts, let's wait till the controller
+			// create it.
+			if kapierrs.IsNotFound(err) || kapierrs.IsForbidden(err) {
+				e2e.Logf("Waiting for service account %q to be available: %v (will retry) ...", name, err)
+				return false, nil
+			}
 			return false, fmt.Errorf("Failed to get service account %q: %v", name, err)
-		}
-		if sa == nil {
-			e2e.Logf("Waiting for service account %q to be available: %v (will retry) ...", name, err)
-			return false, nil
 		}
 		return true, nil
 	}
@@ -1060,18 +1040,28 @@ func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string) 
 // provisioned, including dockercfg secrets
 func WaitForServiceAccountWithSecret(c corev1client.ServiceAccountInterface, name string) error {
 	waitFn := func() (bool, error) {
-		sa, err := getServiceAccount(c, name)
+		sa, err := c.Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
+			// If we can't access the service accounts, let's wait till the controller
+			// create it.
+			if kapierrs.IsNotFound(err) || kapierrs.IsForbidden(err) {
+				e2e.Logf("Waiting for service account %q to be available: %v (will retry) ...", name, err)
+				return false, nil
+			}
 			return false, fmt.Errorf("Failed to get service account %q: %v", name, err)
 		}
-		if sa == nil {
-			e2e.Logf("Waiting for service account %q to be available: %v (will retry) ...", name, err)
-			return false, nil
+		secretNames := []string{}
+		var hasDockercfg bool
+		for _, s := range sa.ImagePullSecrets {
+			if strings.Contains(s.Name, "-dockercfg-") {
+				hasDockercfg = true
+			}
+			secretNames = append(secretNames, s.Name)
 		}
-		if serviceAccountContainsPullSecret(sa) {
+		if hasDockercfg {
 			return true, nil
 		}
-		e2e.Logf("Waiting for service account %q secrets to include dockercfg ...", name)
+		e2e.Logf("Waiting for service account %q secrets (%s) to include dockercfg ...", name, strings.Join(secretNames, ","))
 		return false, nil
 	}
 	return wait.Poll(100*time.Millisecond, 3*time.Minute, waitFn)
@@ -1101,32 +1091,6 @@ func WaitForNamespaceSCCAnnotations(c corev1client.CoreV1Interface, name string)
 		return false, nil
 	}
 	return wait.Poll(time.Duration(250*time.Millisecond), 30*time.Minute, waitFn)
-}
-
-// WaitForProjectSCCAnnotations waits up to 30s for the cluster-policy-controller to add the SCC related
-// annotations to the provided namespace.
-func WaitForProjectSCCAnnotations(c projectv1typedclient.ProjectV1Interface, name string) error {
-	waitFn := func() (bool, error) {
-		proj, err := c.Projects().Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			// it is assumed the project was created prior to calling this, so we
-			// do not distinguish not found errors
-			return false, err
-		}
-		if proj.Annotations == nil {
-			return false, nil
-		}
-		for k := range proj.Annotations {
-			// annotations to check based off of
-			// https://github.com/openshift/cluster-policy-controller/blob/master/pkg/security/controller/namespace_scc_allocation_controller.go#L112
-			if k == securityv1.UIDRangeAnnotation {
-				return true, nil
-			}
-		}
-		e2e.Logf("project %s current annotation set: %#v", name, proj.Annotations)
-		return false, nil
-	}
-	return wait.Poll(time.Duration(500*time.Millisecond), 30*time.Minute, waitFn)
 }
 
 // WaitForAnImageStream waits for an ImageStream to fulfill the isOK function

--- a/test/extended/util/oc_copy.go
+++ b/test/extended/util/oc_copy.go
@@ -49,7 +49,7 @@ func getUserPartOfNickname(clientCfg *restclient.Config) (string, error) {
 		return "", err
 	}
 	userInfo, err := userClient.Users().Get(context.Background(), "~", metav1.GetOptions{})
-	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
+	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) || kerrors.IsUnauthorized(err) {
 		// if we're talking to kube (or likely talking to kube), take a best guess consistent with login
 		switch {
 		case len(clientCfg.BearerToken) > 0:

--- a/test/extended/util/oc_copy.go
+++ b/test/extended/util/oc_copy.go
@@ -49,7 +49,7 @@ func getUserPartOfNickname(clientCfg *restclient.Config) (string, error) {
 		return "", err
 	}
 	userInfo, err := userClient.Users().Get(context.Background(), "~", metav1.GetOptions{})
-	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) || kerrors.IsUnauthorized(err) {
+	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
 		// if we're talking to kube (or likely talking to kube), take a best guess consistent with login
 		switch {
 		case len(clientCfg.BearerToken) > 0:
@@ -60,7 +60,6 @@ func getUserPartOfNickname(clientCfg *restclient.Config) (string, error) {
 	} else if err != nil {
 		return "", err
 	}
-
 	return userInfo.Name, nil
 }
 


### PR DESCRIPTION
Swaps project API with k8s namespaces in test/extended/util package. Automatic detection of project API to create a CLI object according to whats available in the cluster.