### PR TITLE
OCPBUGS-559: update signature of mapiterinit of go 1.18

### DIFF
--- a/vendor/github.com/modern-go/reflect2/unsafe_link.go
+++ b/vendor/github.com/modern-go/reflect2/unsafe_link.go
@@ -19,7 +19,7 @@ func typedslicecopy(elemType unsafe.Pointer, dst, src sliceHeader) int
 
 //go:linkname mapassign reflect.mapassign
 //go:noescape
-func mapassign(rtype unsafe.Pointer, m unsafe.Pointer, key, val unsafe.Pointer)
+func mapassign(rtype unsafe.Pointer, m unsafe.Pointer, key unsafe.Pointer, val unsafe.Pointer)
 
 //go:linkname mapaccess reflect.mapaccess
 //go:noescape
@@ -29,7 +29,7 @@ func mapaccess(rtype unsafe.Pointer, m unsafe.Pointer, key unsafe.Pointer) (val 
 // doesn't let the return value escape.
 //go:noescape
 //go:linkname mapiterinit reflect.mapiterinit
-func mapiterinit(rtype unsafe.Pointer, m unsafe.Pointer) *hiter
+func mapiterinit(rtype unsafe.Pointer, m unsafe.Pointer, it *hiter)
 
 //go:noescape
 //go:linkname mapiternext reflect.mapiternext
@@ -42,9 +42,21 @@ func ifaceE2I(rtype unsafe.Pointer, src interface{}, dst unsafe.Pointer)
 // If you modify hiter, also change cmd/internal/gc/reflect.go to indicate
 // the layout of this structure.
 type hiter struct {
-	key   unsafe.Pointer // Must be in first position.  Write nil to indicate iteration end (see cmd/internal/gc/range.go).
-	value unsafe.Pointer // Must be in second position (see cmd/internal/gc/range.go).
-	// rest fields are ignored
+	key         unsafe.Pointer
+	value       unsafe.Pointer
+	t           unsafe.Pointer
+	h           unsafe.Pointer
+	buckets     unsafe.Pointer
+	bptr        unsafe.Pointer
+	overflow    *[]unsafe.Pointer
+	oldoverflow *[]unsafe.Pointer
+	startBucket uintptr
+	offset      uint8
+	wrapped     bool
+	B           uint8
+	i           uint8
+	bucket      uintptr
+	checkBucket uintptr
 }
 
 // add returns p+x.

--- a/vendor/github.com/modern-go/reflect2/unsafe_map.go
+++ b/vendor/github.com/modern-go/reflect2/unsafe_map.go
@@ -108,8 +108,10 @@ func (type2 *UnsafeMapType) Iterate(obj interface{}) MapIterator {
 }
 
 func (type2 *UnsafeMapType) UnsafeIterate(obj unsafe.Pointer) MapIterator {
+	var it hiter
+	mapiterinit(type2.rtype, *(*unsafe.Pointer)(obj), &it)
 	return &UnsafeMapIterator{
-		hiter:      mapiterinit(type2.rtype, *(*unsafe.Pointer)(obj)),
+		hiter:      &it,
 		pKeyRType:  type2.pKeyRType,
 		pElemRType: type2.pElemRType,
 	}


### PR DESCRIPTION
To pull https://github.com/modern-go/reflect2/pull/25. Otherwise running `oc login` produces panic when build with go >= 1.18:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4145bc]

goroutine 1 [running]:
reflect.mapiternext(0x40?)
	/usr/lib/golang/src/runtime/map.go:1378 +0x19
github.com/openshift/origin/vendor/github.com/modern-go/reflect2.(*UnsafeMapIterator).UnsafeNext(0x0?)
	/builddir/build/BUILD/origin-20c5b86c88657888e4906ed7942b85515c650f96/_output/local/go/src/github.com/openshift/origin/vendor/github.com/modern-go/reflect2/unsafe_map.go:136 +0x32
...
```

Running `glide up` over release-3.11 head produces changes in the vendor directory. Meaning the glide has not been used for a while. Thus, updating the vendor directory without it.