### PR TITLE
Remove flake for 40% Secret/ConfigMap growth test.

### DIFF
--- a/pkg/synthetictests/resource_growth.go
+++ b/pkg/synthetictests/resource_growth.go
@@ -116,8 +116,6 @@ func comparePostUpgradeResourceCountFromMetrics(testName, resource string) []*ju
 					Output: output,
 				},
 			},
-			// Add a success test to cause this to be a flake for now until we see how it behaves broadly.
-			{Name: testName},
 		}
 	}
 	return []*junitapi.JUnitTestCase{


### PR DESCRIPTION
1100 runs, this hasn't flaked once, test appears reliable enough to hard
fail if it does happen.

[TRT-454](https://issues.redhat.com//browse/TRT-454)