### PR TITLE
OCPBUGS-1237: Fix s2i ruby test that relys on rack

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -18973,6 +18973,7 @@ func testExtendedTestdataBuildsS2iEnvironmentBuildAppS2iEnvironment() (*asset, e
 var _testExtendedTestdataBuildsS2iEnvironmentBuildAppGemfile = []byte(`source "https://rubygems.org"
 
 gem "rack"
+gem "rackup"
 `)
 
 func testExtendedTestdataBuildsS2iEnvironmentBuildAppGemfileBytes() ([]byte, error) {

--- a/test/extended/testdata/builds/s2i-environment-build-app/Gemfile
+++ b/test/extended/testdata/builds/s2i-environment-build-app/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "rack"
+gem "rackup"


### PR DESCRIPTION
This test is failing in CI:

```
[sig-builds][Feature:Builds][Slow] s2i build with environment file in
sources Building from a template should create a image from
"test-env-build.json" template and run it in a pod
[apigroup:build.openshift.io][apigroup:image.openshift.io]
```

The error output from the container is:

```
2022-09-13 09:52:05	       Add rack to your Gemfile in order to start the web server.
2022-09-13 09:52:05	 ERROR: Rubygem Rack is not installed in the present image.
2022-09-13 09:52:05	 You might consider adding 'puma' into your Gemfile.
```

This is coming from https://github.com/sclorg/s2i-ruby-container/blob/master/2.2/s2i/bin/assemble#L52, which is trying to execute `rackup`.

In https://github.com/rack/rack/pull/1937, rackup was moved to a different gem.

This adds "rackup" gem.