### PR TITLE
Label tests with openshift crafted API groups (round 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 	github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2
 	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/fsouza/go-dockerclient v1.7.1
@@ -90,6 +89,7 @@ require (
 	github.com/auth0/go-jwt-middleware v0.0.0-20201030150249-d783b5c46b39 // indirect
 	github.com/aws/aws-sdk-go v1.38.49 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/test/extended/adminack/adminack.go
+++ b/test/extended/adminack/adminack.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 	oc := exutil.NewCLI("cli-deployment")
 
 	g.Describe("TestAdminAck", func() {
-		g.It("should succeed", func() {
+		g.It("should succeed [apigroup:config.openshift.io]", func() {
 			config, err := framework.LoadConfig()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			ctx := context.Background()

--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("api-requests")
 
-	g.It("clients should not use APIs that are removed in upcoming releases", func() {
+	g.It("clients should not use APIs that are removed in upcoming releases [apigroup:config.openshift.io]", func() {
 		ctx := context.Background()
 		apirequestCountClient, err := apiserverclientv1.NewForConfig(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -91,7 +91,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 		}
 	})
 
-	g.It("operators should not create watch channels very often", func() {
+	g.It("operators should not create watch channels very often [apigroup:config.openshift.io]", func() {
 		ctx := context.Background()
 		apirequestCountClient, err := apiserverclientv1.NewForConfig(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -144,7 +144,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 		}
 	})
 
-	g.It("API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients", func() {
+	g.It("API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients [apigroup:config.openshift.io]", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/apiserver/kubeconfigs.go
+++ b/test/extended/apiserver/kubeconfigs.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] local ku
 		"localhost-recovery.kubeconfig",
 	} {
 		kubeconfig := kc
-		g.It(fmt.Sprintf("%q should be present on all masters and work", kubeconfig), func() {
+		g.It(fmt.Sprintf("%q should be present on all masters and work [apigroup:config.openshift.io]", kubeconfig), func() {
 			// external controlplane topology doesn't have master nodes
 			controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/apiserver/resiliency.go
+++ b/test/extended/apiserver/resiliency.go
@@ -3,9 +3,6 @@ package apiserver
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/origin/test/extended/operators"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"net/http"
 	"strings"
 	"time"
@@ -13,15 +10,18 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
+	"github.com/openshift/origin/test/extended/operators"
 	"github.com/openshift/origin/test/extended/scheme"
 	"github.com/openshift/origin/test/extended/single_node"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe("[Conformance][sig-sno][Serial] Cluster", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("cluster-resiliency")
 
-	ginkgo.It("should allow a fast rollout of kube-apiserver with no pods restarts during API disruption", func() {
+	ginkgo.It("should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]", func() {
 		controlPlaneTopology, _ := single_node.GetTopologies(f)
 
 		if controlPlaneTopology != configv1.SingleReplicaTopologyMode {

--- a/test/extended/apiserver/root_403.go
+++ b/test/extended/apiserver/root_403.go
@@ -1,19 +1,16 @@
 package apiserver
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/rest"
 
@@ -28,15 +25,6 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 	g.It("anonymous browsers should get a 403 from /", func() {
 		transport, err := anonymousHttpTransport(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		// For more info, refer to release notes of https://bugzilla.redhat.com/show_bug.cgi?id=1821771
-		for _, history := range cv.Status.History {
-			if strings.HasPrefix(history.Version, "4.1.") {
-				g.Skip("the test is not expected to work with clusters upgraded from 4.1.x")
-			}
-		}
 
 		req, err := http.NewRequest("GET", oc.AdminConfig().Host, nil)
 		req.Header.Set("Accept", "*/*")

--- a/test/extended/authentication/front_proxy.go
+++ b/test/extended/authentication/front_proxy.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-auth][Feature:Authentication] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestFrontProxy", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:config.openshift.io]"), func() {
 			controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/authorization/authorization.go
+++ b/test/extended/authorization/authorization.go
@@ -231,7 +231,7 @@ func (test resourceAccessReviewTest) run() {
 	failMessage := ""
 	var err error
 
-	g.By("resourceAccessReviewTest - "+test.description, func() {
+	g.By("resourceAccessReviewTest - "+test.description+" [apigroup:config.openshift.io]", func() {
 		// keep trying the test until you get a success or you timeout.  Every time you have a failure, set the fail message
 		// so that if you never have a success, we can call t.Errorf with a reasonable message
 		// exiting the poll with `failMessage=""` indicates success.
@@ -312,7 +312,7 @@ func (test localResourceAccessReviewTest) run() {
 	failMessage := ""
 	var err error
 
-	g.By("localResourceAccessReviewTest - "+test.description, func() {
+	g.By("localResourceAccessReviewTest - "+test.description+" [apigroup:authorization.openshift.io][apigroup:config.openshift.io]", func() {
 		// keep trying the test until you get a success or you timeout.  Every time you have a failure, set the fail message
 		// so that if you never have a success, we can call t.Errorf with a reasonable message
 		// exiting the poll with `failMessage=""` indicates success.
@@ -397,7 +397,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization][Serial] authoriza
 
 	g.Context("", func() {
 		g.Describe("TestAuthorizationResourceAccessReview", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				clusterAdminAuthorizationClient := oc.AdminAuthorizationClient().AuthorizationV1()
 
 				hammerProjectName := oc.CreateProject()
@@ -500,7 +500,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 
 	g.Context("", func() {
 		g.Describe("TestAuthorizationSubjectAccessReview", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				t := g.GinkgoT()
 
 				clusterAdminLocalSARGetter := oc.AdminKubeClient().AuthorizationV1()
@@ -825,7 +825,7 @@ func (test subjectAccessReviewTest) run(t g.GinkgoTInterface) {
 	PolicyCachePollInterval := 100 * time.Millisecond
 	PolicyCachePollTimeout := 10 * time.Second
 
-	g.By(test.description+" with openshift api", func() {
+	g.By(test.description+" with openshift api [apigroup:authorization.openshift.io]", func() {
 		failMessage := ""
 		err := wait.Poll(PolicyCachePollInterval, PolicyCachePollTimeout, func() (bool, error) {
 			var err error
@@ -1055,7 +1055,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 
 	g.Context("", func() {
 		g.Describe("TestAuthorizationSubjectAccessReviewAPIGroup", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				t := g.GinkgoT()
 
 				clusterAdminKubeClient := oc.AdminKubeClient()
@@ -1191,7 +1191,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 
 	g.Context("", func() {
 		g.Describe("TestBrowserSafeAuthorizer", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io]"), func() {
 				t := g.GinkgoT()
 
 				// this client has an API token so it is safe

--- a/test/extended/authorization/authorization_rbac_proxy.go
+++ b/test/extended/authorization/authorization_rbac_proxy.go
@@ -31,31 +31,31 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for op
 	oc := exutil.NewCLI("rbac-proxy")
 	g.Context("", func() {
 		g.Describe("RunLegacyLocalRoleBindingEndpoint", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				RunLegacyLocalRoleBindingEndpoint(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 
-		g.Describe("RunLegacyEndpointConfirmNoEscalation", func() {
+		g.Describe("RunLegacyEndpointConfirmNoEscalation [apigroup:authorization.openshift.io]", func() {
 			g.It(fmt.Sprintf("should succeed"), func() {
 				RunLegacyEndpointConfirmNoEscalation(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Username(), oc.Namespace())
 			})
 		})
 
 		g.Describe("RunLegacyClusterRoleBindingEndpoint", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				RunLegacyClusterRoleBindingEndpoint(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 
 		g.Describe("RunLegacyClusterRoleEndpoint", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				RunLegacyClusterRoleEndpoint(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 
 		g.Describe("RunLegacyLocalRoleEndpoint", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				RunLegacyLocalRoleEndpoint(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})

--- a/test/extended/authorization/rolebinding_restrictions.go
+++ b/test/extended/authorization/rolebinding_restrictions.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 	oc := exutil.NewCLI("rolebinding-restrictions")
 	g.Context("", func() {
 		g.Describe("Create a rolebinding when there are no restrictions", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				ns := oc.Namespace()
 				user := "alice"
 				roleBindingCreate(oc, false, false, ns, user, "rb1")
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a rolebinding when subject is permitted by RBR", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				ns := oc.Namespace()
 				users := []string{"bob"}
 				_, err := oc.AdminAuthorizationClient().AuthorizationV1().RoleBindingRestrictions(ns).Create(context.Background(), generateAllowUserRolebindingRestriction(ns, users), metav1.CreateOptions{})
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a rolebinding when subject is already bound", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				users := []string{"cindy"}
 				ns := oc.Namespace()
 				roleBindingCreate(oc, false, false, ns, users[0], "rb1")
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a rolebinding when subject is not already bound and is not permitted by any RBR", func() {
-			g.It(fmt.Sprintf("should fail"), func() {
+			g.It(fmt.Sprintf("should fail [apigroup:authorization.openshift.io]"), func() {
 				ns := oc.Namespace()
 				users := []string{"dave", "eve"}
 				roleBindingCreate(oc, false, false, ns, users[0], "rb1")
@@ -67,7 +67,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a RBAC rolebinding when subject is not already bound and is not permitted by any RBR", func() {
-			g.It(fmt.Sprintf("should fail"), func() {
+			g.It(fmt.Sprintf("should fail [apigroup:authorization.openshift.io]"), func() {
 				ns := oc.Namespace()
 				users := []string{"frank", "george"}
 				roleBindingCreate(oc, false, false, ns, users[0], "rb1")
@@ -80,7 +80,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a rolebinding that also contains system:non-existing users", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				ns := oc.Namespace()
 				users := []string{"harry", "system:non-existing"}
 				_, err := oc.AdminAuthorizationClient().AuthorizationV1().RoleBindingRestrictions(ns).Create(context.Background(), generateAllowUserRolebindingRestriction(ns, users), metav1.CreateOptions{})
@@ -93,7 +93,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Rolebinding restrictions tests single project", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
 				ns := oc.Namespace()
 				users := []string{"zed", "yvette"}
 				users2 := []string{"xavier", "system:non-existing"}

--- a/test/extended/authorization/scopes.go
+++ b/test/extended/authorization/scopes.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestScopedTokens", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:oauth.openshift.io][apigroup:build.openshift.io]"), func() {
 			t := g.GinkgoT()
 
 			projectName := oc.Namespace()
@@ -104,7 +104,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestScopedImpersonation", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io]"), func() {
 			t := g.GinkgoT()
 
 			projectName := oc.Namespace()
@@ -139,7 +139,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestScopeEscalations", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io][apigroup:oauth.openshift.io]"), func() {
 			t := g.GinkgoT()
 
 			projectName := oc.Namespace()
@@ -216,7 +216,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestTokensWithIllegalScopes", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:oauth.openshift.io]"), func() {
 			t := g.GinkgoT()
 
 			clusterAdminClientConfig := oc.AdminConfig()
@@ -447,7 +447,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestUnknownScopes", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]"), func() {
 			t := g.GinkgoT()
 
 			clusterAdminClientConfig := oc.AdminConfig()

--- a/test/extended/authorization/self_sar.go
+++ b/test/extended/authorization/self_sar.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] self-SAR compatib
 
 	g.Context("", func() {
 		g.Describe("TestBootstrapPolicySelfSubjectAccessReviews", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io]"), func() {
 				t := g.GinkgoT()
 
 				valerieName := oc.CreateUser("valerie-").Name
@@ -56,7 +56,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] self-SAR compatib
 		})
 
 		g.Describe("TestSelfSubjectAccessReviewsNonExistingNamespace", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io]"), func() {
 				t := g.GinkgoT()
 
 				valerieName := oc.CreateUser("valerie-").Name

--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 			}
 		})
 
-		g.It("should prune completed builds based on the successfulBuildsHistoryLimit setting", func() {
+		g.It("should prune completed builds based on the successfulBuildsHistoryLimit setting [apigroup:build.openshift.io]", func() {
 
 			g.By("creating test successful build config")
 			err := oc.Run("create").Args("-f", successfulBuildConfig).Execute()
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("should prune failed builds based on the failedBuildsHistoryLimit setting", func() {
+		g.It("should prune failed builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]", func() {
 
 			g.By("creating test failed build config")
 			err := oc.Run("create").Args("-f", failedBuildConfig).Execute()
@@ -144,7 +144,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("should prune canceled builds based on the failedBuildsHistoryLimit setting", func() {
+		g.It("should prune canceled builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]", func() {
 
 			g.By("creating test successful build config")
 			err := oc.Run("create").Args("-f", failedBuildConfig).Execute()
@@ -234,7 +234,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("should prune builds after a buildConfig change", func() {
+		g.It("should prune builds after a buildConfig change [apigroup:build.openshift.io]", func() {
 
 			g.By("creating test failed build config")
 			err := oc.Run("create").Args("-f", failedBuildConfig).Execute()
@@ -285,7 +285,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("buildconfigs should have a default history limit set when created via the group api", func() {
+		g.It("buildconfigs should have a default history limit set when created via the group api [apigroup:build.openshift.io]", func() {
 
 			g.By("creating a build config with the group api")
 			err := oc.Run("create").Args("-f", groupBuildConfig).Execute()

--- a/test/extended/builds/build_timing.go
+++ b/test/extended/builds/build_timing.go
@@ -55,7 +55,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][timing] capture build stages an
 			}
 		})
 
-		g.It("should record build stages and durations for s2i", func() {
+		g.It("should record build stages and durations for s2i [apigroup:build.openshift.io]", func() {
 			expectedBuildStages := make(map[string][]string)
 			expectedBuildStages["PullImages"] = []string{"", "1000s"}
 			expectedBuildStages["Build"] = []string{"10ms", "1000s"}
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][timing] capture build stages an
 			verifyStages(br.Build.Status.Stages, expectedBuildStages)
 		})
 
-		g.It("should record build stages and durations for docker", func() {
+		g.It("should record build stages and durations for docker [apigroup:build.openshift.io]", func() {
 			expectedBuildStages := make(map[string][]string)
 			expectedBuildStages["PullImages"] = []string{"", "1000s"}
 			expectedBuildStages["Build"] = []string{"10ms", "1000s"}

--- a/test/extended/builds/buildconfigsecretinjector.go
+++ b/test/extended/builds/buildconfigsecretinjector.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] buildconfig secret injector", f
 			}
 		})
 
-		g.It("should inject secrets to the appropriate buildconfigs", func() {
+		g.It("should inject secrets to the appropriate buildconfigs [apigroup:build.openshift.io]", func() {
 			out, err := oc.Run("get").Args("bc/test1", "-o", "template", "--template", "{{.spec.source.sourceSecret.name}}").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(out).To(o.Equal("secret1"))

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -240,7 +240,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 
 		})
 
-		g.Context("build config no ocm rollout", func() {
+		g.Context("build config no ocm rollout [apigroup:config.openshift.io]", func() {
 			g.AfterEach(func() {
 				g.By("reset build cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
@@ -251,7 +251,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("Apply default proxy configuration to source build pod through env vars", func() {
+			g.It("Apply default proxy configuration to source build pod through env vars [apigroup:build.openshift.io]", func() {
 				g.By("apply proxy cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", invalidproxyConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -276,7 +276,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				checkPodProxyEnvs(pod.Spec.InitContainers, buildConfig.Spec.BuildDefaults.DefaultProxy)
 			})
 
-			g.It("Apply default proxy configuration to docker build pod through env vars", func() {
+			g.It("Apply default proxy configuration to docker build pod through env vars [apigroup:build.openshift.io]", func() {
 				g.By("apply proxy cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", invalidproxyConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -302,7 +302,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 
 			// this replaces coverage from the TestBuildDefaultGitHTTPProxy and TestBuildDefaultGitHTTPSProxy integration test
-			g.It("Apply git proxy configuration to build pod", func() {
+			g.It("Apply git proxy configuration to build pod [apigroup:build.openshift.io]", func() {
 				g.By("apply proxy cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -341,7 +341,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 		})
 
-		g.Context("build config with ocm rollout", func() {
+		g.Context("build config with ocm rollout [apigroup:config.openshift.io]", func() {
 
 			g.AfterEach(func() {
 				g.By("reset build cluster configuration")
@@ -463,7 +463,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 
 			// this replaces coverage from the TestBuildOverrideLabels integration test
-			g.It("Apply override image label configuration to build pod", func() {
+			g.It("Apply override image label configuration to build pod [apigroup:build.openshift.io]", func() {
 				g.By("apply label cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/completiondeadlineseconds.go
+++ b/test/extended/builds/completiondeadlineseconds.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should have deadli
 		})
 
 		g.Describe("oc start-build source-build --wait", func() {
-			g.It("Source: should start a build and wait for the build failed and build pod being killed by kubelet", func() {
+			g.It("Source: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]", func() {
 
 				g.By("calling oc create source-build")
 				err := oc.Run("create").Args("-f", sourceFixture).Execute()
@@ -60,7 +60,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should have deadli
 		})
 
 		g.Describe("oc start-build docker-build --wait", func() {
-			g.It("Docker: should start a build and wait for the build failed and build pod being killed by kubelet", func() {
+			g.It("Docker: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]", func() {
 
 				g.By("calling oc create docker-build")
 				err := oc.Run("create").Args("-f", dockerFixture).Execute()

--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds with a context dir
 		})
 
 		g.Describe("s2i context directory build", func() {
-			g.It(fmt.Sprintf("should s2i build an application using a context directory"), func() {
+			g.It(fmt.Sprintf("should s2i build an application using a context directory [apigroup:build.openshift.io]"), func() {
 
 				exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc create -f %q", appFixture))
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds with a context dir
 		})
 
 		g.Describe("docker context directory build", func() {
-			g.It(fmt.Sprintf("should docker build an application using a context directory"), func() {
+			g.It(fmt.Sprintf("should docker build an application using a context directory [apigroup:build.openshift.io]"), func() {
 				g.By("initializing local repo")
 				repo, err := exutil.NewGitRepo("contextdir")
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/controller_compat.go
+++ b/test/extended/builds/controller_compat.go
@@ -26,17 +26,17 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build controller", func()
 		})
 
 		g.Describe("RunBuildCompletePodDeleteTest", func() {
-			g.It("should succeed", func() {
+			g.It("should succeed [apigroup:build.openshift.io]", func() {
 				RunBuildCompletePodDeleteTest(g.GinkgoT(), oc.BuildClient().BuildV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 		g.Describe("RunBuildDeleteTest", func() {
-			g.It("should succeed", func() {
+			g.It("should succeed [apigroup:build.openshift.io]", func() {
 				RunBuildDeleteTest(g.GinkgoT(), oc.AdminBuildClient().BuildV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 		g.Describe("RunBuildRunningPodDeleteTest", func() {
-			g.It("should succeed", func() {
+			g.It("should succeed [apigroup:build.openshift.io]", func() {
 				g.Skip("skipping until devex team figures this out in the new split API setup, see https://bugzilla.redhat.com/show_bug.cgi?id=164118")
 				RunBuildRunningPodDeleteTest(g.GinkgoT(), oc.AdminBuildClient().BuildV1(), oc.AdminKubeClient(), oc.Namespace())
 			})

--- a/test/extended/builds/custom_build.go
+++ b/test/extended/builds/custom_build.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] custom build with buildah", fun
 		})
 
 		g.Describe("being created from new-build", func() {
-			g.It("should complete build with custom builder image", func() {
+			g.It("should complete build with custom builder image [apigroup:build.openshift.io]", func() {
 				g.By("create custom builder image")
 				err := oc.Run("new-build").Args("--binary", "--strategy=docker", "--name=custom-builder-image").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/digest.go
+++ b/test/extended/builds/digest.go
@@ -64,7 +64,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] completed builds should h
 })
 
 func testBuildDigest(oc *exutil.CLI, buildFixture string, buildLogLevel uint) {
-	g.It(fmt.Sprintf("should save the image digest when finished"), func() {
+	g.It(fmt.Sprintf("should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]"), func() {
 		g.By("creating test build")
 		err := oc.Run("create").Args("-f", buildFixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/docker_pullsearch.go
+++ b/test/extended/builds/docker_pullsearch.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][pullsearch] docker build where 
 		})
 
 		g.Describe("Building from a Dockerfile whose FROM image ref does not specify the image registry", func() {
-			g.It("should create a docker build that has buildah search from our predefined list of image registries and succeed", func() {
+			g.It("should create a docker build that has buildah search from our predefined list of image registries and succeed [apigroup:build.openshift.io]", func() {
 
 				g.By("creating a BuildConfig whose base image does not have a fully qualified registry name")
 				err := oc.Run("create").Args("-f", buildFixture).Execute()

--- a/test/extended/builds/docker_pullsecret.go
+++ b/test/extended/builds/docker_pullsecret.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][pullsecret] docker build using 
 		})
 
 		g.Describe("Building from a template", func() {
-			g.It("should create a docker build that pulls using a secret run it", func() {
+			g.It("should create a docker build that pulls using a secret run it [apigroup:build.openshift.io]", func() {
 
 				g.By(fmt.Sprintf("calling oc create -f %q", buildFixture))
 				err := oc.Run("create").Args("-f", buildFixture).Execute()

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -51,7 +51,7 @@ USER 1001
 		})
 
 		g.Describe("being created from new-build", func() {
-			g.It("should create a image via new-build", func() {
+			g.It("should create a image via new-build [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
 				g.By("calling oc new-build with Dockerfile")
 				err := oc.Run("new-build").Args("-D", "-", "--to", "busybox:custom").InputString(testDockerfile).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -80,7 +80,7 @@ USER 1001
 				o.Expect(image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.User).To(o.Equal("1001"))
 			})
 
-			g.It("should create a image via new-build and infer the origin tag", func() {
+			g.It("should create a image via new-build and infer the origin tag [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
 				g.By("calling oc new-build with Dockerfile that uses the same tag as the output")
 				err := oc.Run("new-build").Args("-D", "-").InputString(testDockerfile2).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -114,7 +114,7 @@ USER 1001
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("should be able to start a build from Dockerfile with FROM reference to scratch", func() {
+			g.It("should be able to start a build from Dockerfile with FROM reference to scratch [apigroup:build.openshift.io]", func() {
 				g.By("calling oc new-build with Dockerfile that uses scratch")
 				err := oc.Run("new-build").Args("-D", "-").InputString(testDockerfile3).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -134,7 +134,7 @@ USER 1001
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("testing build image with invalid dockerfile content", func() {
+			g.It("testing build image with invalid dockerfile content [apigroup:build.openshift.io]", func() {
 				// https://bugzilla.redhat.com/show_bug.cgi?id=1694867
 				g.By("creating a build")
 				err := oc.Run("new-build").Args("--binary", "--strategy=docker", "--name=centos").Execute()
@@ -147,7 +147,7 @@ USER 1001
 				o.Expect(logs).To(o.ContainSubstring("no such file or directory"))
 			})
 
-			g.It("testing build image with dockerfile contains a file path uses a variable in its name", func() {
+			g.It("testing build image with dockerfile contains a file path uses a variable in its name [apigroup:build.openshift.io]", func() {
 				// https://bugzilla.redhat.com/show_bug.cgi?id=1810174
 				g.By("creating a build")
 				err := oc.Run("new-build").Args("--binary", "--strategy=docker", "--name=buildah-env").Execute()

--- a/test/extended/builds/failure_status.go
+++ b/test/extended/builds/failure_status.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status postcommit hook failure", func() {
-			g.It("should contain the post commit hook failure reason and message", func() {
+			g.It("should contain the post commit hook failure reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", postCommitHookFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -89,7 +89,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status Docker fetch image content failure", func() {
-			g.It("should contain the Docker build fetch image content reason and message", func() {
+			g.It("should contain the Docker build fetch image content reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", fetchDockerImg).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -108,7 +108,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status Docker fetch source failure", func() {
-			g.It("should contain the Docker build fetch source failure reason and message", func() {
+			g.It("should contain the Docker build fetch source failure reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", fetchDockerSrc).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -143,7 +143,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status S2I fetch source failure", func() {
-			g.It("should contain the S2I fetch source failure reason and message", func() {
+			g.It("should contain the S2I fetch source failure reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", fetchS2ISrc).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -162,7 +162,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status OutOfMemoryKilled", func() {
-			g.It("should contain OutOfMemoryKilled failure reason and message", func() {
+			g.It("should contain OutOfMemoryKilled failure reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", oomkilled).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -188,7 +188,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status S2I bad context dir failure", func() {
-			g.It("should contain the S2I bad context dir failure reason and message", func() {
+			g.It("should contain the S2I bad context dir failure reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", badContextDirS2ISrc).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -207,7 +207,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status fetch builder image failure", func() {
-			g.It("should contain the fetch builder image failure reason and message", func() {
+			g.It("should contain the fetch builder image failure reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", builderImageFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -226,7 +226,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status push image to registry failure", func() {
-			g.It("should contain the image push to registry failure reason and message", func() {
+			g.It("should contain the image push to registry failure reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", pushToRegistryFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -250,7 +250,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status failed assemble container", func() {
-			g.It("should contain the failure reason related to an assemble script failing in s2i", func() {
+			g.It("should contain the failure reason related to an assemble script failing in s2i [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", failedAssembleFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -269,7 +269,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status failed https proxy invalid url", func() {
-			g.It("should contain the generic failure reason and message", func() {
+			g.It("should contain the generic failure reason and message [apigroup:build.openshift.io]", func() {
 				err := oc.Run("create").Args("-f", failedGenericReason).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use private repositor
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("should be able to clone source code via an HTTP token", func() {
+			g.It("should be able to clone source code via an HTTP token [apigroup:build.openshift.io]", func() {
 				testGitAuth("https://github.com/openshift-github-testing/nodejs-ex-private.git", "github-http-token")
 			})
 
@@ -110,11 +110,11 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use private repositor
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("should be able to clone source code via ssh", func() {
+			g.It("should be able to clone source code via ssh [apigroup:build.openshift.io]", func() {
 				testGitAuth("ssh://git@github.com/openshift-github-testing/nodejs-ex-private.git", "github-ssh-privatekey")
 			})
 
-			g.It("should be able to clone source code via ssh using SCP-style URIs", func() {
+			g.It("should be able to clone source code via ssh using SCP-style URIs [apigroup:build.openshift.io]", func() {
 				testGitAuth("git@github.com:openshift-github-testing/nodejs-ex-private.git", "github-ssh-privatekey")
 			})
 		})

--- a/test/extended/builds/hooks.go
+++ b/test/extended/builds/hooks.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] testing build configurati
 
 		g.Describe("testing postCommit hook", func() {
 
-			g.It("should run s2i postCommit hooks", func() {
+			g.It("should run s2i postCommit hooks [apigroup:build.openshift.io]", func() {
 				oc.Run("create").Args("-f", imagestreamFixture).Execute()
 				oc.Run("create").Args("-f", s2iBuildFixture).Execute()
 
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] testing build configurati
 
 			})
 
-			g.It("should run docker postCommit hooks", func() {
+			g.It("should run docker postCommit hooks [apigroup:build.openshift.io]", func() {
 				oc.Run("create").Args("-f", imagestreamFixture).Execute()
 				oc.Run("create").Args("-f", dockerBuildFixture).Execute()
 

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -55,7 +55,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 		customBuildLabel   = exutil.ParseLabelsOrDie("openshift.io/build.name=imagecustombuild")
 	)
 
-	g.Context("", func() {
+	g.Context("[apigroup:image.openshift.io]", func() {
 		g.BeforeEach(func() {
 			exutil.PreTestDump()
 		})
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 		})
 
 		g.Describe("buildconfig with input source image and s2i strategy", func() {
-			g.It("should complete successfully and contain the expected file", func() {
+			g.It("should complete successfully and contain the expected file [apigroup:build.openshift.io]", func() {
 				g.By("Creating build configs for source build")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 			})
 		})
 		g.Describe("buildconfig with input source image and docker strategy", func() {
-			g.It("should complete successfully and contain the expected file", func() {
+			g.It("should complete successfully and contain the expected file [apigroup:build.openshift.io]", func() {
 				g.By("Creating build configs for docker build")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -129,7 +129,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 			})
 		})
 		g.Describe("creating a build with an input source image and s2i strategy", func() {
-			g.It("should resolve the imagestream references and secrets", func() {
+			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", func() {
 				g.By("Creating build configs for input image")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -174,7 +174,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 			})
 		})
 		g.Describe("creating a build with an input source image and docker strategy", func() {
-			g.It("should resolve the imagestream references and secrets", func() {
+			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", func() {
 				g.By("Creating build configs for input image")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -219,7 +219,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 			})
 		})
 		g.Describe("creating a build with an input source image and custom strategy", func() {
-			g.It("should resolve the imagestream references and secrets", func() {
+			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", func() {
 				g.By("Creating build configs for input image")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/imagechangetriggers.go
+++ b/test/extended/builds/imagechangetriggers.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] imagechangetriggers", func() {
 			}
 		})
 
-		g.It("imagechangetriggers should trigger builds of all types", func() {
+		g.It("imagechangetriggers should trigger builds of all types [apigroup:build.openshift.io]", func() {
 			err := oc.AsAdmin().Run("create").Args("-f", buildFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] result image should have proper
 		})
 
 		g.Describe("S2I build from a template", func() {
-			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels", filepath.Base(stiBuildFixture)), func() {
+			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(stiBuildFixture)), func() {
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()
@@ -65,7 +65,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] result image should have proper
 		})
 
 		g.Describe("Docker build from a template", func() {
-			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels", filepath.Base(dockerBuildFixture)), func() {
+			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(dockerBuildFixture)), func() {
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()

--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -42,7 +42,7 @@ COPY --from=%[2]s /bin/ping /test/
 		}
 	})
 
-	g.It("should succeed", func() {
+	g.It("should succeed [apigroup:build.openshift.io]", func() {
 		g.By("creating a build directly")
 		registryURL, err := eximages.GetDockerRegistryURL(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 			deployutil.DeploymentConfigFailureTrap(oc, a59, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should succeed with a --name of 58 characters", func() {
+		g.It("should succeed with a --name of 58 characters [apigroup:build.openshift.io]", func() {
 			g.By("calling oc new-app")
 			err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--name", a58, "--build-env=BUILD_LOGLEVEL=5").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/no_outputname.go
+++ b/test/extended/builds/no_outputname.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build without output image", fu
 		})
 
 		g.Describe("building from templates", func() {
-			g.It(fmt.Sprintf("should create an image from a docker template without an output image reference defined"), func() {
+			g.It(fmt.Sprintf("should create an image from a docker template without an output image reference defined [apigroup:build.openshift.io]"), func() {
 				err := oc.Run("create").Args("-f", dockerImageFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build without output image", fu
 				o.Expect(buildLog).Should(o.ContainSubstring(`Build complete, no image push requested`))
 			})
 
-			g.It(fmt.Sprintf("should create an image from a S2i template without an output image reference defined"), func() {
+			g.It(fmt.Sprintf("should create an image from a S2i template without an output image reference defined [apigroup:build.openshift.io]"), func() {
 				err := oc.Run("create").Args("-f", s2iImageFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/builds/nosrc.go
+++ b/test/extended/builds/nosrc.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build with empty source", func(
 		})
 
 		g.Describe("started build", func() {
-			g.It("should build even with an empty source in build config", func() {
+			g.It("should build even with an empty source in build config [apigroup:build.openshift.io]", func() {
 				g.By("starting the empty source build")
 				br, err := exutil.StartBuildAndWait(oc, "nosrc-build", fmt.Sprintf("--from-dir=%s", exampleBuild))
 				br.AssertSuccess()

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -45,7 +45,7 @@ USER 1001
 			}
 		})
 
-		g.It("should succeed", func() {
+		g.It("should succeed [apigroup:build.openshift.io]", func() {
 			g.By("creating a build directly")
 			build, err := oc.AdminBuildClient().BuildV1().Builds(oc.Namespace()).Create(context.Background(), &buildv1.Build{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -89,7 +89,7 @@ var _ = g.Describe("[sig-builds][Feature:JenkinsRHELImagesOnly][Feature:Jenkins]
 	g.Context("", func() {
 
 		g.Describe("jenkins pipeline build config strategy", func() {
-			g.It("using a jenkins instance launched with the ephemeral template", func() {
+			g.It("using a jenkins instance launched with the ephemeral template [apigroup:build.openshift.io]", func() {
 				defer cleanup()
 				setupJenkins()
 

--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 		})
 
 		g.Describe("start build with broken proxy", func() {
-			g.It("should start a build and wait for the build to fail", func() {
+			g.It("should start a build and wait for the build to fail [apigroup:build.openshift.io]", func() {
 				g.By("starting the build")
 
 				br, _ := exutil.StartBuildAndWait(oc, "sample-build", "--build-loglevel=5")
@@ -57,7 +57,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 		})
 
 		g.Describe("start build with broken proxy and a no_proxy override", func() {
-			g.It("should start an s2i build and wait for the build to succeed", func() {
+			g.It("should start an s2i build and wait for the build to succeed [apigroup:build.openshift.io]", func() {
 				g.By("starting the build")
 				br, _ := exutil.StartBuildAndWait(oc, "sample-s2i-build-noproxy", "--build-loglevel=5")
 				br.AssertSuccess()
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 				o.Expect(buildLog).To(o.ContainSubstring("proxy3"), "build log should include proxy host")
 				o.Expect(buildLog).To(o.ContainSubstring("proxy4"), "build log should include proxy host")
 			})
-			g.It("should start a docker build and wait for the build to succeed", func() {
+			g.It("should start a docker build and wait for the build to succeed [apigroup:build.openshift.io]", func() {
 				g.By("starting the build")
 				br, _ := exutil.StartBuildAndWait(oc, "sample-docker-build-noproxy", "--build-loglevel=5")
 				br.AssertSuccess()
@@ -89,7 +89,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 
 		g.Describe("start build with cluster-wide custom PKI", func() {
 
-			g.It("should mount the custom PKI into the build if specified", func() {
+			g.It("should mount the custom PKI into the build if specified [apigroup:config.openshift.io][apigroup:build.openshift.io]", func() {
 				ctx := context.TODO()
 				proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/pullsecret.go
+++ b/test/extended/builds/pullsecret.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using pull secrets in a b
 			})
 
 			g.Describe("binary builds", func() {
-				g.It("should be able to run a build that is implicitly pulling from the internal registry", func() {
+				g.It("should be able to run a build that is implicitly pulling from the internal registry [apigroup:build.openshift.io]", func() {
 					g.By("creating a build")
 					err := oc.Run("new-build").Args("--binary", "--strategy=docker", "--name=docker").Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using pull secrets in a b
 					oc.Run("delete").Args("secret", "local-ps").Execute()
 				})
 
-				g.It("should be able to use a pull secret in a build", func() {
+				g.It("should be able to use a pull secret in a build [apigroup:build.openshift.io]", func() {
 					g.By("creating build config")
 					err := oc.Run("create").Args("-f", pullSecretBuild).Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -81,7 +81,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using pull secrets in a b
 					br.AssertSuccess()
 				})
 
-				g.It("should be able to use a pull secret linked to the builder service account", func() {
+				g.It("should be able to use a pull secret linked to the builder service account [apigroup:build.openshift.io]", func() {
 					g.By("linking pull secret with the builder service account")
 					err := oc.Run("secrets").Args("link", "builder", "local-ps").Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/remove_buildconfig.go
+++ b/test/extended/builds/remove_buildconfig.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] remove all builds when build co
 		})
 
 		g.Describe("oc delete buildconfig", func() {
-			g.It("should start builds and delete the buildconfig", func() {
+			g.It("should start builds and delete the buildconfig [apigroup:build.openshift.io]", func() {
 				var (
 					err    error
 					builds [4]string

--- a/test/extended/builds/revision.go
+++ b/test/extended/builds/revision.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build have source revision meta
 		})
 
 		g.Describe("started build", func() {
-			g.It("should contain source revision information", func() {
+			g.It("should contain source revision information [apigroup:build.openshift.io]", func() {
 				g.By("starting the build")
 				br, _ := exutil.StartBuildAndWait(oc, "sample-build")
 				br.AssertSuccess()

--- a/test/extended/builds/run_fs_verification.go
+++ b/test/extended/builds/run_fs_verification.go
@@ -109,7 +109,7 @@ valid_fields.json
 		})
 
 		g.Describe("do not have unexpected content", func() {
-			g.It("using a simple Docker Strategy Build", func() {
+			g.It("using a simple Docker Strategy Build [apigroup:build.openshift.io]", func() {
 				g.By("calling oc create with yaml")
 				err := oc.Run("create").Args("-f", "-").InputString(testVerifyRunFSContentsBuildConfigYaml).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -135,7 +135,7 @@ valid_fields.json
 		})
 
 		g.Describe("are writeable", func() {
-			g.It("using a simple Docker Strategy Build", func() {
+			g.It("using a simple Docker Strategy Build [apigroup:build.openshift.io]", func() {
 				g.By("calling oc create with yaml")
 				err := oc.Run("create").Args("-f", "-").InputString(testVerityRunFSWriteableBuildConfigYaml).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/run_policy.go
+++ b/test/extended/builds/run_policy.go
@@ -3,10 +3,11 @@ package builds
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -58,7 +59,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Parallel build run policy", func() {
-			g.It("runs the builds in parallel", func() {
+			g.It("runs the builds in parallel [apigroup:build.openshift.io]", func() {
 				g.By("starting multiple builds")
 				var (
 					startedBuilds []string
@@ -137,7 +138,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Serial build run policy", func() {
-			g.It("runs the builds in serial order", func() {
+			g.It("runs the builds in serial order [apigroup:build.openshift.io]", func() {
 				g.By("starting multiple builds")
 				var (
 					startedBuilds []string
@@ -216,7 +217,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Serial build run policy handling cancellation", func() {
-			g.It("starts the next build immediately after one is canceled", func() {
+			g.It("starts the next build immediately after one is canceled [apigroup:build.openshift.io]", func() {
 				g.By("starting multiple builds")
 				bcName := "sample-serial-build"
 
@@ -265,7 +266,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Serial build run policy handling failure", func() {
-			g.It("starts the next build immediately after one fails", func() {
+			g.It("starts the next build immediately after one fails [apigroup:build.openshift.io]", func() {
 				g.By("starting multiple builds")
 				bcName := "sample-serial-build-fail"
 
@@ -345,7 +346,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Serial build run policy handling deletion", func() {
-			g.It("starts the next build immediately after running one is deleted", func() {
+			g.It("starts the next build immediately after running one is deleted [apigroup:build.openshift.io]", func() {
 				g.By("starting multiple builds")
 
 				bcName := "sample-serial-build"
@@ -403,7 +404,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with SerialLatestOnly build run policy", func() {
-			g.It("runs the builds in serial order but cancel previous builds", func() {
+			g.It("runs the builds in serial order but cancel previous builds [apigroup:build.openshift.io]", func() {
 				g.By("starting multiple builds")
 				var (
 					startedBuilds        []string

--- a/test/extended/builds/s2i_dropcaps.go
+++ b/test/extended/builds/s2i_dropcaps.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] Capabilities should be dr
 		})
 
 		g.Describe("s2i build with a rootable builder", func() {
-			g.It("should not be able to switch to root with an assemble script", func() {
+			g.It("should not be able to switch to root with an assemble script [apigroup:build.openshift.io]", func() {
 
 				g.By("calling oc new-build for rootable-builder")
 				err := oc.Run("new-build").Args("--binary", "--name=rootable-ruby").Execute()

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -44,7 +44,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] s2i build with environmen
 		})
 
 		g.Describe("Building from a template", func() {
-			g.It(fmt.Sprintf("should create a image from %q template and run it in a pod", filepath.Base(stiEnvBuildFixture)), func() {
+			g.It(fmt.Sprintf("should create a image from %q template and run it in a pod [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(stiEnvBuildFixture)), func() {
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -44,7 +44,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] incremental s2i build", f
 		})
 
 		g.Describe("Building from a template", func() {
-			g.It(fmt.Sprintf("should create a build from %q template and run it", filepath.Base(templateFixture)), func() {
+			g.It(fmt.Sprintf("should create a build from %q template and run it [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(templateFixture)), func() {
 
 				g.By(fmt.Sprintf("calling oc new-app -f %q", templateFixture))
 				err := oc.Run("new-app").Args("-f", templateFixture).Execute()

--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -2,6 +2,7 @@ package builds
 
 import (
 	"fmt"
+
 	"k8s.io/pod-security-admission/api"
 
 	g "github.com/onsi/ginkgo"
@@ -39,7 +40,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a quota", func()
 		})
 
 		g.Describe("Building from a template", func() {
-			g.It("should create an s2i build with a quota and run it", func() {
+			g.It("should create an s2i build with a quota and run it [apigroup:build.openshift.io]", func() {
 				g.By(fmt.Sprintf("calling oc create -f %q", buildFixture))
 				err := oc.Run("create").Args("-f", buildFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("s2i-build-root", admissionapi.LevelBaseline)
 
-	g.It("should create a root build and fail without a privileged SCC", func() {
+	g.It("should create a root build and fail without a privileged SCC [apigroup:build.openshift.io]", func() {
 		g.Skip("TODO: figure out why we aren't properly denying this, also consider whether we still need to deny it")
 		Before(oc)
 		defer After(oc)
@@ -70,7 +70,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 		}
 	})
 
-	g.It("should create a root build and pass with a privileged SCC", func() {
+	g.It("should create a root build and pass with a privileged SCC [apigroup:build.openshift.io]", func() {
 		Before(oc)
 		defer After(oc)
 		g.By("adding builder account to privileged SCC")

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -59,7 +59,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use build secrets", f
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("should contain secrets during the source strategy build", func() {
+			g.It("should contain secrets during the source strategy build [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
 				g.By("creating test build config")
 				err := oc.Run("create").Args("-f", sourceBuildFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/service.go
+++ b/test/extended/builds/service.go
@@ -42,7 +42,7 @@ RUN curl -vvv hello-nodejs:8080
 		})
 
 		g.Describe("with a build being created from new-build", func() {
-			g.It("should be able to run a build that references a cluster service", func() {
+			g.It("should be able to run a build that references a cluster service [apigroup:build.openshift.io]", func() {
 				g.By("standing up a new hello world nodejs service via oc new-app")
 				err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex.git", "--name", "hello-nodejs").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -64,7 +64,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("oc start-build --wait", func() {
-				g.It("should start a build and wait for the build to complete", func() {
+				g.It("should start a build and wait for the build to complete [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with --wait flag")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", "--wait")
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -72,7 +72,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					verifyNodeSelector(oc, br.BuildName)
 				})
 
-				g.It("should start a build and wait for the build to fail", func() {
+				g.It("should start a build and wait for the build to fail [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with --wait flag but wrong --commit")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build", "--wait", "--commit=fffffff")
 					br.AssertFailure()
@@ -83,7 +83,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("oc start-build with pr ref", func() {
-				g.It("should start a build from a PR ref, wait for the build to complete, and confirm the right level was used", func() {
+				g.It("should start a build from a PR ref, wait for the build to complete, and confirm the right level was used [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
 					g.By("make sure python imagestream has latest tag")
 					err := exutil.WaitForAnImageStreamTag(oc.AsAdmin(), "openshift", "python", "latest")
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -128,7 +128,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("override environment", func() {
-				g.It("should accept environment variables", func() {
+				g.It("should accept environment variables [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with -e FOO=bar,-e VAR=test")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", "-e", "FOO=bar", "-e", "VAR=test")
 					br.AssertSuccess()
@@ -145,7 +145,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("BAR=test"))
 				})
 
-				g.It("BUILD_LOGLEVEL in buildconfig should create verbose output", func() {
+				g.It("BUILD_LOGLEVEL in buildconfig should create verbose output [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with buildconfig strategy env BUILD_LOGLEVEL=5")
 					br, err := exutil.StartBuildAndWait(oc, "sample-verbose-build")
 					br.AssertSuccess()
@@ -160,7 +160,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).NotTo(o.ContainSubstring("ERROR: logging before flag.Parse"))
 				})
 
-				g.It("BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel", func() {
+				g.It("BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with buildconfig strategy env BUILD_LOGLEVEL=5 but build-loglevel=1")
 					br, err := exutil.StartBuildAndWait(oc, "sample-verbose-build", "--build-loglevel=1")
 					br.AssertSuccess()
@@ -183,7 +183,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					fmt.Fprintf(g.GinkgoWriter, "Tried to init git repo: %v\n%s\n", err, string(out))
 				}
 
-				g.It("should accept --from-file as input", func() {
+				g.It("should accept --from-file as input [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with a Dockerfile")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-file=%s", exampleGemfile))
 					br.AssertSuccess()
@@ -197,7 +197,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
-				g.It("should accept --from-dir as input", func() {
+				g.It("should accept --from-dir as input [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with a directory")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-dir=%s", exampleBuild))
 					br.AssertSuccess()
@@ -210,7 +210,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
-				g.It("should accept --from-repo as input", func() {
+				g.It("should accept --from-repo as input [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with a Git repository")
 					tryRepoInit(exampleBuild)
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-repo=%s", exampleBuild))
@@ -225,7 +225,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
-				g.It("should accept --from-repo with --commit as input", func() {
+				g.It("should accept --from-repo with --commit as input [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with a Git repository")
 					tryRepoInit(exampleBuild)
 					gitCmd := exec.Command("git", "rev-parse", "HEAD~1")
@@ -247,7 +247,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 				})
 
 				// run one valid binary build so we can do --from-build later
-				g.It("should reject binary build requests without a --from-xxxx value", func() {
+				g.It("should reject binary build requests without a --from-xxxx value [apigroup:build.openshift.io]", func() {
 					g.Skip("TODO: refactor such that we don't rely on external package managers (i.e. Rubygems)")
 					g.By("starting a valid build with a directory")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build-binary", "--follow", fmt.Sprintf("--from-dir=%s", exampleBuild))
@@ -270,7 +270,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("has no valid source inputs"))
 				})
 
-				g.It("shoud accept --from-file with https URL as an input", func() {
+				g.It("shoud accept --from-file with https URL as an input [apigroup:build.openshift.io]", func() {
 					g.By("starting a valid build with input file served by https")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-file=%s", exampleGemfileURL))
 					br.AssertSuccess()
@@ -281,7 +281,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
-				g.It("shoud accept --from-archive with https URL as an input", func() {
+				g.It("shoud accept --from-archive with https URL as an input [apigroup:build.openshift.io]", func() {
 					g.By("starting a valid build with input archive served by https")
 					// can't use sample-build-binary because we need contextDir due to github archives containing the top-level directory
 					br, err := exutil.StartBuildAndWait(oc, "sample-build-github-archive", fmt.Sprintf("--from-archive=%s", exampleArchiveURL))
@@ -295,7 +295,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("cancel a binary build that doesn't start running in 5 minutes", func() {
-				g.It("should start a build and wait for the build to be cancelled", func() {
+				g.It("should start a build and wait for the build to be cancelled [apigroup:build.openshift.io]", func() {
 					g.By("starting a build with a nodeselector that can't be matched")
 					go func() {
 						exutil.StartBuild(oc, "sample-build-binary-invalidnodeselector", fmt.Sprintf("--from-file=%s", exampleGemfile))
@@ -314,7 +314,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("cancel a build started by oc start-build --wait", func() {
-				g.It("should start a build and wait for the build to cancel", func() {
+				g.It("should start a build and wait for the build to cancel [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with --wait flag")
 					var wg sync.WaitGroup
 					wg.Add(1)
@@ -357,7 +357,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("Setting build-args on Docker builds", func() {
-				g.It("Should copy build args from BuildConfig to Build", func() {
+				g.It("Should copy build args from BuildConfig to Build [apigroup:build.openshift.io]", func() {
 					g.By("starting the build without --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")
 					br.AssertSuccess()
@@ -367,7 +367,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("verifying the build output contains the build args from the BuildConfig.")
 					o.Expect(buildLog).To(o.ContainSubstring("default"))
 				})
-				g.It("Should accept build args that are specified in the Dockerfile", func() {
+				g.It("Should accept build args that are specified in the Dockerfile [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=foofoo=bar")
 					br.AssertSuccess()
@@ -377,7 +377,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("verifying the build output contains the changes.")
 					o.Expect(buildLog).To(o.ContainSubstring("bar"))
 				})
-				g.It("Should complete with a warning on non-existent build-arg", func() {
+				g.It("Should complete with a warning on non-existent build-arg [apigroup:build.openshift.io]", func() {
 					g.By("starting the build with --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=bar=foo")
 					br.AssertSuccess()
@@ -390,7 +390,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("Trigger builds with branch refs matching directories on master branch", func() {
-				g.It("Should checkout the config branch, not config directory", func() {
+				g.It("Should checkout the config branch, not config directory [apigroup:build.openshift.io]", func() {
 					g.By("calling oc new-app")
 					_, err := oc.Run("new-app").Args("https://github.com/openshift/ruby-hello-world#config").Output()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -409,7 +409,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("start a build via a webhook", func() {
-				g.It("should be able to start builds via the webhook with valid secrets and fail with invalid secrets", func() {
+				g.It("should be able to start builds via the webhook with valid secrets and fail with invalid secrets [apigroup:build.openshift.io]", func() {
 					g.By("clearing existing builds")
 					_, err := oc.Run("delete").Args("builds", "--all").Output()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -488,7 +488,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("s2i build maintaining symlinks", func() {
-				g.It(fmt.Sprintf("should s2i build image and maintain symlinks"), func() {
+				g.It(fmt.Sprintf("should s2i build image and maintain symlinks [apigroup:build.openshift.io][apigroup:image.openshift.io]"), func() {
 					g.By("initializing a local git repo")
 					repo, err := exutil.NewGitRepo("symlinks")
 					o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/valuefrom.go
+++ b/test/extended/builds/valuefrom.go
@@ -53,7 +53,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 
 		})
 
-		g.It("should successfully resolve valueFrom in s2i build environment variables", func() {
+		g.It("should successfully resolve valueFrom in s2i build environment variables [apigroup:build.openshift.io]", func() {
 
 			g.By("creating test successful build config")
 			err := oc.Run("create").Args("-f", successfulSTIBuildValueFrom).Execute()
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 
 		})
 
-		g.It("should successfully resolve valueFrom in docker build environment variables", func() {
+		g.It("should successfully resolve valueFrom in docker build environment variables [apigroup:build.openshift.io]", func() {
 
 			g.By("creating test successful build config")
 			err := oc.Run("create").Args("-f", successfulDockerBuildValueFrom).Execute()
@@ -97,7 +97,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 
 		})
 
-		g.It("should fail resolving unresolvable valueFrom in sti build environment variable references", func() {
+		g.It("should fail resolving unresolvable valueFrom in sti build environment variable references [apigroup:build.openshift.io]", func() {
 
 			g.By("creating test build config")
 			err := oc.Run("create").Args("-f", failedSTIBuildValueFrom).Execute()
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 
 		})
 
-		g.It("should fail resolving unresolvable valueFrom in docker build environment variable references", func() {
+		g.It("should fail resolving unresolvable valueFrom in docker build environment variable references [apigroup:build.openshift.io]", func() {
 
 			g.By("creating test build config")
 			err := oc.Run("create").Args("-f", failedDockerBuildValueFrom).Execute()

--- a/test/extended/builds/volumes.go
+++ b/test/extended/builds/volumes.go
@@ -59,7 +59,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func()
 			}
 		})
 
-		g.It("should mount given secrets and configmaps into the build pod for source strategy builds", func() {
+		g.It("should mount given secrets and configmaps into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]", func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", s2iImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -97,7 +97,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func()
 			o.Expect(out).To(o.ContainSubstring("cat: /var/run/configmaps/some-configmap/key: No such file or directory"))
 		})
 
-		g.It("should mount given secrets and configmaps into the build pod for docker strategy builds", func() {
+		g.It("should mount given secrets and configmaps into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]", func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", dockerImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -147,7 +147,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 		csiDockerBuildConfig = filepath.Join(baseDir, "csi-docker-buildconfig.yaml")
 	)
 
-	g.Context("", func() {
+	g.Context("[apigroup:config.openshift.io]", func() {
 		g.BeforeEach(func() {
 			exutil.PreTestDump()
 		})
@@ -166,7 +166,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 			}
 		})
 
-		g.It("should fail mounting given csi shared resource secret into the build pod for source strategy builds", func() {
+		g.It("should fail mounting given csi shared resource secret into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", s2iImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -187,7 +187,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 			o.Expect(build.Status.Message).To(o.ContainSubstring("Failed to create pod spec"))
 
 		})
-		g.It("should fail mounting given csi shared resource secret into the build pod for docker strategy builds", func() {
+		g.It("should fail mounting given csi shared resource secret into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", dockerImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -230,7 +230,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 		csiWithoutResourceRefreshDockerBuildConfig = filepath.Join(baseDir, "csi-without-rr-docker-buildconfig.yaml")
 	)
 
-	g.Context("", func() {
+	g.Context("[apigroup:config.openshift.io]", func() {
 		g.BeforeEach(func() {
 			exutil.PreTestDump()
 		})
@@ -274,7 +274,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 			}
 		})
 
-		g.It("should mount given csi shared resource secret into the build pod for source strategy builds", func() {
+		g.It("should mount given csi shared resource secret into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]", func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", s2iImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -306,7 +306,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 			o.Expect(out).To(o.ContainSubstring("cat: /var/run/secrets/some-secret/key: No such file or directory"))
 		})
 
-		g.It("should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds", func() {
+		g.It("should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]", func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", s2iImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -338,7 +338,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 			o.Expect(out).To(o.ContainSubstring("cat: /var/run/secrets/some-secret/key: No such file or directory"))
 		})
 
-		g.It("should mount given csi shared resource secret into the build pod for docker strategy builds", func() {
+		g.It("should mount given csi shared resource secret into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]", func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", dockerImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -370,7 +370,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes with
 			o.Expect(out).To(o.ContainSubstring("cat: /var/run/secrets/some-secret/key: No such file or directory"))
 		})
 
-		g.It("should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds", func() {
+		g.It("should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]", func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", dockerImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/webhook.go
+++ b/test/extended/builds/webhook.go
@@ -27,16 +27,16 @@ var _ = g.Describe("[sig-builds][Feature:Builds][webhook]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("build-webhooks", admissionapi.LevelBaseline)
 
-	g.It("TestWebhook", func() {
+	g.It("TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
 		TestWebhook(g.GinkgoT(), oc)
 	})
-	g.It("TestWebhookGitHubPushWithImage", func() {
+	g.It("TestWebhookGitHubPushWithImage [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
 		TestWebhookGitHubPushWithImage(g.GinkgoT(), oc)
 	})
-	g.It("TestWebhookGitHubPushWithImageStream", func() {
+	g.It("TestWebhookGitHubPushWithImageStream [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
 		TestWebhookGitHubPushWithImageStream(g.GinkgoT(), oc)
 	})
-	g.It("TestWebhookGitHubPing", func() {
+	g.It("TestWebhookGitHubPing [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
 		TestWebhookGitHubPing(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("job-names")
 
-	g.It("should match platform type", func() {
+	g.It("should match platform type [apigroup:config.openshift.io]", func() {
 		jobName := os.Getenv("JOB_NAME")
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
@@ -62,7 +62,7 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 
 	})
 
-	g.It("should match network type", func() {
+	g.It("should match network type [apigroup:config.openshift.io]", func() {
 		jobName := os.Getenv("JOB_NAME")
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")

--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -68,7 +68,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(oc.Run("adm", "node-logs").Args(randomNode(oc), "--tail=5").Execute()).To(o.Succeed())
 	})
 
-	g.It("groups", func() {
+	g.It("groups [apigroup:user.openshift.io]", func() {
 		shortoutputgroup := gen.GenerateName("shortoutputgroup-")
 		out, err := oc.Run("adm", "groups", "new").Args(shortoutputgroup, "--output=name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -126,7 +126,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete", fmt.Sprintf("groups/%s", group1)).Execute()
 	})
 
-	g.It("who-can", func() {
+	g.It("who-can [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
 		o.Expect(oc.Run("adm", "policy", "who-can").Args("get", "pods").Execute()).To(o.Succeed())
 		o.Expect(oc.Run("adm", "policy", "who-can").Args("get", "pods", "-n", "default").Execute()).To(o.Succeed())
 		o.Expect(oc.Run("adm", "policy", "who-can").Args("get", "pods", "--all-namespaces").Execute()).To(o.Succeed())
@@ -153,7 +153,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.ContainSubstring("Resource:  horizontalpodautoscalers.autoscaling"))
 	})
 
-	g.It("policy", func() {
+	g.It("policy [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
 		o.Expect(ocns.Run("adm", "policy", "add-role-to-group").Args("--rolebinding-name=cluster-admin", "cluster-admin", "system:unauthenticated").Execute()).To(o.Succeed())
 		o.Expect(ocns.Run("adm", "policy", "add-role-to-user").Args("--rolebinding-name=cluster-admin", "cluster-admin", "system:no-user").Execute()).To(o.Succeed())
 
@@ -239,7 +239,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.ContainSubstring("clusterrolebinding.rbac.authorization.k8s.io/system:openshift:scc:privileged updated"))
 	})
 
-	g.It("storage-admin", func() {
+	g.It("storage-admin [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
 		g.By("Test storage-admin role and impersonation")
 		o.Expect(oc.Run("adm", "policy", "add-cluster-role-to-user").Args("storage-admin", "storage-adm").Execute()).To(o.Succeed())
 		o.Expect(oc.Run("adm", "policy", "add-cluster-role-to-user").Args("storage-admin", "storage-adm2").Execute()).To(o.Succeed())
@@ -313,7 +313,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args("project/policy-can-i").Execute()
 	})
 
-	g.It("role-reapers", func() {
+	g.It("role-reapers [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
 		policyRoles, _, err := ocns.Run("process").Args("-f", policyRolesPath, "-p", fmt.Sprintf("NAMESPACE=%s", ocns.Namespace())).Outputs()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(ocns.Run("create").Args("-f", "-").InputString(policyRoles).Execute()).To(o.Succeed())
@@ -333,7 +333,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 	})
 
 	// "oc adm prune auth clusterrole/edit" is a disruptive command and needs to be run in a Serial test
-	g.It("cluster-role-reapers [Serial]", func() {
+	g.It("cluster-role-reapers [Serial][apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
 		clusterRole := gen.GenerateName("basic-user2-")
 		clusterBinding := gen.GenerateName("basic-users2-")
 		policyClusterRoles, _, err := ocns.Run("process").Args("-f", policyClusterRolesPath, "-p", fmt.Sprintf("ROLE_NAME=%s", clusterRole), "-p", fmt.Sprintf("BINDING_NAME=%s", clusterBinding)).Outputs()
@@ -394,7 +394,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args("-f", "-").InputString(policyClusterRoles).Execute()
 	})
 
-	g.It("ui-project-commands", func() {
+	g.It("ui-project-commands [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
 		// Test the commands the UI projects page tells users to run
 		// These should match what is described in projects.html
 		o.Expect(oc.Run("adm", "new-project").Args("ui-test-project", "--admin=createuser").Execute()).To(o.Succeed())
@@ -416,7 +416,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		ocns.Run("delete").Args("project/ui-test-project").Execute()
 	})
 
-	g.It("new-project", func() {
+	g.It("new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io]", func() {
 		// Test deleting and recreating a project
 		o.Expect(oc.Run("adm", "new-project").Args("recreated-project", "--admin=createuser1").Execute()).To(o.Succeed())
 		o.Expect(oc.Run("delete").Args("project", "recreated-project").Execute()).To(o.Succeed())
@@ -435,7 +435,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args("project", "recreated-project").Execute()
 	})
 
-	g.It("build-chain", func() {
+	g.It("build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io]", func() {
 		// Test building a dependency tree
 		s2iBuildPath := exutil.FixturePath("..", "..", "examples", "sample-app", "application-template-stibuild.json")
 		out, _, err := ocns.Run("process").Args("-f", s2iBuildPath, "-l", "build=sti").Outputs()
@@ -494,7 +494,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		ocns.Run("delete").Args("sa/my-sa-name").Execute()
 	})
 
-	g.It("user-creation", func() {
+	g.It("user-creation [apigroup:user.openshift.io]", func() {
 		user := gen.GenerateName("test-cmd-user-")
 		identity := gen.GenerateName("test-idp:test-uid-")
 		o.Expect(oc.Run("create", "user").Args(user).Execute()).To(o.Succeed())
@@ -513,7 +513,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args(fmt.Sprintf("useridentitymapping/%s", identity)).Execute()
 	})
 
-	g.It("images", func() {
+	g.It("images [apigroup:image.openshift.io]", func() {
 		stableBusyboxPath := exutil.FixturePath("testdata", "stable-busybox.yaml")
 		o.Expect(oc.Run("create").Args("-f", stableBusyboxPath).Execute()).To(o.Succeed())
 

--- a/test/extended/cli/builds.go
+++ b/test/extended/cli/builds.go
@@ -69,7 +69,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		testDockerfileContent = fmt.Sprintf("FROM %s", image.ShellImage())
 	)
 
-	g.It("new-build", func() {
+	g.It("new-build [apigroup:build.openshift.io]", func() {
 		g.By("build from a binary with no inputs requires name")
 		out, err := oc.Run("new-build").Args("--binary").Output()
 		o.Expect(err).To(o.HaveOccurred())
@@ -153,7 +153,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		o.Expect(json.Valid([]byte(out))).To(o.BeTrue())
 	})
 
-	g.It("get buildconfig", func() {
+	g.It("get buildconfig [apigroup:build.openshift.io]", func() {
 		err := oc.Run("new-build").Args("-D", testDockerfileContent, "--name", "get-test").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -175,7 +175,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		o.Expect(strings.Fields(lines[1])[1]).To(o.MatchRegexp(fmt.Sprintf("%v/get-test$", oc.Namespace())))
 	})
 
-	g.It("patch buildconfig", func() {
+	g.It("patch buildconfig [apigroup:build.openshift.io]", func() {
 		err := oc.Run("new-build").Args("-D", testDockerfileContent, "--name", "patch-test").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		realOutputTo, err := oc.Run("get").Args("bc/patch-test", "--template", bcOutputToNameTemplate).Output()
@@ -226,7 +226,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("webhooks CRUD", func() {
+		g.It("webhooks CRUD [apigroup:build.openshift.io]", func() {
 			g.By("check bc webhooks")
 			out, err := oc.Run("describe").Args("buildConfigs", "ruby-sample-build").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -284,7 +284,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 			))
 		})
 
-		g.It("start-build", func() {
+		g.It("start-build [apigroup:build.openshift.io]", func() {
 			g.By("valid build")
 			out, err := oc.Run("start-build").Args("--from-webhook", getTriggerURL("secret101", "generic")).Output()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -22,7 +22,7 @@ import (
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have same number of Machines and Nodes", func() {
+	g.It("have same number of Machines and Nodes [apigroup:machine.openshift.io]", func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()

--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -30,7 +30,7 @@ const (
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have machine resources", func() {
+	g.It("have machine resources [apigroup:machine.openshift.io]", func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -221,7 +221,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 	// provisioning the new host, while it could take approx another 10 minutes for deprovisioning
 	// and deleting it. The extra timeout amount should be enough to cover future slower execution
 	// environments.
-	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m]", func() {
+	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]", func() {
 		// expect new nodes to come up for machineSet
 		verifyNodeScalingFunc := func(c *kubernetes.Clientset, dc dynamic.Interface, expectedScaleOut int, machineSet objx.Map) bool {
 			nodes, err := getNodesFromMachineSet(c, dc, machineName(machineSet))

--- a/test/extended/machines/workers.go
+++ b/test/extended/machines/workers.go
@@ -130,7 +130,7 @@ func isNodeReady(node corev1.Node) bool {
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("recover from deleted worker machines", func() {
+	g.It("recover from deleted worker machines [apigroup:machine.openshift.io]", func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()

--- a/test/extended/networking/acl_audit_log.go
+++ b/test/extended/networking/acl_audit_log.go
@@ -44,7 +44,7 @@ var _ = Describe("[sig-network][Feature:Network Policy Audit logging]", func() {
 	InOVNKubernetesContext(
 		func() {
 			f := oc.KubeFramework()
-			It("should ensure acl logs are created and correct", func() {
+			It("should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io]", func() {
 				ns = append(ns, f.Namespace.Name)
 				makeNamespaceScheduleToAllNodes(f)
 				makeNamespaceACLLoggingEnabled(oc)

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -43,14 +43,14 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 	// For Openshift SDN its supports EgressNetworkPolicy objects
 	InOpenShiftSDNContext(
 		func() {
-			g.It("should ensure egressnetworkpolicy is created", func() {
+			g.It("should ensure egressnetworkpolicy is created [apigroup:network.openshift.io]", func() {
 				doEgressFwTest(egFwf, egFwoc, openShiftSDNManifest)
 			})
 		},
 	)
 	noegFwoc := exutil.NewCLIWithPodSecurityLevel(noEgressFWE2E, admissionapi.LevelBaseline)
 	noegFwf := noegFwoc.KubeFramework()
-	g.It("egressFirewall should have no impact outside its namespace", func() {
+	g.It("egressFirewall should have no impact outside its namespace [apigroup:config.openshift.io]", func() {
 		g.By("creating test pod")
 		pod := "dummy"
 		o.Expect(createTestEgressFw(noegFwf, pod)).To(o.Succeed())

--- a/test/extended/networking/egress_router_cni.go
+++ b/test/extended/networking/egress_router_cni.go
@@ -36,12 +36,12 @@ const (
 var _ = g.Describe("[sig-network][Feature:EgressRouterCNI]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel(egressRouterCNIE2E, admissionapi.LevelPrivileged)
 
-	g.It("should ensure ipv4 egressrouter cni resources are created", func() {
+	g.It("should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io]", func() {
 		doEgressRouterCNI(egressRouterCNIV4Manifest, oc, ipv4MatchPattern)
 	})
 	InOVNKubernetesContext(
 		func() {
-			g.It("should ensure ipv6 egressrouter cni resources are created", func() {
+			g.It("should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io]", func() {
 				doEgressRouterCNI(egressRouterCNIV6Manifest, oc, ipv6MatchPattern)
 			})
 		},

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -43,7 +43,7 @@ const (
 	egressUpdateTimeout = 180
 )
 
-var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
+var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel(namespacePrefix, admissionapi.LevelPrivileged)
 	portAllocator := NewPortAllocator(egressIPTargetHostPortMin, egressIPTargetHostPortMax)
 
@@ -341,7 +341,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 		})
 	}) // end testing to internal targets
 
-	g.Context("[external-targets]", func() {
+	g.Context("[external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io]", func() {
 		g.JustBeforeEach(func() {
 			// SCC privileged is needed to run tcpdump on the packet sniffer containers, and at the minimum host networked is needed for
 			// host networked pods.
@@ -362,7 +362,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 		// OVNKubernetes
 		// OpenShiftSDN
 		// Skipped on Azure due to https://bugzilla.redhat.com/show_bug.cgi?id=2073045
-		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure]", func() {
+		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]", func() {
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
 			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/networking/endpoint_admission.go
+++ b/test/extended/networking/endpoint_admission.go
@@ -21,7 +21,7 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-var _ = g.Describe("[sig-network][endpoints] admission", func() {
+var _ = g.Describe("[sig-network][endpoints] admission [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("endpoint-admission")
 

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -500,7 +500,7 @@ func InOpenShiftSDNContext(body func()) {
 }
 
 func InBareMetalIPv4ClusterContext(oc *exutil.CLI, body func()) {
-	Context("when running openshift ipv4 cluster on bare metal",
+	Context("when running openshift ipv4 cluster on bare metal [apigroup:config.openshift.io]",
 		func() {
 			BeforeEach(func() {
 				pType, err := platformType(oc.AdminConfigClient())

--- a/test/extended/oauth/client_secret.go
+++ b/test/extended/oauth/client_secret.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer]", func() {
 	ctx := context.Background()
 
 	g.Describe("ClientSecretWithPlus", func() {
-		g.It(fmt.Sprintf("should create oauthclient"), func() {
+		g.It(fmt.Sprintf("should create oauthclient [apigroup:config.openshift.io][apigroup:oauth.openshift.io][apigroup:user.openshift.io]"), func() {
 			controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 		oauthServerCleanup()
 	})
 
-	g.Context("Using a OAuth client with a non-default token max age", func() {
+	g.Context("Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io]", func() {
 		var oAuthClientResource *oauthv1.OAuthClient
 		var accessTokenMaxAgeSeconds int32
 
@@ -64,11 +64,11 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 				accessTokenMaxAgeSeconds = 0
 			})
 
-			g.It("works as expected when using a token authorization flow", func() {
+			g.It("works as expected when using a token authorization flow [apigroup:user.openshift.io]", func() {
 				testTokenFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 
-			g.It("works as expected when using a code authorization flow", func() {
+			g.It("works as expected when using a code authorization flow [apigroup:user.openshift.io]", func() {
 				testCodeFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 
@@ -79,10 +79,10 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 				accessTokenMaxAgeSeconds = 10
 			})
 
-			g.It("works as expected when using a token authorization flow", func() {
+			g.It("works as expected when using a token authorization flow [apigroup:user.openshift.io]", func() {
 				testTokenFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
-			g.It("works as expected when using a code authorization flow", func() {
+			g.It("works as expected when using a code authorization flow [apigroup:user.openshift.io]", func() {
 				testCodeFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 		})

--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP][Serial] ldap group sync", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("ldap-group-sync", admissionapi.LevelPrivileged).AsAdmin()
 	)
 
-	g.It("can sync groups from ldap", func() {
+	g.It("can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", func() {
 		g.By("starting an openldap server")
 		ldapNS, ldapName, _, ca, err := exutil.CreateLDAPTestServer(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -32,7 +32,7 @@ func init() {
 var _ = g.Describe("[sig-auth][Feature:HTPasswdAuth] HTPasswd IDP", func() {
 	var oc = exutil.NewCLIWithPodSecurityLevel("htpasswd-idp", admissionapi.LevelBaseline)
 
-	g.It("should successfully configure htpasswd and be responsive", func() {
+	g.It("should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io]", func() {
 		newTokenReqOpts, cleanup, err := deployOAuthServer(oc)
 		defer cleanup()
 		o.Expect(err).ToNot(o.HaveOccurred())

--- a/test/extended/oauth/ldap.go
+++ b/test/extended/oauth/ldap.go
@@ -15,7 +15,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("oauth-ldap", admissionapi.LevelPrivileged)
 	)
 
-	g.It("should start an OpenLDAP test server", func() {
+	g.It("should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io]", func() {
 		_, _, _, _, err := exutil.CreateLDAPTestServer(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})

--- a/test/extended/oauth/oauth_ldap.go
+++ b/test/extended/oauth/oauth_ldap.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP IDP", func() {
 		myEmail        = "person1smith@example.com"
 	)
 
-	g.It("should authenticate against an ldap server", func() {
+	g.It("should authenticate against an ldap server [apigroup:user.openshift.io][apigroup:route.openshift.io]", func() {
 		adminConfig := oc.AdminConfig()
 
 		// Clean up mapped identity and user.

--- a/test/extended/oauth/oauthcertfallback.go
+++ b/test/extended/oauth/oauthcertfallback.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth server", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("oauth")
 
-	g.It("has the correct token and certificate fallback semantics", func() {
+	g.It("has the correct token and certificate fallback semantics [apigroup:config.openshift.io][apigroup:user.openshift.io]", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -61,7 +61,7 @@ type certAuthTest struct {
 var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP]", func() {
 	var oc = exutil.NewCLI("request-headers")
 
-	g.It("test RequestHeaders IdP", func() {
+	g.It("test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io][apigroup:apps.openshift.io]", func() {
 
 		// In some rare cases, CAO might be damaged when entering this test. If it is - the results
 		// of this test might flaky. This check ensures that we capture such situation early and

--- a/test/extended/oauth/server_headers.go
+++ b/test/extended/oauth/server_headers.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/oauthserver"
 )
 
-var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers]", func() {
+var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io]", func() {
 	var oc = exutil.NewCLIWithPodSecurityLevel("oauth-server-headers", admissionapi.LevelBaseline)
 	var transport http.RoundTripper
 	var oauthServerAddr string

--- a/test/extended/oauth/token.go
+++ b/test/extended/oauth/token.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 	oc := exutil.NewCLI("oauth-access-token-e2e-test")
 	ctx := context.Background()
 
-	g.It(fmt.Sprintf("accepts sha256 access tokens"), func() {
+	g.It(fmt.Sprintf("accepts sha256 access tokens [apigroup:user.openshift.io][apigroup:oauth.openshift.io]"), func() {
 		user, err := oc.AdminUserClient().UserV1().Users().Create(ctx, &userv1.User{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/extended/oauth/well_known.go
+++ b/test/extended/oauth/well_known.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] well-known endpoint", func()
 		oauthNamespace = "openshift-authentication"
 	)
 
-	g.It("should be reachable", func() {
+	g.It("should be reachable [apigroup:config.openshift.io][apigroup:route.openshift.io]", func() {
 		metadataJSON, err := oc.Run("get").Args("--raw", "/.well-known/oauth-authorization-server").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/olm/olm.go
+++ b/test/extended/olm/olm.go
@@ -82,7 +82,7 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 
 	// OCP-24061 - [bz 1685230] OLM operator should use imagePullPolicy: IfNotPresent
 	// author: bandrade@redhat.com
-	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {
+	g.It("have imagePullPolicy:IfNotPresent on thier deployments [apigroup:config.openshift.io]", func() {
 		oc := oc.AsAdmin().WithoutNamespace()
 		namespace := "openshift-operator-lifecycle-manager"
 
@@ -138,7 +138,7 @@ var _ = g.Describe("[sig-arch] ocp payload should be based on existing source", 
 	// TODO: This test should be more generic and across components
 	// OCP-20981, [BZ 1626434]The olm/catalog binary should output the exact version info
 	// author: jiazha@redhat.com
-	g.It("OLM version should contain the source commit id", func() {
+	g.It("OLM version should contain the source commit id [apigroup:config.openshift.io]", func() {
 
 		oc := oc
 		namespace := "openshift-operator-lifecycle-manager"
@@ -265,7 +265,7 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 	)
 
 	files := []string{sub}
-	g.It("can subscribe to the operator", func() {
+	g.It("can subscribe to the operator [apigroup:config.openshift.io]", func() {
 		g.By("Cluster-admin user subscribe the operator resource")
 
 		// skip test if marketplace-operator is not enabled

--- a/test/extended/operators/clusteroperators.go
+++ b/test/extended/operators/clusteroperators.go
@@ -19,7 +19,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-arch] ClusterOperators", func() {
+var _ = g.Describe("[sig-arch] ClusterOperators [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	var clusterOperators []config.ClusterOperator

--- a/test/extended/operators/daemon_set.go
+++ b/test/extended/operators/daemon_set.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 	// during an upgrade as new pods start and then establish connections.
 	//
 	// Currently only applies to daemonsets that don't explicitly target the control plane.
-	g.It("should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent", func() {
+	g.It("should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [apigroup:config.openshift.io]", func() {
 		// iterate over the references to find valid images
 		daemonSets, err := oc.KubeFramework().ClientSet.AppsV1().DaemonSets("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -30,7 +30,7 @@ var (
 	vmxPattern = regexp.MustCompile(`VMwareVSphereControllerUpgradeable.+vmx-13`)
 )
 
-var _ = g.Describe("[sig-arch][Early] Managed cluster should", func() {
+var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	g.It("start all core operators", func() {
@@ -120,7 +120,7 @@ var _ = g.Describe("[sig-arch][Early] Managed cluster should", func() {
 var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have operators on the cluster version", func() {
+	g.It("have operators on the cluster version [apigroup:config.openshift.io]", func() {
 		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions")
 		}

--- a/test/extended/operators/recover.go
+++ b/test/extended/operators/recover.go
@@ -24,7 +24,7 @@ import (
 var _ = g.Describe("[sig-arch] Managed cluster should recover", func() {
 	defer g.GinkgoRecover()
 
-	g.It("when operator-owned objects are deleted [Disruptive]", func() {
+	g.It("when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io]", func() {
 		daemonsets := false
 		deployments := false
 		secrets := true

--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -19,7 +19,7 @@ import (
 	exurl "github.com/openshift/origin/test/extended/util/url"
 )
 
-var _ = g.Describe("[sig-arch] Managed cluster should", func() {
+var _ = g.Describe("[sig-arch] Managed cluster should [apigroup:apps.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 		}
 	})
 
-	g.It("should expose cluster services outside the cluster", func() {
+	g.It("should expose cluster services outside the cluster [apigroup:route.openshift.io]", func() {
 		ns := oc.KubeFramework().Namespace.Name
 
 		tester := exurl.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)

--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	ctx := context.Background()
 
 	g.Describe("TestProjectIsNamespace", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io]"), func() {
 			t := g.GinkgoT()
 
 			// create a namespace
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestProjectWatch", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]"), func() {
 			bobName := oc.CreateUser("bob-").Name
 			bobConfig := oc.GetClientConfigForUser(bobName)
 			bobProjectClient := projectv1client.NewForConfigOrDie(bobConfig)
@@ -158,7 +158,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestProjectWatchWithSelectionPredicate", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]"), func() {
 			bobName := oc.CreateUser("bob-").Name
 			bobConfig := oc.GetClientConfigForUser(bobName)
 			bobProjectClient := projectv1client.NewForConfigOrDie(bobConfig)
@@ -340,7 +340,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestScopedProjectAccess", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]"), func() {
 			t := g.GinkgoT()
 
 			bobName := oc.CreateUser("bob-").Name
@@ -458,7 +458,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestInvalidRoleRefs", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io]"), func() {
 			clusterAdminRbacClient := oc.AdminKubeClient().RbacV1()
 			clusterAdminAuthorizationClient := oc.AdminAuthorizationClient().AuthorizationV1()
 

--- a/test/extended/project/unprivileged_newproject.go
+++ b/test/extended/project/unprivileged_newproject.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("project-api")
 
-	g.It("TestUnprivilegedNewProject", func() {
+	g.It("TestUnprivilegedNewProject [apigroup:project.openshift.io]", func() {
 		t := g.GinkgoT()
 
 		valerieProjectClient := oc.ProjectClient()
@@ -67,7 +67,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI][Serial] ", func() {
 	oc := exutil.NewCLI("project-api")
 	ctx := context.Background()
 
-	g.It("TestUnprivilegedNewProjectDenied", func() {
+	g.It("TestUnprivilegedNewProjectDenied [apigroup:authorization.openshift.io][apigroup:project.openshift.io]", func() {
 		t := g.GinkgoT()
 
 		clusterAdminAuthorizationConfig := oc.AdminAuthorizationClient().AuthorizationV1()

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -39,7 +39,7 @@ import (
 	helper "github.com/openshift/origin/test/extended/util/prometheus"
 )
 
-var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules", func() {
+var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	// These alerts are known to be missing the summary and/or description
@@ -190,7 +190,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		oc = exutil.NewCLIWithoutNamespace("prometheus")
 	)
 
-	g.It("shouldn't report any unexpected alerts in firing or pending state", func() {
+	g.It("shouldn't report any unexpected alerts in firing or pending state [apigroup:config.openshift.io]", func() {
 		// Watchdog and AlertmanagerReceiversNotConfigured are expected.
 		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
@@ -467,7 +467,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			e2e.Logf("Telemetry is enabled: %s", bearerToken)
 		})
 
-		g.It("should start and expose a secured proxy and unsecured metrics", func() {
+		g.It("should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io]", func() {
 			ns := oc.Namespace()
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
 			defer func() {
@@ -607,7 +607,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			e2e.Logf("AlertmanagerReceiversNotConfigured alert is firing")
 		})
 
-		g.It("should have important platform topology metrics", func() {
+		g.It("should have important platform topology metrics [apigroup:config.openshift.io]", func() {
 			exutil.SkipIfExternalControlplaneTopology(oc, "topology metrics are not available for clusters with external controlPlaneTopology")
 
 			tests := map[string]bool{
@@ -659,7 +659,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			})
 		})
 
-		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early]", func() {
+		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io]", func() {
 			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 				e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
 			}
@@ -729,7 +729,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should provide named network metrics", func() {
+		g.It("should provide named network metrics [apigroup:project.openshift.io]", func() {
 			ns := oc.SetupProject()
 
 			cs, err := newDynClientSet()

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus
 	})
 
 	g.Describe("when installed on the cluster", func() {
-		g.It("should start and expose a secured proxy and verify build metrics", func() {
+		g.It("should start and expose a secured proxy and verify build metrics [apigroup:config.openshift.io][apigroup:build.openshift.io]", func() {
 			controlPlaneTopology, infra_err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(infra_err).NotTo(o.HaveOccurred())
 

--- a/test/extended/quota/clusterquota.go
+++ b/test/extended/quota/clusterquota.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ClusterResourceQuota]", func() {
 	oc := exutil.NewCLI("crq")
 
 	g.Describe("Cluster resource quota", func() {
-		g.It(fmt.Sprintf("should control resource limits across namespaces"), func() {
+		g.It(fmt.Sprintf("should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io]"), func() {
 			t := g.GinkgoT(1)
 
 			clusterAdminKubeClient := oc.AdminKubeClient()

--- a/test/extended/quota/resourcequota.go
+++ b/test/extended/quota/resourcequota.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 	oc := exutil.NewCLI("object-count-rq")
 
 	g.Describe("Object count", func() {
-		g.It(fmt.Sprintf("should properly count the number of imagestreams resources"), func() {
+		g.It(fmt.Sprintf("should properly count the number of imagestreams resources [apigroup:image.openshift.io]"), func() {
 			clusterAdminKubeClient := oc.AdminKubeClient()
 			clusterAdminImageClient := oc.AdminImageClient().ImageV1()
 			testProject := oc.CreateProject()

--- a/test/extended/router/certs.go
+++ b/test/extended/router/certs.go
@@ -21,7 +21,7 @@ import (
 	exurl "github.com/openshift/origin/test/extended/util/url"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc          *exutil.CLI
@@ -101,7 +101,7 @@ u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
 
 	g.When("FIPS is enabled", func() {
 		g.Describe("the HAProxy router", func() {
-			g.It("should not work when configured with a 1024-bit RSA key", func() {
+			g.It("should not work when configured with a 1024-bit RSA key [apigroup:template.openshift.io]", func() {
 				if !isFIPS {
 					g.Skip("skipping on non-FIPS cluster")
 				}
@@ -139,7 +139,7 @@ u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
 
 	g.When("FIPS is disabled", func() {
 		g.Describe("the HAProxy router", func() {
-			g.It("should serve routes when configured with a 1024-bit RSA key", func() {
+			g.It("should serve routes when configured with a 1024-bit RSA key [apigroup:template.openshift.io]", func() {
 				if isFIPS {
 					g.Skip("skipping on FIPS cluster")
 				}

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -21,7 +21,7 @@ import (
 
 const timeoutSeconds = 3 * 60
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "router-config-manager.yaml")

--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the gRPC interoperability tests", func() {
+		g.It("should pass the gRPC interoperability tests [apigroup:config.openshift.io][apigroup:route.openshift.io][apigroup:template.openshift.io]", func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -34,7 +34,7 @@ type h2specFailingTest struct {
 	TestNumber int
 }
 
-var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
+var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -64,7 +64,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the h2spec conformance tests", func() {
+		g.It("should pass the h2spec conformance tests [apigroup:config.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:template.openshift.io]", func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -23,7 +23,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:operator.openshift.io][apigroup:apps.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "router-http-echo-server.yaml")

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -56,7 +56,7 @@ func makeHTTPClient(useHTTP2Transport bool, timeout time.Duration) *http.Client 
 	return c
 }
 
-var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
+var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -88,7 +88,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the http2 tests", func() {
+		g.It("should pass the http2 tests [apigroup:image.openshift.io][apigroup:template.openshift.io]", func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should be able to connect to a service that is idled because a GET on the route will unidle it", func() {
+		g.It("should be able to connect to a service that is idled because a GET on the route will unidle it [apigroup:config.openshift.io][apigroup:template.openshift.io]", func() {
 			network, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster network configuration")
 			if !(network.Status.NetworkType == "OVNKubernetes" || network.Status.NetworkType == "OpenShiftSDN") {

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -37,7 +37,7 @@ import (
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc = exutil.NewCLIWithPodSecurityLevel("router-metrics", admissionapi.LevelBaseline)
@@ -120,7 +120,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should expose prometheus metrics for a route", func() {
+		g.It("should expose prometheus metrics for a route [apigroup:route.openshift.io]", func() {
 			g.By("when a route exists")
 			configPath := exutil.FixturePath("testdata", "router", "router-metrics.yaml")
 			err := oc.Run("create").Args("-f", configPath).Execute()

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -16,7 +16,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:operator.openshift.io][apigroup:apps.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "reencrypt-serving-cert.yaml")

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -18,7 +18,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/url"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io][apigroup:apps.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		host, ns string
@@ -68,7 +68,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			)
 		})
 
-		g.It("should serve routes that were created from an ingress", func() {
+		g.It("should serve routes that were created from an ingress [apigroup:route.openshift.io]", func() {
 			g.By("deploying an ingress rule")
 			err := oc.Run("create").Args("-f", configPath).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -26,7 +26,7 @@ import (
 
 const changeTimeoutSeconds = 3 * 60
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:template.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc          *exutil.CLI
@@ -170,7 +170,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			o.Expect(condition.LastTransitionTime).NotTo(o.BeNil())
 		})
 
-		g.It("should override the route host for overridden domains with a custom value", func() {
+		g.It("should override the route host for overridden domains with a custom value [apigroup:image.openshift.io]", func() {
 
 			configPath := exutil.FixturePath("testdata", "router", "router-override-domains.yaml")
 			g.By(fmt.Sprintf("creating a router from a config file %q", configPath))

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -28,7 +28,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		routerImage string

--- a/test/extended/router/subdomain.go
+++ b/test/extended/router/subdomain.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                   *exutil.CLI

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -19,7 +19,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io][apigroup:template.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc          *exutil.CLI
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should run even if it has no access to update status", func() {
+		g.It("should run even if it has no access to update status [apigroup:image.openshift.io]", func() {
 
 			configPath := exutil.FixturePath("testdata", "router", "router-scoped.yaml")
 			g.By(fmt.Sprintf("creating a router from a config file %q", configPath))

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -23,7 +23,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:image.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "weighted-router.yaml")

--- a/test/extended/scheduling/pods.go
+++ b/test/extended/scheduling/pods.go
@@ -2,11 +2,9 @@ package scheduling
 
 import (
 	"context"
-	"strings"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -89,33 +87,6 @@ func (p requirePodsOnDifferentNodesTest) getDeploymentPods(oc *exutil.CLI) []*co
 }
 
 func (p requirePodsOnDifferentNodesTest) run(oc *exutil.CLI) {
-	ctx := context.TODO()
-
-	if clusterVersion, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{}); err == nil && len(clusterVersion.Status.History) > 0 {
-		// most recent is first.  Check the most recently installed version, if it is 4.10 or earlier, skip this test
-		for _, releaseUpdate := range clusterVersion.Status.History {
-			if releaseUpdate.State != configv1.CompletedUpdate {
-				continue
-			}
-			switch {
-			case strings.HasPrefix(releaseUpdate.Version, "4.0") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.1.") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.2.") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.3.") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.4.") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.5.") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.6") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.7") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.8") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.9") ||
-				strings.HasPrefix(releaseUpdate.Version, "4.10"):
-				return
-			}
-			// if we got here, then we're 4.11 or after, so we run the test.  skip the rest of the history.
-			break
-		}
-	}
-
 	deploymentPods := p.getDeploymentPods(oc)
 
 	if len(deploymentPods) == 0 {

--- a/test/extended/security/fips.go
+++ b/test/extended/security/fips.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-arch] [Conformance] FIPS", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("fips", admissionapi.LevelPrivileged)
 
-	g.It("TestFIPS", func() {
+	g.It("TestFIPS [apigroup:config.openshift.io]", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		clusterAdminKubeClientset := oc.AdminKubeClient()

--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
 	ctx := context.Background()
 
-	g.It("TestPodUpdateSCCEnforcement", func() {
+	g.It("TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io]", func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClientset := oc.AdminKubeClient()
@@ -92,7 +92,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	// pods running as root are being started here
 	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
 
-	g.It("TestAllowedSCCViaRBAC", func() {
+	g.It("TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClientset := oc.AdminKubeClient()

--- a/test/extended/security/supplemental_groups.go
+++ b/test/extended/security/supplemental_groups.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-node] supplemental groups", func() {
 	)
 
 	g.Describe("Ensure supplemental groups propagate to docker", func() {
-		g.It("should propagate requested groups to the container [Local]", func() {
+		g.It("should propagate requested groups to the container [Local][apigroup:user.openshift.io][apigroup:security.openshift.io]", func() {
 
 			fsGroup := int64(1111)
 			supGroup := int64(2222)

--- a/test/extended/single_node/topology.go
+++ b/test/extended/single_node/topology.go
@@ -128,7 +128,7 @@ func validateDeploymentReplicas(deployment appsv1.Deployment,
 	validateReplicas(deployment.Name, deployment.Namespace, int(*deployment.Spec.Replicas))
 }
 
-var _ = ginkgo.Describe("[sig-arch] Cluster topology single node tests", func() {
+var _ = ginkgo.Describe("[sig-arch] Cluster topology single node tests [apigroup:config.openshift.io]", func() {
 	f := framework.NewDefaultFramework("single-node")
 
 	ginkgo.It("Verify that OpenShift components deploy one replica in SingleReplica topology mode", func() {

--- a/test/extended/tbr_health/check.go
+++ b/test/extended/tbr_health/check.go
@@ -11,7 +11,7 @@ var _ = g.Describe("[sig-devex] check registry.redhat.io is available and sample
 	var (
 		oc = exutil.NewCLI("samples-health-check")
 	)
-	g.It("run sample related validations", func() {
+	g.It("run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io]", func() {
 		err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 		if err != nil {
 			// so the error string shows up in the top level ginkgo message

--- a/test/extended/templates/template.go
+++ b/test/extended/templates/template.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] template-api", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("templates")
 
-	g.It("TestTemplate", func() {
+	g.It("TestTemplate [apigroup:template.openshift.io]", func() {
 		t := g.GinkgoT()
 
 		for _, version := range []schema.GroupVersion{v1.SchemeGroupVersion} {
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] template-api", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("templates")
 
-	g.It("TestTemplateTransformationFromConfig", func() {
+	g.It("TestTemplateTransformationFromConfig [apigroup:template.openshift.io]", func() {
 		t := g.GinkgoT()
 
 		clusterAdminClientConfig := oc.AdminConfig()

--- a/test/extended/templates/templateinstance_cross_namespace.go
+++ b/test/extended/templates/templateinstance_cross_namespace.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance cross-namesp
 		cli2 = exutil.NewCLI("templates2")
 	)
 
-	g.It("should create and delete objects across namespaces", func() {
+	g.It("should create and delete objects across namespaces [apigroup:user.openshift.io][apigroup:template.openshift.io]", func() {
 		err := cli2.AsAdmin().Run("adm").Args("policy", "add-role-to-user", "admin", cli.Username()).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/templates/templateinstance_fail.go
+++ b/test/extended/templates/templateinstance_fail.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance creation wit
 	)
 
 	g.Context("", func() {
-		g.It("should report a failure on creation", func() {
+		g.It("should report a failure on creation [apigroup:template.openshift.io]", func() {
 			err := cli.Run("create").Args("-f", templatefixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/templates/templateinstance_impersonation.go
+++ b/test/extended/templates/templateinstance_impersonation.go
@@ -24,7 +24,7 @@ import (
 // or can impersonate, the requester.
 // 2. Check that templateinstancespecs, particularly including
 // requester.username and groups, are immutable.
-var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonation tests", func() {
+var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonation tests [apigroup:user.openshift.io][apigroup:authorization.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -228,7 +228,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		deleteGroup(cli, impersonategroup)
 	})
 
-	g.It("should pass impersonation creation tests", func() {
+	g.It("should pass impersonation creation tests [apigroup:template.openshift.io]", func() {
 		// check who can create TemplateInstances (anyone with project write access
 		// AND is/can impersonate spec.requester.username)
 		for _, test := range tests {
@@ -249,7 +249,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		}
 	})
 
-	g.It("should pass impersonation update tests", func() {
+	g.It("should pass impersonation update tests [apigroup:template.openshift.io]", func() {
 		// check who can update TemplateInstances.  Via Update(), spec updates
 		// should be rejected (with the exception of spec.metadata fields used
 		// by the garbage collector, not tested here).  Status updates should be
@@ -349,7 +349,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		}
 	})
 
-	g.It("should pass impersonation deletion tests", func() {
+	g.It("should pass impersonation deletion tests [apigroup:template.openshift.io]", func() {
 		// check who can delete TemplateInstances (anyone with project write access)
 		for _, test := range tests {
 			setUser(cli, test.user)

--- a/test/extended/templates/templateinstance_objectkinds.go
+++ b/test/extended/templates/templateinstance_objectkinds.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance object kinds
 		cli     = exutil.NewCLI("templates")
 	)
 
-	g.It("should create and delete objects from varying API groups", func() {
+	g.It("should create and delete objects from varying API groups [apigroup:template.openshift.io][apigroup:route.openshift.io]", func() {
 		g.By("creating a template instance")
 		err := cli.Run("create").Args("-f", fixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -122,7 +122,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 			}
 		})
 
-		g.It("should report ready soon after all annotated objects are ready", func() {
+		g.It("should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io]", func() {
 			var err error
 
 			templateinstance = &templatev1.TemplateInstance{
@@ -171,7 +171,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should report failed soon after an annotated objects has failed", func() {
+		g.It("should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io]", func() {
 			var err error
 
 			secret, err := cli.KubeClient().CoreV1().Secrets(cli.Namespace()).Create(context.Background(), &v1.Secret{

--- a/test/extended/templates/templateinstance_security.go
+++ b/test/extended/templates/templateinstance_security.go
@@ -79,7 +79,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance security tes
 		}
 	)
 
-	g.Context("", func() {
+	g.Context("[apigroup:authorization.openshift.io][apigroup:template.openshift.io]", func() {
 		g.BeforeEach(func() {
 			adminuser = createUser(cli, "adminuser", "admin")
 			edituser = createUser(cli, "edituser", "edit")
@@ -127,7 +127,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance security tes
 			deleteGroup(cli, editgroup)
 		})
 
-		g.It("should pass security tests", func() {
+		g.It("should pass security tests [apigroup:route.openshift.io]", func() {
 			tests := []struct {
 				by              string
 				user            *userv1.User

--- a/test/extended/templates/templateservicebroker_bind.go
+++ b/test/extended/templates/templateservicebroker_bind.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker bind te
 		cliUser            user.Info
 	)
 
-	g.Context("", func() {
+	g.Context("[apigroup:authorization.openshift.io][apigroup:template.openshift.io]", func() {
 		g.BeforeEach(func() {
 			var err error
 			brokercli, err = TSBClient(cli)

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -33,7 +33,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker end-to-end test", func() {
+var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker end-to-end test [apigroup:template.openshift.io][apigroup:authorization.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -25,7 +25,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker security test", func() {
+var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker security test [apigroup:template.openshift.io][apigroup:authorization.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	ctx := context.Background()
 

--- a/test/extended/user/basic.go
+++ b/test/extended/user/basic.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-auth][Feature:UserAPI]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("user-api")
 
-	g.It("users can manipulate groups", func() {
+	g.It("users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]", func() {
 		t := g.GinkgoT()
 
 		clusterAdminUserClient := oc.AdminUserClient().UserV1()
@@ -131,7 +131,7 @@ var _ = g.Describe("[sig-auth][Feature:UserAPI]", func() {
 		})
 	})
 
-	g.It("groups should work", func() {
+	g.It("groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]", func() {
 		t := g.GinkgoT()
 		clusterAdminUserClient := oc.AdminUserClient().UserV1()
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -17,7 +17,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [Conformance][sig-sno][Serial] Cluster should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]": "should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io] [Suite:openshift/conformance/serial/minimal]",
 
-	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP": "test RequestHeaders IdP [Suite:openshift/conformance/serial]",
+	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io][apigroup:apps.openshift.io]": "test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial]": "should be stored at the correct location and version for all resources [Serial] [Suite:openshift/conformance/serial]",
 
@@ -273,9 +273,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-api-machinery][Feature:Audit] Basic audit should audit API calls": "should audit API calls [Disabled:SpecialConfig]",
 
-	"[Top Level] [sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces": "should control resource limits across namespaces [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io]": "should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of imagestreams resources": "should properly count the number of imagestreams resources [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of imagestreams resources [apigroup:image.openshift.io]": "should properly count the number of imagestreams resources [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-api-machinery][Feature:ServerSideApply] Server-Side Apply should work for apps.openshift.io/v1, Resource=deploymentconfigs": "should work for apps.openshift.io/v1, Resource=deploymentconfigs [Suite:openshift/conformance/parallel]",
 
@@ -583,13 +583,15 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_manual": "TestTriggers_manual [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Cluster topology single node tests Verify that OpenShift components deploy one replica in SingleReplica topology mode": "Verify that OpenShift components deploy one replica in SingleReplica topology mode [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] Cluster topology single node tests [apigroup:config.openshift.io] Verify that OpenShift components deploy one replica in SingleReplica topology mode": "Verify that OpenShift components deploy one replica in SingleReplica topology mode [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] ClusterOperators should define at least one namespace in their lists of related objects": "at least one namespace in their lists of related objects [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] ClusterOperators [apigroup:config.openshift.io] should define at least one namespace in their lists of related objects": "at least one namespace in their lists of related objects [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] ClusterOperators should define at least one related object that is not a namespace": "at least one related object that is not a namespace [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] ClusterOperators [apigroup:config.openshift.io] should define at least one related object that is not a namespace": "at least one related object that is not a namespace [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] ClusterOperators should define valid related objects": "valid related objects [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] ClusterOperators [apigroup:config.openshift.io] should define valid related objects": "valid related objects [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch] Managed cluster should [apigroup:apps.openshift.io] should expose cluster services outside the cluster [apigroup:route.openshift.io]": "should expose cluster services outside the cluster [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch] Managed cluster should ensure control plane operators do not make themselves unevictable": "ensure control plane operators do not make themselves unevictable [Suite:openshift/conformance/parallel]",
 
@@ -599,17 +601,15 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] Managed cluster should ensure pods use downstream images from our release image with proper ImagePullPolicy": "should ensure pods use downstream images from our release image with proper ImagePullPolicy [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should have operators on the cluster version": "have operators on the cluster version [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] Managed cluster should have operators on the cluster version [apigroup:config.openshift.io]": "have operators on the cluster version [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent": "should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] Managed cluster should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [apigroup:config.openshift.io]": "should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should recover when operator-owned objects are deleted [Disruptive]": "when operator-owned objects are deleted [Disruptive] [Serial]",
+	"[Top Level] [sig-arch] Managed cluster should recover when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io]": "when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io] [Serial]",
 
 	"[Top Level] [sig-arch] Managed cluster should set requests but not limits": "should set requests but not limits [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should should expose cluster services outside the cluster": "should expose cluster services outside the cluster [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-arch] [Conformance] FIPS TestFIPS": "TestFIPS [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-arch] [Conformance] FIPS TestFIPS [apigroup:config.openshift.io]": "TestFIPS [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
 
 	"[Top Level] [sig-arch] [Conformance] sysctl pod should not start for sysctl not on whitelist kernel.msgmax": "kernel.msgmax [Suite:openshift/conformance/parallel/minimal]",
 
@@ -625,13 +625,13 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] [Conformance] sysctl whitelists net.ipv4.tcp_syncookies": "net.ipv4.tcp_syncookies [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-arch] ocp payload should be based on existing source OLM version should contain the source commit id": "OLM version should contain the source commit id [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] ocp payload should be based on existing source OLM version should contain the source commit id [apigroup:config.openshift.io]": "OLM version should contain the source commit id [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][Early] CRDs for openshift.io should have a status in the CRD schema": "should have a status in the CRD schema [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][Early] CRDs for openshift.io should have subresource.status": "should have subresource.status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch][Early] Managed cluster should start all core operators": "start all core operators [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch][Early] Managed cluster should [apigroup:config.openshift.io] start all core operators": "start all core operators [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][Feature:ClusterUpgrade] Cluster should remain functional during upgrade [Disruptive]": "Cluster should remain functional during upgrade [Disruptive] [Serial]",
 
@@ -1007,49 +1007,49 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:BootstrapUser] The bootstrap user should successfully login with password decoded from kubeadmin secret [Disruptive]": "should successfully login with password decoded from kubeadmin secret [Disruptive] [Serial]",
 
-	"[Top Level] [sig-auth][Feature:HTPasswdAuth] HTPasswd IDP should successfully configure htpasswd and be responsive": "should successfully configure htpasswd and be responsive [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:HTPasswdAuth] HTPasswd IDP should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io]": "should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:LDAP] LDAP IDP should authenticate against an ldap server": "should authenticate against an ldap server [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:LDAP] LDAP IDP should authenticate against an ldap server [apigroup:user.openshift.io][apigroup:route.openshift.io]": "should authenticate against an ldap server [apigroup:user.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:LDAP] LDAP should start an OpenLDAP test server": "should start an OpenLDAP test server [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:LDAP] LDAP should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io]": "should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap": "can sync groups from ldap [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]": "can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] ClientSecretWithPlus should create oauthclient": "should create oauthclient [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] ClientSecretWithPlus should create oauthclient [apigroup:config.openshift.io][apigroup:oauth.openshift.io][apigroup:user.openshift.io]": "should create oauthclient [apigroup:config.openshift.io][apigroup:oauth.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth Authenticator accepts sha256 access tokens": "accepts sha256 access tokens [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth Authenticator accepts sha256 access tokens [apigroup:user.openshift.io][apigroup:oauth.openshift.io]": "accepts sha256 access tokens [apigroup:user.openshift.io][apigroup:oauth.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth server has the correct token and certificate fallback semantics": "has the correct token and certificate fallback semantics [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth server has the correct token and certificate fallback semantics [apigroup:config.openshift.io][apigroup:user.openshift.io]": "has the correct token and certificate fallback semantics [apigroup:config.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth server should use http1.1 only to prevent http2 connection reuse": "should use http1.1 only to prevent http2 connection reuse [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the authorize URL": "authorize URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the authorize URL": "authorize URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the grant URL": "grant URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the grant URL": "grant URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the login URL for the allow all IDP": "login URL for the allow all IDP [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the login URL for the allow all IDP": "login URL for the allow all IDP [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the login URL for the bootstrap IDP": "login URL for the bootstrap IDP [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the login URL for the bootstrap IDP": "login URL for the bootstrap IDP [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the login URL for when there is only one IDP": "login URL for when there is only one IDP [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the login URL for when there is only one IDP": "login URL for when there is only one IDP [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the logout URL": "logout URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the logout URL": "logout URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the root URL": "root URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the root URL": "root URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the token URL": "token URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the token URL": "token URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the token request URL": "token request URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the token request URL": "token request URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age to generate tokens that do not expire works as expected when using a code authorization flow": "works as expected when using a code authorization flow [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io] to generate tokens that do not expire works as expected when using a code authorization flow [apigroup:user.openshift.io]": "works as expected when using a code authorization flow [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age to generate tokens that do not expire works as expected when using a token authorization flow": "works as expected when using a token authorization flow [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io] to generate tokens that do not expire works as expected when using a token authorization flow [apigroup:user.openshift.io]": "works as expected when using a token authorization flow [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age to generate tokens that expire shortly works as expected when using a code authorization flow": "works as expected when using a code authorization flow [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io] to generate tokens that expire shortly works as expected when using a code authorization flow [apigroup:user.openshift.io]": "works as expected when using a code authorization flow [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age to generate tokens that expire shortly works as expected when using a token authorization flow": "works as expected when using a token authorization flow [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io] to generate tokens that expire shortly works as expected when using a token authorization flow [apigroup:user.openshift.io]": "works as expected when using a token authorization flow [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] well-known endpoint should be reachable": "should be reachable [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] well-known endpoint should be reachable [apigroup:config.openshift.io][apigroup:route.openshift.io]": "should be reachable [apigroup:config.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyClusterRoleBindingEndpoint should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
@@ -1089,19 +1089,19 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:PodSecurity] restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile": "restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestInvalidRoleRefs should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestInvalidRoleRefs should succeed [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io]": "should succeed [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectIsNamespace should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectIsNamespace should succeed [apigroup:project.openshift.io]": "should succeed [apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectWatch should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectWatch should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectWatchWithSelectionPredicate should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectWatchWithSelectionPredicate should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestScopedProjectAccess should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestScopedProjectAccess should succeed [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]": "should succeed [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestUnprivilegedNewProject": "TestUnprivilegedNewProject [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestUnprivilegedNewProject [apigroup:project.openshift.io]": "TestUnprivilegedNewProject [apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI][Serial]  TestUnprivilegedNewProjectDenied": "TestUnprivilegedNewProjectDenied [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI][Serial]  TestUnprivilegedNewProjectDenied [apigroup:authorization.openshift.io][apigroup:project.openshift.io]": "TestUnprivilegedNewProjectDenied [apigroup:authorization.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a RBAC rolebinding when subject is not already bound and is not permitted by any RBR should fail [apigroup:authorization.openshift.io]": "should fail [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
@@ -1119,15 +1119,15 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:SCC][Early] should not have pod creation failures during install": "should not have pod creation failures during install [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestAllowedSCCViaRBAC": "TestAllowedSCCViaRBAC [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]": "TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestPodDefaultCapabilities": "TestPodDefaultCapabilities [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestPodUpdateSCCEnforcement": "TestPodUpdateSCCEnforcement [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io]": "TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:UserAPI] groups should work": "groups should work [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:UserAPI] groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]": "groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:UserAPI] users can manipulate groups": "users can manipulate groups [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:UserAPI] users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]": "users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-autoscaling] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]": "CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6] [Suite:k8s]",
 
@@ -1837,17 +1837,17 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive] [Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks": "[Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks [Serial]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines] Managed cluster should have machine resources": "have machine resources [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines] Managed cluster should have machine resources [apigroup:machine.openshift.io]": "have machine resources [apigroup:machine.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Disruptive] Managed cluster should recover from deleted worker machines": "recover from deleted worker machines [Serial]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Disruptive] Managed cluster should recover from deleted worker machines [apigroup:machine.openshift.io]": "recover from deleted worker machines [apigroup:machine.openshift.io] [Serial]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should have same number of Machines and Nodes": "have same number of Machines and Nodes [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should have same number of Machines and Nodes [apigroup:machine.openshift.io]": "have same number of Machines and Nodes [apigroup:machine.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:30m]": "grow and decrease when scaling different machineSets simultaneously [Timeout:30m] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]": "grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-coreos] [Conformance] CoreOS bootimages TestBootimagesPresent": "TestBootimagesPresent [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations": "run sample related validations [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io]": "run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should print the usage",
 
@@ -1981,33 +1981,33 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:OpenShiftControllerManager] TestDockercfgTokenDeletedController": "TestDockercfgTokenDeletedController [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] template-api TestTemplate": "TestTemplate [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] template-api TestTemplate [apigroup:template.openshift.io]": "TestTemplate [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] template-api TestTemplateTransformationFromConfig": "TestTemplateTransformationFromConfig [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] template-api TestTemplateTransformationFromConfig [apigroup:template.openshift.io]": "TestTemplateTransformationFromConfig [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance creation with invalid object reports error  should report a failure on creation": "should report a failure on creation [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance creation with invalid object reports error  should report a failure on creation [apigroup:template.openshift.io]": "should report a failure on creation [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance cross-namespace test should create and delete objects across namespaces": "should create and delete objects across namespaces [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance cross-namespace test should create and delete objects across namespaces [apigroup:user.openshift.io][apigroup:template.openshift.io]": "should create and delete objects across namespaces [apigroup:user.openshift.io][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests should pass impersonation creation tests": "should pass impersonation creation tests [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests [apigroup:user.openshift.io][apigroup:authorization.openshift.io] should pass impersonation creation tests [apigroup:template.openshift.io]": "should pass impersonation creation tests [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests should pass impersonation deletion tests": "should pass impersonation deletion tests [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests [apigroup:user.openshift.io][apigroup:authorization.openshift.io] should pass impersonation deletion tests [apigroup:template.openshift.io]": "should pass impersonation deletion tests [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests should pass impersonation update tests": "should pass impersonation update tests [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests [apigroup:user.openshift.io][apigroup:authorization.openshift.io] should pass impersonation update tests [apigroup:template.openshift.io]": "should pass impersonation update tests [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance object kinds test should create and delete objects from varying API groups": "should create and delete objects from varying API groups [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance object kinds test should create and delete objects from varying API groups [apigroup:template.openshift.io][apigroup:route.openshift.io]": "should create and delete objects from varying API groups [apigroup:template.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance readiness test  should report failed soon after an annotated objects has failed": "should report failed soon after an annotated objects has failed [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance readiness test  should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io]": "should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance readiness test  should report ready soon after all annotated objects are ready": "should report ready soon after all annotated objects are ready [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance readiness test  should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io]": "should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance security tests  should pass security tests": "should pass security tests [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance security tests [apigroup:authorization.openshift.io][apigroup:template.openshift.io] should pass security tests [apigroup:route.openshift.io]": "should pass security tests [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker bind test  should pass bind tests": "should pass bind tests [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker bind test [apigroup:authorization.openshift.io][apigroup:template.openshift.io] should pass bind tests": "should pass bind tests [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker end-to-end test  should pass an end-to-end test": "should pass an end-to-end test [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker end-to-end test [apigroup:template.openshift.io][apigroup:authorization.openshift.io]  should pass an end-to-end test": "should pass an end-to-end test [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker security test  should pass security tests": "should pass security tests [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker security test [apigroup:template.openshift.io][apigroup:authorization.openshift.io]  should pass security tests": "should pass security tests [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-etcd] etcd cluster has the same number of master nodes and voting members from the endpoints configmap [Early]": "cluster has the same number of master nodes and voting members from the endpoints configmap [Early] [Suite:openshift/conformance/parallel]",
 
@@ -2151,21 +2151,21 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should have a AlertmanagerReceiversNotConfigured alert in firing state": "should have a AlertmanagerReceiversNotConfigured alert in firing state [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should have important platform topology metrics": "should have important platform topology metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should have important platform topology metrics [apigroup:config.openshift.io]": "should have important platform topology metrics [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should have non-Pod host cAdvisor metrics": "should have non-Pod host cAdvisor metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should provide ingress metrics": "should provide ingress metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should provide named network metrics": "should provide named network metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should provide named network metrics [apigroup:project.openshift.io]": "should provide named network metrics [apigroup:project.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should report telemetry if a cloud.openshift.com token is present [Late]": "should report telemetry if a cloud.openshift.com token is present [Late] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should start and expose a secured proxy and unsecured metrics": "should start and expose a secured proxy and unsecured metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io]": "should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster shouldn't have failing rules evaluation": "shouldn't have failing rules evaluation [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early]": "shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io]": "shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster when using openshift-sdn should be able to get the sdn ovs flows": "should be able to get the sdn ovs flows [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
@@ -2183,27 +2183,27 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster": "shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any unexpected alerts in firing or pending state": "shouldn't report any unexpected alerts in firing or pending state [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any unexpected alerts in firing or pending state [apigroup:config.openshift.io]": "shouldn't report any unexpected alerts in firing or pending state [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules should have a runbook_url annotation if the alert is critical": "should have a runbook_url annotation if the alert is critical [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have a runbook_url annotation if the alert is critical": "should have a runbook_url annotation if the alert is critical [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules should have a valid severity label": "should have a valid severity label [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have a valid severity label": "should have a valid severity label [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules should have description and summary annotations": "should have description and summary annotations [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have description and summary annotations": "should have description and summary annotations [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics": "should start and expose a secured proxy and verify build metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [apigroup:config.openshift.io][apigroup:build.openshift.io]": "should start and expose a secured proxy and verify build metrics [apigroup:config.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service": "should answer A and AAAA queries for a dual-stack service [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": "should answer endpoint and wildcard queries for the cluster [Disabled:Broken]",
 
-	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should be able to connect to a service that is idled because a GET on the route will unidle it": "should be able to connect to a service that is idled because a GET on the route will unidle it [Skipped:Disconnected] [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should be able to connect to a service that is idled because a GET on the route will unidle it [apigroup:config.openshift.io][apigroup:template.openshift.io]": "should be able to connect to a service that is idled because a GET on the route will unidle it [apigroup:config.openshift.io][apigroup:template.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the gRPC interoperability tests": "should pass the gRPC interoperability tests [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the gRPC interoperability tests [apigroup:config.openshift.io][apigroup:route.openshift.io][apigroup:template.openshift.io]": "should pass the gRPC interoperability tests [apigroup:config.openshift.io][apigroup:route.openshift.io][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the h2spec conformance tests": "should pass the h2spec conformance tests [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io] The HAProxy router should pass the h2spec conformance tests [apigroup:config.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:template.openshift.io]": "should pass the h2spec conformance tests [apigroup:config.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the http2 tests": "should pass the http2 tests [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router should pass the http2 tests [apigroup:image.openshift.io][apigroup:template.openshift.io]": "should pass the http2 tests [apigroup:image.openshift.io][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Idling with a single service and DeploymentConfig should idle the service and DeploymentConfig properly": "should idle the service and DeploymentConfig properly [Disabled:Broken]",
 
@@ -2761,7 +2761,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services when running openshift ipv4 cluster ensures external ip policy is configured correctly on the cluster [Serial]": "ensures external ip policy is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network] services when running openshift ipv4 cluster on bare metal ensures external auto assign cidr is configured correctly on the cluster [Serial]": "ensures external auto assign cidr is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network] services when running openshift ipv4 cluster on bare metal [apigroup:config.openshift.io] ensures external auto assign cidr is configured correctly on the cluster [Serial]": "ensures external auto assign cidr is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-network] services when using a plugin in a mode that does not isolate namespaces by default should allow connections to pods in different namespaces on different nodes via service IPs": "should allow connections to pods in different namespaces on different nodes via service IPs [Suite:openshift/conformance/parallel]",
 
@@ -2779,69 +2779,69 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services when using a plugin in a mode that isolates namespaces by default should prevent connections to pods in different namespaces on the same node via service IPs": "should prevent connections to pods in different namespaces on the same node via service IPs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:EgressFirewall] egressFirewall should have no impact outside its namespace": "egressFirewall should have no impact outside its namespace [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:EgressFirewall] egressFirewall should have no impact outside its namespace [apigroup:config.openshift.io]": "egressFirewall should have no impact outside its namespace [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift ovn-kubernetes should ensure egressfirewall is created": "should ensure egressfirewall is created [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift-sdn should ensure egressnetworkpolicy is created": "should ensure egressnetworkpolicy is created [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift-sdn should ensure egressnetworkpolicy is created [apigroup:network.openshift.io]": "should ensure egressnetworkpolicy is created [apigroup:network.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes]": "EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes]": "EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes] [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN]": "only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN]": "only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure]": "pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]": "pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io] [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN]": "pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN]": "pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should keep the assigned EgressIPs when being rescheduled to another node": "pods should keep the assigned EgressIPs when being rescheduled to another node [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should keep the assigned EgressIPs when being rescheduled to another node": "pods should keep the assigned EgressIPs when being rescheduled to another node [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP] [internal-targets] EgressIP pods should query hostNetwork pods with the local node's SNAT": "EgressIP pods should query hostNetwork pods with the local node's SNAT [Disabled:Broken] [Serial]",
+	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [internal-targets] EgressIP pods should query hostNetwork pods with the local node's SNAT": "EgressIP pods should query hostNetwork pods with the local node's SNAT [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created": "should ensure ipv4 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io]": "should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created": "should ensure ipv6 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io]": "should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:Multus] should use multus to create net1 device from network-attachment-definition": "should use multus to create net1 device from network-attachment-definition [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Network Policy Audit logging] when using openshift ovn-kubernetes should ensure acl logs are created and correct": "should ensure acl logs are created and correct [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Network Policy Audit logging] when using openshift ovn-kubernetes should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io]": "should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router converges when multiple routers are writing conflicting status": "converges when multiple routers are writing conflicting status [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should enable openshift-monitoring to pull metrics": "should enable openshift-monitoring to pull metrics [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router converges when multiple routers are writing status": "converges when multiple routers are writing status [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should expose a health check on the metrics port": "should expose a health check on the metrics port [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router reports the expected host names in admitted routes' statuses": "reports the expected host names in admitted routes' statuses [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should expose prometheus metrics for a route [apigroup:route.openshift.io]": "should expose prometheus metrics for a route [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should enable openshift-monitoring to pull metrics": "should enable openshift-monitoring to pull metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should expose the profiling endpoints": "should expose the profiling endpoints [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should expose a health check on the metrics port": "should expose a health check on the metrics port [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:image.openshift.io] The HAProxy router should serve a route that points to two services and respect weights": "should serve a route that points to two services and respect weights [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should expose prometheus metrics for a route": "should expose prometheus metrics for a route [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:operator.openshift.io][apigroup:apps.openshift.io] The HAProxy router should set Forwarded headers appropriately": "should set Forwarded headers appropriately [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should expose the profiling endpoints": "should expose the profiling endpoints [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:operator.openshift.io][apigroup:apps.openshift.io] The HAProxy router should respond with 503 to unrecognized hosts": "should respond with 503 to unrecognized hosts [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should override the route host for overridden domains with a custom value": "should override the route host for overridden domains with a custom value [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:operator.openshift.io][apigroup:apps.openshift.io] The HAProxy router should serve routes that were created from an ingress [apigroup:route.openshift.io]": "should serve routes that were created from an ingress [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should override the route host with a custom value": "should override the route host with a custom value [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router converges when multiple routers are writing conflicting status": "converges when multiple routers are writing conflicting status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should respond with 503 to unrecognized hosts": "should respond with 503 to unrecognized hosts [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router converges when multiple routers are writing status": "converges when multiple routers are writing status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should run even if it has no access to update status": "should run even if it has no access to update status [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io] when FIPS is disabled the HAProxy router should serve routes when configured with a 1024-bit RSA key [apigroup:template.openshift.io]": "should serve routes when configured with a 1024-bit RSA key [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should serve a route that points to two services and respect weights": "should serve a route that points to two services and respect weights [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io] when FIPS is enabled the HAProxy router should not work when configured with a 1024-bit RSA key [apigroup:template.openshift.io]": "should not work when configured with a 1024-bit RSA key [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should serve routes that were created from an ingress": "should serve routes that were created from an ingress [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router reports the expected host names in admitted routes' statuses": "reports the expected host names in admitted routes' statuses [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should serve the correct routes when running with the haproxy config manager": "should serve the correct routes when running with the haproxy config manager [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router should serve the correct routes when running with the haproxy config manager": "should serve the correct routes when running with the haproxy config manager [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should serve the correct routes when scoped to a single namespace and label set": "should serve the correct routes when scoped to a single namespace and label set [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io][apigroup:template.openshift.io] The HAProxy router should run even if it has no access to update status [apigroup:image.openshift.io]": "should run even if it has no access to update status [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should set Forwarded headers appropriately": "should set Forwarded headers appropriately [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:operator.openshift.io][apigroup:apps.openshift.io] The HAProxy router should support reencrypt to services backed by a serving certificate automatically": "should support reencrypt to services backed by a serving certificate automatically [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] The HAProxy router should support reencrypt to services backed by a serving certificate automatically": "should support reencrypt to services backed by a serving certificate automatically [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:template.openshift.io] The HAProxy router should override the route host for overridden domains with a custom value [apigroup:image.openshift.io]": "should override the route host for overridden domains with a custom value [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] when FIPS is disabled the HAProxy router should serve routes when configured with a 1024-bit RSA key": "should serve routes when configured with a 1024-bit RSA key [Feature:Networking-IPv4] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:template.openshift.io] The HAProxy router should override the route host with a custom value": "should override the route host with a custom value [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router] when FIPS is enabled the HAProxy router should not work when configured with a 1024-bit RSA key": "should not work when configured with a 1024-bit RSA key [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:template.openshift.io] The HAProxy router should serve the correct routes when scoped to a single namespace and label set": "should serve the correct routes when scoped to a single namespace and label set [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:Whereabouts] should assign unique IP addresses to each pod in the event of a race condition case": "should assign unique IP addresses to each pod in the event of a race condition case [Suite:openshift/conformance/parallel]",
 
@@ -2859,9 +2859,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:tuning] pod sysctls should not affect node": "pod sysctls should not affect node [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][endpoints] admission blocks manual creation of EndpointSlices pointing to the cluster or service network": "blocks manual creation of EndpointSlices pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of EndpointSlices pointing to the cluster or service network": "blocks manual creation of EndpointSlices pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][endpoints] admission blocks manual creation of Endpoints pointing to the cluster or service network": "blocks manual creation of Endpoints pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of Endpoints pointing to the cluster or service network": "blocks manual creation of Endpoints pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined": "can disable an AppArmor profile, using unconfined [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -3203,7 +3203,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] should override timeoutGracePeriodSeconds when annotation is set": "should override timeoutGracePeriodSeconds when annotation is set [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [Local]": "should propagate requested groups to the container [Local]",
+	"[Top Level] [sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [Local][apigroup:user.openshift.io][apigroup:security.openshift.io]": "should propagate requested groups to the container [Local][apigroup:user.openshift.io][apigroup:security.openshift.io]",
 
 	"[Top Level] [sig-node][Late] should not have pod creation failures due to systemd timeouts": "should not have pod creation failures due to systemd timeouts [Suite:openshift/conformance/parallel]",
 
@@ -3221,11 +3221,11 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-operator] OLM should be installed with subscriptions at version v1alpha1": "be installed with subscriptions at version v1alpha1 [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-operator] OLM should have imagePullPolicy:IfNotPresent on thier deployments": "have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-operator] OLM should have imagePullPolicy:IfNotPresent on thier deployments [apigroup:config.openshift.io]": "have imagePullPolicy:IfNotPresent on thier deployments [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-operator] an end user can use OLM Report Upgradeable in OLM ClusterOperators status": "Report Upgradeable in OLM ClusterOperators status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-operator] an end user can use OLM can subscribe to the operator": "can subscribe to the operator [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-operator] an end user can use OLM can subscribe to the operator [apigroup:config.openshift.io]": "can subscribe to the operator [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-scalability][Feature:Performance] Load cluster should populate the cluster [Slow][Serial]": "should populate the cluster [Slow][Serial]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -7,15 +7,15 @@ import (
 )
 
 var annotations = map[string]string{
-	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-ext.kubeconfig\" should be present on all masters and work": "\"lb-ext.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-ext.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io]": "\"lb-ext.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-int.kubeconfig\" should be present on all masters and work": "\"lb-int.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"lb-int.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io]": "\"lb-int.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"localhost-recovery.kubeconfig\" should be present on all masters and work": "\"localhost-recovery.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"localhost-recovery.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io]": "\"localhost-recovery.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"localhost.kubeconfig\" should be present on all masters and work": "\"localhost.kubeconfig\" should be present on all masters and work [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"localhost.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io]": "\"localhost.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [Conformance][sig-sno][Serial] Cluster should allow a fast rollout of kube-apiserver with no pods restarts during API disruption": "should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [Suite:openshift/conformance/serial/minimal]",
+	"[Top Level] [Conformance][sig-sno][Serial] Cluster should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]": "should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io] [Suite:openshift/conformance/serial/minimal]",
 
 	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP": "test RequestHeaders IdP [Suite:openshift/conformance/serial]",
 
@@ -263,7 +263,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and don't send request early": "API LBs follow /readyz of kube-apiserver and don't send request early [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients": "API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients [apigroup:config.openshift.io]": "API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and stop sending requests": "API LBs follow /readyz of kube-apiserver and stop sending requests [Suite:openshift/conformance/parallel]",
 
@@ -635,9 +635,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch][Feature:ClusterUpgrade] Cluster should remain functional during upgrade [Disruptive]": "Cluster should remain functional during upgrade [Disruptive] [Serial]",
 
-	"[Top Level] [sig-arch][Late] clients should not use APIs that are removed in upcoming releases": "clients should not use APIs that are removed in upcoming releases [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch][Late] clients should not use APIs that are removed in upcoming releases [apigroup:config.openshift.io]": "clients should not use APIs that are removed in upcoming releases [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch][Late] operators should not create watch channels very often": "operators should not create watch channels very often [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch][Late] operators should not create watch channels very often [apigroup:config.openshift.io]": "operators should not create watch channels very often [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][bz-Cloud Compute][Late] Alerts alert/KubePodNotReady should not be at or above info in ns/openshift-cloud-controller-manager": "alert/KubePodNotReady should not be at or above info in ns/openshift-cloud-controller-manager [Suite:openshift/conformance/parallel]",
 
@@ -1003,7 +1003,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth] [Feature:NodeAuthorizer] Getting an existing secret should exit with the Forbidden error": "Getting an existing secret should exit with the Forbidden error [Skipped:ibmroks] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-auth][Feature:Authentication]  TestFrontProxy should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:Authentication]  TestFrontProxy should succeed [apigroup:config.openshift.io]": "should succeed [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:BootstrapUser] The bootstrap user should successfully login with password decoded from kubeadmin secret [Disruptive]": "should successfully login with password decoded from kubeadmin secret [Disruptive] [Serial]",
 
@@ -1051,41 +1051,41 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:OAuthServer] well-known endpoint should be reachable": "should be reachable [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyClusterRoleBindingEndpoint should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyClusterRoleBindingEndpoint should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyClusterRoleEndpoint should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyClusterRoleEndpoint should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyEndpointConfirmNoEscalation should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyEndpointConfirmNoEscalation [apigroup:authorization.openshift.io] should succeed": "should succeed [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyLocalRoleBindingEndpoint should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyLocalRoleBindingEndpoint should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyLocalRoleEndpoint should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyLocalRoleEndpoint should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] The default cluster RBAC policy should have correct RBAC rules": "should have correct RBAC rules [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] authorization  TestAuthorizationSubjectAccessReview should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] authorization  TestAuthorizationSubjectAccessReview should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] authorization  TestAuthorizationSubjectAccessReviewAPIGroup should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] authorization  TestAuthorizationSubjectAccessReviewAPIGroup should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] authorization  TestBrowserSafeAuthorizer should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] authorization  TestBrowserSafeAuthorizer should succeed [apigroup:user.openshift.io]": "should succeed [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] authorization  TestClusterReaderCoverage should succeed": "should succeed [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestScopeEscalations should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestScopeEscalations should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io][apigroup:oauth.openshift.io]": "should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io][apigroup:oauth.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestScopedImpersonation should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestScopedImpersonation should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io]": "should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestScopedTokens should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestScopedTokens should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:oauth.openshift.io][apigroup:build.openshift.io]": "should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:oauth.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestTokensWithIllegalScopes should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestTokensWithIllegalScopes should succeed [apigroup:oauth.openshift.io]": "should succeed [apigroup:oauth.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestUnknownScopes should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] scopes TestUnknownScopes should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]": "should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestBootstrapPolicySelfSubjectAccessReviews should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestBootstrapPolicySelfSubjectAccessReviews should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io]": "should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestSelfSubjectAccessReviewsNonExistingNamespace should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] self-SAR compatibility  TestSelfSubjectAccessReviewsNonExistingNamespace should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io]": "should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization][Serial] authorization  TestAuthorizationResourceAccessReview should succeed": "should succeed [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization][Serial] authorization  TestAuthorizationResourceAccessReview should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-auth][Feature:PodSecurity] restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile": "restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile [Suite:openshift/conformance/parallel]",
 
@@ -1103,19 +1103,19 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:ProjectAPI][Serial]  TestUnprivilegedNewProjectDenied": "TestUnprivilegedNewProjectDenied [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a RBAC rolebinding when subject is not already bound and is not permitted by any RBR should fail": "should fail [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a RBAC rolebinding when subject is not already bound and is not permitted by any RBR should fail [apigroup:authorization.openshift.io]": "should fail [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding that also contains system:non-existing users should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding that also contains system:non-existing users should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding when subject is already bound should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding when subject is already bound should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding when subject is not already bound and is not permitted by any RBR should fail": "should fail [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding when subject is not already bound and is not permitted by any RBR should fail [apigroup:authorization.openshift.io]": "should fail [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding when subject is permitted by RBR should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding when subject is permitted by RBR should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding when there are no restrictions should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a rolebinding when there are no restrictions should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Rolebinding restrictions tests single project should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Rolebinding restrictions tests single project should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:SCC][Early] should not have pod creation failures during install": "should not have pod creation failures during install [Suite:openshift/conformance/parallel]",
 
@@ -1243,79 +1243,79 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]": "should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling] [Skipped:gce] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-builds][Feature:Builds] Multi-stage image builds should succeed": "should succeed [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] Multi-stage image builds should succeed [apigroup:build.openshift.io]": "should succeed [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] Optimized image builds  should succeed": "should succeed [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] Optimized image builds  should succeed [apigroup:build.openshift.io]": "should succeed [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] build can reference a cluster service  with a build being created from new-build should be able to run a build that references a cluster service": "should be able to run a build that references a cluster service [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] build can reference a cluster service  with a build being created from new-build should be able to run a build that references a cluster service [apigroup:build.openshift.io]": "should be able to run a build that references a cluster service [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] build have source revision metadata  started build should contain source revision information": "should contain source revision information [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] build have source revision metadata  started build should contain source revision information [apigroup:build.openshift.io]": "should contain source revision information [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] build with empty source  started build should build even with an empty source in build config": "should build even with an empty source in build config [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] build with empty source  started build should build even with an empty source in build config [apigroup:build.openshift.io]": "should build even with an empty source in build config [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] build without output image  building from templates should create an image from a S2i template without an output image reference defined": "should create an image from a S2i template without an output image reference defined [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] build without output image  building from templates should create an image from a S2i template without an output image reference defined [apigroup:build.openshift.io]": "should create an image from a S2i template without an output image reference defined [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] build without output image  building from templates should create an image from a docker template without an output image reference defined": "should create an image from a docker template without an output image reference defined [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] build without output image  building from templates should create an image from a docker template without an output image reference defined [apigroup:build.openshift.io]": "should create an image from a docker template without an output image reference defined [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] buildconfig secret injector  should inject secrets to the appropriate buildconfigs": "should inject secrets to the appropriate buildconfigs [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] buildconfig secret injector  should inject secrets to the appropriate buildconfigs [apigroup:build.openshift.io]": "should inject secrets to the appropriate buildconfigs [apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-builds][Feature:Builds] clone repository using git:// protocol  should clone using git:// if no proxy is configured": "should clone using git:// if no proxy is configured [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] custom build with buildah  being created from new-build should complete build with custom builder image": "should complete build with custom builder image [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] custom build with buildah  being created from new-build should complete build with custom builder image [apigroup:build.openshift.io]": "should complete build with custom builder image [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] imagechangetriggers  imagechangetriggers should trigger builds of all types": "imagechangetriggers should trigger builds of all types [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] imagechangetriggers  imagechangetriggers should trigger builds of all types [apigroup:build.openshift.io]": "imagechangetriggers should trigger builds of all types [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-builds][Feature:Builds] oc new-app  should fail with a --name longer than 58 characters": "should fail with a --name longer than 58 characters [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] oc new-app  should succeed with a --name of 58 characters": "should succeed with a --name of 58 characters [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] oc new-app  should succeed with a --name of 58 characters [apigroup:build.openshift.io]": "should succeed with a --name of 58 characters [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-builds][Feature:Builds] oc new-app  should succeed with an imagestream": "should succeed with an imagestream [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  buildconfigs should have a default history limit set when created via the group api": "buildconfigs should have a default history limit set when created via the group api [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  buildconfigs should have a default history limit set when created via the group api [apigroup:build.openshift.io]": "buildconfigs should have a default history limit set when created via the group api [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune builds after a buildConfig change": "should prune builds after a buildConfig change [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune builds after a buildConfig change [apigroup:build.openshift.io]": "should prune builds after a buildConfig change [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune canceled builds based on the failedBuildsHistoryLimit setting": "should prune canceled builds based on the failedBuildsHistoryLimit setting [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune canceled builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]": "should prune canceled builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune completed builds based on the successfulBuildsHistoryLimit setting": "should prune completed builds based on the successfulBuildsHistoryLimit setting [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune completed builds based on the successfulBuildsHistoryLimit setting [apigroup:build.openshift.io]": "should prune completed builds based on the successfulBuildsHistoryLimit setting [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune errored builds based on the failedBuildsHistoryLimit setting": "should prune errored builds based on the failedBuildsHistoryLimit setting [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune failed builds based on the failedBuildsHistoryLimit setting": "should prune failed builds based on the failedBuildsHistoryLimit setting [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig  should prune failed builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]": "should prune failed builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] remove all builds when build configuration is removed  oc delete buildconfig should start builds and delete the buildconfig": "should start builds and delete the buildconfig [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] remove all builds when build configuration is removed  oc delete buildconfig should start builds and delete the buildconfig [apigroup:build.openshift.io]": "should start builds and delete the buildconfig [apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] result image should have proper labels set  Docker build from a template should create a image from \"test-docker-build.json\" template with proper Docker labels": "should create a image from \"test-docker-build.json\" template with proper Docker labels [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] result image should have proper labels set  Docker build from a template should create a image from \"test-docker-build.json\" template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should create a image from \"test-docker-build.json\" template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] result image should have proper labels set  S2I build from a template should create a image from \"test-s2i-build.json\" template with proper Docker labels": "should create a image from \"test-s2i-build.json\" template with proper Docker labels [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] result image should have proper labels set  S2I build from a template should create a image from \"test-s2i-build.json\" template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should create a image from \"test-s2i-build.json\" template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] s2i build with a quota  Building from a template should create an s2i build with a quota and run it": "should create an s2i build with a quota and run it [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] s2i build with a quota  Building from a template should create an s2i build with a quota and run it [apigroup:build.openshift.io]": "should create an s2i build with a quota and run it [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] s2i build with a root user image should create a root build and fail without a privileged SCC": "should create a root build and fail without a privileged SCC [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] s2i build with a root user image should create a root build and fail without a privileged SCC [apigroup:build.openshift.io]": "should create a root build and fail without a privileged SCC [apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] s2i build with a root user image should create a root build and pass with a privileged SCC": "should create a root build and pass with a privileged SCC [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] s2i build with a root user image should create a root build and pass with a privileged SCC [apigroup:build.openshift.io]": "should create a root build and pass with a privileged SCC [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] verify /run filesystem contents  are writeable using a simple Docker Strategy Build": "using a simple Docker Strategy Build [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] verify /run filesystem contents  are writeable using a simple Docker Strategy Build [apigroup:build.openshift.io]": "using a simple Docker Strategy Build [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds] verify /run filesystem contents  do not have unexpected content using a simple Docker Strategy Build": "using a simple Docker Strategy Build [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds] verify /run filesystem contents  do not have unexpected content using a simple Docker Strategy Build [apigroup:build.openshift.io]": "using a simple Docker Strategy Build [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config no ocm rollout Apply default proxy configuration to docker build pod through env vars": "Apply default proxy configuration to docker build pod through env vars",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config no ocm rollout [apigroup:config.openshift.io] Apply default proxy configuration to docker build pod through env vars [apigroup:build.openshift.io]": "Apply default proxy configuration to docker build pod through env vars [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config no ocm rollout Apply default proxy configuration to source build pod through env vars": "Apply default proxy configuration to source build pod through env vars",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config no ocm rollout [apigroup:config.openshift.io] Apply default proxy configuration to source build pod through env vars [apigroup:build.openshift.io]": "Apply default proxy configuration to source build pod through env vars [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config no ocm rollout Apply git proxy configuration to build pod": "Apply git proxy configuration to build pod",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config no ocm rollout [apigroup:config.openshift.io] Apply git proxy configuration to build pod [apigroup:build.openshift.io]": "Apply git proxy configuration to build pod [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout Apply default image label configuration to build pod": "Apply default image label configuration to build pod",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout [apigroup:config.openshift.io] Apply default image label configuration to build pod": "Apply default image label configuration to build pod",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout Apply env configuration to build pod": "Apply env configuration to build pod",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout [apigroup:config.openshift.io] Apply env configuration to build pod": "Apply env configuration to build pod",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout Apply node selector configuration to build pod": "Apply node selector configuration to build pod",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout [apigroup:config.openshift.io] Apply node selector configuration to build pod": "Apply node selector configuration to build pod",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout Apply override image label configuration to build pod": "Apply override image label configuration to build pod",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout [apigroup:config.openshift.io] Apply override image label configuration to build pod [apigroup:build.openshift.io]": "Apply override image label configuration to build pod [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout Apply resource configuration to build pod": "Apply resource configuration to build pod",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout [apigroup:config.openshift.io] Apply resource configuration to build pod": "Apply resource configuration to build pod",
 
-	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout Apply toleration override configuration to build pod": "Apply toleration override configuration to build pod",
+	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  build config with ocm rollout [apigroup:config.openshift.io] Apply toleration override configuration to build pod": "Apply toleration override configuration to build pod",
 
 	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  registries config context should allow registries to be blacklisted": "should allow registries to be blacklisted",
 
@@ -1323,201 +1323,201 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter builds via cluster configuration  registries config context should default registry search to docker.io for image pulls": "should default registry search to docker.io for image pulls",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] Capabilities should be dropped for s2i builders  s2i build with a rootable builder should not be able to switch to root with an assemble script": "should not be able to switch to root with an assemble script",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] Capabilities should be dropped for s2i builders  s2i build with a rootable builder should not be able to switch to root with an assemble script [apigroup:build.openshift.io]": "should not be able to switch to root with an assemble script [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build should be able to start a build from Dockerfile with FROM reference to scratch": "should be able to start a build from Dockerfile with FROM reference to scratch",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build should be able to start a build from Dockerfile with FROM reference to scratch [apigroup:build.openshift.io]": "should be able to start a build from Dockerfile with FROM reference to scratch [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build should create a image via new-build and infer the origin tag": "should create a image via new-build and infer the origin tag",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build should create a image via new-build [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should create a image via new-build [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build should create a image via new-build": "should create a image via new-build",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build should create a image via new-build and infer the origin tag [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should create a image via new-build and infer the origin tag [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build testing build image with dockerfile contains a file path uses a variable in its name": "testing build image with dockerfile contains a file path uses a variable in its name",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build testing build image with dockerfile contains a file path uses a variable in its name [apigroup:build.openshift.io]": "testing build image with dockerfile contains a file path uses a variable in its name [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build testing build image with invalid dockerfile content": "testing build image with invalid dockerfile content",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have Dockerfile input  being created from new-build testing build image with invalid dockerfile content [apigroup:build.openshift.io]": "testing build image with invalid dockerfile content [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source  buildconfig with input source image and docker strategy should complete successfully and contain the expected file": "should complete successfully and contain the expected file",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source [apigroup:image.openshift.io] buildconfig with input source image and docker strategy should complete successfully and contain the expected file [apigroup:build.openshift.io]": "should complete successfully and contain the expected file [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source  buildconfig with input source image and s2i strategy should complete successfully and contain the expected file": "should complete successfully and contain the expected file",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source [apigroup:image.openshift.io] buildconfig with input source image and s2i strategy should complete successfully and contain the expected file [apigroup:build.openshift.io]": "should complete successfully and contain the expected file [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source  creating a build with an input source image and custom strategy should resolve the imagestream references and secrets": "should resolve the imagestream references and secrets",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source [apigroup:image.openshift.io] creating a build with an input source image and custom strategy should resolve the imagestream references and secrets [apigroup:build.openshift.io]": "should resolve the imagestream references and secrets [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source  creating a build with an input source image and docker strategy should resolve the imagestream references and secrets": "should resolve the imagestream references and secrets",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source [apigroup:image.openshift.io] creating a build with an input source image and docker strategy should resolve the imagestream references and secrets [apigroup:build.openshift.io]": "should resolve the imagestream references and secrets [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source  creating a build with an input source image and s2i strategy should resolve the imagestream references and secrets": "should resolve the imagestream references and secrets",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build can have container image source [apigroup:image.openshift.io] creating a build with an input source image and s2i strategy should resolve the imagestream references and secrets [apigroup:build.openshift.io]": "should resolve the imagestream references and secrets [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build controller  RunBuildCompletePodDeleteTest should succeed": "should succeed",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build controller  RunBuildCompletePodDeleteTest should succeed [apigroup:build.openshift.io]": "should succeed [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build controller  RunBuildDeleteTest should succeed": "should succeed",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build controller  RunBuildDeleteTest should succeed [apigroup:build.openshift.io]": "should succeed [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] build controller  RunBuildRunningPodDeleteTest should succeed": "should succeed",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] build controller  RunBuildRunningPodDeleteTest should succeed [apigroup:build.openshift.io]": "should succeed [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should have deadlines  oc start-build docker-build --wait Docker: should start a build and wait for the build failed and build pod being killed by kubelet": "Docker: should start a build and wait for the build failed and build pod being killed by kubelet",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should have deadlines  oc start-build docker-build --wait Docker: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]": "Docker: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should have deadlines  oc start-build source-build --wait Source: should start a build and wait for the build failed and build pod being killed by kubelet": "Source: should start a build and wait for the build failed and build pod being killed by kubelet",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should have deadlines  oc start-build source-build --wait Source: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]": "Source: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with broken proxy and a no_proxy override should start a docker build and wait for the build to succeed": "should start a docker build and wait for the build to succeed",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with broken proxy and a no_proxy override should start a docker build and wait for the build to succeed [apigroup:build.openshift.io]": "should start a docker build and wait for the build to succeed [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with broken proxy and a no_proxy override should start an s2i build and wait for the build to succeed": "should start an s2i build and wait for the build to succeed",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with broken proxy and a no_proxy override should start an s2i build and wait for the build to succeed [apigroup:build.openshift.io]": "should start an s2i build and wait for the build to succeed [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with broken proxy should start a build and wait for the build to fail": "should start a build and wait for the build to fail",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with broken proxy should start a build and wait for the build to fail [apigroup:build.openshift.io]": "should start a build and wait for the build to fail [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with cluster-wide custom PKI should mount the custom PKI into the build if specified": "should mount the custom PKI into the build if specified",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds should support proxies  start build with cluster-wide custom PKI should mount the custom PKI into the build if specified [apigroup:config.openshift.io][apigroup:build.openshift.io]": "should mount the custom PKI into the build if specified [apigroup:config.openshift.io][apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] builds with a context directory  docker context directory build should docker build an application using a context directory": "should docker build an application using a context directory",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds with a context directory  docker context directory build should docker build an application using a context directory [apigroup:build.openshift.io]": "should docker build an application using a context directory [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] builds with a context directory  s2i context directory build should s2i build an application using a context directory": "should s2i build an application using a context directory",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] builds with a context directory  s2i context directory build should s2i build an application using a context directory [apigroup:build.openshift.io]": "should s2i build an application using a context directory [apigroup:build.openshift.io]",
 
 	"[Top Level] [sig-builds][Feature:Builds][Slow] can use build secrets  build with secrets and configMaps should contain secrets during the docker strategy build": "should contain secrets during the docker strategy build",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] can use build secrets  build with secrets and configMaps should contain secrets during the source strategy build": "should contain secrets during the source strategy build",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] can use build secrets  build with secrets and configMaps should contain secrets during the source strategy build [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should contain secrets during the source strategy build [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] can use private repositories as build input  build using an HTTP token should be able to clone source code via an HTTP token": "should be able to clone source code via an HTTP token",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] can use private repositories as build input  build using an HTTP token should be able to clone source code via an HTTP token [apigroup:build.openshift.io]": "should be able to clone source code via an HTTP token [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] can use private repositories as build input  build using an ssh private key should be able to clone source code via ssh using SCP-style URIs": "should be able to clone source code via ssh using SCP-style URIs",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] can use private repositories as build input  build using an ssh private key should be able to clone source code via ssh [apigroup:build.openshift.io]": "should be able to clone source code via ssh [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] can use private repositories as build input  build using an ssh private key should be able to clone source code via ssh": "should be able to clone source code via ssh",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] can use private repositories as build input  build using an ssh private key should be able to clone source code via ssh using SCP-style URIs [apigroup:build.openshift.io]": "should be able to clone source code via ssh using SCP-style URIs [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] completed builds should have digest of the image in their status  Docker build started with log level >5 should save the image digest when finished": "should save the image digest when finished",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] completed builds should have digest of the image in their status  Docker build started with log level >5 should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] completed builds should have digest of the image in their status  Docker build started with normal log level should save the image digest when finished": "should save the image digest when finished",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] completed builds should have digest of the image in their status  Docker build started with normal log level should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] completed builds should have digest of the image in their status  S2I build started with log level >5 should save the image digest when finished": "should save the image digest when finished",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] completed builds should have digest of the image in their status  S2I build started with log level >5 should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] completed builds should have digest of the image in their status  S2I build started with normal log level should save the image digest when finished": "should save the image digest when finished",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] completed builds should have digest of the image in their status  S2I build started with normal log level should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] incremental s2i build  Building from a template should create a build from \"incremental-auth-build.json\" template and run it": "should create a build from \"incremental-auth-build.json\" template and run it",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] incremental s2i build  Building from a template should create a build from \"incremental-auth-build.json\" template and run it [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should create a build from \"incremental-auth-build.json\" template and run it [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] s2i build with environment file in sources  Building from a template should create a image from \"test-env-build.json\" template and run it in a pod": "should create a image from \"test-env-build.json\" template and run it in a pod",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] s2i build with environment file in sources  Building from a template should create a image from \"test-env-build.json\" template and run it in a pod [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should create a image from \"test-env-build.json\" template and run it in a pod [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context Setting build-args on Docker builds Should accept build args that are specified in the Dockerfile": "Should accept build args that are specified in the Dockerfile",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context Setting build-args on Docker builds Should accept build args that are specified in the Dockerfile [apigroup:build.openshift.io]": "Should accept build args that are specified in the Dockerfile [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context Setting build-args on Docker builds Should complete with a warning on non-existent build-arg": "Should complete with a warning on non-existent build-arg",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context Setting build-args on Docker builds Should complete with a warning on non-existent build-arg [apigroup:build.openshift.io]": "Should complete with a warning on non-existent build-arg [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context Setting build-args on Docker builds Should copy build args from BuildConfig to Build": "Should copy build args from BuildConfig to Build",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context Setting build-args on Docker builds Should copy build args from BuildConfig to Build [apigroup:build.openshift.io]": "Should copy build args from BuildConfig to Build [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context Trigger builds with branch refs matching directories on master branch Should checkout the config branch, not config directory": "Should checkout the config branch, not config directory",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context Trigger builds with branch refs matching directories on master branch Should checkout the config branch, not config directory [apigroup:build.openshift.io]": "Should checkout the config branch, not config directory [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds shoud accept --from-archive with https URL as an input": "shoud accept --from-archive with https URL as an input",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds shoud accept --from-archive with https URL as an input [apigroup:build.openshift.io]": "shoud accept --from-archive with https URL as an input [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds shoud accept --from-file with https URL as an input": "shoud accept --from-file with https URL as an input",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds shoud accept --from-file with https URL as an input [apigroup:build.openshift.io]": "shoud accept --from-file with https URL as an input [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should accept --from-dir as input": "should accept --from-dir as input",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should accept --from-dir as input [apigroup:build.openshift.io]": "should accept --from-dir as input [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should accept --from-file as input": "should accept --from-file as input",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should accept --from-file as input [apigroup:build.openshift.io]": "should accept --from-file as input [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should accept --from-repo as input": "should accept --from-repo as input",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should accept --from-repo as input [apigroup:build.openshift.io]": "should accept --from-repo as input [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should accept --from-repo with --commit as input": "should accept --from-repo with --commit as input",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should accept --from-repo with --commit as input [apigroup:build.openshift.io]": "should accept --from-repo with --commit as input [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should reject binary build requests without a --from-xxxx value": "should reject binary build requests without a --from-xxxx value",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context binary builds should reject binary build requests without a --from-xxxx value [apigroup:build.openshift.io]": "should reject binary build requests without a --from-xxxx value [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context cancel a binary build that doesn't start running in 5 minutes should start a build and wait for the build to be cancelled": "should start a build and wait for the build to be cancelled",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context cancel a binary build that doesn't start running in 5 minutes should start a build and wait for the build to be cancelled [apigroup:build.openshift.io]": "should start a build and wait for the build to be cancelled [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context cancel a build started by oc start-build --wait should start a build and wait for the build to cancel": "should start a build and wait for the build to cancel",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context cancel a build started by oc start-build --wait should start a build and wait for the build to cancel [apigroup:build.openshift.io]": "should start a build and wait for the build to cancel [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context oc start-build --wait should start a build and wait for the build to complete": "should start a build and wait for the build to complete",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context oc start-build --wait should start a build and wait for the build to complete [apigroup:build.openshift.io]": "should start a build and wait for the build to complete [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context oc start-build --wait should start a build and wait for the build to fail": "should start a build and wait for the build to fail",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context oc start-build --wait should start a build and wait for the build to fail [apigroup:build.openshift.io]": "should start a build and wait for the build to fail [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context oc start-build with pr ref should start a build from a PR ref, wait for the build to complete, and confirm the right level was used": "should start a build from a PR ref, wait for the build to complete, and confirm the right level was used",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context oc start-build with pr ref should start a build from a PR ref, wait for the build to complete, and confirm the right level was used [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should start a build from a PR ref, wait for the build to complete, and confirm the right level was used [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context override environment BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel": "BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context override environment BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel [apigroup:build.openshift.io]": "BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context override environment BUILD_LOGLEVEL in buildconfig should create verbose output": "BUILD_LOGLEVEL in buildconfig should create verbose output",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context override environment BUILD_LOGLEVEL in buildconfig should create verbose output [apigroup:build.openshift.io]": "BUILD_LOGLEVEL in buildconfig should create verbose output [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context override environment should accept environment variables": "should accept environment variables",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context override environment should accept environment variables [apigroup:build.openshift.io]": "should accept environment variables [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context s2i build maintaining symlinks should s2i build image and maintain symlinks": "should s2i build image and maintain symlinks",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context s2i build maintaining symlinks should s2i build image and maintain symlinks [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should s2i build image and maintain symlinks [apigroup:build.openshift.io][apigroup:image.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context start a build via a webhook should be able to start builds via the webhook with valid secrets and fail with invalid secrets": "should be able to start builds via the webhook with valid secrets and fail with invalid secrets",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] starting a build using CLI  start-build test context start a build via a webhook should be able to start builds via the webhook with valid secrets and fail with invalid secrets [apigroup:build.openshift.io]": "should be able to start builds via the webhook with valid secrets and fail with invalid secrets [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] testing build configuration hooks  testing postCommit hook should run docker postCommit hooks": "should run docker postCommit hooks",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] testing build configuration hooks  testing postCommit hook should run docker postCommit hooks [apigroup:build.openshift.io]": "should run docker postCommit hooks [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] testing build configuration hooks  testing postCommit hook should run s2i postCommit hooks": "should run s2i postCommit hooks",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] testing build configuration hooks  testing postCommit hook should run s2i postCommit hooks [apigroup:build.openshift.io]": "should run s2i postCommit hooks [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status Docker fetch image content failure should contain the Docker build fetch image content reason and message": "should contain the Docker build fetch image content reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status Docker fetch image content failure should contain the Docker build fetch image content reason and message [apigroup:build.openshift.io]": "should contain the Docker build fetch image content reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status Docker fetch source failure should contain the Docker build fetch source failure reason and message": "should contain the Docker build fetch source failure reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status Docker fetch source failure should contain the Docker build fetch source failure reason and message [apigroup:build.openshift.io]": "should contain the Docker build fetch source failure reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status OutOfMemoryKilled should contain OutOfMemoryKilled failure reason and message": "should contain OutOfMemoryKilled failure reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status OutOfMemoryKilled should contain OutOfMemoryKilled failure reason and message [apigroup:build.openshift.io]": "should contain OutOfMemoryKilled failure reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status S2I bad context dir failure should contain the S2I bad context dir failure reason and message": "should contain the S2I bad context dir failure reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status S2I bad context dir failure should contain the S2I bad context dir failure reason and message [apigroup:build.openshift.io]": "should contain the S2I bad context dir failure reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status S2I fetch source failure should contain the S2I fetch source failure reason and message": "should contain the S2I fetch source failure reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status S2I fetch source failure should contain the S2I fetch source failure reason and message [apigroup:build.openshift.io]": "should contain the S2I fetch source failure reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status failed assemble container should contain the failure reason related to an assemble script failing in s2i": "should contain the failure reason related to an assemble script failing in s2i",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status failed assemble container should contain the failure reason related to an assemble script failing in s2i [apigroup:build.openshift.io]": "should contain the failure reason related to an assemble script failing in s2i [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status failed https proxy invalid url should contain the generic failure reason and message": "should contain the generic failure reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status failed https proxy invalid url should contain the generic failure reason and message [apigroup:build.openshift.io]": "should contain the generic failure reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status fetch builder image failure should contain the fetch builder image failure reason and message": "should contain the fetch builder image failure reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status fetch builder image failure should contain the fetch builder image failure reason and message [apigroup:build.openshift.io]": "should contain the fetch builder image failure reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status postcommit hook failure should contain the post commit hook failure reason and message": "should contain the post commit hook failure reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status postcommit hook failure should contain the post commit hook failure reason and message [apigroup:build.openshift.io]": "should contain the post commit hook failure reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status push image to registry failure should contain the image push to registry failure reason and message": "should contain the image push to registry failure reason and message",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] update failure status  Build status push image to registry failure should contain the image push to registry failure reason and message [apigroup:build.openshift.io]": "should contain the image push to registry failure reason and message [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Parallel build run policy runs the builds in parallel": "runs the builds in parallel",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Parallel build run policy runs the builds in parallel [apigroup:build.openshift.io]": "runs the builds in parallel [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Serial build run policy handling cancellation starts the next build immediately after one is canceled": "starts the next build immediately after one is canceled",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Serial build run policy handling cancellation starts the next build immediately after one is canceled [apigroup:build.openshift.io]": "starts the next build immediately after one is canceled [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Serial build run policy handling deletion starts the next build immediately after running one is deleted": "starts the next build immediately after running one is deleted",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Serial build run policy handling deletion starts the next build immediately after running one is deleted [apigroup:build.openshift.io]": "starts the next build immediately after running one is deleted [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Serial build run policy handling failure starts the next build immediately after one fails": "starts the next build immediately after one fails",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Serial build run policy handling failure starts the next build immediately after one fails [apigroup:build.openshift.io]": "starts the next build immediately after one fails [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Serial build run policy runs the builds in serial order": "runs the builds in serial order",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with Serial build run policy runs the builds in serial order [apigroup:build.openshift.io]": "runs the builds in serial order [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with SerialLatestOnly build run policy runs the builds in serial order but cancel previous builds": "runs the builds in serial order but cancel previous builds",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using build configuration runPolicy  build configuration with SerialLatestOnly build run policy runs the builds in serial order but cancel previous builds [apigroup:build.openshift.io]": "runs the builds in serial order but cancel previous builds [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using pull secrets in a build  start-build test context binary builds should be able to run a build that is implicitly pulling from the internal registry": "should be able to run a build that is implicitly pulling from the internal registry",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using pull secrets in a build  start-build test context binary builds should be able to run a build that is implicitly pulling from the internal registry [apigroup:build.openshift.io]": "should be able to run a build that is implicitly pulling from the internal registry [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using pull secrets in a build  start-build test context pulling from an external authenticated registry should be able to use a pull secret in a build": "should be able to use a pull secret in a build",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using pull secrets in a build  start-build test context pulling from an external authenticated registry should be able to use a pull secret in a build [apigroup:build.openshift.io]": "should be able to use a pull secret in a build [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][Slow] using pull secrets in a build  start-build test context pulling from an external authenticated registry should be able to use a pull secret linked to the builder service account": "should be able to use a pull secret linked to the builder service account",
+	"[Top Level] [sig-builds][Feature:Builds][Slow] using pull secrets in a build  start-build test context pulling from an external authenticated registry should be able to use a pull secret linked to the builder service account [apigroup:build.openshift.io]": "should be able to use a pull secret linked to the builder service account [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-builds][Feature:Builds][pullsearch] docker build where the registry is not specified  Building from a Dockerfile whose FROM image ref does not specify the image registry should create a docker build that has buildah search from our predefined list of image registries and succeed": "should create a docker build that has buildah search from our predefined list of image registries and succeed [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][pullsearch] docker build where the registry is not specified  Building from a Dockerfile whose FROM image ref does not specify the image registry should create a docker build that has buildah search from our predefined list of image registries and succeed [apigroup:build.openshift.io]": "should create a docker build that has buildah search from our predefined list of image registries and succeed [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][pullsecret] docker build using a pull secret  Building from a template should create a docker build that pulls using a secret run it": "should create a docker build that pulls using a secret run it [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][pullsecret] docker build using a pull secret  Building from a template should create a docker build that pulls using a secret run it [apigroup:build.openshift.io]": "should create a docker build that pulls using a secret run it [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][timing] capture build stages and durations  should record build stages and durations for docker": "should record build stages and durations for docker [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][timing] capture build stages and durations  should record build stages and durations for docker [apigroup:build.openshift.io]": "should record build stages and durations for docker [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][timing] capture build stages and durations  should record build stages and durations for s2i": "should record build stages and durations for s2i [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][timing] capture build stages and durations  should record build stages and durations for s2i [apigroup:build.openshift.io]": "should record build stages and durations for s2i [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][valueFrom] process valueFrom in build strategy environment variables  should fail resolving unresolvable valueFrom in docker build environment variable references": "should fail resolving unresolvable valueFrom in docker build environment variable references [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][valueFrom] process valueFrom in build strategy environment variables  should fail resolving unresolvable valueFrom in docker build environment variable references [apigroup:build.openshift.io]": "should fail resolving unresolvable valueFrom in docker build environment variable references [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][valueFrom] process valueFrom in build strategy environment variables  should fail resolving unresolvable valueFrom in sti build environment variable references": "should fail resolving unresolvable valueFrom in sti build environment variable references [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][valueFrom] process valueFrom in build strategy environment variables  should fail resolving unresolvable valueFrom in sti build environment variable references [apigroup:build.openshift.io]": "should fail resolving unresolvable valueFrom in sti build environment variable references [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][valueFrom] process valueFrom in build strategy environment variables  should successfully resolve valueFrom in docker build environment variables": "should successfully resolve valueFrom in docker build environment variables [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][valueFrom] process valueFrom in build strategy environment variables  should successfully resolve valueFrom in docker build environment variables [apigroup:build.openshift.io]": "should successfully resolve valueFrom in docker build environment variables [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][valueFrom] process valueFrom in build strategy environment variables  should successfully resolve valueFrom in s2i build environment variables": "should successfully resolve valueFrom in s2i build environment variables [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][valueFrom] process valueFrom in build strategy environment variables  should successfully resolve valueFrom in s2i build environment variables [apigroup:build.openshift.io]": "should successfully resolve valueFrom in s2i build environment variables [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][volumes] build volumes  should mount given secrets and configmaps into the build pod for docker strategy builds": "should mount given secrets and configmaps into the build pod for docker strategy builds [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][volumes] build volumes  should mount given secrets and configmaps into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": "should mount given secrets and configmaps into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][volumes] build volumes  should mount given secrets and configmaps into the build pod for source strategy builds": "should mount given secrets and configmaps into the build pod for source strategy builds [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][volumes] build volumes  should mount given secrets and configmaps into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": "should mount given secrets and configmaps into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview disabled clusters  should fail mounting given csi shared resource secret into the build pod for docker strategy builds": "should fail mounting given csi shared resource secret into the build pod for docker strategy builds [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview disabled clusters [apigroup:config.openshift.io] should fail mounting given csi shared resource secret into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io]": "should fail mounting given csi shared resource secret into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview disabled clusters  should fail mounting given csi shared resource secret into the build pod for source strategy builds": "should fail mounting given csi shared resource secret into the build pod for source strategy builds [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview disabled clusters [apigroup:config.openshift.io] should fail mounting given csi shared resource secret into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io]": "should fail mounting given csi shared resource secret into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster  should mount given csi shared resource secret into the build pod for docker strategy builds": "should mount given csi shared resource secret into the build pod for docker strategy builds [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": "should mount given csi shared resource secret into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster  should mount given csi shared resource secret into the build pod for source strategy builds": "should mount given csi shared resource secret into the build pod for source strategy builds [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": "should mount given csi shared resource secret into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster  should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds": "should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": "should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster  should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds": "should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": "should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhook": "TestWebhook [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io]": "TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhookGitHubPing": "TestWebhookGitHubPing [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhookGitHubPing [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestWebhookGitHubPing [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhookGitHubPushWithImage": "TestWebhookGitHubPushWithImage [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhookGitHubPushWithImage [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestWebhookGitHubPushWithImage [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhookGitHubPushWithImageStream": "TestWebhookGitHubPushWithImageStream [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-builds][Feature:Builds][webhook] TestWebhookGitHubPushWithImageStream [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestWebhookGitHubPushWithImageStream [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-builds][Feature:JenkinsRHELImagesOnly][Feature:Jenkins][Feature:Builds][sig-devex][Slow] openshift pipeline build  jenkins pipeline build config strategy using a jenkins instance launched with the ephemeral template": "using a jenkins instance launched with the ephemeral template",
+	"[Top Level] [sig-builds][Feature:JenkinsRHELImagesOnly][Feature:Jenkins][Feature:Builds][sig-devex][Slow] openshift pipeline build  jenkins pipeline build config strategy using a jenkins instance launched with the ephemeral template [apigroup:build.openshift.io]": "using a jenkins instance launched with the ephemeral template [apigroup:build.openshift.io]",
 
-	"[Top Level] [sig-ci] [Early] prow job name should match network type": "should match network type [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-ci] [Early] prow job name should match network type [apigroup:config.openshift.io]": "should match network type [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-ci] [Early] prow job name should match platform type": "should match platform type [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-ci] [Early] prow job name should match platform type [apigroup:config.openshift.io]": "should match platform type [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 should support forwarding over websockets": "should support forwarding over websockets [Skipped:Proxy] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -1633,13 +1633,13 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc --request-timeout works as expected": "works as expected [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm build-chain": "build-chain [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io]": "build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm cluster-role-reapers [Serial]": "cluster-role-reapers [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-cli] oc adm cluster-role-reapers [Serial][apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "cluster-role-reapers [Serial][apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-cli] oc adm groups": "groups [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm groups [apigroup:user.openshift.io]": "groups [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm images": "images [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm images [apigroup:image.openshift.io]": "images [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc adm must-gather runs successfully for audit logs": "runs successfully for audit logs [Suite:openshift/conformance/parallel]",
 
@@ -1649,25 +1649,25 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc adm must-gather when looking at the audit logs [sig-node] kubelet runs apiserver processes strictly sequentially in order to not risk audit log corruption": "runs apiserver processes strictly sequentially in order to not risk audit log corruption [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm new-project": "new-project [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io]": "new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc adm node-logs": "node-logs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm policy": "policy [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm policy [apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "policy [apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm role-reapers": "role-reapers [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm role-reapers [apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "role-reapers [apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc adm role-selectors": "role-selectors [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc adm serviceaccounts": "serviceaccounts [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm storage-admin": "storage-admin [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm storage-admin [apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "storage-admin [apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm ui-project-commands": "ui-project-commands [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm ui-project-commands [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "ui-project-commands [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm user-creation": "user-creation [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm user-creation [apigroup:user.openshift.io]": "user-creation [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm who-can": "who-can [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm who-can [apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "who-can [apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc annotate pod": "pod [Suite:openshift/conformance/parallel]",
 
@@ -1689,15 +1689,15 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc basics can process templates": "can process templates [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc builds complex build start-build": "start-build [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc builds complex build start-build [apigroup:build.openshift.io]": "start-build [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc builds complex build webhooks CRUD": "webhooks CRUD [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc builds complex build webhooks CRUD [apigroup:build.openshift.io]": "webhooks CRUD [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc builds get buildconfig": "get buildconfig [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc builds get buildconfig [apigroup:build.openshift.io]": "get buildconfig [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc builds new-build": "new-build [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc builds new-build [apigroup:build.openshift.io]": "new-build [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc builds patch buildconfig": "patch buildconfig [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc builds patch buildconfig [apigroup:build.openshift.io]": "patch buildconfig [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc can get list of nodes": "can get list of nodes [Suite:openshift/conformance/parallel]",
 
@@ -1833,7 +1833,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cluster-lifecycle] Pods cannot access the /config/master API endpoint": "Pods cannot access the /config/master API endpoint [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle] TestAdminAck should succeed": "should succeed [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cluster-lifecycle] TestAdminAck should succeed [apigroup:config.openshift.io]": "should succeed [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive] [Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks": "[Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks [Serial]",
 

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/blang/semver"
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
@@ -40,7 +39,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -53,7 +51,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	buildv1clienttyped "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	imagev1typedclient "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	projectv1typedclient "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	"github.com/openshift/library-go/pkg/build/naming"
@@ -1973,38 +1970,6 @@ func IsClusterOperated(oc *CLI) bool {
 		return false
 	}
 	return true
-}
-
-// AllClusterVersionsAreGTE returns true if all historical versions on the cluster version are
-// at or newer than the provided semver, ignoring prerelease status. If no versions are found
-// an error is returned.
-func AllClusterVersionsAreGTE(version semver.Version, config *rest.Config) (bool, error) {
-	c, err := configv1client.NewForConfig(config)
-	if err != nil {
-		return false, err
-	}
-	cv, err := c.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-	if len(cv.Status.History) == 0 {
-		return false, fmt.Errorf("no versions in cluster version history")
-	}
-	for _, v := range cv.Status.History {
-		ver, err := semver.Parse(v.Version)
-		if err != nil {
-			return false, err
-		}
-
-		// ignore prerelease version matching here
-		ver.Pre = nil
-		ver.Build = nil
-
-		if ver.LT(version) {
-			return false, nil
-		}
-	}
-	return true, nil
 }
 
 var (


### PR DESCRIPTION
Built on top of https://github.com/openshift/origin/pull/27355

Procedure for detecting API groups in use:
- search for all Get, Update, Patch, Delete and List client invocations
  (for both direct and indirect)
- go through every e2e test code and identify all possible invocations of an api group (e.g. oc command)

jira: https://issues.redhat.com/browse/WRKLDS-488