### PR TITLE
Revert "Label tests with openshift crafted API groups (round 3)"

### DIFF
--- a/test/extended/cli/debug.go
+++ b/test/extended/cli/debug.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 	helloPod := exutil.FixturePath("..", "..", "examples", "hello-openshift", "hello-pod.json")
 	imageStreamsCentos := exutil.FixturePath("..", "..", "examples", "image-streams", "image-streams-centos7.json")
 
-	g.It("deployment configs from a build [apigroup:image.openshift.io][apigroup:apps.openshift.io]", func() {
+	g.It("deployment configs from a build", func() {
 		err := oc.Run("create").Args("-f", testCLIDebug).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// wait for image stream to be present which means the build has completed
@@ -66,7 +66,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 		o.Expect(out).To(o.ContainSubstring("Starting pod/busybox2-debug, command was: foo bar baz qux\n"))
 	})
 
-	g.It("dissect deployment config debug [apigroup:apps.openshift.io]", func() {
+	g.It("dissect deployment config debug", func() {
 		err := oc.Run("create").Args("-f", testDeploymentConfig).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -128,7 +128,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 
 	// TODO: write a test that emulates a TTY to verify the correct defaulting of what the pod is created
 
-	g.It("ensure debug does not depend on a container actually existing for the selected resource [apigroup:apps.openshift.io]", func() {
+	g.It("ensure debug does not depend on a container actually existing for the selected resource", func() {
 		err := oc.Run("create").Args("-f", testReplicationController).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = oc.Run("create").Args("-f", testDeploymentConfig).Execute()
@@ -180,7 +180,7 @@ spec:
 		o.Expect(out).To(o.ContainSubstring("test-deployment-debug"))
 	})
 
-	g.It("ensure it works with image streams [apigroup:image.openshift.io]", func() {
+	g.It("ensure it works with image streams", func() {
 		err := oc.Run("create").Args("-f", imageStreamsCentos).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = wait.Poll(cliInterval, cliTimeout, func() (bool, error) {

--- a/test/extended/cli/env.go
+++ b/test/extended/cli/env.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-cli] oc env", func() {
 		oc              = exutil.NewCLI("oc-env")
 	)
 
-	g.It("can set environment variables [apigroup:apps.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("can set environment variables", func() {
 		g.By("creating a test-deployment-config deploymentconfig")
 		err := oc.Run("create").Args("-f", file).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -503,7 +503,7 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 		}
 	})
 
-	g.It("should contain proper spec+status for CRDs [apigroup:config.openshift.io]", func() {
+	g.It("should contain proper spec+status for CRDs", func() {
 		crdClient := apiextensionsclientset.NewForConfigOrDie(oc.AdminConfig())
 		crdTypesTest := getCrdTypes(oc)
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)

--- a/test/extended/cli/expose.go
+++ b/test/extended/cli/expose.go
@@ -18,7 +18,7 @@ var _ = g.Describe("[sig-cli] oc expose", func() {
 		multiportSvcFile    = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "multiport-service.yaml")
 	)
 
-	g.It("can ensure the expose command is functioning as expected [apigroup:route.openshift.io]", func() {
+	g.It("can ensure the expose command is functioning as expected", func() {
 		frontendServiceFile, err := writeObjectToFile(newFrontendService())
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer os.Remove(frontendServiceFile)

--- a/test/extended/cli/help.go
+++ b/test/extended/cli/help.go
@@ -14,7 +14,7 @@ var _ = g.Describe("[sig-cli] oc help", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("oc-help")
 
-	g.It("works as expected [apigroup:user.openshift.io][apigroup:project.openshift.io]", func() {
+	g.It("works as expected", func() {
 		err := exec.Command("kubectl").Run()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("runs successfully [apigroup:config.openshift.io]", func() {
+	g.It("runs successfully", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
@@ -101,7 +101,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		}
 	})
 
-	g.It("runs successfully with options [apigroup:config.openshift.io]", func() {
+	g.It("runs successfully with options", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
@@ -126,7 +126,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		o.Expect(stat.Size()).To(o.BeNumerically(">", 0))
 	})
 
-	g.It("runs successfully for audit logs [apigroup:config.openshift.io][apigroup:oauth.openshift.io]", func() {
+	g.It("runs successfully for audit logs", func() {
 		// On External clusters, events will not be part of the output, since audit logs do not include control plane logs.
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -301,7 +301,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 
 	g.When("looking at the audit logs", func() {
 		g.Describe("[sig-node] kubelet", func() {
-			g.It("runs apiserver processes strictly sequentially in order to not risk audit log corruption [apigroup:config.openshift.io]", func() {
+			g.It("runs apiserver processes strictly sequentially in order to not risk audit log corruption", func() {
 				controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/cli/observe.go
+++ b/test/extended/cli/observe.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-cli] oc observe", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("oc-observe").AsAdmin()
 
-	g.It("works as expected [apigroup:config.openshift.io]", func() {
+	g.It("works as expected", func() {
 		g.By("Find out the clusterIP of the kubernetes.default service")
 		kubernetesSVC, err := oc.AdminKubeClient().CoreV1().Services("default").Get(context.Background(), "kubernetes", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/project.go
+++ b/test/extended/cli/project.go
@@ -12,7 +12,7 @@ var _ = g.Describe("[sig-cli] oc project", func() {
 
 	var oc = exutil.NewCLI("oc-project").AsAdmin()
 
-	g.It("--show-labels works for projects [apigroup:project.openshift.io]", func() {
+	g.It("--show-labels works for projects", func() {
 		out, err := oc.Run("label").Args("namespace", oc.Namespace(), "foo=bar").Output()
 		o.Expect(out).To(o.ContainSubstring("labeled"))
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/rsync.go
+++ b/test/extended/cli/rsync.go
@@ -20,7 +20,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io]", func() {
+var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/cli/status.go
+++ b/test/extended/cli/status.go
@@ -12,7 +12,7 @@ var _ = g.Describe("[sig-cli] oc status", func() {
 
 	var oc = exutil.NewCLI("oc-status")
 
-	g.It("returns expected help messages [apigroup:project.openshift.io][apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:apps.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("returns expected help messages", func() {
 		out, err := oc.Run("status").Args("-h").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("oc describe buildconfig"))

--- a/test/extended/cli/timeout.go
+++ b/test/extended/cli/timeout.go
@@ -13,7 +13,7 @@ var _ = g.Describe("[sig-cli] oc --request-timeout", func() {
 
 	oc := exutil.NewCLI("oc-request-timeout")
 
-	g.It("works as expected [apigroup:apps.openshift.io]", func() {
+	g.It("works as expected", func() {
 		busyBoxImage := k8simage.GetE2EImage(k8simage.BusyBox)
 		err := oc.Run("create").Args("deploymentconfig", "testdc", "--image="+busyBoxImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cluster/cl.go
+++ b/test/extended/cluster/cl.go
@@ -60,7 +60,7 @@ var _ = g.Describe("[sig-scalability][Feature:Performance] Load cluster", func()
 		}
 	})
 
-	g.It("should populate the cluster [Slow][Serial][apigroup:template.openshift.io][apigroup:apps.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("should populate the cluster [Slow][Serial]", func() {
 		project := ConfigContext.ClusterLoader.Projects
 		tuningSets := ConfigContext.ClusterLoader.TuningSets
 		sync := ConfigContext.ClusterLoader.Sync

--- a/test/extended/cluster/cm.go
+++ b/test/extended/cluster/cm.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-scalability][Feature:Performance][Serial][Slow] Mirror 
 		e2e.Logf("We have %v\n", nodeinfo)
 	})
 
-	g.It("it should read the cluster apps [apigroup:apps.openshift.io]", func() {
+	g.It("it should read the cluster apps", func() {
 		var pods *v1.PodList
 		config := ContextType{}
 		config.ClusterLoader.Cleanup = true

--- a/test/extended/cmd/cmd.go
+++ b/test/extended/cmd/cmd.go
@@ -48,7 +48,7 @@ var _ = g.Describe("[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] te
 			continue
 		}
 
-		g.It("test/cmd/"+currFilename+" [apigroup:image.openshift.io][apigroup:config.openshift.io]", func() {
+		g.It("test/cmd/"+currFilename, func() {
 			testsDir := exutil.FixturePath("testdata", "cmd", "test", "cmd")
 			oc.AddExplicitResourceToDelete(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}, "", "cmd-"+currFilename[0:len(currFilename)-3])
 

--- a/test/extended/controller_manager/deploy_defaults.go
+++ b/test/extended/controller_manager/deploy_defaults.go
@@ -98,7 +98,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("deployment-defaults")
 
-	g.It("TestDeploymentConfigDefaults [apigroup:apps.openshift.io]", func() {
+	g.It("TestDeploymentConfigDefaults", func() {
 		t := g.GinkgoT()
 
 		namespace := oc.Namespace()

--- a/test/extended/controller_manager/deploy_scale.go
+++ b/test/extended/controller_manager/deploy_scale.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("deployment-scale")
 
-	g.It("TestDeployScale [apigroup:apps.openshift.io]", func() {
+	g.It("TestDeployScale", func() {
 		t := g.GinkgoT()
 
 		namespace := oc.Namespace()

--- a/test/extended/controller_manager/deploy_trigger.go
+++ b/test/extended/controller_manager/deploy_trigger.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("deployment-trigger")
 
-	g.It("TestTriggers_manual [apigroup:apps.openshift.io]", func() {
+	g.It("TestTriggers_manual", func() {
 		t := g.GinkgoT()
 
 		const maxUpdateRetries = 10
@@ -98,7 +98,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 
 	// TestTriggers_imageChange ensures that a deployment config with an ImageChange trigger
 	// will start a new deployment when an image change happens.
-	g.It("TestTriggers_imageChange [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("TestTriggers_imageChange", func() {
 		t := g.GinkgoT()
 
 		const registryHostname = "registry:8080"
@@ -199,7 +199,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 
 	// TestTriggers_imageChange_nonAutomatic ensures that a deployment config with a non-automatic
 	// trigger will have its image updated when a deployment is started manually.
-	g.It("TestTriggers_imageChange_nonAutomatic [apigroup:image.openshift.io][apigroup:apps.openshift.io]", func() {
+	g.It("TestTriggers_imageChange_nonAutomatic", func() {
 		t := g.GinkgoT()
 
 		const maxUpdateRetries = 10
@@ -384,7 +384,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 
 	// TestTriggers_MultipleICTs ensures that a deployment config with more than one ImageChange trigger
 	// will start a new deployment iff all images are resolved.
-	g.It("TestTriggers_MultipleICTs [apigroup:apps.openshift.io][apigroup:images.openshift.io]", func() {
+	g.It("TestTriggers_MultipleICTs", func() {
 		t := g.GinkgoT()
 
 		const registryHostname = "registry:8080"
@@ -541,7 +541,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 
 	// TestTriggers_configChange ensures that a change in the template of a deployment config with
 	// a config change trigger will start a new deployment.
-	g.It("TestTriggers_configChange [apigroup:apps.openshift.io]", func() {
+	g.It("TestTriggers_configChange", func() {
 		t := g.GinkgoT()
 
 		const maxUpdateRetries = 10

--- a/test/extended/controller_manager/pull_secret.go
+++ b/test/extended/controller_manager/pull_secret.go
@@ -60,7 +60,7 @@ var _ = g.Describe("[sig-devex][Feature:OpenShiftControllerManager]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("pull-secrets")
 
-	g.It("TestAutomaticCreationOfPullSecrets [apigroup:config.openshift.io]", func() {
+	g.It("TestAutomaticCreationOfPullSecrets", func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClient := oc.AdminKubeClient()

--- a/test/extended/crdvalidation/apiserver.go
+++ b/test/extended/crdvalidation/apiserver.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-api-machinery] APIServer CR fields validation", func() 
 	)
 	defer g.GinkgoRecover()
 
-	g.It("additionalCORSAllowedOrigins [apigroup:config.openshift.io]", func() {
+	g.It("additionalCORSAllowedOrigins", func() {
 		apiServerClient := oc.AdminConfigClient().ConfigV1().APIServers()
 
 		apiServer, err := apiServerClient.Get(context.Background(), "cluster", metav1.GetOptions{})

--- a/test/extended/csrapprover/csrapprover.go
+++ b/test/extended/csrapprover/csrapprover.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("cluster-client-cert", admissionapi.LevelBaseline)
 	defer g.GinkgoRecover()
 
-	g.It("Pods cannot access the /config/master API endpoint [apigroup:config.openshift.io]", func() {
+	g.It("Pods cannot access the /config/master API endpoint", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 		o.Expect(curlOutput).To(o.ContainSubstring("Connection refused"))
 	})
 
-	g.It("CSRs from machines that are not recognized by the cloud provider are not approved [apigroup:config.openshift.io]", func() {
+	g.It("CSRs from machines that are not recognized by the cloud provider are not approved", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should only deploy the last deployment [apigroup:apps.openshift.io]", func() {
+		g.It("should only deploy the last deployment", func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -203,7 +203,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForLatestCondition(oc, "deployment-simple", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should immediately start a new deployment [apigroup:apps.openshift.io]", func() {
+		g.It("should immediately start a new deployment", func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -289,7 +289,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("resolve the image pull spec [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("resolve the image pull spec", func() {
 			// FIXME: Wrap the IS creation into utility helper
 			err := oc.Run("create").Args("-f", resolutionIsFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -337,7 +337,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should run a deployment to completion and then scale to zero [apigroup:apps.openshift.io]", func() {
+		g.It("should run a deployment to completion and then scale to zero", func() {
 			namespace := oc.Namespace()
 
 			dc := ReadFixtureOrFail(deploymentFixture).(*appsv1.DeploymentConfig)
@@ -421,7 +421,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should successfully trigger from an updated image [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("should successfully trigger from an updated image", func() {
 			dc, err := createDeploymentConfig(oc, imageChangeTriggerFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -473,7 +473,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should successfully tag the deployed image [apigroup:apps.openshift.io][apigroup:authorization.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("should successfully tag the deployed image", func() {
 			g.By("creating the deployment config fixture")
 			dc, err := createDeploymentConfig(oc, tagImagesFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -518,7 +518,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should expand the config map key to a value [apigroup:apps.openshift.io]", func() {
+		g.It("should expand the config map key to a value", func() {
 			_, err := oc.Run("create").Args("configmap", "test", "--from-literal=foo=bar").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -545,7 +545,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should run a successful deployment with multiple triggers [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("should run a successful deployment with multiple triggers", func() {
 			g.By("creating DC")
 
 			_, err := oc.Run("import-image").Args("registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
@@ -561,7 +561,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForLatestCondition(oc, dcName, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should run a successful deployment with a trigger used by different containers [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("should run a successful deployment with a trigger used by different containers", func() {
 
 			_, err := oc.Run("import-image").Args("registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -582,7 +582,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should include various info in status [apigroup:apps.openshift.io]", func() {
+		g.It("should include various info in status", func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -615,7 +615,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should run the custom deployment steps [apigroup:apps.openshift.io]", func() {
+		g.It("should run the custom deployment steps", func() {
 			namespace := oc.Namespace()
 
 			dc := ReadFixtureOrFail(customDeploymentFixture).(*appsv1.DeploymentConfig)
@@ -652,7 +652,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should print the rollout history [apigroup:apps.openshift.io]", func() {
+		g.It("should print the rollout history", func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -703,7 +703,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, "generation-test", g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should deploy based on a status version bump [apigroup:apps.openshift.io]", func() {
+		g.It("should deploy based on a status version bump", func() {
 			dc, err := createDeploymentConfig(oc, generationFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -792,7 +792,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should disable actions on deployments [apigroup:apps.openshift.io]", func() {
+		g.It("should disable actions on deployments", func() {
 			dc, err := createDeploymentConfig(oc, pausedDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -856,7 +856,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should get all logs from retried hooks [apigroup:apps.openshift.io]", func() {
+		g.It("should get all logs from retried hooks", func() {
 			dc, err := createDeploymentConfig(oc, failedHookFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -879,7 +879,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should rollback to an older deployment [apigroup:apps.openshift.io]", func() {
+		g.It("should rollback to an older deployment", func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -926,7 +926,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should delete all failed deployer pods and hook pods [apigroup:apps.openshift.io]", func() {
+		g.It("should delete all failed deployer pods and hook pods", func() {
 			dc, err := createDeploymentConfig(oc, brokenDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -967,7 +967,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should not deploy if pods never transition to ready [apigroup:apps.openshift.io]", func() {
+		g.It("should not deploy if pods never transition to ready", func() {
 			dc, err := createDeploymentConfig(oc, readinessFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -984,7 +984,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should never persist more old deployments than acceptable after being observed by the controller [apigroup:apps.openshift.io]", func() {
+		g.It("should never persist more old deployments than acceptable after being observed by the controller", func() {
 			revisionHistoryLimit := 3 // as specified in the fixture
 
 			dc, err := createDeploymentConfig(oc, historyLimitedDeploymentFixture)
@@ -1045,7 +1045,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should not transition the deployment to Complete before satisfied [apigroup:apps.openshift.io]", func() {
+		g.It("should not transition the deployment to Complete before satisfied", func() {
 			dc := ReadFixtureOrFail(minReadySecondsFixture).(*appsv1.DeploymentConfig)
 			o.Expect(dc.Name).To(o.Equal(dcName))
 			o.Expect(dc.Spec.Triggers).To(o.BeNil())
@@ -1118,7 +1118,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should let the deployment config with a NewReplicationControllerCreated reason [apigroup:apps.openshift.io]", func() {
+		g.It("should let the deployment config with a NewReplicationControllerCreated reason", func() {
 			dc, err := createDeploymentConfig(oc, ignoresDeployersFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -1161,7 +1161,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrapForDetachedRCs(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should adhere to Three Laws of Controllers [apigroup:apps.openshift.io]", func() {
+		g.It("should adhere to Three Laws of Controllers", func() {
 			namespace := oc.Namespace()
 			rcName := func(i int) string { return fmt.Sprintf("%s-%d", dcName, i) }
 
@@ -1268,7 +1268,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("should deal with cancellation of running deployment [apigroup:apps.openshift.io]", func() {
+		g.It("should deal with cancellation of running deployment", func() {
 			namespace := oc.Namespace()
 
 			g.By("creating DC")
@@ -1342,7 +1342,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should deal with config change in case the deployment is still running [apigroup:apps.openshift.io]", func() {
+		g.It("should deal with config change in case the deployment is still running", func() {
 			namespace := oc.Namespace()
 
 			g.By("creating DC")
@@ -1405,7 +1405,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should deal with cancellation after deployer pod succeeded [apigroup:apps.openshift.io]", func() {
+		g.It("should deal with cancellation after deployer pod succeeded", func() {
 			namespace := oc.Namespace()
 			const (
 				deploymentCancelledAnnotation    = "openshift.io/deployment.cancelled"
@@ -1520,7 +1520,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("when patched with empty image [apigroup:apps.openshift.io]", func() {
+		g.It("when patched with empty image", func() {
 			namespace := oc.Namespace()
 
 			g.By("creating DC")
@@ -1599,7 +1599,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentGinkgoTestDescription().Failed)
 		})
 
-		g.It("will orphan all RCs and adopt them back when recreated [apigroup:apps.openshift.io]", func() {
+		g.It("will orphan all RCs and adopt them back when recreated", func() {
 			namespace := oc.Namespace()
 
 			g.By("creating DC")

--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -467,7 +467,7 @@ var _ = Describe("[sig-network-edge] DNS", func() {
 		validateDNSResults(f, pod, expect, times)
 	})
 
-	It("should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io]", func() {
+	It("should answer A and AAAA queries for a dual-stack service", func() {
 		// Only run this test on dual-stack enabled clusters.
 		networkConfig, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
 		if err != nil {

--- a/test/extended/dr/backup_restore.go
+++ b/test/extended/dr/backup_restore.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 	// corresponds to a step in the documentation.
 	//
 	// Backing up and recovering on the same node is tested by quorum_restore.go.
-	g.It("[Feature:EtcdRecovery] Cluster should recover from a backup taken on one node and recovered on another [apigroup:operator.openshift.io]", func() {
+	g.It("[Feature:EtcdRecovery] Cluster should recover from a backup taken on one node and recovered on another", func() {
 		masters := masterNodes(oc)
 		// Need one node to backup from and another to restore to
 		o.Expect(len(masters)).To(o.BeNumerically(">=", 2))

--- a/test/extended/dr/machine_recover.go
+++ b/test/extended/dr/machine_recover.go
@@ -15,7 +15,7 @@ import (
 	o "github.com/onsi/gomega"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
-	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +44,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive
 
 	oc := exutil.NewCLIWithoutNamespace("machine-recovery")
 
-	g.It("[Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks [apigroup:machine.openshift.io]", func() {
+	g.It("[Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks", func() {
 
 		framework.Logf("Verify SSH is available before restart")
 		masters, workers := clusterNodes(oc)

--- a/test/extended/dr/quorum_restore.go
+++ b/test/extended/dr/quorum_restore.go
@@ -53,7 +53,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Disruptive]", func() {
 
 	// Validate backing up and restoring to the same node on a cluster
 	// that has lost quorum after the backup was taken.
-	g.It("[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io]", func() {
+	g.It("[Feature:EtcdRecovery] Cluster should restore itself after quorum loss", func() {
 		config, err := framework.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		dynamicClient := dynamic.NewForConfigOrDie(config)

--- a/test/extended/etcd/etcd_test_runner.go
+++ b/test/extended/etcd/etcd_test_runner.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-api-machinery] API data in etcd", func() {
 
 	oc := exutil.NewCLIWithPodSecurityLevel("etcd-storage-path", psapi.LevelBaseline).AsAdmin()
 
-	_ = g.It("should be stored at the correct location and version for all resources [Serial][apigroup:config.openshift.io]", func() {
+	_ = g.It("should be stored at the correct location and version for all resources [Serial]", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/etcd/invariants.go
+++ b/test/extended/etcd/invariants.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-invariants").AsAdmin()
 
-	g.It("cluster has the same number of master nodes and voting members from the endpoints configmap [Early][apigroup:config.openshift.io]", func() {
+	g.It("cluster has the same number of master nodes and voting members from the endpoints configmap [Early]", func() {
 		exutil.SkipIfExternalControlplaneTopology(oc, "clusters with external controlplane topology don't have master nodes")
 		masterNodeLabelSelectorString := "node-role.kubernetes.io/master"
 		masterNodeList, err := oc.KubeClient().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: masterNodeLabelSelectorString})

--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		earlyTimeStamp = time.Now()
 	})
 
-	g.It("leader changes are not excessive [Late][apigroup:config.openshift.io]", func() {
+	g.It("leader changes are not excessive [Late]", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-etcd][Serial] etcd", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-scaling").AsAdmin()
 
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 	// next it validates the size of etcd cluster and makes sure the new member is healthy.
 	// The test ends by removing the newly added machine and validating the size of the cluster
 	// and asserting the member was removed from the etcd cluster by contacting MemberList API.
-	g.It("is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]", func() {
+	g.It("is able to vertically scale up and down with a single node [Timeout:60m]", func() {
 		// set up
 		ctx := context.TODO()
 		etcdClientFactory := scalingtestinglibrary.NewEtcdClientFactory(oc.KubeClient())

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -222,7 +222,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 				fixture = echoServerFixture
 			})
 
-			g.It("should idle the service and DeploymentConfig properly [apigroup:apps.openshift.io]", func() {
+			g.It("should idle the service and DeploymentConfig properly", func() {
 				checkSingleIdle(oc, idlingFile, resources, "deploymentconfig.apps.openshift.io", "DeploymentConfig")
 			})
 		})

--- a/test/extended/image_ecosystem/mariadb_ephemeral.go
+++ b/test/extended/image_ecosystem/mariadb_ephemeral.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][mariadb][Slow] openshift
 		})
 
 		g.Describe("Creating from a template", func() {
-			g.It(fmt.Sprintf("should instantiate the template [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:apps.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should instantiate the template"), func() {
 				exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 
 				g.By(fmt.Sprintf("calling oc process %q", templatePath))

--- a/test/extended/image_ecosystem/mysql_ephemeral.go
+++ b/test/extended/image_ecosystem/mysql_ephemeral.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][mysql][Slow] openshift m
 		})
 
 		g.Describe("Creating from a template", func() {
-			g.It(fmt.Sprintf("should instantiate the template [apigroup:apps.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should instantiate the template"), func() {
 
 				g.By(fmt.Sprintf("calling oc process %q", templatePath))
 				configFile, err := oc.Run("process").Args("openshift//" + templatePath).OutputToFile("config.json")

--- a/test/extended/image_ecosystem/s2i_perl.go
+++ b/test/extended/image_ecosystem/s2i_perl.go
@@ -63,7 +63,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][perl][Slow] hot deploy f
 		})
 
 		g.Describe("hot deploy test", func() {
-			g.It("should work [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]", func() {
+			g.It("should work", func() {
 				// This image-ecosystem test fails on ARM because it depends on behaviour specific to mod_perl,
 				// which is only included in the RHSCL (RHEL 7) perl images which are not available on ARM.
 				if !archHasModPerl(oc) {

--- a/test/extended/image_ecosystem/s2i_php.go
+++ b/test/extended/image_ecosystem/s2i_php.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][php][Slow] hot deploy fo
 		})
 
 		g.Describe("CakePHP example", func() {
-			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should work with hot deploy"), func() {
 
 				exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc new-app %q -p %q", cakephpTemplate, hotDeployParam))

--- a/test/extended/image_ecosystem/s2i_python.go
+++ b/test/extended/image_ecosystem/s2i_python.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][python][Slow] hot deploy
 		})
 
 		g.Describe("Django example", func() {
-			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should work with hot deploy"), func() {
 
 				// skipping this test for now until we figure out why is not
 				// passing on CI bz: 2023238

--- a/test/extended/image_ecosystem/s2i_ruby.go
+++ b/test/extended/image_ecosystem/s2i_ruby.go
@@ -44,7 +44,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][ruby][Slow] hot deploy f
 		})
 
 		g.Describe("Rails example", func() {
-			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should work with hot deploy"), func() {
 
 				exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc new-app %q", railsTemplate))

--- a/test/extended/image_ecosystem/sample_repos.go
+++ b/test/extended/image_ecosystem/sample_repos.go
@@ -51,7 +51,7 @@ func NewSampleRepoTest(c sampleRepoConfig) func() {
 			})
 
 			g.Describe("Building "+c.repoName+" app from new-app", func() {
-				g.It(fmt.Sprintf("should build a "+c.repoName+" image and run it in a pod [apigroup:build.openshift.io]"), func() {
+				g.It(fmt.Sprintf("should build a "+c.repoName+" image and run it in a pod"), func() {
 
 					err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 					o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/imageapis/imagesigning.go
+++ b/test/extended/imageapis/imagesigning.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:Image] signature", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("image")
 
-	g.It("TestImageAddSignature [apigroup:image.openshift.io]", func() {
+	g.It("TestImageAddSignature", func() {
 		t := g.GinkgoT()
 
 		clusterAdminConfig := oc.AdminConfig()
@@ -125,7 +125,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:Image] signature", func() {
 	oc := exutil.NewCLI("image").AsAdmin()
 	ctx := context.Background()
 
-	g.It("TestImageRemoveSignature [apigroup:image.openshift.io]", func() {
+	g.It("TestImageRemoveSignature", func() {
 		t := g.GinkgoT()
 
 		adminClient := oc.AdminImageClient()

--- a/test/extended/imageapis/limitrange_admission.go
+++ b/test/extended/imageapis/limitrange_admission.go
@@ -26,7 +26,7 @@ const (
 	imageSize      = 100
 )
 
-var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range [apigroup:config.openshift.io][apigroup:image.openshift.io][apigroup:operator.openshift.io]", func() {
+var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range", func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("limitrange-admission")
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:opensh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny a push of built image exceeding %s limit [apigroup:build.openshift.io]", imagev1.LimitTypeImage), func() {
+	g.It(fmt.Sprintf("should deny a push of built image exceeding %s limit", imagev1.LimitTypeImage), func() {
 		_, err := createLimitRangeOfType(oc, imagev1.LimitTypeImage, corev1.ResourceList{
 			corev1.ResourceStorage: resource.MustParse("10Ki"),
 		})
@@ -59,7 +59,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:opensh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny a push of built image exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamImages), func() {
+	g.It(fmt.Sprintf("should deny a push of built image exceeding limit on %s resource", imagev1.ResourceImageStreamImages), func() {
 		limits := corev1.ResourceList{
 			imagev1.ResourceImageStreamTags:   resource.MustParse("0"),
 			imagev1.ResourceImageStreamImages: resource.MustParse("0"),
@@ -106,7 +106,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:opensh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny a container image reference exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamTags), func() {
+	g.It(fmt.Sprintf("should deny a container image reference exceeding limit on %s resource", imagev1.ResourceImageStreamTags), func() {
 		tag2Image, err := buildAndPushTestImagesTo(oc, "src", "tag", 2)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -163,7 +163,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:opensh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny an import of a repository exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamTags), func() {
+	g.It(fmt.Sprintf("should deny an import of a repository exceeding limit on %s resource", imagev1.ResourceImageStreamTags), func() {
 		maxBulkImport, err := getMaxImagesBulkImportedPerRepository()
 		if err != nil {
 			g.Skip(err.Error())

--- a/test/extended/imageapis/quota_admission.go
+++ b/test/extended/imageapis/quota_admission.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota] Image resource quota
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("resourcequota-admission")
 
-	g.It(fmt.Sprintf("should deny a push of built image exceeding %s quota [apigroup:image.openshift.io]", imagev1.ResourceImageStreams), func() {
+	g.It(fmt.Sprintf("should deny a push of built image exceeding %s quota", imagev1.ResourceImageStreams), func() {
 		g.Skip("TODO: determine why this test is not skipped/fails on 4.0 clusters")
 		quota := corev1.ResourceList{
 			imagev1.ResourceImageStreams: resource.MustParse("0"),

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -81,7 +81,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageAppend] Image append", func
 
 	oc = exutil.NewCLIWithPodSecurityLevel("image-append", admissionapi.LevelBaseline)
 
-	g.It("should create images by appending them [apigroup:image.openshift.io]", func() {
+	g.It("should create images by appending them", func() {
 		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")

--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 
 	oc = exutil.NewCLIWithPodSecurityLevel("image-extract", admissionapi.LevelBaseline)
 
-	g.It("should extract content from an image [apigroup:image.openshift.io]", func() {
+	g.It("should extract content from an image", func() {
 		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")

--- a/test/extended/images/hardprune.go
+++ b/test/extended/images/hardprune.go
@@ -26,7 +26,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image hard prune [apigroup:apps.openshift.io][apigroup:user.openshift.io]", func() {
+var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image hard prune", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("prune-images")
 	var originalAcceptSchema2 *bool
@@ -327,11 +327,11 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 		}
 	}
 
-	g.It("should show orphaned blob deletions in dry-run mode [apigroup:image.openshift.io]", func() {
+	g.It("should show orphaned blob deletions in dry-run mode", func() {
 		testHardPrune(true)
 	})
 
-	g.It("should delete orphaned blobs [apigroup:image.openshift.io]", func() {
+	g.It("should delete orphaned blobs", func() {
 		testHardPrune(false)
 	})
 })

--- a/test/extended/images/imagechange_buildtrigger.go
+++ b/test/extended/images/imagechange_buildtrigger.go
@@ -23,25 +23,25 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers] Image change buil
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("image-change-build-trigger")
 
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI", func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange", func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker", func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange", func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom", func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange", func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange(g.GinkgoT(), oc)
 	})
-	g.It("TestMultipleImageChangeBuildTriggers [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestMultipleImageChangeBuildTriggers", func() {
 		TestMultipleImageChangeBuildTriggers(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/images/imagestream.go
+++ b/test/extended/images/imagestream.go
@@ -25,13 +25,13 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers][Serial] ImageStre
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("imagestream-api")
 
-	g.It("TestImageStreamMappingCreate [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamMappingCreate", func() {
 		TestImageStreamMappingCreate(g.GinkgoT(), oc)
 	})
-	g.It("TestImageStreamWithoutDockerImageConfig [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamWithoutDockerImageConfig", func() {
 		TestImageStreamWithoutDockerImageConfig(g.GinkgoT(), oc)
 	})
-	g.It("TestImageStreamTagLifecycleHook [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamTagLifecycleHook", func() {
 		TestImageStreamTagLifecycleHook(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/images/imagestream_admission.go
+++ b/test/extended/images/imagestream_admission.go
@@ -27,13 +27,13 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers][Serial] ImageStre
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("imagestream-admission")
 
-	g.It("TestImageStreamTagsAdmission [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamTagsAdmission", func() {
 		TestImageStreamTagsAdmission(g.GinkgoT(), oc)
 	})
-	g.It("TestImageStreamAdmitSpecUpdate [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamAdmitSpecUpdate", func() {
 		TestImageStreamAdmitSpecUpdate(g.GinkgoT(), oc)
 	})
-	g.It("TestImageStreamAdmitStatusUpdate [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamAdmitStatusUpdate", func() {
 		TestImageStreamAdmitStatusUpdate(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/images/imagestreamimport.go
+++ b/test/extended/images/imagestreamimport.go
@@ -32,7 +32,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/image"
 )
 
-var _ = g.Describe("[sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("imagestream-api", admissionapi.LevelBaseline)
 	g.BeforeEach(func() {
@@ -74,16 +74,16 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageStreamImport][Serial][Slow]
 		}
 	})
 
-	g.It("TestImportImageFromInsecureRegistry [apigroup:image.openshift.io]", func() {
+	g.It("TestImportImageFromInsecureRegistry", func() {
 		TestImportImageFromInsecureRegistry(oc)
 	})
-	g.It("TestImportImageFromBlockedRegistry [apigroup:image.openshift.io]", func() {
+	g.It("TestImportImageFromBlockedRegistry", func() {
 		TestImportImageFromBlockedRegistry(oc)
 	})
-	g.It("TestImportRepositoryFromInsecureRegistry [apigroup:image.openshift.io]", func() {
+	g.It("TestImportRepositoryFromInsecureRegistry", func() {
 		TestImportRepositoryFromInsecureRegistry(oc)
 	})
-	g.It("TestImportRepositoryFromBlockedRegistry [apigroup:image.openshift.io]", func() {
+	g.It("TestImportRepositoryFromBlockedRegistry", func() {
 		TestImportRepositoryFromBlockedRegistry(oc)
 	})
 })

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 
 	oc = exutil.NewCLIWithPodSecurityLevel("image-layers", admissionapi.LevelBaseline)
 
-	g.It("should identify a deleted image as missing [apigroup:image.openshift.io]", func() {
+	g.It("should identify a deleted image as missing", func() {
 		client := imagev1client.NewForConfigOrDie(oc.AdminConfig()).ImageV1()
 		_, err := client.ImageStreams(oc.Namespace()).Create(ctx, &imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("should return layers from tagged images [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("should return layers from tagged images", func() {
 		ns = []string{oc.Namespace()}
 		client := imagev1client.NewForConfigOrDie(oc.UserConfig()).ImageV1()
 		isi, err := client.ImageStreamImports(oc.Namespace()).Create(ctx, &imagev1.ImageStreamImport{

--- a/test/extended/images/mirror.go
+++ b/test/extended/images/mirror.go
@@ -280,7 +280,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageMirror][Slow] Image mirror"
 
 	var oc = exutil.NewCLIWithPodSecurityLevel("image-mirror", admissionapi.LevelBaseline)
 
-	g.It("mirror image from integrated registry to external registry [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("mirror image from integrated registry to external registry", func() {
 		g.By("get user credentials")
 		user, token := getCreds(oc)
 
@@ -326,7 +326,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageMirror][Slow] Image mirror"
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("mirror image from integrated registry into few external registries [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("mirror image from integrated registry into few external registries", func() {
 		g.By("get user credentials")
 		user, token := getCreds(oc)
 

--- a/test/extended/images/oc_tag.go
+++ b/test/extended/images/oc_tag.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:Image] oc tag", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("image-oc-tag", admissionapi.LevelBaseline)
 	ctx := context.Background()
 
-	g.It("should preserve image reference for external images [apigroup:image.openshift.io]", func() {
+	g.It("should preserve image reference for external images", func() {
 		var (
 			externalImage = k8simage.GetE2EImage(k8simage.BusyBox)
 			isName        = "busybox"
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:Image] oc tag", func() {
 		o.Expect(tag2.Items[0].DockerImageReference).To(o.Equal(tag1.Items[0].DockerImageReference))
 	})
 
-	g.It("should change image reference for internal images [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("should change image reference for internal images", func() {
 		var (
 			isName     = "localimage"
 			isName2    = "localimage2"
@@ -125,7 +125,7 @@ RUN touch /test-image
 		o.Expect(tag.Items[0].DockerImageReference).To(o.Equal(fmt.Sprintf("%s/%s/%s@%s", registryHost, oc.Namespace(), isName2, digest)))
 	})
 
-	g.It("should work when only imagestreams api is available [apigroup:image.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("should work when only imagestreams api is available", func() {
 		err := oc.Run("tag").Args("--source=docker", image.ShellImage(), "testis:latest").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/images/prune.go
+++ b/test/extended/images/prune.go
@@ -31,7 +31,7 @@ const (
 	externalImageReference = "docker.io/openshift/origin-release:golang-1.4"
 )
 
-var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune [apigroup:user.openshift.io]", func() {
+var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("prune-images")
 
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune old image [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testPruneImages(oc, 1) })
+		g.It("should prune old image", func() { testPruneImages(oc, 1) })
 	})
 
 	g.Describe("of schema 2", func() {
@@ -106,7 +106,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune old image with config [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testPruneImages(oc, 2) })
+		g.It("should prune old image with config", func() { testPruneImages(oc, 2) })
 	})
 
 	g.Describe("with --prune-registry==false", func() {
@@ -134,7 +134,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune old image but skip registry [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testSoftPruneImages(oc) })
+		g.It("should prune old image but skip registry", func() { testSoftPruneImages(oc) })
 	})
 
 	g.Describe("with default --all flag", func() {
@@ -162,7 +162,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune both internally managed and external images [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testPruneAllImages(oc, true, 2) })
+		g.It("should prune both internally managed and external images", func() { testPruneAllImages(oc, true, 2) })
 	})
 
 	g.Describe("with --all=false flag", func() {
@@ -190,7 +190,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune only internally managed images [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testPruneAllImages(oc, false, 2) })
+		g.It("should prune only internally managed images", func() { testPruneAllImages(oc, false, 2) })
 	})
 })
 

--- a/test/extended/images/redirect.go
+++ b/test/extended/images/redirect.go
@@ -26,7 +26,7 @@ func storageSupportsRedirects(storage imageregistryv1.ImageRegistryConfigStorage
 	return storage.S3 != nil || storage.GCS != nil || storage.Azure != nil || storage.Swift != nil || storage.OSS != nil
 }
 
-var _ = g.Describe("[sig-imageregistry] Image registry [apigroup:route.openshift.io]", func() {
+var _ = g.Describe("[sig-imageregistry] Image registry", func() {
 	defer g.GinkgoRecover()
 
 	routeNamespace := "openshift-image-registry"
@@ -51,7 +51,7 @@ var _ = g.Describe("[sig-imageregistry] Image registry [apigroup:route.openshift
 
 	oc = exutil.NewCLI("image-redirect")
 
-	g.It("should redirect on blob pull [apigroup:image.openshift.io]", func() {
+	g.It("should redirect on blob pull", func() {
 		ctx := context.TODO()
 		imageRegistryConfigClient, err := imageregistry.NewForConfig(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/images/resolve.go
+++ b/test/extended/images/resolve.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLookup] Image policy", func
 	one := int64(0)
 	ctx := context.Background()
 
-	g.It("should update standard Kube object image fields when local names are on [apigroup:image.openshift.io][apigroup:apps.openshift.io]", func() {
+	g.It("should update standard Kube object image fields when local names are on", func() {
 		err := oc.Run("tag").Args(k8simage.GetE2EImage(k8simage.BusyBox), "busybox:latest").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = oc.Run("set", "image-lookup").Args("busybox").Execute()

--- a/test/extended/images/signatures.go
+++ b/test/extended/images/signatures.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-imageregistry][Serial][Suite:openshift/registry/serial]
 		}
 	})
 
-	g.It("can push a signed image to openshift registry and verify it [apigroup:user.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("can push a signed image to openshift registry and verify it", func() {
 		g.By("building a signer image that knows how to sign images")
 		output, err := oc.Run("create").Args("-f", signerBuildFixture).Output()
 		if err != nil {

--- a/test/extended/images/trigger/annotation.go
+++ b/test/extended/images/trigger/annotation.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers] Annotation trigge
 		deploymentFixture = exutil.FixturePath("testdata", "image", "deployment-with-annotation-trigger.yaml")
 	)
 
-	g.It("reconciles after the image is overwritten [apigroup:image.openshift.io]", func() {
+	g.It("reconciles after the image is overwritten", func() {
 		namespace := oc.Namespace()
 
 		g.By("creating a Deployment")

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -22,7 +22,7 @@ import (
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have same number of Machines and Nodes [apigroup:machine.openshift.io]", func() {
+	g.It("have same number of Machines and Nodes", func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()

--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -30,7 +30,7 @@ const (
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have machine resources [apigroup:machine.openshift.io]", func() {
+	g.It("have machine resources", func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -221,7 +221,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 	// provisioning the new host, while it could take approx another 10 minutes for deprovisioning
 	// and deleting it. The extra timeout amount should be enough to cover future slower execution
 	// environments.
-	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]", func() {
+	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m]", func() {
 		// expect new nodes to come up for machineSet
 		verifyNodeScalingFunc := func(c *kubernetes.Clientset, dc dynamic.Interface, expectedScaleOut int, machineSet objx.Map) bool {
 			nodes, err := getNodesFromMachineSet(c, dc, machineName(machineSet))

--- a/test/extended/machines/workers.go
+++ b/test/extended/machines/workers.go
@@ -130,7 +130,7 @@ func isNodeReady(node corev1.Node) bool {
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("recover from deleted worker machines [apigroup:machine.openshift.io]", func() {
+	g.It("recover from deleted worker machines", func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()

--- a/test/extended/networking/acl_audit_log.go
+++ b/test/extended/networking/acl_audit_log.go
@@ -44,7 +44,7 @@ var _ = Describe("[sig-network][Feature:Network Policy Audit logging]", func() {
 	InOVNKubernetesContext(
 		func() {
 			f := oc.KubeFramework()
-			It("should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io]", func() {
+			It("should ensure acl logs are created and correct", func() {
 				ns = append(ns, f.Namespace.Name)
 				makeNamespaceScheduleToAllNodes(f)
 				makeNamespaceACLLoggingEnabled(oc)

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -43,14 +43,14 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 	// For Openshift SDN its supports EgressNetworkPolicy objects
 	InOpenShiftSDNContext(
 		func() {
-			g.It("should ensure egressnetworkpolicy is created [apigroup:network.openshift.io]", func() {
+			g.It("should ensure egressnetworkpolicy is created", func() {
 				doEgressFwTest(egFwf, egFwoc, openShiftSDNManifest)
 			})
 		},
 	)
 	noegFwoc := exutil.NewCLIWithPodSecurityLevel(noEgressFWE2E, admissionapi.LevelBaseline)
 	noegFwf := noegFwoc.KubeFramework()
-	g.It("egressFirewall should have no impact outside its namespace [apigroup:config.openshift.io]", func() {
+	g.It("egressFirewall should have no impact outside its namespace", func() {
 		g.By("creating test pod")
 		pod := "dummy"
 		o.Expect(createTestEgressFw(noegFwf, pod)).To(o.Succeed())

--- a/test/extended/networking/egress_router_cni.go
+++ b/test/extended/networking/egress_router_cni.go
@@ -36,12 +36,12 @@ const (
 var _ = g.Describe("[sig-network][Feature:EgressRouterCNI]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel(egressRouterCNIE2E, admissionapi.LevelPrivileged)
 
-	g.It("should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io]", func() {
+	g.It("should ensure ipv4 egressrouter cni resources are created", func() {
 		doEgressRouterCNI(egressRouterCNIV4Manifest, oc, ipv4MatchPattern)
 	})
 	InOVNKubernetesContext(
 		func() {
-			g.It("should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io]", func() {
+			g.It("should ensure ipv6 egressrouter cni resources are created", func() {
 				doEgressRouterCNI(egressRouterCNIV6Manifest, oc, ipv6MatchPattern)
 			})
 		},

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -43,7 +43,7 @@ const (
 	egressUpdateTimeout = 180
 )
 
-var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel(namespacePrefix, admissionapi.LevelPrivileged)
 	portAllocator := NewPortAllocator(egressIPTargetHostPortMin, egressIPTargetHostPortMax)
 
@@ -342,7 +342,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 		})
 	}) // end testing to internal targets
 
-	g.Context("[external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io]", func() {
+	g.Context("[external-targets]", func() {
 		g.JustBeforeEach(func() {
 			// SCC privileged is needed to run tcpdump on the packet sniffer containers, and at the minimum host networked is needed for
 			// host networked pods.
@@ -363,7 +363,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 		// OVNKubernetes
 		// OpenShiftSDN
 		// Skipped on Azure due to https://bugzilla.redhat.com/show_bug.cgi?id=2073045
-		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]", func() {
+		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure]", func() {
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
 			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/networking/endpoint_admission.go
+++ b/test/extended/networking/endpoint_admission.go
@@ -21,7 +21,7 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-var _ = g.Describe("[sig-network][endpoints] admission [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-network][endpoints] admission", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("endpoint-admission")
 

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -500,7 +500,7 @@ func InOpenShiftSDNContext(body func()) {
 }
 
 func InBareMetalIPv4ClusterContext(oc *exutil.CLI, body func()) {
-	Context("when running openshift ipv4 cluster on bare metal [apigroup:config.openshift.io]",
+	Context("when running openshift ipv4 cluster on bare metal",
 		func() {
 			BeforeEach(func() {
 				pType, err := platformType(oc.AdminConfigClient())

--- a/test/extended/oauth/client_secret.go
+++ b/test/extended/oauth/client_secret.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer]", func() {
 	ctx := context.Background()
 
 	g.Describe("ClientSecretWithPlus", func() {
-		g.It(fmt.Sprintf("should create oauthclient [apigroup:config.openshift.io][apigroup:oauth.openshift.io][apigroup:user.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should create oauthclient"), func() {
 			controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 		oauthServerCleanup()
 	})
 
-	g.Context("Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io]", func() {
+	g.Context("Using a OAuth client with a non-default token max age", func() {
 		var oAuthClientResource *oauthv1.OAuthClient
 		var accessTokenMaxAgeSeconds int32
 
@@ -64,11 +64,11 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 				accessTokenMaxAgeSeconds = 0
 			})
 
-			g.It("works as expected when using a token authorization flow [apigroup:user.openshift.io]", func() {
+			g.It("works as expected when using a token authorization flow", func() {
 				testTokenFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 
-			g.It("works as expected when using a code authorization flow [apigroup:user.openshift.io]", func() {
+			g.It("works as expected when using a code authorization flow", func() {
 				testCodeFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 
@@ -79,10 +79,10 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 				accessTokenMaxAgeSeconds = 10
 			})
 
-			g.It("works as expected when using a token authorization flow [apigroup:user.openshift.io]", func() {
+			g.It("works as expected when using a token authorization flow", func() {
 				testTokenFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
-			g.It("works as expected when using a code authorization flow [apigroup:user.openshift.io]", func() {
+			g.It("works as expected when using a code authorization flow", func() {
 				testCodeFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 		})

--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP][Serial] ldap group sync", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("ldap-group-sync", admissionapi.LevelPrivileged).AsAdmin()
 	)
 
-	g.It("can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", func() {
+	g.It("can sync groups from ldap", func() {
 		g.By("starting an openldap server")
 		ldapNS, ldapName, _, ca, err := exutil.CreateLDAPTestServer(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -32,7 +32,7 @@ func init() {
 var _ = g.Describe("[sig-auth][Feature:HTPasswdAuth] HTPasswd IDP", func() {
 	var oc = exutil.NewCLIWithPodSecurityLevel("htpasswd-idp", admissionapi.LevelBaseline)
 
-	g.It("should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("should successfully configure htpasswd and be responsive", func() {
 		newTokenReqOpts, cleanup, err := deployOAuthServer(oc)
 		defer cleanup()
 		o.Expect(err).ToNot(o.HaveOccurred())

--- a/test/extended/oauth/ldap.go
+++ b/test/extended/oauth/ldap.go
@@ -15,7 +15,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("oauth-ldap", admissionapi.LevelPrivileged)
 	)
 
-	g.It("should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("should start an OpenLDAP test server", func() {
 		_, _, _, _, err := exutil.CreateLDAPTestServer(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})

--- a/test/extended/oauth/oauth_ldap.go
+++ b/test/extended/oauth/oauth_ldap.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP IDP", func() {
 		myEmail        = "person1smith@example.com"
 	)
 
-	g.It("should authenticate against an ldap server [apigroup:user.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("should authenticate against an ldap server", func() {
 		adminConfig := oc.AdminConfig()
 
 		// Clean up mapped identity and user.

--- a/test/extended/oauth/oauthcertfallback.go
+++ b/test/extended/oauth/oauthcertfallback.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth server", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("oauth")
 
-	g.It("has the correct token and certificate fallback semantics [apigroup:config.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("has the correct token and certificate fallback semantics", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -61,7 +61,7 @@ type certAuthTest struct {
 var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP]", func() {
 	var oc = exutil.NewCLI("request-headers")
 
-	g.It("test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io][apigroup:apps.openshift.io]", func() {
+	g.It("test RequestHeaders IdP", func() {
 
 		// In some rare cases, CAO might be damaged when entering this test. If it is - the results
 		// of this test might flaky. This check ensures that we capture such situation early and

--- a/test/extended/oauth/server_headers.go
+++ b/test/extended/oauth/server_headers.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/oauthserver"
 )
 
-var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io]", func() {
+var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers]", func() {
 	var oc = exutil.NewCLIWithPodSecurityLevel("oauth-server-headers", admissionapi.LevelBaseline)
 	var transport http.RoundTripper
 	var oauthServerAddr string

--- a/test/extended/oauth/token.go
+++ b/test/extended/oauth/token.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 	oc := exutil.NewCLI("oauth-access-token-e2e-test")
 	ctx := context.Background()
 
-	g.It(fmt.Sprintf("accepts sha256 access tokens [apigroup:user.openshift.io][apigroup:oauth.openshift.io]"), func() {
+	g.It(fmt.Sprintf("accepts sha256 access tokens"), func() {
 		user, err := oc.AdminUserClient().UserV1().Users().Create(ctx, &userv1.User{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/extended/oauth/well_known.go
+++ b/test/extended/oauth/well_known.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] well-known endpoint", func()
 		oauthNamespace = "openshift-authentication"
 	)
 
-	g.It("should be reachable [apigroup:config.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("should be reachable", func() {
 		metadataJSON, err := oc.Run("get").Args("--raw", "/.well-known/oauth-authorization-server").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/olm/olm.go
+++ b/test/extended/olm/olm.go
@@ -82,7 +82,7 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 
 	// OCP-24061 - [bz 1685230] OLM operator should use imagePullPolicy: IfNotPresent
 	// author: bandrade@redhat.com
-	g.It("have imagePullPolicy:IfNotPresent on thier deployments [apigroup:config.openshift.io]", func() {
+	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {
 		oc := oc.AsAdmin().WithoutNamespace()
 		namespace := "openshift-operator-lifecycle-manager"
 
@@ -138,7 +138,7 @@ var _ = g.Describe("[sig-arch] ocp payload should be based on existing source", 
 	// TODO: This test should be more generic and across components
 	// OCP-20981, [BZ 1626434]The olm/catalog binary should output the exact version info
 	// author: jiazha@redhat.com
-	g.It("OLM version should contain the source commit id [apigroup:config.openshift.io]", func() {
+	g.It("OLM version should contain the source commit id", func() {
 
 		oc := oc
 		namespace := "openshift-operator-lifecycle-manager"
@@ -265,7 +265,7 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 	)
 
 	files := []string{sub}
-	g.It("can subscribe to the operator [apigroup:config.openshift.io]", func() {
+	g.It("can subscribe to the operator", func() {
 		g.By("Cluster-admin user subscribe the operator resource")
 
 		// skip test if marketplace-operator is not enabled

--- a/test/extended/operators/clusteroperators.go
+++ b/test/extended/operators/clusteroperators.go
@@ -19,7 +19,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-arch] ClusterOperators [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-arch] ClusterOperators", func() {
 	defer g.GinkgoRecover()
 
 	var clusterOperators []config.ClusterOperator

--- a/test/extended/operators/daemon_set.go
+++ b/test/extended/operators/daemon_set.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 	// during an upgrade as new pods start and then establish connections.
 	//
 	// Currently only applies to daemonsets that don't explicitly target the control plane.
-	g.It("should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [apigroup:config.openshift.io]", func() {
+	g.It("should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent", func() {
 		// iterate over the references to find valid images
 		daemonSets, err := oc.KubeFramework().ClientSet.AppsV1().DaemonSets("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -30,7 +30,7 @@ var (
 	vmxPattern = regexp.MustCompile(`VMwareVSphereControllerUpgradeable.+vmx-13`)
 )
 
-var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-arch][Early] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	g.It("start all core operators", func() {
@@ -120,7 +120,7 @@ var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.op
 var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have operators on the cluster version [apigroup:config.openshift.io]", func() {
+	g.It("have operators on the cluster version", func() {
 		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions")
 		}

--- a/test/extended/operators/recover.go
+++ b/test/extended/operators/recover.go
@@ -24,7 +24,7 @@ import (
 var _ = g.Describe("[sig-arch] Managed cluster should recover", func() {
 	defer g.GinkgoRecover()
 
-	g.It("when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io]", func() {
+	g.It("when operator-owned objects are deleted [Disruptive]", func() {
 		daemonsets := false
 		deployments := false
 		secrets := true

--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -19,7 +19,7 @@ import (
 	exurl "github.com/openshift/origin/test/extended/util/url"
 )
 
-var _ = g.Describe("[sig-arch] Managed cluster should [apigroup:apps.openshift.io]", func() {
+var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-arch] Managed cluster should [apigroup:apps.openshift.i
 		}
 	})
 
-	g.It("should expose cluster services outside the cluster [apigroup:route.openshift.io]", func() {
+	g.It("should expose cluster services outside the cluster", func() {
 		ns := oc.KubeFramework().Namespace.Name
 
 		tester := exurl.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)

--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	ctx := context.Background()
 
 	g.Describe("TestProjectIsNamespace", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed"), func() {
 			t := g.GinkgoT()
 
 			// create a namespace
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestProjectWatch", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed"), func() {
 			bobName := oc.CreateUser("bob-").Name
 			bobConfig := oc.GetClientConfigForUser(bobName)
 			bobProjectClient := projectv1client.NewForConfigOrDie(bobConfig)
@@ -158,7 +158,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestProjectWatchWithSelectionPredicate", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed"), func() {
 			bobName := oc.CreateUser("bob-").Name
 			bobConfig := oc.GetClientConfigForUser(bobName)
 			bobProjectClient := projectv1client.NewForConfigOrDie(bobConfig)
@@ -340,7 +340,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestScopedProjectAccess", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed"), func() {
 			t := g.GinkgoT()
 
 			bobName := oc.CreateUser("bob-").Name
@@ -458,7 +458,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestInvalidRoleRefs", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed"), func() {
 			clusterAdminRbacClient := oc.AdminKubeClient().RbacV1()
 			clusterAdminAuthorizationClient := oc.AdminAuthorizationClient().AuthorizationV1()
 

--- a/test/extended/project/unprivileged_newproject.go
+++ b/test/extended/project/unprivileged_newproject.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("project-api")
 
-	g.It("TestUnprivilegedNewProject [apigroup:project.openshift.io]", func() {
+	g.It("TestUnprivilegedNewProject", func() {
 		t := g.GinkgoT()
 
 		valerieProjectClient := oc.ProjectClient()
@@ -67,7 +67,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI][Serial] ", func() {
 	oc := exutil.NewCLI("project-api")
 	ctx := context.Background()
 
-	g.It("TestUnprivilegedNewProjectDenied [apigroup:authorization.openshift.io][apigroup:project.openshift.io]", func() {
+	g.It("TestUnprivilegedNewProjectDenied", func() {
 		t := g.GinkgoT()
 
 		clusterAdminAuthorizationConfig := oc.AdminAuthorizationClient().AuthorizationV1()

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -39,7 +39,7 @@ import (
 	helper "github.com/openshift/origin/test/extended/util/prometheus"
 )
 
-var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io]", func() {
+var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules", func() {
 	defer g.GinkgoRecover()
 
 	// These alerts are known to be missing the summary and/or description
@@ -190,7 +190,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		oc = exutil.NewCLIWithoutNamespace("prometheus")
 	)
 
-	g.It("shouldn't report any unexpected alerts in firing or pending state [apigroup:config.openshift.io]", func() {
+	g.It("shouldn't report any unexpected alerts in firing or pending state", func() {
 		// Watchdog and AlertmanagerReceiversNotConfigured are expected.
 		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
@@ -467,7 +467,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			e2e.Logf("Telemetry is enabled: %s", bearerToken)
 		})
 
-		g.It("should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io]", func() {
+		g.It("should start and expose a secured proxy and unsecured metrics", func() {
 			ns := oc.Namespace()
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
 			defer func() {
@@ -607,7 +607,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			e2e.Logf("AlertmanagerReceiversNotConfigured alert is firing")
 		})
 
-		g.It("should have important platform topology metrics [apigroup:config.openshift.io]", func() {
+		g.It("should have important platform topology metrics", func() {
 			exutil.SkipIfExternalControlplaneTopology(oc, "topology metrics are not available for clusters with external controlPlaneTopology")
 
 			tests := map[string]bool{
@@ -659,7 +659,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			})
 		})
 
-		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io]", func() {
+		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early]", func() {
 			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 				e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
 			}
@@ -729,7 +729,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should provide named network metrics [apigroup:project.openshift.io]", func() {
+		g.It("should provide named network metrics", func() {
 			ns := oc.SetupProject()
 
 			cs, err := newDynClientSet()

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus
 	})
 
 	g.Describe("when installed on the cluster", func() {
-		g.It("should start and expose a secured proxy and verify build metrics [apigroup:config.openshift.io][apigroup:build.openshift.io]", func() {
+		g.It("should start and expose a secured proxy and verify build metrics", func() {
 			controlPlaneTopology, infra_err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(infra_err).NotTo(o.HaveOccurred())
 

--- a/test/extended/quota/clusterquota.go
+++ b/test/extended/quota/clusterquota.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ClusterResourceQuota]", func() {
 	oc := exutil.NewCLI("crq")
 
 	g.Describe("Cluster resource quota", func() {
-		g.It(fmt.Sprintf("should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should control resource limits across namespaces"), func() {
 			t := g.GinkgoT(1)
 
 			clusterAdminKubeClient := oc.AdminKubeClient()

--- a/test/extended/quota/resourcequota.go
+++ b/test/extended/quota/resourcequota.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 	oc := exutil.NewCLI("object-count-rq")
 
 	g.Describe("Object count", func() {
-		g.It(fmt.Sprintf("should properly count the number of imagestreams resources [apigroup:image.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should properly count the number of imagestreams resources"), func() {
 			clusterAdminKubeClient := oc.AdminKubeClient()
 			clusterAdminImageClient := oc.AdminImageClient().ImageV1()
 			testProject := oc.CreateProject()

--- a/test/extended/router/certs.go
+++ b/test/extended/router/certs.go
@@ -21,7 +21,7 @@ import (
 	exurl "github.com/openshift/origin/test/extended/util/url"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc          *exutil.CLI
@@ -101,7 +101,7 @@ u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
 
 	g.When("FIPS is enabled", func() {
 		g.Describe("the HAProxy router", func() {
-			g.It("should not work when configured with a 1024-bit RSA key [apigroup:template.openshift.io]", func() {
+			g.It("should not work when configured with a 1024-bit RSA key", func() {
 				if !isFIPS {
 					g.Skip("skipping on non-FIPS cluster")
 				}
@@ -139,7 +139,7 @@ u3YLAbyW/lHhOCiZu2iAI8AbmXem9lW6Tr7p/97s0w==
 
 	g.When("FIPS is disabled", func() {
 		g.Describe("the HAProxy router", func() {
-			g.It("should serve routes when configured with a 1024-bit RSA key [apigroup:template.openshift.io]", func() {
+			g.It("should serve routes when configured with a 1024-bit RSA key", func() {
 				if isFIPS {
 					g.Skip("skipping on FIPS cluster")
 				}

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -21,7 +21,7 @@ import (
 
 const timeoutSeconds = 3 * 60
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "router-config-manager.yaml")

--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the gRPC interoperability tests [apigroup:config.openshift.io][apigroup:route.openshift.io][apigroup:template.openshift.io]", func() {
+		g.It("should pass the gRPC interoperability tests", func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -34,7 +34,7 @@ type h2specFailingTest struct {
 	TestNumber int
 }
 
-var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io]", func() {
+var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -64,7 +64,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the h2spec conformance tests [apigroup:config.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:template.openshift.io]", func() {
+		g.It("should pass the h2spec conformance tests", func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -23,7 +23,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:operator.openshift.io][apigroup:apps.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "router-http-echo-server.yaml")

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -56,7 +56,7 @@ func makeHTTPClient(useHTTP2Transport bool, timeout time.Duration) *http.Client 
 	return c
 }
 
-var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -88,7 +88,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the http2 tests [apigroup:image.openshift.io][apigroup:template.openshift.io]", func() {
+		g.It("should pass the http2 tests", func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should be able to connect to a service that is idled because a GET on the route will unidle it [apigroup:config.openshift.io][apigroup:template.openshift.io]", func() {
+		g.It("should be able to connect to a service that is idled because a GET on the route will unidle it", func() {
 			network, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster network configuration")
 			if !(network.Status.NetworkType == "OVNKubernetes" || network.Status.NetworkType == "OpenShiftSDN") {

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -37,7 +37,7 @@ import (
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc = exutil.NewCLIWithPodSecurityLevel("router-metrics", admissionapi.LevelBaseline)
@@ -120,7 +120,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:config.openshift.io]"
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should expose prometheus metrics for a route [apigroup:route.openshift.io]", func() {
+		g.It("should expose prometheus metrics for a route", func() {
 			g.By("when a route exists")
 			configPath := exutil.FixturePath("testdata", "router", "router-metrics.yaml")
 			err := oc.Run("create").Args("-f", configPath).Execute()

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -16,7 +16,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:operator.openshift.io][apigroup:apps.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "reencrypt-serving-cert.yaml")

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -18,7 +18,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/url"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io][apigroup:apps.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		host, ns string
@@ -68,7 +68,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 			)
 		})
 
-		g.It("should serve routes that were created from an ingress [apigroup:route.openshift.io]", func() {
+		g.It("should serve routes that were created from an ingress", func() {
 			g.By("deploying an ingress rule")
 			err := oc.Run("create").Args("-f", configPath).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -26,7 +26,7 @@ import (
 
 const changeTimeoutSeconds = 3 * 60
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:template.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc          *exutil.CLI
@@ -170,7 +170,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][a
 			o.Expect(condition.LastTransitionTime).NotTo(o.BeNil())
 		})
 
-		g.It("should override the route host for overridden domains with a custom value [apigroup:image.openshift.io]", func() {
+		g.It("should override the route host for overridden domains with a custom value", func() {
 
 			configPath := exutil.FixturePath("testdata", "router", "router-override-domains.yaml")
 			g.By(fmt.Sprintf("creating a router from a config file %q", configPath))

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -28,7 +28,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		routerImage string

--- a/test/extended/router/subdomain.go
+++ b/test/extended/router/subdomain.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                   *exutil.CLI

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -19,7 +19,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io][apigroup:template.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc          *exutil.CLI
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][a
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should run even if it has no access to update status [apigroup:image.openshift.io]", func() {
+		g.It("should run even if it has no access to update status", func() {
 
 			configPath := exutil.FixturePath("testdata", "router", "router-scoped.yaml")
 			g.By(fmt.Sprintf("creating a router from a config file %q", configPath))

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -23,7 +23,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:image.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "weighted-router.yaml")

--- a/test/extended/scheduling/pods.go
+++ b/test/extended/scheduling/pods.go
@@ -2,9 +2,11 @@ package scheduling
 
 import (
 	"context"
+	"strings"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -87,6 +89,33 @@ func (p requirePodsOnDifferentNodesTest) getDeploymentPods(oc *exutil.CLI) []*co
 }
 
 func (p requirePodsOnDifferentNodesTest) run(oc *exutil.CLI) {
+	ctx := context.TODO()
+
+	if clusterVersion, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{}); err == nil && len(clusterVersion.Status.History) > 0 {
+		// most recent is first.  Check the most recently installed version, if it is 4.10 or earlier, skip this test
+		for _, releaseUpdate := range clusterVersion.Status.History {
+			if releaseUpdate.State != configv1.CompletedUpdate {
+				continue
+			}
+			switch {
+			case strings.HasPrefix(releaseUpdate.Version, "4.0") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.1.") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.2.") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.3.") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.4.") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.5.") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.6") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.7") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.8") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.9") ||
+				strings.HasPrefix(releaseUpdate.Version, "4.10"):
+				return
+			}
+			// if we got here, then we're 4.11 or after, so we run the test.  skip the rest of the history.
+			break
+		}
+	}
+
 	deploymentPods := p.getDeploymentPods(oc)
 
 	if len(deploymentPods) == 0 {

--- a/test/extended/security/fips.go
+++ b/test/extended/security/fips.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-arch] [Conformance] FIPS", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("fips", admissionapi.LevelPrivileged)
 
-	g.It("TestFIPS [apigroup:config.openshift.io]", func() {
+	g.It("TestFIPS", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		clusterAdminKubeClientset := oc.AdminKubeClient()

--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
 	ctx := context.Background()
 
-	g.It("TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("TestPodUpdateSCCEnforcement", func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClientset := oc.AdminKubeClient()
@@ -92,7 +92,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	// pods running as root are being started here
 	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
 
-	g.It("TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", func() {
+	g.It("TestAllowedSCCViaRBAC", func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClientset := oc.AdminKubeClient()

--- a/test/extended/security/supplemental_groups.go
+++ b/test/extended/security/supplemental_groups.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-node] supplemental groups", func() {
 	)
 
 	g.Describe("Ensure supplemental groups propagate to docker", func() {
-		g.It("should propagate requested groups to the container [Local][apigroup:user.openshift.io][apigroup:security.openshift.io]", func() {
+		g.It("should propagate requested groups to the container [Local]", func() {
 
 			fsGroup := int64(1111)
 			supGroup := int64(2222)

--- a/test/extended/single_node/topology.go
+++ b/test/extended/single_node/topology.go
@@ -128,7 +128,7 @@ func validateDeploymentReplicas(deployment appsv1.Deployment,
 	validateReplicas(deployment.Name, deployment.Namespace, int(*deployment.Spec.Replicas))
 }
 
-var _ = ginkgo.Describe("[sig-arch] Cluster topology single node tests [apigroup:config.openshift.io]", func() {
+var _ = ginkgo.Describe("[sig-arch] Cluster topology single node tests", func() {
 	f := framework.NewDefaultFramework("single-node")
 
 	ginkgo.It("Verify that OpenShift components deploy one replica in SingleReplica topology mode", func() {

--- a/test/extended/tbr_health/check.go
+++ b/test/extended/tbr_health/check.go
@@ -11,7 +11,7 @@ var _ = g.Describe("[sig-devex] check registry.redhat.io is available and sample
 	var (
 		oc = exutil.NewCLI("samples-health-check")
 	)
-	g.It("run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("run sample related validations", func() {
 		err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 		if err != nil {
 			// so the error string shows up in the top level ginkgo message

--- a/test/extended/templates/template.go
+++ b/test/extended/templates/template.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] template-api", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("templates")
 
-	g.It("TestTemplate [apigroup:template.openshift.io]", func() {
+	g.It("TestTemplate", func() {
 		t := g.GinkgoT()
 
 		for _, version := range []schema.GroupVersion{v1.SchemeGroupVersion} {
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] template-api", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("templates")
 
-	g.It("TestTemplateTransformationFromConfig [apigroup:template.openshift.io]", func() {
+	g.It("TestTemplateTransformationFromConfig", func() {
 		t := g.GinkgoT()
 
 		clusterAdminClientConfig := oc.AdminConfig()

--- a/test/extended/templates/templateinstance_cross_namespace.go
+++ b/test/extended/templates/templateinstance_cross_namespace.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance cross-namesp
 		cli2 = exutil.NewCLI("templates2")
 	)
 
-	g.It("should create and delete objects across namespaces [apigroup:user.openshift.io][apigroup:template.openshift.io]", func() {
+	g.It("should create and delete objects across namespaces", func() {
 		err := cli2.AsAdmin().Run("adm").Args("policy", "add-role-to-user", "admin", cli.Username()).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/templates/templateinstance_fail.go
+++ b/test/extended/templates/templateinstance_fail.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance creation wit
 	)
 
 	g.Context("", func() {
-		g.It("should report a failure on creation [apigroup:template.openshift.io]", func() {
+		g.It("should report a failure on creation", func() {
 			err := cli.Run("create").Args("-f", templatefixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/templates/templateinstance_impersonation.go
+++ b/test/extended/templates/templateinstance_impersonation.go
@@ -24,7 +24,7 @@ import (
 // or can impersonate, the requester.
 // 2. Check that templateinstancespecs, particularly including
 // requester.username and groups, are immutable.
-var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonation tests [apigroup:user.openshift.io][apigroup:authorization.openshift.io]", func() {
+var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonation tests", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -228,7 +228,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		deleteGroup(cli, impersonategroup)
 	})
 
-	g.It("should pass impersonation creation tests [apigroup:template.openshift.io]", func() {
+	g.It("should pass impersonation creation tests", func() {
 		// check who can create TemplateInstances (anyone with project write access
 		// AND is/can impersonate spec.requester.username)
 		for _, test := range tests {
@@ -249,7 +249,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		}
 	})
 
-	g.It("should pass impersonation update tests [apigroup:template.openshift.io]", func() {
+	g.It("should pass impersonation update tests", func() {
 		// check who can update TemplateInstances.  Via Update(), spec updates
 		// should be rejected (with the exception of spec.metadata fields used
 		// by the garbage collector, not tested here).  Status updates should be
@@ -349,7 +349,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		}
 	})
 
-	g.It("should pass impersonation deletion tests [apigroup:template.openshift.io]", func() {
+	g.It("should pass impersonation deletion tests", func() {
 		// check who can delete TemplateInstances (anyone with project write access)
 		for _, test := range tests {
 			setUser(cli, test.user)

--- a/test/extended/templates/templateinstance_objectkinds.go
+++ b/test/extended/templates/templateinstance_objectkinds.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance object kinds
 		cli     = exutil.NewCLI("templates")
 	)
 
-	g.It("should create and delete objects from varying API groups [apigroup:template.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("should create and delete objects from varying API groups", func() {
 		g.By("creating a template instance")
 		err := cli.Run("create").Args("-f", fixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -122,7 +122,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 			}
 		})
 
-		g.It("should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io]", func() {
+		g.It("should report ready soon after all annotated objects are ready", func() {
 			var err error
 
 			templateinstance = &templatev1.TemplateInstance{
@@ -171,7 +171,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io]", func() {
+		g.It("should report failed soon after an annotated objects has failed", func() {
 			var err error
 
 			secret, err := cli.KubeClient().CoreV1().Secrets(cli.Namespace()).Create(context.Background(), &v1.Secret{

--- a/test/extended/templates/templateinstance_security.go
+++ b/test/extended/templates/templateinstance_security.go
@@ -79,7 +79,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance security tes
 		}
 	)
 
-	g.Context("[apigroup:authorization.openshift.io][apigroup:template.openshift.io]", func() {
+	g.Context("", func() {
 		g.BeforeEach(func() {
 			adminuser = createUser(cli, "adminuser", "admin")
 			edituser = createUser(cli, "edituser", "edit")
@@ -127,7 +127,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance security tes
 			deleteGroup(cli, editgroup)
 		})
 
-		g.It("should pass security tests [apigroup:route.openshift.io]", func() {
+		g.It("should pass security tests", func() {
 			tests := []struct {
 				by              string
 				user            *userv1.User

--- a/test/extended/templates/templateservicebroker_bind.go
+++ b/test/extended/templates/templateservicebroker_bind.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker bind te
 		cliUser            user.Info
 	)
 
-	g.Context("[apigroup:authorization.openshift.io][apigroup:template.openshift.io]", func() {
+	g.Context("", func() {
 		g.BeforeEach(func() {
 			var err error
 			brokercli, err = TSBClient(cli)

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -33,7 +33,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker end-to-end test [apigroup:template.openshift.io][apigroup:authorization.openshift.io]", func() {
+var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker end-to-end test", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -25,7 +25,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker security test [apigroup:template.openshift.io][apigroup:authorization.openshift.io]", func() {
+var _ = g.Describe("[sig-devex][Feature:Templates] templateservicebroker security test", func() {
 	defer g.GinkgoRecover()
 	ctx := context.Background()
 

--- a/test/extended/user/basic.go
+++ b/test/extended/user/basic.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-auth][Feature:UserAPI]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("user-api")
 
-	g.It("users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]", func() {
+	g.It("users can manipulate groups", func() {
 		t := g.GinkgoT()
 
 		clusterAdminUserClient := oc.AdminUserClient().UserV1()
@@ -131,7 +131,7 @@ var _ = g.Describe("[sig-auth][Feature:UserAPI]", func() {
 		})
 	})
 
-	g.It("groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("groups should work", func() {
 		t := g.GinkgoT()
 		clusterAdminUserClient := oc.AdminUserClient().UserV1()
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -17,9 +17,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [Conformance][sig-sno][Serial] Cluster should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]": "should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io] [Suite:openshift/conformance/serial/minimal]",
 
-	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io][apigroup:apps.openshift.io]": "test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP": "test RequestHeaders IdP [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial][apigroup:config.openshift.io]": "should be stored at the correct location and version for all resources [Serial][apigroup:config.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial]": "should be stored at the correct location and version for all resources [Serial] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-api-machinery] API priority and fairness should ensure that requests can be classified by adding FlowSchema and PriorityLevelConfiguration": "should ensure that requests can be classified by adding FlowSchema and PriorityLevelConfiguration [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -27,7 +27,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-api-machinery] API priority and fairness should ensure that requests can't be drowned out (priority)": "should ensure that requests can't be drowned out (priority) [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-api-machinery] APIServer CR fields validation additionalCORSAllowedOrigins [apigroup:config.openshift.io]": "additionalCORSAllowedOrigins [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-api-machinery] APIServer CR fields validation additionalCORSAllowedOrigins": "additionalCORSAllowedOrigins [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] listing mutating webhooks should work [Conformance]": "listing mutating webhooks should work [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
@@ -273,9 +273,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-api-machinery][Feature:Audit] Basic audit should audit API calls": "should audit API calls [Disabled:SpecialConfig]",
 
-	"[Top Level] [sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io]": "should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces": "should control resource limits across namespaces [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of imagestreams resources [apigroup:image.openshift.io]": "should properly count the number of imagestreams resources [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of imagestreams resources": "should properly count the number of imagestreams resources [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-api-machinery][Feature:ServerSideApply] Server-Side Apply should work for apps.openshift.io/v1, Resource=deploymentconfigs": "should work for apps.openshift.io/v1, Resource=deploymentconfigs [Suite:openshift/conformance/parallel]",
 
@@ -513,85 +513,83 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-apps] TTLAfterFinished job should be deleted once it finishes after TTL seconds": "job should be deleted once it finishes after TTL seconds [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs  should adhere to Three Laws of Controllers [apigroup:apps.openshift.io]": "should adhere to Three Laws of Controllers [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs  should adhere to Three Laws of Controllers": "should adhere to Three Laws of Controllers [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs adoption will orphan all RCs and adopt them back when recreated [apigroup:apps.openshift.io]": "will orphan all RCs and adopt them back when recreated [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs adoption will orphan all RCs and adopt them back when recreated": "will orphan all RCs and adopt them back when recreated [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs generation should deploy based on a status version bump [apigroup:apps.openshift.io]": "should deploy based on a status version bump [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs generation should deploy based on a status version bump": "should deploy based on a status version bump [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs ignores deployer and lets the config with a NewReplicationControllerCreated reason should let the deployment config with a NewReplicationControllerCreated reason [apigroup:apps.openshift.io]": "should let the deployment config with a NewReplicationControllerCreated reason [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs ignores deployer and lets the config with a NewReplicationControllerCreated reason should let the deployment config with a NewReplicationControllerCreated reason": "should let the deployment config with a NewReplicationControllerCreated reason [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs initially should not deploy if pods never transition to ready [apigroup:apps.openshift.io]": "should not deploy if pods never transition to ready [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs initially should not deploy if pods never transition to ready": "should not deploy if pods never transition to ready [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs keep the deployer pod invariant valid should deal with cancellation after deployer pod succeeded [apigroup:apps.openshift.io]": "should deal with cancellation after deployer pod succeeded [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs keep the deployer pod invariant valid should deal with cancellation after deployer pod succeeded": "should deal with cancellation after deployer pod succeeded [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs keep the deployer pod invariant valid should deal with cancellation of running deployment [apigroup:apps.openshift.io]": "should deal with cancellation of running deployment [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs keep the deployer pod invariant valid should deal with cancellation of running deployment": "should deal with cancellation of running deployment [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs keep the deployer pod invariant valid should deal with config change in case the deployment is still running [apigroup:apps.openshift.io]": "should deal with config change in case the deployment is still running [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs keep the deployer pod invariant valid should deal with config change in case the deployment is still running": "should deal with config change in case the deployment is still running [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs paused should disable actions on deployments [apigroup:apps.openshift.io]": "should disable actions on deployments [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs paused should disable actions on deployments": "should disable actions on deployments [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs reaper [Slow] should delete all failed deployer pods and hook pods [apigroup:apps.openshift.io]": "should delete all failed deployer pods and hook pods [apigroup:apps.openshift.io]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs reaper [Slow] should delete all failed deployer pods and hook pods": "should delete all failed deployer pods and hook pods",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs rolled back should rollback to an older deployment [apigroup:apps.openshift.io]": "should rollback to an older deployment [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs rolled back should rollback to an older deployment": "should rollback to an older deployment [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs should respect image stream tag reference policy resolve the image pull spec [apigroup:apps.openshift.io][apigroup:image.openshift.io]": "resolve the image pull spec [apigroup:apps.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs should respect image stream tag reference policy resolve the image pull spec": "resolve the image pull spec [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs viewing rollout history should print the rollout history [apigroup:apps.openshift.io]": "should print the rollout history [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs viewing rollout history should print the rollout history": "should print the rollout history [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs when changing image change trigger should successfully trigger from an updated image [apigroup:apps.openshift.io][apigroup:image.openshift.io]": "should successfully trigger from an updated image [apigroup:apps.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs when changing image change trigger should successfully trigger from an updated image": "should successfully trigger from an updated image [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs when run iteratively should immediately start a new deployment [apigroup:apps.openshift.io]": "should immediately start a new deployment [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs when run iteratively should immediately start a new deployment": "should immediately start a new deployment [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs when run iteratively should only deploy the last deployment [apigroup:apps.openshift.io]": "should only deploy the last deployment [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs when run iteratively should only deploy the last deployment": "should only deploy the last deployment [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs when tagging images should successfully tag the deployed image [apigroup:apps.openshift.io][apigroup:authorization.openshift.io][apigroup:image.openshift.io]": "should successfully tag the deployed image [apigroup:apps.openshift.io][apigroup:authorization.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs when tagging images should successfully tag the deployed image": "should successfully tag the deployed image [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with custom deployments should run the custom deployment steps [apigroup:apps.openshift.io]": "should run the custom deployment steps [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with custom deployments should run the custom deployment steps": "should run the custom deployment steps [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with enhanced status should include various info in status [apigroup:apps.openshift.io]": "should include various info in status [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with enhanced status should include various info in status": "should include various info in status [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with env in params referencing the configmap should expand the config map key to a value [apigroup:apps.openshift.io]": "should expand the config map key to a value [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with env in params referencing the configmap should expand the config map key to a value": "should expand the config map key to a value [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with failing hook should get all logs from retried hooks [apigroup:apps.openshift.io]": "should get all logs from retried hooks [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with failing hook should get all logs from retried hooks": "should get all logs from retried hooks [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with minimum ready seconds set should not transition the deployment to Complete before satisfied [apigroup:apps.openshift.io]": "should not transition the deployment to Complete before satisfied [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with minimum ready seconds set should not transition the deployment to Complete before satisfied": "should not transition the deployment to Complete before satisfied [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with multiple image change triggers should run a successful deployment with a trigger used by different containers [apigroup:apps.openshift.io][apigroup:image.openshift.io]": "should run a successful deployment with a trigger used by different containers [apigroup:apps.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with multiple image change triggers should run a successful deployment with a trigger used by different containers": "should run a successful deployment with a trigger used by different containers [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with multiple image change triggers should run a successful deployment with multiple triggers [apigroup:apps.openshift.io][apigroup:image.openshift.io]": "should run a successful deployment with multiple triggers [apigroup:apps.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with multiple image change triggers should run a successful deployment with multiple triggers": "should run a successful deployment with multiple triggers [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with revision history limits should never persist more old deployments than acceptable after being observed by the controller [apigroup:apps.openshift.io]": "should never persist more old deployments than acceptable after being observed by the controller [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with revision history limits should never persist more old deployments than acceptable after being observed by the controller": "should never persist more old deployments than acceptable after being observed by the controller [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with test deployments should run a deployment to completion and then scale to zero [apigroup:apps.openshift.io]": "should run a deployment to completion and then scale to zero [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs with test deployments should run a deployment to completion and then scale to zero": "should run a deployment to completion and then scale to zero [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs won't deploy RC with unresolved images when patched with empty image [apigroup:apps.openshift.io]": "when patched with empty image [apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:DeploymentConfig] deploymentconfigs won't deploy RC with unresolved images when patched with empty image": "when patched with empty image [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-apps][Feature:Jobs] Users should be able to create and run a job in a user project": "Users should be able to create and run a job in a user project [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestDeployScale [apigroup:apps.openshift.io]": "TestDeployScale [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestDeployScale": "TestDeployScale [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestDeploymentConfigDefaults [apigroup:apps.openshift.io]": "TestDeploymentConfigDefaults [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestDeploymentConfigDefaults": "TestDeploymentConfigDefaults [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_MultipleICTs [apigroup:apps.openshift.io][apigroup:images.openshift.io]": "TestTriggers_MultipleICTs [apigroup:apps.openshift.io][apigroup:images.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_MultipleICTs": "TestTriggers_MultipleICTs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_configChange [apigroup:apps.openshift.io]": "TestTriggers_configChange [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_configChange": "TestTriggers_configChange [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_imageChange [apigroup:apps.openshift.io][apigroup:image.openshift.io]": "TestTriggers_imageChange [apigroup:apps.openshift.io][apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_imageChange": "TestTriggers_imageChange [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_imageChange_nonAutomatic [apigroup:image.openshift.io][apigroup:apps.openshift.io]": "TestTriggers_imageChange_nonAutomatic [apigroup:image.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_imageChange_nonAutomatic": "TestTriggers_imageChange_nonAutomatic [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_manual [apigroup:apps.openshift.io]": "TestTriggers_manual [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-apps][Feature:OpenShiftControllerManager] TestTriggers_manual": "TestTriggers_manual [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Cluster topology single node tests [apigroup:config.openshift.io] Verify that OpenShift components deploy one replica in SingleReplica topology mode": "Verify that OpenShift components deploy one replica in SingleReplica topology mode [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] Cluster topology single node tests Verify that OpenShift components deploy one replica in SingleReplica topology mode": "Verify that OpenShift components deploy one replica in SingleReplica topology mode [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] ClusterOperators [apigroup:config.openshift.io] should define at least one namespace in their lists of related objects": "at least one namespace in their lists of related objects [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] ClusterOperators should define at least one namespace in their lists of related objects": "at least one namespace in their lists of related objects [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] ClusterOperators [apigroup:config.openshift.io] should define at least one related object that is not a namespace": "at least one related object that is not a namespace [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] ClusterOperators should define at least one related object that is not a namespace": "at least one related object that is not a namespace [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] ClusterOperators [apigroup:config.openshift.io] should define valid related objects": "valid related objects [Suite:openshift/conformance/parallel]",
-
-	"[Top Level] [sig-arch] Managed cluster should [apigroup:apps.openshift.io] should expose cluster services outside the cluster [apigroup:route.openshift.io]": "should expose cluster services outside the cluster [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] ClusterOperators should define valid related objects": "valid related objects [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch] Managed cluster should ensure control plane operators do not make themselves unevictable": "ensure control plane operators do not make themselves unevictable [Suite:openshift/conformance/parallel]",
 
@@ -601,15 +599,17 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] Managed cluster should ensure pods use downstream images from our release image with proper ImagePullPolicy": "should ensure pods use downstream images from our release image with proper ImagePullPolicy [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should have operators on the cluster version [apigroup:config.openshift.io]": "have operators on the cluster version [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] Managed cluster should have operators on the cluster version": "have operators on the cluster version [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [apigroup:config.openshift.io]": "should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] Managed cluster should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent": "should only include cluster daemonsets that have maxUnavailable update of 10 or 33 percent [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] Managed cluster should recover when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io]": "when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io] [Serial]",
+	"[Top Level] [sig-arch] Managed cluster should recover when operator-owned objects are deleted [Disruptive]": "when operator-owned objects are deleted [Disruptive] [Serial]",
 
 	"[Top Level] [sig-arch] Managed cluster should set requests but not limits": "should set requests but not limits [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch] [Conformance] FIPS TestFIPS [apigroup:config.openshift.io]": "TestFIPS [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-arch] Managed cluster should should expose cluster services outside the cluster": "should expose cluster services outside the cluster [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-arch] [Conformance] FIPS TestFIPS": "TestFIPS [Suite:openshift/conformance/parallel/minimal]",
 
 	"[Top Level] [sig-arch] [Conformance] sysctl pod should not start for sysctl not on whitelist kernel.msgmax": "kernel.msgmax [Suite:openshift/conformance/parallel/minimal]",
 
@@ -625,13 +625,13 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-arch] [Conformance] sysctl whitelists net.ipv4.tcp_syncookies": "net.ipv4.tcp_syncookies [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-arch] ocp payload should be based on existing source OLM version should contain the source commit id [apigroup:config.openshift.io]": "OLM version should contain the source commit id [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch] ocp payload should be based on existing source OLM version should contain the source commit id": "OLM version should contain the source commit id [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][Early] CRDs for openshift.io should have a status in the CRD schema": "should have a status in the CRD schema [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][Early] CRDs for openshift.io should have subresource.status": "should have subresource.status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-arch][Early] Managed cluster should [apigroup:config.openshift.io] start all core operators": "start all core operators [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-arch][Early] Managed cluster should start all core operators": "start all core operators [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-arch][Feature:ClusterUpgrade] Cluster should remain functional during upgrade [Disruptive]": "Cluster should remain functional during upgrade [Disruptive] [Serial]",
 
@@ -1007,49 +1007,49 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:BootstrapUser] The bootstrap user should successfully login with password decoded from kubeadmin secret [Disruptive]": "should successfully login with password decoded from kubeadmin secret [Disruptive] [Serial]",
 
-	"[Top Level] [sig-auth][Feature:HTPasswdAuth] HTPasswd IDP should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io]": "should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:HTPasswdAuth] HTPasswd IDP should successfully configure htpasswd and be responsive": "should successfully configure htpasswd and be responsive [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:LDAP] LDAP IDP should authenticate against an ldap server [apigroup:user.openshift.io][apigroup:route.openshift.io]": "should authenticate against an ldap server [apigroup:user.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:LDAP] LDAP IDP should authenticate against an ldap server": "should authenticate against an ldap server [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:LDAP] LDAP should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io]": "should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:LDAP] LDAP should start an OpenLDAP test server": "should start an OpenLDAP test server [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]": "can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-auth][Feature:LDAP][Serial] ldap group sync can sync groups from ldap": "can sync groups from ldap [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] ClientSecretWithPlus should create oauthclient [apigroup:config.openshift.io][apigroup:oauth.openshift.io][apigroup:user.openshift.io]": "should create oauthclient [apigroup:config.openshift.io][apigroup:oauth.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] ClientSecretWithPlus should create oauthclient": "should create oauthclient [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth Authenticator accepts sha256 access tokens [apigroup:user.openshift.io][apigroup:oauth.openshift.io]": "accepts sha256 access tokens [apigroup:user.openshift.io][apigroup:oauth.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth Authenticator accepts sha256 access tokens": "accepts sha256 access tokens [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth server has the correct token and certificate fallback semantics [apigroup:config.openshift.io][apigroup:user.openshift.io]": "has the correct token and certificate fallback semantics [apigroup:config.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth server has the correct token and certificate fallback semantics": "has the correct token and certificate fallback semantics [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:OAuthServer] OAuth server should use http1.1 only to prevent http2 connection reuse": "should use http1.1 only to prevent http2 connection reuse [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the authorize URL": "authorize URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the authorize URL": "authorize URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the grant URL": "grant URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the grant URL": "grant URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the login URL for the allow all IDP": "login URL for the allow all IDP [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the login URL for the allow all IDP": "login URL for the allow all IDP [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the login URL for the bootstrap IDP": "login URL for the bootstrap IDP [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the login URL for the bootstrap IDP": "login URL for the bootstrap IDP [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the login URL for when there is only one IDP": "login URL for when there is only one IDP [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the login URL for when there is only one IDP": "login URL for when there is only one IDP [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the logout URL": "logout URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the logout URL": "logout URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the root URL": "root URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the root URL": "root URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the token URL": "token URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the token URL": "token URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io] expected headers returned from the token request URL": "token request URL [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Headers] expected headers returned from the token request URL": "token request URL [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io] to generate tokens that do not expire works as expected when using a code authorization flow [apigroup:user.openshift.io]": "works as expected when using a code authorization flow [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age to generate tokens that do not expire works as expected when using a code authorization flow": "works as expected when using a code authorization flow [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io] to generate tokens that do not expire works as expected when using a token authorization flow [apigroup:user.openshift.io]": "works as expected when using a token authorization flow [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age to generate tokens that do not expire works as expected when using a token authorization flow": "works as expected when using a token authorization flow [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io] to generate tokens that expire shortly works as expected when using a code authorization flow [apigroup:user.openshift.io]": "works as expected when using a code authorization flow [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age to generate tokens that expire shortly works as expected when using a code authorization flow": "works as expected when using a code authorization flow [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age [apigroup:oauth.openshift.io] to generate tokens that expire shortly works as expected when using a token authorization flow [apigroup:user.openshift.io]": "works as expected when using a token authorization flow [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] [Token Expiration] Using a OAuth client with a non-default token max age to generate tokens that expire shortly works as expected when using a token authorization flow": "works as expected when using a token authorization flow [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:OAuthServer] well-known endpoint should be reachable [apigroup:config.openshift.io][apigroup:route.openshift.io]": "should be reachable [apigroup:config.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:OAuthServer] well-known endpoint should be reachable": "should be reachable [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for openshift authz  RunLegacyClusterRoleBindingEndpoint should succeed [apigroup:authorization.openshift.io]": "should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
@@ -1089,19 +1089,19 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:PodSecurity] restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile": "restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestInvalidRoleRefs should succeed [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io]": "should succeed [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestInvalidRoleRefs should succeed": "should succeed [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectIsNamespace should succeed [apigroup:project.openshift.io]": "should succeed [apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectIsNamespace should succeed": "should succeed [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectWatch should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectWatch should succeed": "should succeed [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectWatchWithSelectionPredicate should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]": "should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestProjectWatchWithSelectionPredicate should succeed": "should succeed [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestScopedProjectAccess should succeed [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]": "should succeed [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestScopedProjectAccess should succeed": "should succeed [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestUnprivilegedNewProject [apigroup:project.openshift.io]": "TestUnprivilegedNewProject [apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI]  TestUnprivilegedNewProject": "TestUnprivilegedNewProject [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:ProjectAPI][Serial]  TestUnprivilegedNewProjectDenied [apigroup:authorization.openshift.io][apigroup:project.openshift.io]": "TestUnprivilegedNewProjectDenied [apigroup:authorization.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-auth][Feature:ProjectAPI][Serial]  TestUnprivilegedNewProjectDenied": "TestUnprivilegedNewProjectDenied [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestrictions should be functional  Create a RBAC rolebinding when subject is not already bound and is not permitted by any RBR should fail [apigroup:authorization.openshift.io]": "should fail [apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
@@ -1119,15 +1119,15 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-auth][Feature:SCC][Early] should not have pod creation failures during install": "should not have pod creation failures during install [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]": "TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestAllowedSCCViaRBAC": "TestAllowedSCCViaRBAC [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestPodDefaultCapabilities": "TestPodDefaultCapabilities [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io]": "TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:SecurityContextConstraints]  TestPodUpdateSCCEnforcement": "TestPodUpdateSCCEnforcement [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:UserAPI] groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]": "groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:UserAPI] groups should work": "groups should work [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-auth][Feature:UserAPI] users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]": "users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-auth][Feature:UserAPI] users can manipulate groups": "users can manipulate groups [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-autoscaling] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]": "CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6] [Suite:k8s]",
 
@@ -1631,7 +1631,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] Kubectl client kubectl wait should ignore not found error with --for=delete": "should ignore not found error with --for=delete [Disabled:Broken] [Suite:k8s]",
 
-	"[Top Level] [sig-cli] oc --request-timeout works as expected [apigroup:apps.openshift.io]": "works as expected [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc --request-timeout works as expected": "works as expected [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc adm build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io]": "build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
 
@@ -1641,13 +1641,13 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc adm images [apigroup:image.openshift.io]": "images [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm must-gather runs successfully [apigroup:config.openshift.io]": "runs successfully [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm must-gather runs successfully for audit logs": "runs successfully for audit logs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm must-gather runs successfully for audit logs [apigroup:config.openshift.io][apigroup:oauth.openshift.io]": "runs successfully for audit logs [apigroup:config.openshift.io][apigroup:oauth.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm must-gather runs successfully with options": "runs successfully with options [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm must-gather runs successfully with options [apigroup:config.openshift.io]": "runs successfully with options [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm must-gather runs successfully": "runs successfully [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc adm must-gather when looking at the audit logs [sig-node] kubelet runs apiserver processes strictly sequentially in order to not risk audit log corruption [apigroup:config.openshift.io]": "runs apiserver processes strictly sequentially in order to not risk audit log corruption [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc adm must-gather when looking at the audit logs [sig-node] kubelet runs apiserver processes strictly sequentially in order to not risk audit log corruption": "runs apiserver processes strictly sequentially in order to not risk audit log corruption [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc adm new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io]": "new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel]",
 
@@ -1703,17 +1703,17 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc can run inside of a busybox container": "can run inside of a busybox container [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc debug deployment configs from a build [apigroup:image.openshift.io][apigroup:apps.openshift.io]": "deployment configs from a build [apigroup:image.openshift.io][apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc debug deployment configs from a build": "deployment configs from a build [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc debug dissect deployment config debug [apigroup:apps.openshift.io]": "dissect deployment config debug [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc debug dissect deployment config debug": "dissect deployment config debug [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc debug does not require a real resource on the server": "does not require a real resource on the server [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc debug ensure debug does not depend on a container actually existing for the selected resource [apigroup:apps.openshift.io]": "ensure debug does not depend on a container actually existing for the selected resource [apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc debug ensure debug does not depend on a container actually existing for the selected resource": "ensure debug does not depend on a container actually existing for the selected resource [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc debug ensure it works with image streams [apigroup:image.openshift.io]": "ensure it works with image streams [apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc debug ensure it works with image streams": "ensure it works with image streams [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc env can set environment variables [apigroup:apps.openshift.io][apigroup:build.openshift.io]": "can set environment variables [apigroup:apps.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc env can set environment variables": "can set environment variables [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc explain list uncovered GroupVersionResources": "list uncovered GroupVersionResources [Suite:openshift/conformance/parallel]",
 
@@ -1721,23 +1721,23 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc explain should contain proper fields description for special types": "should contain proper fields description for special types [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc explain should contain proper spec+status for CRDs [apigroup:config.openshift.io]": "should contain proper spec+status for CRDs [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc explain should contain proper spec+status for CRDs": "should contain proper spec+status for CRDs [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc explain should contain spec+status for builtinTypes": "should contain spec+status for builtinTypes [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc expose can ensure the expose command is functioning as expected [apigroup:route.openshift.io]": "can ensure the expose command is functioning as expected [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc expose can ensure the expose command is functioning as expected": "can ensure the expose command is functioning as expected [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc help works as expected [apigroup:user.openshift.io][apigroup:project.openshift.io]": "works as expected [apigroup:user.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc help works as expected": "works as expected [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc label pod": "pod [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc observe works as expected [apigroup:config.openshift.io]": "works as expected [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc observe works as expected": "works as expected [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc probe can ensure the probe command is functioning as expected on deploymentconfigs": "can ensure the probe command is functioning as expected on deploymentconfigs [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc probe can ensure the probe command is functioning as expected on pods": "can ensure the probe command is functioning as expected on pods [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc project --show-labels works for projects [apigroup:project.openshift.io]": "--show-labels works for projects [apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc project --show-labels works for projects": "--show-labels works for projects [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cli] oc rsh specific flags should work well when access to a remote shell": "should work well when access to a remote shell [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
@@ -1747,107 +1747,107 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc statefulset creates and deletes statefulsets": "creates and deletes statefulsets [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc status returns expected help messages [apigroup:project.openshift.io][apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:apps.openshift.io][apigroup:route.openshift.io]": "returns expected help messages [apigroup:project.openshift.io][apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:apps.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc status returns expected help messages": "returns expected help messages [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/authentication.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/authentication.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/authentication.sh": "test/cmd/authentication.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/builds.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/builds.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/builds.sh": "test/cmd/builds.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/completions.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/completions.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/completions.sh": "test/cmd/completions.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/config.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/config.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/config.sh": "test/cmd/config.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/deployments.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/deployments.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/deployments.sh": "test/cmd/deployments.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/describer.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/describer.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/describer.sh": "test/cmd/describer.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/edit.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/edit.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/edit.sh": "test/cmd/edit.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/env.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/env.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/env.sh": "test/cmd/env.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/framework-test.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/framework-test.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/framework-test.sh": "test/cmd/framework-test.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/get.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/get.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/get.sh": "test/cmd/get.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/idle.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/idle.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/idle.sh": "test/cmd/idle.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/image-lookup.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/image-lookup.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/image-lookup.sh": "test/cmd/image-lookup.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/images.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/images.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/images.sh": "test/cmd/images.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/printer.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/printer.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/printer.sh": "test/cmd/printer.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/projects.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/projects.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/projects.sh": "test/cmd/projects.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/quota.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/quota.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/quota.sh": "test/cmd/quota.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/routes.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/routes.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/routes.sh": "test/cmd/routes.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/run.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/run.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/run.sh": "test/cmd/run.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/secrets.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/secrets.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/secrets.sh": "test/cmd/secrets.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/services.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/services.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/services.sh": "test/cmd/services.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/set-data.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/set-data.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/set-data.sh": "test/cmd/set-data.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/set-image.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/set-image.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/set-image.sh": "test/cmd/set-image.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/set-liveness-probe.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/set-liveness-probe.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/set-liveness-probe.sh": "test/cmd/set-liveness-probe.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/setbuildhook.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/setbuildhook.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/setbuildhook.sh": "test/cmd/setbuildhook.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/setbuildsecret.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/setbuildsecret.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/setbuildsecret.sh": "test/cmd/setbuildsecret.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/status.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/status.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/status.sh": "test/cmd/status.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/templates.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/templates.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/templates.sh": "test/cmd/templates.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/triggers.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/triggers.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/triggers.sh": "test/cmd/triggers.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/volumes.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/volumes.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/volumes.sh": "test/cmd/volumes.sh",
 
-	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/whoami.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "test/cmd/whoami.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]",
+	"[Top Level] [sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/whoami.sh": "test/cmd/whoami.sh",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] copy by strategy should copy files with the rsync strategy": "should copy files with the rsync strategy",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods copy by strategy should copy files with the rsync strategy": "should copy files with the rsync strategy",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] copy by strategy should copy files with the rsync-daemon strategy": "should copy files with the rsync-daemon strategy",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods copy by strategy should copy files with the rsync-daemon strategy": "should copy files with the rsync-daemon strategy",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] copy by strategy should copy files with the tar strategy": "should copy files with the tar strategy",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods copy by strategy should copy files with the tar strategy": "should copy files with the tar strategy",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] rsync specific flags should honor multiple --exclude flags": "should honor multiple --exclude flags",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods rsync specific flags should honor multiple --exclude flags": "should honor multiple --exclude flags",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] rsync specific flags should honor multiple --include flags": "should honor multiple --include flags",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods rsync specific flags should honor multiple --include flags": "should honor multiple --include flags",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] rsync specific flags should honor the --exclude flag": "should honor the --exclude flag",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods rsync specific flags should honor the --exclude flag": "should honor the --exclude flag",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] rsync specific flags should honor the --include flag": "should honor the --include flag",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods rsync specific flags should honor the --include flag": "should honor the --include flag",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] rsync specific flags should honor the --no-perms flag": "should honor the --no-perms flag",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods rsync specific flags should honor the --no-perms flag": "should honor the --no-perms flag",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] rsync specific flags should honor the --progress flag": "should honor the --progress flag",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods rsync specific flags should honor the --progress flag": "should honor the --progress flag",
 
-	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] using a watch should watch for changes and rsync them": "should watch for changes and rsync them",
+	"[Top Level] [sig-cli][Slow] can use rsync to upload files to pods using a watch should watch for changes and rsync them": "should watch for changes and rsync them",
 
-	"[Top Level] [sig-cluster-lifecycle] CSRs from machines that are not recognized by the cloud provider are not approved [apigroup:config.openshift.io]": "CSRs from machines that are not recognized by the cloud provider are not approved [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cluster-lifecycle] CSRs from machines that are not recognized by the cloud provider are not approved": "CSRs from machines that are not recognized by the cloud provider are not approved [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle] Pods cannot access the /config/master API endpoint [apigroup:config.openshift.io]": "Pods cannot access the /config/master API endpoint [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cluster-lifecycle] Pods cannot access the /config/master API endpoint": "Pods cannot access the /config/master API endpoint [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-cluster-lifecycle] TestAdminAck should succeed [apigroup:config.openshift.io]": "should succeed [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive] [Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks [apigroup:machine.openshift.io]": "[Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks [apigroup:machine.openshift.io] [Serial]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:DisasterRecovery][Disruptive] [Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks": "[Feature:NodeRecovery] Cluster should survive master and worker failure and recover with machine health checks [Serial]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines] Managed cluster should have machine resources [apigroup:machine.openshift.io]": "have machine resources [apigroup:machine.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines] Managed cluster should have machine resources": "have machine resources [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Disruptive] Managed cluster should recover from deleted worker machines [apigroup:machine.openshift.io]": "recover from deleted worker machines [apigroup:machine.openshift.io] [Serial]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Disruptive] Managed cluster should recover from deleted worker machines": "recover from deleted worker machines [Serial]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should have same number of Machines and Nodes [apigroup:machine.openshift.io]": "have same number of Machines and Nodes [apigroup:machine.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should have same number of Machines and Nodes": "have same number of Machines and Nodes [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]": "grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:30m]": "grow and decrease when scaling different machineSets simultaneously [Timeout:30m] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-coreos] [Conformance] CoreOS bootimages TestBootimagesPresent": "TestBootimagesPresent [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io]": "run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations": "run sample related validations [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should print the usage": "\"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should print the usage",
 
@@ -1957,81 +1957,81 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled  using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8\" should be SCL enabled": "\"image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8\" should be SCL enabled",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][nodejs] test nodejs images with nodejs-rest-http-crud db repo  Building nodejs-postgresql app from new-app should build a nodejs-postgresql image and run it in a pod [apigroup:build.openshift.io]": "should build a nodejs-postgresql image and run it in a pod [apigroup:build.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][nodejs] test nodejs images with nodejs-rest-http-crud db repo  Building nodejs-postgresql app from new-app should build a nodejs-postgresql image and run it in a pod": "should build a nodejs-postgresql image and run it in a pod",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][php] test php images with cakephp-ex db repo  Building cakephp-mysql app from new-app should build a cakephp-mysql image and run it in a pod [apigroup:build.openshift.io]": "should build a cakephp-mysql image and run it in a pod [apigroup:build.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][php] test php images with cakephp-ex db repo  Building cakephp-mysql app from new-app should build a cakephp-mysql image and run it in a pod": "should build a cakephp-mysql image and run it in a pod",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][python] test python images with django-ex db repo  Building django-psql app from new-app should build a django-psql image and run it in a pod [apigroup:build.openshift.io]": "should build a django-psql image and run it in a pod [apigroup:build.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][python] test python images with django-ex db repo  Building django-psql app from new-app should build a django-psql image and run it in a pod": "should build a django-psql image and run it in a pod",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][ruby] test ruby images with rails-ex db repo  Building rails-postgresql app from new-app should build a rails-postgresql image and run it in a pod [apigroup:build.openshift.io]": "should build a rails-postgresql image and run it in a pod [apigroup:build.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][Slow] openshift sample application repositories [sig-devex][Feature:ImageEcosystem][ruby] test ruby images with rails-ex db repo  Building rails-postgresql app from new-app should build a rails-postgresql image and run it in a pod": "should build a rails-postgresql image and run it in a pod",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][mariadb][Slow] openshift mariadb image  Creating from a template should instantiate the template [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:apps.openshift.io]": "should instantiate the template [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:apps.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][mariadb][Slow] openshift mariadb image  Creating from a template should instantiate the template": "should instantiate the template",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][mysql][Slow] openshift mysql image  Creating from a template should instantiate the template [apigroup:apps.openshift.io]": "should instantiate the template [apigroup:apps.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][mysql][Slow] openshift mysql image  Creating from a template should instantiate the template": "should instantiate the template",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][perl][Slow] hot deploy for openshift perl image  hot deploy test should work [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": "should work [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][perl][Slow] hot deploy for openshift perl image  hot deploy test should work": "should work",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][php][Slow] hot deploy for openshift php image  CakePHP example should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]": "should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][php][Slow] hot deploy for openshift php image  CakePHP example should work with hot deploy": "should work with hot deploy",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][python][Slow] hot deploy for openshift python image  Django example should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]": "should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][python][Slow] hot deploy for openshift python image  Django example should work with hot deploy": "should work with hot deploy",
 
-	"[Top Level] [sig-devex][Feature:ImageEcosystem][ruby][Slow] hot deploy for openshift ruby image  Rails example should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]": "should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]",
+	"[Top Level] [sig-devex][Feature:ImageEcosystem][ruby][Slow] hot deploy for openshift ruby image  Rails example should work with hot deploy": "should work with hot deploy",
 
-	"[Top Level] [sig-devex][Feature:OpenShiftControllerManager] TestAutomaticCreationOfPullSecrets [apigroup:config.openshift.io]": "TestAutomaticCreationOfPullSecrets [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:OpenShiftControllerManager] TestAutomaticCreationOfPullSecrets": "TestAutomaticCreationOfPullSecrets [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-devex][Feature:OpenShiftControllerManager] TestDockercfgTokenDeletedController": "TestDockercfgTokenDeletedController [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] template-api TestTemplate [apigroup:template.openshift.io]": "TestTemplate [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] template-api TestTemplate": "TestTemplate [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] template-api TestTemplateTransformationFromConfig [apigroup:template.openshift.io]": "TestTemplateTransformationFromConfig [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] template-api TestTemplateTransformationFromConfig": "TestTemplateTransformationFromConfig [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance creation with invalid object reports error  should report a failure on creation [apigroup:template.openshift.io]": "should report a failure on creation [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance creation with invalid object reports error  should report a failure on creation": "should report a failure on creation [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance cross-namespace test should create and delete objects across namespaces [apigroup:user.openshift.io][apigroup:template.openshift.io]": "should create and delete objects across namespaces [apigroup:user.openshift.io][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance cross-namespace test should create and delete objects across namespaces": "should create and delete objects across namespaces [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests [apigroup:user.openshift.io][apigroup:authorization.openshift.io] should pass impersonation creation tests [apigroup:template.openshift.io]": "should pass impersonation creation tests [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests should pass impersonation creation tests": "should pass impersonation creation tests [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests [apigroup:user.openshift.io][apigroup:authorization.openshift.io] should pass impersonation deletion tests [apigroup:template.openshift.io]": "should pass impersonation deletion tests [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests should pass impersonation deletion tests": "should pass impersonation deletion tests [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests [apigroup:user.openshift.io][apigroup:authorization.openshift.io] should pass impersonation update tests [apigroup:template.openshift.io]": "should pass impersonation update tests [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance impersonation tests should pass impersonation update tests": "should pass impersonation update tests [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance object kinds test should create and delete objects from varying API groups [apigroup:template.openshift.io][apigroup:route.openshift.io]": "should create and delete objects from varying API groups [apigroup:template.openshift.io][apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance object kinds test should create and delete objects from varying API groups": "should create and delete objects from varying API groups [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance readiness test  should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io]": "should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance readiness test  should report failed soon after an annotated objects has failed": "should report failed soon after an annotated objects has failed [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance readiness test  should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io]": "should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance readiness test  should report ready soon after all annotated objects are ready": "should report ready soon after all annotated objects are ready [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateinstance security tests [apigroup:authorization.openshift.io][apigroup:template.openshift.io] should pass security tests [apigroup:route.openshift.io]": "should pass security tests [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateinstance security tests  should pass security tests": "should pass security tests [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker bind test [apigroup:authorization.openshift.io][apigroup:template.openshift.io] should pass bind tests": "should pass bind tests [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker bind test  should pass bind tests": "should pass bind tests [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker end-to-end test [apigroup:template.openshift.io][apigroup:authorization.openshift.io]  should pass an end-to-end test": "should pass an end-to-end test [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker end-to-end test  should pass an end-to-end test": "should pass an end-to-end test [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker security test [apigroup:template.openshift.io][apigroup:authorization.openshift.io]  should pass security tests": "should pass security tests [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-devex][Feature:Templates] templateservicebroker security test  should pass security tests": "should pass security tests [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-etcd] etcd cluster has the same number of master nodes and voting members from the endpoints configmap [Early][apigroup:config.openshift.io]": "cluster has the same number of master nodes and voting members from the endpoints configmap [Early][apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-etcd] etcd cluster has the same number of master nodes and voting members from the endpoints configmap [Early]": "cluster has the same number of master nodes and voting members from the endpoints configmap [Early] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-etcd] etcd leader changes are not excessive [Late][apigroup:config.openshift.io]": "leader changes are not excessive [Late][apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-etcd] etcd leader changes are not excessive [Late]": "leader changes are not excessive [Late] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-etcd] etcd record the start revision of the etcd-operator [Early]": "record the start revision of the etcd-operator [Early] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should recover from a backup taken on one node and recovered on another [apigroup:operator.openshift.io]": "[Feature:EtcdRecovery] Cluster should recover from a backup taken on one node and recovered on another [apigroup:operator.openshift.io] [Serial]",
+	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should recover from a backup taken on one node and recovered on another": "[Feature:EtcdRecovery] Cluster should recover from a backup taken on one node and recovered on another [Serial]",
 
-	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io]": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io] [Serial]",
+	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [Serial]",
 
-	"[Top Level] [sig-etcd][Serial] etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-etcd][Serial] etcd is able to vertically scale up and down with a single node [Timeout:60m]": "is able to vertically scale up and down with a single node [Timeout:60m] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": "should redirect on blob pull [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry] Image registry should redirect on blob pull": "should redirect on blob pull [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageAppend] Image append should create images by appending them [apigroup:image.openshift.io]": "should create images by appending them [apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageAppend] Image append should create images by appending them": "should create images by appending them [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageExtract] Image extract should extract content from an image [apigroup:image.openshift.io]": "should extract content from an image [apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageExtract] Image extract should extract content from an image": "should extract content from an image [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-imageregistry][Feature:ImageInfo] Image info should display information about images": "should display information about images [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageLayers] Image layer subresource should identify a deleted image as missing [apigroup:image.openshift.io]": "should identify a deleted image as missing [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageLayers] Image layer subresource should identify a deleted image as missing": "should identify a deleted image as missing [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageLayers] Image layer subresource should return layers from tagged images [apigroup:image.openshift.io][apigroup:build.openshift.io]": "should return layers from tagged images [apigroup:image.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageLayers] Image layer subresource should return layers from tagged images": "should return layers from tagged images [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-imageregistry][Feature:ImageLookup] Image policy should perform lookup when the Deployment gets the resolve-names annotation later": "should perform lookup when the Deployment gets the resolve-names annotation later [Suite:openshift/conformance/parallel]",
 
@@ -2039,83 +2039,83 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-imageregistry][Feature:ImageLookup] Image policy should update OpenShift object image fields when local names are on": "should update OpenShift object image fields when local names are on [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageLookup] Image policy should update standard Kube object image fields when local names are on [apigroup:image.openshift.io][apigroup:apps.openshift.io]": "should update standard Kube object image fields when local names are on [apigroup:image.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageLookup] Image policy should update standard Kube object image fields when local names are on": "should update standard Kube object image fields when local names are on [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageMirror][Slow] Image mirror mirror image from integrated registry into few external registries [apigroup:image.openshift.io][apigroup:build.openshift.io]": "mirror image from integrated registry into few external registries [apigroup:image.openshift.io][apigroup:build.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImageMirror][Slow] Image mirror mirror image from integrated registry into few external registries": "mirror image from integrated registry into few external registries",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageMirror][Slow] Image mirror mirror image from integrated registry to external registry [apigroup:image.openshift.io][apigroup:build.openshift.io]": "mirror image from integrated registry to external registry [apigroup:image.openshift.io][apigroup:build.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImageMirror][Slow] Image mirror mirror image from integrated registry to external registry": "mirror image from integrated registry to external registry",
 
-	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image hard prune [apigroup:apps.openshift.io][apigroup:user.openshift.io] should delete orphaned blobs [apigroup:image.openshift.io]": "should delete orphaned blobs [apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image hard prune should delete orphaned blobs": "should delete orphaned blobs",
 
-	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image hard prune [apigroup:apps.openshift.io][apigroup:user.openshift.io] should show orphaned blob deletions in dry-run mode [apigroup:image.openshift.io]": "should show orphaned blob deletions in dry-run mode [apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image hard prune should show orphaned blob deletions in dry-run mode": "should show orphaned blob deletions in dry-run mode",
 
-	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune [apigroup:user.openshift.io] of schema 1 should prune old image [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should prune old image [apigroup:build.openshift.io][apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune of schema 1 should prune old image": "should prune old image",
 
-	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune [apigroup:user.openshift.io] of schema 2 should prune old image with config [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should prune old image with config [apigroup:build.openshift.io][apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune of schema 2 should prune old image with config": "should prune old image with config",
 
-	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune [apigroup:user.openshift.io] with --all=false flag should prune only internally managed images [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should prune only internally managed images [apigroup:build.openshift.io][apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune with --all=false flag should prune only internally managed images": "should prune only internally managed images",
 
-	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune [apigroup:user.openshift.io] with --prune-registry==false should prune old image but skip registry [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should prune old image but skip registry [apigroup:build.openshift.io][apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune with --prune-registry==false should prune old image but skip registry": "should prune old image but skip registry",
 
-	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune [apigroup:user.openshift.io] with default --all flag should prune both internally managed and external images [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should prune both internally managed and external images [apigroup:build.openshift.io][apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImagePrune][Serial][Suite:openshift/registry/serial][Local] Image prune with default --all flag should prune both internally managed and external images": "should prune both internally managed and external images",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageQuota] Image resource quota should deny a push of built image exceeding openshift.io/imagestreams quota [apigroup:image.openshift.io]": "should deny a push of built image exceeding openshift.io/imagestreams quota [apigroup:image.openshift.io] [Disabled:SpecialConfig]",
+	"[Top Level] [sig-imageregistry][Feature:ImageQuota] Image resource quota should deny a push of built image exceeding openshift.io/imagestreams quota": "should deny a push of built image exceeding openshift.io/imagestreams quota [Disabled:SpecialConfig]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range [apigroup:config.openshift.io][apigroup:image.openshift.io][apigroup:operator.openshift.io] should deny a container image reference exceeding limit on openshift.io/image-tags resource [apigroup:build.openshift.io]": "should deny a container image reference exceeding limit on openshift.io/image-tags resource [apigroup:build.openshift.io] [Disabled:SpecialConfig]",
+	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range should deny a container image reference exceeding limit on openshift.io/image-tags resource": "should deny a container image reference exceeding limit on openshift.io/image-tags resource [Disabled:SpecialConfig]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range [apigroup:config.openshift.io][apigroup:image.openshift.io][apigroup:operator.openshift.io] should deny a push of built image exceeding limit on openshift.io/images resource [apigroup:build.openshift.io]": "should deny a push of built image exceeding limit on openshift.io/images resource [apigroup:build.openshift.io] [Disabled:SpecialConfig]",
+	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range should deny a push of built image exceeding limit on openshift.io/images resource": "should deny a push of built image exceeding limit on openshift.io/images resource [Disabled:SpecialConfig]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range [apigroup:config.openshift.io][apigroup:image.openshift.io][apigroup:operator.openshift.io] should deny a push of built image exceeding openshift.io/Image limit [apigroup:build.openshift.io]": "should deny a push of built image exceeding openshift.io/Image limit [apigroup:build.openshift.io] [Disabled:SpecialConfig]",
+	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range should deny a push of built image exceeding openshift.io/Image limit": "should deny a push of built image exceeding openshift.io/Image limit [Disabled:SpecialConfig]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range [apigroup:config.openshift.io][apigroup:image.openshift.io][apigroup:operator.openshift.io] should deny an import of a repository exceeding limit on openshift.io/image-tags resource [apigroup:build.openshift.io]": "should deny an import of a repository exceeding limit on openshift.io/image-tags resource [apigroup:build.openshift.io] [Disabled:SpecialConfig]",
+	"[Top Level] [sig-imageregistry][Feature:ImageQuota][Serial][Suite:openshift/registry/serial] Image limit range should deny an import of a repository exceeding limit on openshift.io/image-tags resource": "should deny an import of a repository exceeding limit on openshift.io/image-tags resource [Disabled:SpecialConfig]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API [apigroup:config.openshift.io] TestImportImageFromBlockedRegistry [apigroup:image.openshift.io]": "TestImportImageFromBlockedRegistry [apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API TestImportImageFromBlockedRegistry": "TestImportImageFromBlockedRegistry",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API [apigroup:config.openshift.io] TestImportImageFromInsecureRegistry [apigroup:image.openshift.io]": "TestImportImageFromInsecureRegistry [apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API TestImportImageFromInsecureRegistry": "TestImportImageFromInsecureRegistry",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API [apigroup:config.openshift.io] TestImportRepositoryFromBlockedRegistry [apigroup:image.openshift.io]": "TestImportRepositoryFromBlockedRegistry [apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API TestImportRepositoryFromBlockedRegistry": "TestImportRepositoryFromBlockedRegistry",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API [apigroup:config.openshift.io] TestImportRepositoryFromInsecureRegistry [apigroup:image.openshift.io]": "TestImportRepositoryFromInsecureRegistry [apigroup:image.openshift.io]",
+	"[Top Level] [sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API TestImportRepositoryFromInsecureRegistry": "TestImportRepositoryFromInsecureRegistry",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Annotation trigger reconciles after the image is overwritten [apigroup:image.openshift.io]": "reconciles after the image is overwritten [apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Annotation trigger reconciles after the image is overwritten": "reconciles after the image is overwritten [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestMultipleImageChangeBuildTriggers [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestMultipleImageChangeBuildTriggers [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestMultipleImageChangeBuildTriggers": "TestMultipleImageChangeBuildTriggers [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom": "TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange": "TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker": "TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange": "TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI": "TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]": "TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers] Image change build triggers TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange": "TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream API TestImageStreamMappingCreate [apigroup:image.openshift.io]": "TestImageStreamMappingCreate [apigroup:image.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream API TestImageStreamMappingCreate": "TestImageStreamMappingCreate [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream API TestImageStreamTagLifecycleHook [apigroup:image.openshift.io]": "TestImageStreamTagLifecycleHook [apigroup:image.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream API TestImageStreamTagLifecycleHook": "TestImageStreamTagLifecycleHook [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream API TestImageStreamWithoutDockerImageConfig [apigroup:image.openshift.io]": "TestImageStreamWithoutDockerImageConfig [apigroup:image.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream API TestImageStreamWithoutDockerImageConfig": "TestImageStreamWithoutDockerImageConfig [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream admission TestImageStreamAdmitSpecUpdate [apigroup:image.openshift.io]": "TestImageStreamAdmitSpecUpdate [apigroup:image.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream admission TestImageStreamAdmitSpecUpdate": "TestImageStreamAdmitSpecUpdate [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream admission TestImageStreamAdmitStatusUpdate [apigroup:image.openshift.io]": "TestImageStreamAdmitStatusUpdate [apigroup:image.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream admission TestImageStreamAdmitStatusUpdate": "TestImageStreamAdmitStatusUpdate [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream admission TestImageStreamTagsAdmission [apigroup:image.openshift.io]": "TestImageStreamTagsAdmission [apigroup:image.openshift.io] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream admission TestImageStreamTagsAdmission": "TestImageStreamTagsAdmission [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-imageregistry][Feature:Image] oc tag should change image reference for internal images [apigroup:build.openshift.io][apigroup:image.openshift.io]": "should change image reference for internal images [apigroup:build.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:Image] oc tag should change image reference for internal images": "should change image reference for internal images [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:Image] oc tag should preserve image reference for external images [apigroup:image.openshift.io]": "should preserve image reference for external images [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:Image] oc tag should preserve image reference for external images": "should preserve image reference for external images [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:Image] oc tag should work when only imagestreams api is available [apigroup:image.openshift.io][apigroup:authorization.openshift.io]": "should work when only imagestreams api is available [apigroup:image.openshift.io][apigroup:authorization.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:Image] oc tag should work when only imagestreams api is available": "should work when only imagestreams api is available [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:Image] signature TestImageAddSignature [apigroup:image.openshift.io]": "TestImageAddSignature [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:Image] signature TestImageAddSignature": "TestImageAddSignature [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Feature:Image] signature TestImageRemoveSignature [apigroup:image.openshift.io]": "TestImageRemoveSignature [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-imageregistry][Feature:Image] signature TestImageRemoveSignature": "TestImageRemoveSignature [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-imageregistry][Serial][Suite:openshift/registry/serial] Image signature workflow can push a signed image to openshift registry and verify it [apigroup:user.openshift.io][apigroup:image.openshift.io]": "can push a signed image to openshift registry and verify it [apigroup:user.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-imageregistry][Serial][Suite:openshift/registry/serial] Image signature workflow can push a signed image to openshift registry and verify it": "can push a signed image to openshift registry and verify it [Skipped:Disconnected] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-installer][Feature:baremetal] Baremetal platform should have baremetalhost resources": "have baremetalhost resources [Suite:openshift/conformance/parallel]",
 
@@ -2151,21 +2151,21 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should have a AlertmanagerReceiversNotConfigured alert in firing state": "should have a AlertmanagerReceiversNotConfigured alert in firing state [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should have important platform topology metrics [apigroup:config.openshift.io]": "should have important platform topology metrics [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should have important platform topology metrics": "should have important platform topology metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should have non-Pod host cAdvisor metrics": "should have non-Pod host cAdvisor metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should provide ingress metrics": "should provide ingress metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should provide named network metrics [apigroup:project.openshift.io]": "should provide named network metrics [apigroup:project.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should provide named network metrics": "should provide named network metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should report telemetry if a cloud.openshift.com token is present [Late]": "should report telemetry if a cloud.openshift.com token is present [Late] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io]": "should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster should start and expose a secured proxy and unsecured metrics": "should start and expose a secured proxy and unsecured metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster shouldn't have failing rules evaluation": "shouldn't have failing rules evaluation [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io]": "shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early]": "shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Prometheus when installed on the cluster when using openshift-sdn should be able to get the sdn ovs flows": "should be able to get the sdn ovs flows [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
@@ -2183,29 +2183,29 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster": "shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any unexpected alerts in firing or pending state [apigroup:config.openshift.io]": "shouldn't report any unexpected alerts in firing or pending state [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] Alerts shouldn't report any unexpected alerts in firing or pending state": "shouldn't report any unexpected alerts in firing or pending state [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have a runbook_url annotation if the alert is critical": "should have a runbook_url annotation if the alert is critical [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules should have a runbook_url annotation if the alert is critical": "should have a runbook_url annotation if the alert is critical [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have a valid severity label": "should have a valid severity label [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules should have a valid severity label": "should have a valid severity label [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have description and summary annotations": "should have description and summary annotations [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][Late] OpenShift alerting rules should have description and summary annotations": "should have description and summary annotations [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [apigroup:config.openshift.io][apigroup:build.openshift.io]": "should start and expose a secured proxy and verify build metrics [apigroup:config.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics": "should start and expose a secured proxy and verify build metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io]": "should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service": "should answer A and AAAA queries for a dual-stack service [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": "should answer endpoint and wildcard queries for the cluster [Disabled:Broken]",
 
-	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should be able to connect to a service that is idled because a GET on the route will unidle it [apigroup:config.openshift.io][apigroup:template.openshift.io]": "should be able to connect to a service that is idled because a GET on the route will unidle it [apigroup:config.openshift.io][apigroup:template.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should be able to connect to a service that is idled because a GET on the route will unidle it": "should be able to connect to a service that is idled because a GET on the route will unidle it [Skipped:Disconnected] [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the gRPC interoperability tests [apigroup:config.openshift.io][apigroup:route.openshift.io][apigroup:template.openshift.io]": "should pass the gRPC interoperability tests [apigroup:config.openshift.io][apigroup:route.openshift.io][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the gRPC interoperability tests": "should pass the gRPC interoperability tests [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io] The HAProxy router should pass the h2spec conformance tests [apigroup:config.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:template.openshift.io]": "should pass the h2spec conformance tests [apigroup:config.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the h2spec conformance tests": "should pass the h2spec conformance tests [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router should pass the http2 tests [apigroup:image.openshift.io][apigroup:template.openshift.io]": "should pass the http2 tests [apigroup:image.openshift.io][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel/minimal]",
+	"[Top Level] [sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the http2 tests": "should pass the http2 tests [Suite:openshift/conformance/parallel/minimal]",
 
-	"[Top Level] [sig-network-edge][Feature:Idling] Idling with a single service and DeploymentConfig should idle the service and DeploymentConfig properly [apigroup:apps.openshift.io]": "should idle the service and DeploymentConfig properly [apigroup:apps.openshift.io] [Disabled:Broken]",
+	"[Top Level] [sig-network-edge][Feature:Idling] Idling with a single service and DeploymentConfig should idle the service and DeploymentConfig properly": "should idle the service and DeploymentConfig properly [Disabled:Broken]",
 
 	"[Top Level] [sig-network-edge][Feature:Idling] Idling with a single service and ReplicationController should idle the service and ReplicationController properly": "should idle the service and ReplicationController properly [Suite:openshift/conformance/parallel]",
 
@@ -2761,7 +2761,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services when running openshift ipv4 cluster ensures external ip policy is configured correctly on the cluster [Serial]": "ensures external ip policy is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network] services when running openshift ipv4 cluster on bare metal [apigroup:config.openshift.io] ensures external auto assign cidr is configured correctly on the cluster [Serial]": "ensures external auto assign cidr is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network] services when running openshift ipv4 cluster on bare metal ensures external auto assign cidr is configured correctly on the cluster [Serial]": "ensures external auto assign cidr is configured correctly on the cluster [Serial] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-network] services when using a plugin in a mode that does not isolate namespaces by default should allow connections to pods in different namespaces on different nodes via service IPs": "should allow connections to pods in different namespaces on different nodes via service IPs [Suite:openshift/conformance/parallel]",
 
@@ -2779,69 +2779,69 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] services when using a plugin in a mode that isolates namespaces by default should prevent connections to pods in different namespaces on the same node via service IPs": "should prevent connections to pods in different namespaces on the same node via service IPs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:EgressFirewall] egressFirewall should have no impact outside its namespace [apigroup:config.openshift.io]": "egressFirewall should have no impact outside its namespace [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:EgressFirewall] egressFirewall should have no impact outside its namespace": "egressFirewall should have no impact outside its namespace [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift ovn-kubernetes should ensure egressfirewall is created": "should ensure egressfirewall is created [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift-sdn should ensure egressnetworkpolicy is created [apigroup:network.openshift.io]": "should ensure egressnetworkpolicy is created [apigroup:network.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:EgressFirewall] when using openshift-sdn should ensure egressnetworkpolicy is created": "should ensure egressnetworkpolicy is created [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes]": "EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes]": "EgressIPs can be assigned automatically [Skipped:Network/OVNKubernetes] [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN]": "only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN]": "only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]": "pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure]": "pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure] [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN]": "pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN]": "pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN] [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should keep the assigned EgressIPs when being rescheduled to another node": "pods should keep the assigned EgressIPs when being rescheduled to another node [Serial] [Suite:openshift/conformance/serial]",
+	"[Top Level] [sig-network][Feature:EgressIP] [external-targets] pods should keep the assigned EgressIPs when being rescheduled to another node": "pods should keep the assigned EgressIPs when being rescheduled to another node [Serial] [Suite:openshift/conformance/serial]",
 
-	"[Top Level] [sig-network][Feature:EgressIP][apigroup:config.openshift.io] [internal-targets] EgressIP pods should query hostNetwork pods with the local node's SNAT": "EgressIP pods should query hostNetwork pods with the local node's SNAT [Disabled:Broken] [Serial]",
+	"[Top Level] [sig-network][Feature:EgressIP] [internal-targets] EgressIP pods should query hostNetwork pods with the local node's SNAT": "EgressIP pods should query hostNetwork pods with the local node's SNAT [Disabled:Broken] [Serial]",
 
-	"[Top Level] [sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io]": "should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:EgressRouterCNI] should ensure ipv4 egressrouter cni resources are created": "should ensure ipv4 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io]": "should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created": "should ensure ipv6 egressrouter cni resources are created [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:Multus] should use multus to create net1 device from network-attachment-definition": "should use multus to create net1 device from network-attachment-definition [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Network Policy Audit logging] when using openshift ovn-kubernetes should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io]": "should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Network Policy Audit logging] when using openshift ovn-kubernetes should ensure acl logs are created and correct": "should ensure acl logs are created and correct [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should enable openshift-monitoring to pull metrics": "should enable openshift-monitoring to pull metrics [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router converges when multiple routers are writing conflicting status": "converges when multiple routers are writing conflicting status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should expose a health check on the metrics port": "should expose a health check on the metrics port [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router converges when multiple routers are writing status": "converges when multiple routers are writing status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should expose prometheus metrics for a route [apigroup:route.openshift.io]": "should expose prometheus metrics for a route [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router reports the expected host names in admitted routes' statuses": "reports the expected host names in admitted routes' statuses [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should expose the profiling endpoints": "should expose the profiling endpoints [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should enable openshift-monitoring to pull metrics": "should enable openshift-monitoring to pull metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:image.openshift.io] The HAProxy router should serve a route that points to two services and respect weights": "should serve a route that points to two services and respect weights [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should expose a health check on the metrics port": "should expose a health check on the metrics port [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:operator.openshift.io][apigroup:apps.openshift.io] The HAProxy router should set Forwarded headers appropriately": "should set Forwarded headers appropriately [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should expose prometheus metrics for a route": "should expose prometheus metrics for a route [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:operator.openshift.io][apigroup:apps.openshift.io] The HAProxy router should respond with 503 to unrecognized hosts": "should respond with 503 to unrecognized hosts [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should expose the profiling endpoints": "should expose the profiling endpoints [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:operator.openshift.io][apigroup:apps.openshift.io] The HAProxy router should serve routes that were created from an ingress [apigroup:route.openshift.io]": "should serve routes that were created from an ingress [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should override the route host for overridden domains with a custom value": "should override the route host for overridden domains with a custom value [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router converges when multiple routers are writing conflicting status": "converges when multiple routers are writing conflicting status [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should override the route host with a custom value": "should override the route host with a custom value [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router converges when multiple routers are writing status": "converges when multiple routers are writing status [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should respond with 503 to unrecognized hosts": "should respond with 503 to unrecognized hosts [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io] when FIPS is disabled the HAProxy router should serve routes when configured with a 1024-bit RSA key [apigroup:template.openshift.io]": "should serve routes when configured with a 1024-bit RSA key [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should run even if it has no access to update status": "should run even if it has no access to update status [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io] when FIPS is enabled the HAProxy router should not work when configured with a 1024-bit RSA key [apigroup:template.openshift.io]": "should not work when configured with a 1024-bit RSA key [apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should serve a route that points to two services and respect weights": "should serve a route that points to two services and respect weights [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router reports the expected host names in admitted routes' statuses": "reports the expected host names in admitted routes' statuses [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should serve routes that were created from an ingress": "should serve routes that were created from an ingress [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router should serve the correct routes when running with the haproxy config manager": "should serve the correct routes when running with the haproxy config manager [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should serve the correct routes when running with the haproxy config manager": "should serve the correct routes when running with the haproxy config manager [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io][apigroup:template.openshift.io] The HAProxy router should run even if it has no access to update status [apigroup:image.openshift.io]": "should run even if it has no access to update status [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should serve the correct routes when scoped to a single namespace and label set": "should serve the correct routes when scoped to a single namespace and label set [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:operator.openshift.io][apigroup:apps.openshift.io] The HAProxy router should support reencrypt to services backed by a serving certificate automatically": "should support reencrypt to services backed by a serving certificate automatically [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should set Forwarded headers appropriately": "should set Forwarded headers appropriately [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:template.openshift.io] The HAProxy router should override the route host for overridden domains with a custom value [apigroup:image.openshift.io]": "should override the route host for overridden domains with a custom value [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] The HAProxy router should support reencrypt to services backed by a serving certificate automatically": "should support reencrypt to services backed by a serving certificate automatically [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:template.openshift.io] The HAProxy router should override the route host with a custom value": "should override the route host with a custom value [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] when FIPS is disabled the HAProxy router should serve routes when configured with a 1024-bit RSA key": "should serve routes when configured with a 1024-bit RSA key [Feature:Networking-IPv4] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:template.openshift.io] The HAProxy router should serve the correct routes when scoped to a single namespace and label set": "should serve the correct routes when scoped to a single namespace and label set [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][Feature:Router] when FIPS is enabled the HAProxy router should not work when configured with a 1024-bit RSA key": "should not work when configured with a 1024-bit RSA key [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-network][Feature:Whereabouts] should assign unique IP addresses to each pod in the event of a race condition case": "should assign unique IP addresses to each pod in the event of a race condition case [Suite:openshift/conformance/parallel]",
 
@@ -2859,9 +2859,9 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network][Feature:tuning] pod sysctls should not affect node": "pod sysctls should not affect node [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of EndpointSlices pointing to the cluster or service network": "blocks manual creation of EndpointSlices pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][endpoints] admission blocks manual creation of EndpointSlices pointing to the cluster or service network": "blocks manual creation of EndpointSlices pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of Endpoints pointing to the cluster or service network": "blocks manual creation of Endpoints pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-network][endpoints] admission blocks manual creation of Endpoints pointing to the cluster or service network": "blocks manual creation of Endpoints pointing to the cluster or service network [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined": "can disable an AppArmor profile, using unconfined [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -3203,7 +3203,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] should override timeoutGracePeriodSeconds when annotation is set": "should override timeoutGracePeriodSeconds when annotation is set [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [Local][apigroup:user.openshift.io][apigroup:security.openshift.io]": "should propagate requested groups to the container [Local][apigroup:user.openshift.io][apigroup:security.openshift.io]",
+	"[Top Level] [sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [Local]": "should propagate requested groups to the container [Local]",
 
 	"[Top Level] [sig-node][Late] should not have pod creation failures due to systemd timeouts": "should not have pod creation failures due to systemd timeouts [Suite:openshift/conformance/parallel]",
 
@@ -3221,17 +3221,17 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-operator] OLM should be installed with subscriptions at version v1alpha1": "be installed with subscriptions at version v1alpha1 [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-operator] OLM should have imagePullPolicy:IfNotPresent on thier deployments [apigroup:config.openshift.io]": "have imagePullPolicy:IfNotPresent on thier deployments [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-operator] OLM should have imagePullPolicy:IfNotPresent on thier deployments": "have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-operator] an end user can use OLM Report Upgradeable in OLM ClusterOperators status": "Report Upgradeable in OLM ClusterOperators status [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-operator] an end user can use OLM can subscribe to the operator [apigroup:config.openshift.io]": "can subscribe to the operator [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-operator] an end user can use OLM can subscribe to the operator": "can subscribe to the operator [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-scalability][Feature:Performance] Load cluster should populate the cluster [Slow][Serial][apigroup:template.openshift.io][apigroup:apps.openshift.io][apigroup:build.openshift.io]": "should populate the cluster [Slow][Serial][apigroup:template.openshift.io][apigroup:apps.openshift.io][apigroup:build.openshift.io]",
+	"[Top Level] [sig-scalability][Feature:Performance] Load cluster should populate the cluster [Slow][Serial]": "should populate the cluster [Slow][Serial]",
 
 	"[Top Level] [sig-scalability][Feature:Performance][Serial][Slow] Load cluster concurrently with templates": "concurrently with templates",
 
-	"[Top Level] [sig-scalability][Feature:Performance][Serial][Slow] Mirror cluster it should read the cluster apps [apigroup:apps.openshift.io]": "it should read the cluster apps [apigroup:apps.openshift.io]",
+	"[Top Level] [sig-scalability][Feature:Performance][Serial][Slow] Mirror cluster it should read the cluster apps": "it should read the cluster apps",
 
 	"[Top Level] [sig-scalability][Feature:Performance][Serial][Slow] Mirror cluster it should read the node info": "it should read the node info",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -68,7 +68,7 @@ var (
 			`\[sig-network-edge\]\[Feature:Idling\] Unidling should work with TCP \(while idling\)`,
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=2070929
-			`\[sig-network\]\[Feature:EgressIP\]\[apigroup:config.openshift.io\] \[internal-targets\]`,
+			`\[sig-network\]\[Feature:EgressIP\] \[internal-targets\]`,
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=2093339
 			`\[sig-storage\].* provisioning should provision storage with any volume data source`,


### PR DESCRIPTION
Reverts openshift/origin#27368

[TRT-495](https://issues.redhat.com//browse/TRT-495)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get ci and/or nightly payloads flowing again.

Example: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-ovn-ipv6/1562677330093019136

4.12 nightly payloads appear blocked, I believe because this change renamed HAProxy tests that are explicitly handled in the release repo, most likely here: https://github.com/openshift/release/blob/031c233818f7911be6b10ad058aadd5ff3ad1885/ci-operator/config/openshift/router/openshift-router-master.yaml#L106

Normally we'd ask you to bring this back in by unreverting this change and layering in a separate commit, but in this case the fix is likely required in the release repo. In this case the best course of action would be to unrevert, open the new PR, and run /payload 4.12 nightly blocking. The release repo may need to list *both* new and old test names for a bit so this rolls out smoothly.

CC: @deads2k @ingvagabund 