### PR TITLE
Separate out pathological event test for error updating endpoint slices

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -114,6 +114,9 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 
 	// Separated out in testBackoffStartingFailedContainer
 	regexp.MustCompile(backoffRestartingFailedRegEx),
+
+	// Separated out in testErrorUpdatingEndpointSlices
+	regexp.MustCompile(errorUpdatingEndpointSlicesRegex),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -42,6 +42,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testBackoffStartingFailedContainer(events)...)
 	tests = append(tests, testBackoffStartingFailedContainerForE2ENamespaces(events)...)
 	tests = append(tests, testAPIQuotaEvents(events)...)
+	tests = append(tests, testErrorUpdatingEndpointSlices(events)...)
 
 	return tests
 }
@@ -79,6 +80,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testNoDNSLookupErrorsInDisruptionSamplers(events)...)
 	tests = append(tests, testNoExcessiveSecretGrowthDuringUpgrade()...)
 	tests = append(tests, testNoExcessiveConfigMapGrowthDuringUpgrade()...)
+	tests = append(tests, testErrorUpdatingEndpointSlices(events)...)
 
 	return tests
 }

--- a/pkg/synthetictests/image_pulls_test.go
+++ b/pkg/synthetictests/image_pulls_test.go
@@ -192,3 +192,65 @@ func Test_testBackoffStartingFailedContainer(t *testing.T) {
 		})
 	}
 }
+
+func Test_testErrorUpdatingEndpointSlices(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		kind    string
+	}{
+		{
+			name:    "pass",
+			message: "reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices for Service openshift-ovn-kubernetes/ovn-kubernetes-master: node \"ip-10-0-168-211.us-east-2.compute.internal\" not found (2 times)",
+			kind:    "pass",
+		},
+		{
+			name:    "fail",
+			message: "reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices for Service openshift-ovn-kubernetes/ovn-kubernetes-master: node \"ip-10-0-168-211.us-east-2.compute.internal\" not found (24 times)",
+			kind:    "fail",
+		},
+		{
+			name:    "flake",
+			message: "reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices for Service openshift-ovn-kubernetes/ovn-kubernetes-master: node \"ip-10-0-168-211.us-east-2.compute.internal\" not found (11 times)",
+			kind:    "flake",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := monitorapi.Intervals{
+				{
+					Condition: monitorapi.Condition{
+						Message: tt.message,
+						Locator: "ns/openshift-ovn-kubernetes service/ovn-kubernetes-master",
+					},
+					From: time.Unix(1, 0),
+					To:   time.Unix(1, 0),
+				},
+			}
+			junit_tests := testErrorUpdatingEndpointSlices(e)
+			switch tt.kind {
+			case "pass":
+				if len(junit_tests) != 1 {
+					t.Errorf("This should've been a single passing test, but got %d tests", len(junit_tests))
+				}
+				if len(junit_tests[0].SystemOut) != 0 {
+					t.Errorf("This should've been a pass, but got %s", junit_tests[0].SystemErr)
+				}
+			case "fail":
+				if len(junit_tests) != 1 {
+					t.Errorf("This should've been a single failing test, but got %d tests", len(junit_tests))
+				}
+				if len(junit_tests[0].SystemOut) == 0 {
+					t.Error("This should've been a failure but got no output")
+				}
+			case "flake":
+				if len(junit_tests) != 2 {
+					t.Errorf("This should've been a two tests as flake, but got %d tests", len(junit_tests))
+				}
+			default:
+				t.Errorf("Unknown test kind")
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Re: [TRT-488](https://issues.redhat.com//browse/TRT-488)

We want to handle a case like this:

```
: [sig-arch] events should not repeat pathologically
-- | --
{  2 events happened too frequently  event happened 24 times, something is wrong: ns/openshift-ovn-kubernetes service/ovn-kubernetes-master - reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices for Service openshift-ovn-kubernetes/ovn-kubernetes-master: node "ip-10-0-168-211.us-east-2.compute.internal" not found event happened 24 times, something is wrong: ns/openshift-ovn-kubernetes service/ovnkube-db - reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices for Service openshift-ovn-kubernetes/ovnkube-db: node "ip-10-0-168-211.us-east-2.compute.internal" not found}
```

which shows up in an event like this:

```
{
   "level": "Warning",
   "locator": "ns/openshift-ovn-kubernetes service/ovn-kubernetes-master",
   "message": "reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices for Service openshift-ovn-kubernetes/ovn-kubernetes-master: node \"ip-10-0-168-211.us-east-2.compute.internal\" not found (24 times)",
   "from": "2022-08-25T08:04:42Z",
   "to": "2022-08-25T08:04:42Z"
}
```

A separate it out into its own test.