### PR TITLE
Add trozet to networking approvers

### DIFF
--- a/test/extended/networking/OWNERS
+++ b/test/extended/networking/OWNERS
@@ -3,6 +3,7 @@ reviewers:
   - squeed
   - dcbw
   - danwinship
+  - trozet
 approvers:
   - smarterclayton
   - bparees
@@ -12,4 +13,5 @@ approvers:
   - squeed
   - dcbw
   - danwinship
+  - trozet
   - adambkaplan


### PR DESCRIPTION
I don't know if I have the rights to open this PR (I normally don't do these kind of PRs), but currently we don't have very many on the OVNK-origin side who can approve things including our team lead :) So thought of adding Tim to the list so that we can get some test PRs approved within the team.

/cc @dcbw @knobunc  for approval.