### PR TITLE
Automatically skip tests with apigroups which are not served

### DIFF
--- a/pkg/test/ginkgo/group_filter.go
+++ b/pkg/test/ginkgo/group_filter.go
@@ -2,6 +2,7 @@ package ginkgo
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
@@ -45,8 +46,11 @@ func newApiGroupFilter(discoveryClient *discovery.DiscoveryClient) (*apiGroupFil
 func (agf *apiGroupFilter) markSkippedWhenAPIGroupNotServed(tests []*testCase) {
 	for _, test := range tests {
 		if !agf.apiGroups.HasAll(test.apigroups...) {
+			missingAPIGroups := sets.NewString(test.apigroups...).Difference(agf.apiGroups)
 			test.skipped = true
+			test.out = []byte(fmt.Sprintf("skipped because the following required API groups are missing: %v", strings.Join(missingAPIGroups.List(), ",")))
 			continue
 		}
 	}
+
 }

--- a/pkg/test/ginkgo/group_filter.go
+++ b/pkg/test/ginkgo/group_filter.go
@@ -1,0 +1,52 @@
+package ginkgo
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func getDiscoveryClient() (*discovery.DiscoveryClient, error) {
+	cfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	clusterConfig, err := cfg.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("could not load client configuration: %v", err)
+	}
+
+	return discovery.NewDiscoveryClientForConfig(clusterConfig)
+}
+
+type apiGroupFilter struct {
+	apiGroups sets.String
+}
+
+func newApiGroupFilter(discoveryClient *discovery.DiscoveryClient) (*apiGroupFilter, error) {
+	// Check if the groups is served by the server
+	groups, err := discoveryClient.ServerGroups()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve served resources: %v", err)
+	}
+	apiGroups := sets.NewString()
+	for _, apiGroup := range groups.Groups {
+		// ignore the empty group
+		if apiGroup.Name == "" {
+			continue
+		}
+		apiGroups.Insert(apiGroup.Name)
+	}
+
+	return &apiGroupFilter{
+		apiGroups: apiGroups,
+	}, nil
+}
+
+func (agf *apiGroupFilter) markSkippedWhenAPIGroupNotServed(tests []*testCase) {
+	for _, test := range tests {
+		if !agf.apiGroups.HasAll(test.apigroups...) {
+			test.skipped = true
+			continue
+		}
+	}
+}

--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -143,6 +143,10 @@ func (s *testStatus) Run(ctx context.Context, test *testCase) {
 		Locator: monitorapi.E2ETestLocator(test.name),
 		Message: "started",
 	})
+	// if the test was already marked as skipped, skip it.
+	if test.skipped {
+		return
+	}
 	defer s.finalizeTest(test)
 
 	test.start = time.Now()

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -15,9 +15,10 @@ import (
 )
 
 type testCase struct {
-	name     string
-	spec     ginkgoSpec
-	location types.CodeLocation
+	name      string
+	spec      ginkgoSpec
+	location  types.CodeLocation
+	apigroups []string
 
 	// identifies which tests can be run in parallel (ginkgo runs suites linearly)
 	testExclusion string
@@ -47,6 +48,15 @@ func newTestCase(spec ginkgoSpec) (*testCase, error) {
 		name:     name,
 		spec:     spec,
 		location: summary.ComponentCodeLocations[len(summary.ComponentCodeLocations)-1],
+	}
+
+	matches := regexp.MustCompile(`\[apigroup:([^]]*)\]`).FindAllStringSubmatch(name, -1)
+	for _, match := range matches {
+		if len(match) < 2 {
+			return nil, fmt.Errorf("regexp match %v is invalid: len(match) < 2", match)
+		}
+		apigroup := match[1]
+		tc.apigroups = append(tc.apigroups, apigroup)
 	}
 
 	re := regexp.MustCompile(`.*\[Timeout:(.[^\]]*)\]`)


### PR DESCRIPTION
Excluding tests with [apigroup:GROUP] labels for apigroups which are not served by a cluster. E.g. MicroShift is not serving most of the openshift.io apigroups. Other installations might be serving only a subset of the api groups.

jira: https://issues.redhat.com/browse/WRKLDS-488