### PR TITLE
add retry for checkLADPConn

### DIFF
--- a/test/extended/util/ldap.go
+++ b/test/extended/util/ldap.go
@@ -15,6 +15,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
@@ -155,10 +156,22 @@ func CreateLDAPTestServer(oc *CLI) (svcNs, svcName, svcHostname string, caPem []
 		return "", "", "", nil, fmt.Errorf("replica for %s not avaiable: %v", serverDeployment.Name, err)
 	}
 
-	// Confirm ldap server availability. Since the ldap client does not support SNI, a TLS passthrough route will not
-	// work, so we need to talk to the server over the service network.
-	if err := checkLDAPConn(oc, svcHostname); err != nil {
-		return "", "", "", nil, err
+	// OCPBUGS-1053 add retry to see if periodic failures are intermittent
+	const maxAttempts int = 3
+	for i := 0; i < maxAttempts; i++ {
+
+		// Confirm ldap server availability. Since the ldap client does not support SNI, a TLS passthrough route will not
+		// work, so we need to talk to the server over the service network.
+		if err := checkLDAPConn(oc, svcHostname); err != nil {
+			if i >= maxAttempts-1 {
+				e2e.Logf("checkLDAPConn failed for svcHostName '%s', exhausted retry attempts", svcHostname)
+				return "", "", "", nil, err
+			}
+			e2e.Logf("checkLDAPConn failed for svcHostName '%s', will retry", svcHostname)
+			time.Sleep(time.Duration(i) * time.Second)
+		} else {
+			break
+		}
 	}
 
 	return


### PR DESCRIPTION
In OCPBUGS-1053 we see failures from the runonce-ldapsearch-pod trying to verify the server is active.  
The server pod indicates it is active
`openldap-server-6dbdf9dbbd-wjzfm  ip-10-0-167-146.us-east-2.compute.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2022-09-12 18:11:40 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2022-09-12 18:11:48 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 2022-09-12 18:11:48 +0000 UTC  }`

So we are adding a retry loop to try again / see if the error is persistent or not