### PR TITLE
Add ovnkube-node pods in the interval chart for ingress

### DIFF
--- a/pkg/monitor/intervalcreation/rendering_per_namespace.go
+++ b/pkg/monitor/intervalcreation/rendering_per_namespace.go
@@ -170,7 +170,7 @@ func (r ingressServicePodRendering) WriteRunData(artifactDir string, _ monitorap
 	disruptionReasons := sets.NewString(backenddisruption.DisruptionBeganEventReason,
 		backenddisruption.DisruptionEndedEventReason,
 		backenddisruption.DisruptionSamplerOutageBeganEventReason)
-	relevantNamespaces := sets.NewString("openshift-authentication", "openshift-console", "openshift-image-registry", "openshift-ingress")
+	relevantNamespaces := sets.NewString("openshift-authentication", "openshift-console", "openshift-image-registry", "openshift-ingress", "openshift-ovn-kubernetes")
 	writer := NewNonSpyglassEventIntervalRenderer("image-reg-console-oauth",
 		func(eventInterval monitorapi.EventInterval) bool {
 			switch {


### PR DESCRIPTION
Re: [TRT-475](https://issues.redhat.com//browse/TRT-475)

This adds the openshift-ovn-kubernetes namespace which will show the ovnkube-node pods.