### PR TITLE
Address exceeded maximum resolution of 11,000 points per timeseries

### DIFF
--- a/pkg/monitor/alerts.go
+++ b/pkg/monitor/alerts.go
@@ -120,7 +120,7 @@ func FetchEventIntervalsForAllAlerts(ctx context.Context, restConfig *rest.Confi
 	timeRange := prometheusv1.Range{
 		Start: startTime,
 		End:   time.Now(),
-		Step:  1 * time.Second,
+		Step:  2 * time.Second,
 	}
 	alerts, warningsForQuery, err := prometheusClient.QueryRange(ctx, `ALERTS{alertstate="firing"}`, timeRange)
 	if err != nil {


### PR DESCRIPTION
Re: [TRT-504](https://issues.redhat.com//browse/TRT-504)

Followup to [PR27319](https://github.com/openshift/origin/pull/27319/files) where we set the resolution down to 2 seconds from 1 for tests that exceed 3 hours.  There were two places to change and I only caught one at the time; this [test failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-e2e-aws-sdn-serial/1564469492770148352) found the other.

```
Suite run returned error: AlertErr: bad_data: exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)
```