### PR TITLE
EgressIP: Enable EgressIP tests for OpenStack

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -107,6 +107,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 			configv1.AWSPlatformType,
 			configv1.GCPPlatformType,
 			configv1.AzurePlatformType,
+			configv1.OpenStackPlatformType,
 		}
 		for _, supportedPlatform := range supportedPlatforms {
 			if cloudType == supportedPlatform {


### PR DESCRIPTION
Test with:
~~~
./openshift-tests run all --print-commands  | grep EgressIP | grep external | grep -v "Skipped:Network/OVNKubernetes" | while IFS= read -r line; do bash -c "$line" ; echo =========================; done
~~~

Signed-off-by: Andreas Karis <ak.karis@gmail.com>