### PR TITLE
testDuplicatedEventForStableSystem: Deal with absent etcd clusteroperoperator

### DIFF
--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -43,6 +43,9 @@ func TestDuplicatedEvents(t *testing.T) {
 			}
 
 			actual := testDuplicatedEventForStableSystem(events, nil, "unit-test")
+			if actual == nil {
+				return
+			}
 			if !strings.Contains(actual[0].FailureOutput.Output, test.output) {
 				t.Error(spew.Sdump(actual[0]))
 			}


### PR DESCRIPTION

testDuplicatedEventForStableSystem assumes that there is an etcd cluster
operator and will panic the testsuite if there is not. When using an
external controlplane topology, that cluster operator doesn't exist:
https://github.com/openshift/cluster-etcd-operator/commit/b4537b9f59077fddfcbb3bc6e75021376040b715

Deal with this by checking for the controlplane topology and
short-circuit if it is external.

Sample of such a panic:

```
goroutine 1 [running]:
github.com/openshift/origin/pkg/synthetictests.testDuplicatedEventForStableSystem({0xc020380000, 0x1248c, 0x1405d}, 0xc00b97da00?, {0x82bfe96?, 0x26e4632?})
	github.com/openshift/origin/pkg/synthetictests/duplicated_events.go:266 +0x4de
github.com/openshift/origin/pkg/synthetictests.StableSystemEventInvariants({0xc020380000, 0x1248c, 0x1405d}, 0x73d?, 0x0?, {0x82bfe96, 0x1e}, 0x1?)
	github.com/openshift/origin/pkg/synthetictests/event_junits.go:30 +0xb9d
github.com/openshift/origin/pkg/test/ginkgo.JUnitForEventsFunc.JUnitsForEvents(0x702b480?, {0xc020380000?, 0xc02a0b4c20?, 0xc00ba44308?}, 0xc0139a4000?, 0x721c520?, {0x82bfe96?, 0x7214ce0?}, 0xc0076b3be0?)
	github.com/openshift/origin/pkg/test/ginkgo/synthentic_tests.go:30 +0x43
github.com/openshift/origin/pkg/test/ginkgo.JUnitsForAllEvents.JUnitsForEvents({0xc00be693d8?, 0x2, 0x7ffd07a85517?}, {0xc020380000, 0x1248c, 0x1405d}, 0x1?, 0x1?, {0x82bfe96, 0x1e}, ...)
	github.com/openshift/origin/pkg/test/ginkgo/synthentic_tests.go:43 +0x103
github.com/openshift/origin/pkg/test/ginkgo.(*Options).Run(0xc0001c22a0, 0xc1cde90, {0x824546e, 0xf})
	github.com/openshift/origin/pkg/test/ginkgo/cmd_runsuite.go:433 +0x2c0f
main.newRunCommand.func1.1()
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:320 +0x2d4
main.mirrorToFile(0xc0001c22a0, 0xc0020bfbc0)
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:470 +0x653
main.newRunCommand.func1(0xc001b39400?, {0xc000bfb960?, 0x7?, 0x7?})
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:301 +0x5c
github.com/spf13/cobra.(*Command).execute(0xc001b39400, {0xc000bfb8f0, 0x7, 0x7})
	github.com/spf13/cobra@v1.4.0/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc001b39180)
	github.com/spf13/cobra@v1.4.0/command.go:974 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.4.0/command.go:902
main.main.func1(0xc000270900?)
	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:94 +0x8a
```

Link to a job where this happened: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-conformance-aws-ovn-4-12/1564197041410674688