### PR TITLE
Add a test case to find job name/cluster version mismatches

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1515,6 +1515,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-builds][Feature:JenkinsRHELImagesOnly][Feature:Jenkins][Feature:Builds][sig-devex][Slow] openshift pipeline build  jenkins pipeline build config strategy using a jenkins instance launched with the ephemeral template [apigroup:build.openshift.io]": "using a jenkins instance launched with the ephemeral template [apigroup:build.openshift.io]",
 
+	"[Top Level] [sig-ci] [Early] prow job name should match cluster version [apigroup:config.openshift.io]": "should match cluster version [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-ci] [Early] prow job name should match network type [apigroup:config.openshift.io]": "should match network type [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-ci] [Early] prow job name should match platform type [apigroup:config.openshift.io]": "should match platform type [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
[TRT-541](https://issues.redhat.com//browse/TRT-541)

We have at least one case of a job saying it's 4.11 but actually deploying 4.12. I don't think we can get a perfect test to cover this, but for periodics we can at least check that if a job name mentions a version, that exists in the cluster version history.

There are jobs that mention versions that aren't openshift which will be problematic, but this is just flaking for now until we figure out how to deal with those.