### PR TITLE
skip route-controller-manager scaling events in build testsuite

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -185,9 +185,16 @@ var knownEventsBugs = []knownProblem{
 		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
 		Topology: topologyPointer(v1.SingleReplicaTopologyMode),
 	},
+	// builds tests trigger many changes in the config which creates new rollouts -> event for each pod
+	// working as intended (not a bug) and needs to be tolerated
+	{
+		Regexp:    regexp.MustCompile(`ns/openshift-route-controller-manager deployment/route-controller-manager - reason/ScalingReplicaSet \(combined from similar events\): Scaled (down|up) replica set route-controller-manager-[a-z0-9-]+ to [0-9]+`),
+		TestSuite: stringPointer("openshift/build"),
+	},
+	// builds tests trigger many changes in the config which creates new rollouts -> event for each pod
+	// working as intended (not a bug) and needs to be tolerated
 	{
 		Regexp:    regexp.MustCompile(`ns/openshift-controller-manager daemonset/controller-manager - reason/SuccessfulDelete \(combined from similar events\): Deleted pod: controller-manager-[a-z0-9-]+`),
-		BZ:        "https://bugzilla.redhat.com/show_bug.cgi?id=2034984",
 		TestSuite: stringPointer("openshift/build"),
 	},
 	//{ TODO this should only be skipped for single-node


### PR DESCRIPTION
Skips events that are triggered by the build tests: https://search.ci.openshift.org/?search=ns%2Fopenshift-route-controller-manager+deployment%2Froute-controller-manager&maxAge=336h&context=1&type=junit&name=pull-ci-openshift-origin-master-e2e-gcp-builds&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job 

more background in relevant issues: 
- https://issues.redhat.com/browse/BUILD-495
- https://bugzilla.redhat.com/show_bug.cgi?id=2034984
