### PR TITLE
egressip: avoid curl hanging when sending probes

### DIFF
--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1233,7 +1233,7 @@ func sendProbesToHostPort(oc *exutil.CLI, proberPod *v1.Pod, url, targetProtocol
 		go func() {
 			defer wg.Done()
 			time.Sleep(time.Duration(n) * time.Millisecond)
-			output, err := runOcWithRetry(oc.AsAdmin(), "exec", proberPod.Name, "--", "curl", "-s", request)
+			output, err := runOcWithRetry(oc.AsAdmin(), "exec", proberPod.Name, "--", "curl", "--max-time", "15", "-s", request)
 			// Report errors.
 			if err != nil {
 				errChan <- fmt.Errorf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)


### PR DESCRIPTION
Avoids curl hanging and preventing:

- the test to be tear down up properly, making follow up tests to fail
- the retry mechanism in place from happening

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>