### PR TITLE
Skip etcd scaling test for metal and vsphere platforms

### DIFF
--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -363,6 +363,8 @@ func SkipIfUnsupportedPlatform(ctx context.Context, oc *exutil.CLI) {
 	machineClient := machineClientSet.MachineV1beta1().Machines("openshift-machine-api")
 	skipUnlessFunctionalMachineAPI(ctx, machineClient)
 	skipIfSingleNode(oc)
+	skipIfBareMetal(oc)
+	skipIfVsphere(oc)
 }
 
 func skipUnlessFunctionalMachineAPI(ctx context.Context, machineClient machinev1beta1client.MachineInterface) {


### PR DESCRIPTION
Metal and vsphere platforms have been affected by the etcd scaling test. This will disable the test until it is moved to a separate job. 