### PR TITLE
feat: query data update

### DIFF
--- a/pkg/synthetictests/allowedalerts/query_results.json
+++ b/pkg/synthetictests/allowedalerts/query_results.json
@@ -19,7 +19,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -30,7 +41,29 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.8399999999999963"
+    "P99": "54.099999999999987"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -58,6 +91,17 @@
     "AlertName": "KubeAPIErrorBudgetBurn",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -74,7 +118,29 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.51"
+    "P99": "0.93999999999999906"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -85,7 +151,29 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.8399999999999963"
+    "P99": "54.099999999999987"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -95,6 +183,17 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -107,7 +206,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.1299999999999963"
+    "P99": "2.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -118,7 +217,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "2.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -129,7 +228,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.4199999999999986"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -162,7 +272,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.0399999999999983"
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -178,13 +288,13 @@
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
     "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "3.0"
+    "P99": "2.4499999999999993"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -192,16 +302,60 @@
     "FromRelease": "",
     "Platform": "",
     "Architecture": "amd64",
-    "Network": "ovn",
+    "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.5399999999999996"
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "1.3399999999999976"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "2.5699999999999994"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -212,61 +366,6 @@
     "AlertName": "KubeAPIErrorBudgetBurn",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeAPIErrorBudgetBurn",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "0.0",
-    "P99": "1.3499999999999985"
-  },
-  {
-    "AlertName": "KubeAPIErrorBudgetBurn",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeAPIErrorBudgetBurn",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "1.2599999999999993"
-  },
-  {
-    "AlertName": "KubeAPIErrorBudgetBurn",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "2.4099999999999984"
-  },
-  {
-    "AlertName": "KubeAPIErrorBudgetBurn",
-    "Release": "4.12",
-    "FromRelease": "",
     "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -282,8 +381,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.3899999999999979"
+    "P95": "2.0",
+    "P99": "3.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -324,10 +423,21 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
-    "Network": "sdn",
+    "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeAPIErrorBudgetBurn",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "2.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -338,7 +448,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "2.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -348,8 +458,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "1.0999999999999921",
-    "P99": "3.1099999999999994"
+    "P95": "0.0",
+    "P99": "1.9799999999999982"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -371,7 +481,7 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "1.3499999999999985"
+    "P99": "1.3399999999999976"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -383,17 +493,6 @@
     "Topology": "ha",
     "P95": "2.0",
     "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeAPIErrorBudgetBurn",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "0.0",
-    "P99": "0.0"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -404,7 +503,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "6.1499999999999995"
+    "P99": "6.589999999999999"
   },
   {
     "AlertName": "KubeAPIErrorBudgetBurn",
@@ -415,7 +514,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "6.1499999999999995"
+    "P99": "6.589999999999999"
   },
   {
     "AlertName": "KubeClientErrors",
@@ -445,10 +544,43 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "1.2999999999999816",
+    "P95": "0.0",
     "P99": "2.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1.0999999999999992",
+    "P99": "1.8199999999999998"
   },
   {
     "AlertName": "KubeClientErrors",
@@ -476,83 +608,6 @@
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
     "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "2.51"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.2999999999999816",
-    "P99": "2.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "1.109999999999993"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "2.2499999999999982",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
     "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "sdn",
@@ -563,7 +618,7 @@
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
-    "FromRelease": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -574,31 +629,20 @@
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
-    "FromRelease": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.109999999999993"
+    "P99": "0.93999999999999906"
   },
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -607,72 +651,226 @@
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "1.849999999999999",
-    "P99": "2.7699999999999996"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.2699999999999996"
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "2.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
+    "P95": "0.0",
+    "P99": "2.0"
   },
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.12",
     "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "2.0",
     "P99": "2.63"
   },
   {
     "AlertName": "KubeClientErrors",
     "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "2.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "1.4899999999999995"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
     "FromRelease": "",
     "Platform": "azure",
     "Architecture": "amd64",
@@ -690,7 +888,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.3299999999999983"
+    "P99": "3.0"
   },
   {
     "AlertName": "KubeClientErrors",
@@ -700,7 +898,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.9499999999999886",
+    "P95": "3.0",
     "P99": "4.0"
   },
   {
@@ -734,112 +932,244 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.9899999999999993"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "6.0",
+    "P99": "8.5899999999999981"
+  },
+  {
+    "AlertName": "KubeClientErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "6.0",
+    "P99": "8.5899999999999981"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
     "P99": "4.0"
   },
   {
-    "AlertName": "KubeClientErrors",
+    "AlertName": "KubePersistentVolumeErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "4.1099999999999994"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "5.7499999999999964",
-    "P99": "7.1499999999999995"
-  },
-  {
-    "AlertName": "KubeClientErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "5.7499999999999964",
-    "P99": "7.1499999999999995"
+    "P99": "0.0"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
     "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -851,6 +1181,39 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
@@ -860,7 +1223,18 @@
   {
     "AlertName": "KubePersistentVolumeErrors",
     "Release": "4.12",
-    "FromRelease": "4.11",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "sdn",
@@ -871,116 +1245,50 @@
   {
     "AlertName": "KubePersistentVolumeErrors",
     "Release": "4.12",
-    "FromRelease": "4.11",
+    "FromRelease": "4.12",
     "Platform": "azure",
     "Architecture": "amd64",
-    "Network": "sdn",
+    "Network": "ovn",
     "Topology": "ha",
-    "P95": "0.0",
+    "P95": "2.0",
     "P99": "3.0"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
     "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
+    "FromRelease": "4.12",
+    "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
+    "P95": "0.0",
+    "P99": "3.6299999999999981"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.7499999999999991",
     "P99": "4.0"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
     "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "0.0",
-    "P99": "0.64999999999999969"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.75"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "metal",
     "Architecture": "amd64",
@@ -1010,17 +1318,6 @@
     "Topology": "ha",
     "P95": "2.0",
     "P99": "3.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "2.0"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1030,8 +1327,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
+    "P95": "0.49999999999999512",
+    "P99": "3.0"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1042,7 +1339,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "0.5399999999999987"
+    "P99": "0.0"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1074,7 +1371,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "1.0",
+    "P95": "2.0",
     "P99": "3.0"
   },
   {
@@ -1085,8 +1382,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.1499999999999986",
-    "P99": "3.0"
+    "P95": "0.0",
+    "P99": "2.5699999999999994"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1096,8 +1393,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.099999999999985878",
-    "P99": "3.0"
+    "P95": "3.0",
+    "P99": "1763.76"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1106,17 +1403,6 @@
     "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.6499999999999924",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "3.0",
     "P99": "3.0"
@@ -1125,12 +1411,23 @@
     "AlertName": "KubePersistentVolumeErrors",
     "Release": "4.12",
     "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "4.0"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "1.8299999999999972"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1150,6 +1447,17 @@
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.36999999999999678"
+  },
+  {
+    "AlertName": "KubePersistentVolumeErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "2.0"
@@ -1173,7 +1481,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "0.0",
+    "P95": "2.0",
     "P99": "3.0"
   },
   {
@@ -1185,7 +1493,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "3.1099999999999994"
+    "P99": "3.9899999999999993"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1217,19 +1525,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "1.0",
+    "P95": "2.0",
     "P99": "3.0"
-  },
-  {
-    "AlertName": "KubePersistentVolumeErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "0.0",
-    "P99": "0.0"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1240,7 +1537,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.8999999999999955"
+    "P99": "7.1799999999999979"
   },
   {
     "AlertName": "KubePersistentVolumeErrors",
@@ -1251,7 +1548,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.8999999999999955"
+    "P99": "7.1799999999999979"
   },
   {
     "AlertName": "MCDDrainError",
@@ -1281,8 +1578,41 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1312,6 +1642,17 @@
     "AlertName": "MCDDrainError",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -1324,6 +1665,28 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -1344,11 +1707,44 @@
   {
     "AlertName": "MCDDrainError",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1383,7 +1779,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "MCDDrainError",
@@ -1425,17 +1832,6 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "MCDDrainError",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
@@ -1578,6 +1974,17 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "MCDDrainError",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -1635,17 +2042,6 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "MCDDrainError",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1679,17 +2075,6 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "132.74999999999997",
-    "P99": "168.15"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1698,28 +2083,6 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
@@ -1730,249 +2093,7 @@
     "AlertName": "PrometheusOperatorWatchErrors",
     "Release": "4.12",
     "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.11",
     "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "0.0",
-    "P99": "0.64999999999999969"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.81999999999999718"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "2.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
@@ -1982,7 +2103,84 @@
   {
     "AlertName": "PrometheusOperatorWatchErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
@@ -1993,7 +2191,7 @@
   {
     "AlertName": "PrometheusOperatorWatchErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
     "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
@@ -2004,18 +2202,7 @@
   {
     "AlertName": "PrometheusOperatorWatchErrors",
     "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "PrometheusOperatorWatchErrors",
-    "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
     "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
@@ -2026,9 +2213,42 @@
   {
     "AlertName": "PrometheusOperatorWatchErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
@@ -2037,20 +2257,119 @@
   {
     "AlertName": "PrometheusOperatorWatchErrors",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.12",
     "Platform": "aws",
-    "Architecture": "arm64",
+    "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.24999999999999667"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "PrometheusOperatorWatchErrors",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -2061,8 +2380,19 @@
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
     "Topology": "single",
     "P95": "2.0",
     "P99": "3.0"
@@ -2071,12 +2401,177 @@
     "AlertName": "PrometheusOperatorWatchErrors",
     "Release": "4.12",
     "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.089999999999997415"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "PrometheusOperatorWatchErrors",
+    "Release": "4.12",
+    "FromRelease": "",
     "Platform": "libvirt",
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "0.599999999999997"
+    "P99": "0.0"
   },
   {
     "AlertName": "PrometheusOperatorWatchErrors",
@@ -2087,7 +2582,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "0.599999999999997"
+    "P99": "0.0"
   },
   {
     "AlertName": "VSphereOpenshiftNodeHealthFail",
@@ -2117,8 +2612,41 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2148,6 +2676,17 @@
     "AlertName": "VSphereOpenshiftNodeHealthFail",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -2160,6 +2699,28 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -2180,11 +2741,44 @@
   {
     "AlertName": "VSphereOpenshiftNodeHealthFail",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2219,7 +2813,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "VSphereOpenshiftNodeHealthFail",
@@ -2261,17 +2866,6 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "VSphereOpenshiftNodeHealthFail",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
@@ -2414,6 +3008,17 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "VSphereOpenshiftNodeHealthFail",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -2471,17 +3076,6 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "VSphereOpenshiftNodeHealthFail",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2526,8 +3120,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4.2999999999999616",
-    "P99": "310.3399999999998"
+    "P95": "3.0",
+    "P99": "88.0"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2.2499999999999991",
+    "P99": "2.8499999999999996"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2537,8 +3142,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.0",
-    "P99": "170.7999999999999"
+    "P95": "3.0",
+    "P99": "4.3699999999999974"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "179.49999999999983",
+    "P99": "320.7"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1099.9999999999995",
+    "P99": "1412.0"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2548,8 +3175,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "149.0",
-    "P99": "380.75999999999965"
+    "P95": "178.99999999999997",
+    "P99": "423.59999999999991"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2559,8 +3186,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4.0",
-    "P99": "305.31999999999971"
+    "P95": "5.0",
+    "P99": "208.65"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "113.59999999999991"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2571,7 +3209,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.829999999999999"
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2581,8 +3219,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.51"
+    "P95": "2.3499999999999979",
+    "P99": "42.569999999999986"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "21.419999999999806"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "329.5",
+    "P99": "352.3"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2592,8 +3252,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.0",
-    "P99": "170.7999999999999"
+    "P95": "3.0",
+    "P99": "4.3699999999999974"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "133.99999999999989",
+    "P99": "741.99999999999966"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "133.99999999999989",
+    "P99": "741.99999999999966"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2604,7 +3286,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "174.47999999999979"
+    "P99": "58.809999999999995"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2614,8 +3307,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.0",
-    "P99": "34.999999999999794"
+    "P95": "3.0",
+    "P99": "64.719999999999558"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2625,8 +3318,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "21.649999999999938"
+    "P95": "3.9499999999999833",
+    "P99": "63.699999999999896"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2636,8 +3329,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "573.99999999999989",
-    "P99": "734.11"
+    "P95": "531.0",
+    "P99": "592.5"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "2739.9999999999905"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2659,7 +3363,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.1399999999999992"
+    "P99": "2.0"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2669,8 +3373,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "8.9999999999999947"
+    "P95": "2.0",
+    "P99": "2.4899999999999993"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2681,18 +3385,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "174.47999999999979"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "4.0"
+    "P99": "58.809999999999995"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
@@ -2702,112 +3395,112 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "1.849999999999999",
+    "P95": "2.2499999999999973",
+    "P99": "3.4499999999999993"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "11.06999999999924"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "4.0999999999999943",
+    "P99": "95.199999999999932"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "91.029999999999589"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "4.0",
+    "P99": "5.0"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0899999999999972"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.5499999999999909",
+    "P99": "4.0"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.0",
+    "P99": "4.9599999999999964"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
     "P99": "2.0"
   },
   {
     "AlertName": "etcdGRPCRequestsSlow",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.5399999999999987"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.9999999999999876",
-    "P99": "190.59999999999985"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "3.0",
-    "P99": "81.559999999999917"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "176.19999999999982"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.1499999999999986",
-    "P99": "4.63"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "4.0"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "726.63999999999533"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.4899999999999975"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -2820,369 +3513,6 @@
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.6099999999999968"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "59.0",
-    "P99": "1013.4999999999998"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "875.94999999999925",
-    "P99": "1259.9999999999998"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.9999999999999876",
-    "P99": "190.59999999999985"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "3.0",
-    "P99": "81.559999999999917"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "176.19999999999982"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "109.99999999999983",
-    "P99": "163.02999999999994"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "175.2",
-    "P99": "784.55999999999835"
-  },
-  {
-    "AlertName": "etcdGRPCRequestsSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "175.2",
-    "P99": "784.55999999999835"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "1.5399999999999925"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "3.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "1.5299999999999987"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "59.0",
-    "P99": "119.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "1.5299999999999987"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.809999999999998"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "2.0",
-    "P99": "2.4499999999999993"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "1.2599999999999993"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -3190,21 +3520,109 @@
     "P99": "2.0"
   },
   {
-    "AlertName": "etcdHighCommitDurations",
+    "AlertName": "etcdGRPCRequestsSlow",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "gcp",
+    "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "2.0"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "58.649999999999977",
+    "P99": "1210.4599999999996"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "273.69999999999931",
+    "P99": "924.45"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "11.06999999999924"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "4.0999999999999943",
+    "P99": "95.199999999999932"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "91.029999999999589"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "202.49999999999977",
+    "P99": "1441.8599999999972"
+  },
+  {
+    "AlertName": "etcdGRPCRequestsSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "202.49999999999977",
+    "P99": "1441.8599999999972"
   },
   {
     "AlertName": "etcdHighCommitDurations",
     "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
+    "FromRelease": "4.10",
+    "Platform": "aws",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -3214,8 +3632,8 @@
   {
     "AlertName": "etcdHighCommitDurations",
     "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
+    "FromRelease": "4.11",
+    "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
@@ -3225,8 +3643,8 @@
   {
     "AlertName": "etcdHighCommitDurations",
     "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
+    "FromRelease": "4.11",
+    "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
@@ -3236,7 +3654,84 @@
   {
     "AlertName": "etcdHighCommitDurations",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "165.99999999999994",
+    "P99": "223.6"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "2.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
@@ -3247,7 +3742,7 @@
   {
     "AlertName": "etcdHighCommitDurations",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
     "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
@@ -3258,8 +3753,162 @@
   {
     "AlertName": "etcdHighCommitDurations",
     "Release": "4.12",
-    "FromRelease": "",
+    "FromRelease": "4.11",
     "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "2.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "118.0",
+    "P99": "118.55"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "384.39999999999861"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
@@ -3270,7 +3919,7 @@
     "AlertName": "etcdHighCommitDurations",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "vsphere",
+    "Platform": "",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -3282,7 +3931,7 @@
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "aws",
-    "Architecture": "arm64",
+    "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
@@ -3293,11 +3942,165 @@
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "aws",
-    "Architecture": "arm64",
+    "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.66999999999999882"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
     "P95": "2.0",
-    "P99": "2.4499999999999993"
+    "P99": "2.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighCommitDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.66999999999999882"
   },
   {
     "AlertName": "etcdHighCommitDurations",
@@ -3314,23 +4117,12 @@
     "AlertName": "etcdHighCommitDurations",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "1.0",
-    "P99": "2.4299999999999997"
-  },
-  {
-    "AlertName": "etcdHighCommitDurations",
-    "Release": "4.12",
-    "FromRelease": "",
     "Platform": "libvirt",
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "65.159999999999656"
+    "P95": "2.8499999999999934",
+    "P99": "17.249999999999968"
   },
   {
     "AlertName": "etcdHighCommitDurations",
@@ -3340,8 +4132,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "65.159999999999656"
+    "P95": "2.8499999999999934",
+    "P99": "17.249999999999968"
   },
   {
     "AlertName": "etcdHighFsyncDurations",
@@ -3371,8 +4163,41 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3402,6 +4227,17 @@
     "AlertName": "etcdHighFsyncDurations",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -3414,6 +4250,28 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -3434,11 +4292,44 @@
   {
     "AlertName": "etcdHighFsyncDurations",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3473,7 +4364,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.4199999999999986"
   },
   {
     "AlertName": "etcdHighFsyncDurations",
@@ -3515,17 +4417,6 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighFsyncDurations",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
@@ -3668,6 +4559,17 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighFsyncDurations",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -3725,17 +4627,6 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighFsyncDurations",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3789,8 +4680,41 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3820,6 +4744,17 @@
     "AlertName": "etcdHighNumberOfFailedGRPCRequests",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -3832,6 +4767,28 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -3852,11 +4809,44 @@
   {
     "AlertName": "etcdHighNumberOfFailedGRPCRequests",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3891,7 +4881,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdHighNumberOfFailedGRPCRequests",
@@ -3933,17 +4934,6 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
@@ -4086,6 +5076,17 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -4143,17 +5144,6 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighNumberOfFailedGRPCRequests",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4207,8 +5197,41 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4238,6 +5261,17 @@
     "AlertName": "etcdHighNumberOfLeaderChanges",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -4250,6 +5284,28 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -4270,11 +5326,44 @@
   {
     "AlertName": "etcdHighNumberOfLeaderChanges",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4309,7 +5398,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdHighNumberOfLeaderChanges",
@@ -4351,17 +5451,6 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighNumberOfLeaderChanges",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
@@ -4504,6 +5593,17 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdHighNumberOfLeaderChanges",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -4561,17 +5661,6 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdHighNumberOfLeaderChanges",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4625,8 +5714,41 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4656,6 +5778,17 @@
     "AlertName": "etcdInsufficientMembers",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -4668,6 +5801,28 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -4688,11 +5843,44 @@
   {
     "AlertName": "etcdInsufficientMembers",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4727,7 +5915,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdInsufficientMembers",
@@ -4769,17 +5968,6 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdInsufficientMembers",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
@@ -4922,6 +6110,17 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdInsufficientMembers",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -4979,17 +6178,6 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdInsufficientMembers",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -5043,10 +6231,43 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0999999999999992",
+    "P99": "1.8199999999999998"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5074,12 +6295,23 @@
     "AlertName": "etcdMemberCommunicationSlow",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.2199999999999993"
+    "P99": "0.93999999999999906"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5089,8 +6321,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.69999999999999529",
+    "P99": "2.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.0199999999999991"
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5101,7 +6355,29 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5112,7 +6388,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "3.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5123,7 +6410,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "5.5499999999999963"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5145,7 +6432,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "1228.3999999999955"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5155,7 +6453,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.0",
+    "P95": "4.4999999999999982",
     "P99": "5.0"
   },
   {
@@ -5177,8 +6475,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "2.51"
+    "P95": "0.89999999999999547",
+    "P99": "2.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5189,18 +6487,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
-  },
-  {
-    "AlertName": "etcdMemberCommunicationSlow",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "4.0"
+    "P99": "3.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5255,7 +6542,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
-    "P99": "4.029999999999994"
+    "P99": "3.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5277,7 +6564,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
-    "P99": "2.4099999999999984"
+    "P99": "3.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5288,7 +6575,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "2.9099999999999984"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5299,7 +6586,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
-    "P99": "3.3899999999999979"
+    "P99": "3.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5340,6 +6627,17 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMemberCommunicationSlow",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -5365,7 +6663,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "0.32999999999999763"
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5398,18 +6696,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
-    "P99": "4.029999999999994"
-  },
-  {
-    "AlertName": "etcdMemberCommunicationSlow",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "0.0",
-    "P99": "0.0"
+    "P99": "3.0"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5419,8 +6706,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "4.1499999999999995"
+    "P95": "6.0",
+    "P99": "10.589999999999998"
   },
   {
     "AlertName": "etcdMemberCommunicationSlow",
@@ -5430,8 +6717,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "4.1499999999999995"
+    "P95": "6.0",
+    "P99": "10.589999999999998"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5461,8 +6748,41 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -5492,6 +6812,17 @@
     "AlertName": "etcdMembersDown",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -5504,6 +6835,28 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -5524,11 +6877,44 @@
   {
     "AlertName": "etcdMembersDown",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -5563,7 +6949,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.6299999999999979"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5612,23 +7009,12 @@
   {
     "AlertName": "etcdMembersDown",
     "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdMembersDown",
-    "Release": "4.12",
     "FromRelease": "",
     "Platform": "",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "1.699999999999998",
+    "P95": "0.0",
     "P99": "2.0"
   },
   {
@@ -5639,8 +7025,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.69999999999999352",
-    "P99": "3.0"
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5650,8 +7036,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.2699999999999978"
+    "P95": "2.0",
+    "P99": "3.0"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5684,7 +7070,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "1.889999999999999"
+    "P99": "1.1399999999999992"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5705,7 +7091,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.0",
+    "P95": "0.0",
     "P99": "3.0"
   },
   {
@@ -5716,8 +7102,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.3899999999999979"
+    "P95": "2.0",
+    "P99": "4.0"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5758,10 +7144,21 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.97999999999999909"
+  },
+  {
+    "AlertName": "etcdMembersDown",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.2299999999999986"
+    "P95": "0.0",
+    "P99": "2.0"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5771,7 +7168,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.0",
+    "P95": "0.0",
     "P99": "3.0"
   },
   {
@@ -5793,8 +7190,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.2699999999999978"
+    "P95": "2.0",
+    "P99": "3.0"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5817,17 +7214,6 @@
     "Topology": "ha",
     "P95": "2.0",
     "P99": "3.0"
-  },
-  {
-    "AlertName": "etcdMembersDown",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "0.0",
-    "P99": "0.0"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5838,7 +7224,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "5.0",
-    "P99": "11.149999999999999"
+    "P99": "6.0"
   },
   {
     "AlertName": "etcdMembersDown",
@@ -5849,7 +7235,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "5.0",
-    "P99": "11.149999999999999"
+    "P99": "6.0"
   },
   {
     "AlertName": "etcdNoLeader",
@@ -5879,8 +7265,41 @@
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -5910,6 +7329,17 @@
     "AlertName": "etcdNoLeader",
     "Release": "4.12",
     "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -5922,6 +7352,28 @@
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -5942,11 +7394,44 @@
   {
     "AlertName": "etcdNoLeader",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -5981,7 +7466,18 @@
     "Network": "ovn",
     "Topology": "single",
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.62999999999999967"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdNoLeader",
@@ -6023,17 +7519,6 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdNoLeader",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
     "P99": "0.0"
@@ -6176,6 +7661,17 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "AlertName": "etcdNoLeader",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
@@ -6233,17 +7729,6 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "AlertName": "etcdNoLeader",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -6256,7 +7741,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.0999999999999894"
+    "P99": "0.0"
   },
   {
     "AlertName": "etcdNoLeader",
@@ -6267,6 +7752,6 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "0.0",
-    "P99": "2.0999999999999894"
+    "P99": "0.0"
   }
 ]

--- a/pkg/synthetictests/allowedbackenddisruption/query_results.json
+++ b/pkg/synthetictests/allowedbackenddisruption/query_results.json
@@ -7,8 +7,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "6.4999999999999982",
-    "P99": "9.4999999999999982"
+    "P95": "5.0",
+    "P99": "5.75"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "247.1",
+    "P99": "260.62"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -18,8 +29,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.9499999999999993",
-    "P99": "6.79"
+    "P95": "5.1999999999999984",
+    "P99": "6.64"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "800.2",
+    "P99": "808.84"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -29,8 +62,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "23.799999999999976",
-    "P99": "31.32"
+    "P95": "100.59999999999982",
+    "P99": "218.04"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -40,8 +73,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "11.0",
-    "P99": "12.099999999999996"
+    "P95": "7.0",
+    "P99": "10.129999999999999"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -51,8 +95,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "24.4",
-    "P99": "34.959999999999994"
+    "P95": "10.399999999999997",
+    "P99": "29.919999999999991"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -62,8 +106,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "30.0",
-    "P99": "32.4"
+    "P95": "10.899999999999999",
+    "P99": "24.759999999999991"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "16.599999999999998"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "9.25",
+    "P99": "9.85"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -73,8 +139,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.9499999999999993",
-    "P99": "6.79"
+    "P95": "5.1999999999999984",
+    "P99": "6.64"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "121.7",
+    "P99": "135.32"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "121.7",
+    "P99": "135.32"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -84,8 +172,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "6.0",
-    "P99": "6.0"
+    "P95": "5.0",
+    "P99": "5.79"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "210.15",
+    "P99": "210.83"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -95,8 +194,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "6.0",
-    "P99": "33.29999999999999"
+    "P95": "33.8",
+    "P99": "39.56"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -106,8 +205,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "32.199999999999889",
-    "P99": "105.11999999999999"
+    "P95": "8.2",
+    "P99": "8.84"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -117,8 +216,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "778.9",
-    "P99": "906.58999999999992"
+    "P95": "780.6",
+    "P99": "924.95999999999992"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.6499999999999995",
+    "P99": "2.9299999999999997"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -128,8 +238,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "4.6999999999999993",
+    "P99": "4.9399999999999995"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -139,8 +249,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "27.499999999999989",
-    "P99": "33.62"
+    "P95": "8.0",
+    "P99": "8.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -150,8 +260,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "29.099999999999998",
-    "P99": "30.0"
+    "P95": "10.899999999999999",
+    "P99": "25.819999999999997"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -161,8 +271,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "6.0",
-    "P99": "6.0"
+    "P95": "5.0",
+    "P99": "5.79"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -170,10 +280,10 @@
     "FromRelease": "",
     "Platform": "",
     "Architecture": "amd64",
-    "Network": "ovn",
+    "Network": "sdn",
     "Topology": "ha",
-    "P95": "6.75",
-    "P99": "6.95"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -183,8 +293,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.8999999999999986",
-    "P99": "9.58"
+    "P95": "7.0499999999999954",
+    "P99": "17.029999999999998"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -194,8 +304,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "49.0",
-    "P99": "50.89"
+    "P95": "48.0",
+    "P99": "48.69"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -205,8 +315,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "8.2999999999999936",
-    "P99": "11.659999999999998"
+    "P95": "238.4",
+    "P99": "259.12"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -216,8 +326,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "5.55",
-    "P99": "5.91"
+    "P95": "3.0",
+    "P99": "3.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -227,8 +337,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "51.999999999999964",
-    "P99": "58.4"
+    "P95": "4.55",
+    "P99": "4.91"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -238,8 +348,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.0499999999999989",
-    "P99": "8.81"
+    "P95": "8.25",
+    "P99": "8.85"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -249,8 +359,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.1999999999999984",
-    "P99": "35.519999999999989"
+    "P95": "6.4999999999999982",
+    "P99": "7.6999999999999993"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -260,8 +370,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "27.649999999999995",
-    "P99": "31.13"
+    "P95": "22.0",
+    "P99": "22.8"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -271,8 +381,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "24.0",
-    "P99": "24.0"
+    "P95": "75.6",
+    "P99": "77.52"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -282,11 +392,473 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "31.999999999999993",
-    "P99": "41.599999999999994"
+    "P95": "19.0",
+    "P99": "19.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.95",
+    "P99": "1.99"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "7.0499999999999954",
+    "P99": "17.029999999999998"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "48.0",
+    "P99": "48.69"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "238.4",
+    "P99": "259.12"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "255.99999999999986",
+    "P99": "492.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "255.99999999999986",
+    "P99": "492.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "245.79999999999998",
+    "P99": "260.36"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.55",
+    "P99": "3.91"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "795.05",
+    "P99": "806.21"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "13.099999999999936",
+    "P99": "216.11999999999998"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.8"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "12.0",
+    "P99": "12.629999999999999"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.849999999999998",
+    "P99": "13.709999999999999"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "7.899999999999995",
+    "P99": "11.979999999999999"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "9.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.55",
+    "P99": "3.91"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "96.699999999999989",
+    "P99": "107.34"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "96.699999999999989",
+    "P99": "107.34"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.7399999999999998"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "208.15",
+    "P99": "208.83"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.1999999999999993",
+    "P99": "2.84"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "768.9",
+    "P99": "918.42"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "9.8"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "11.899999999999999",
+    "P99": "12.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.7399999999999998"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "4.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "47.65",
+    "P99": "48.73"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "218.0",
+    "P99": "219.54"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.6099999999999994"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.5999999999999996",
+    "P99": "2.92"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "72.0",
+    "P99": "73.6"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.7999999999999998",
+    "P99": "1.96"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "ovirt",
@@ -297,595 +869,177 @@
     "P99": "2.0"
   },
   {
-    "BackendName": "cache-kube-api-new-connections",
+    "BackendName": "cache-kube-api-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4.0",
-    "P99": "8.7999999999999989"
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.0",
-    "P99": "7.1499999999999995"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
+    "BackendName": "cache-kube-api-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.8999999999999986",
-    "P99": "9.58"
+    "P95": "4.0",
+    "P99": "4.0"
   },
   {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "49.0",
-    "P99": "50.89"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "8.2999999999999936",
-    "P99": "11.659999999999998"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "77.6",
-    "P99": "84.32"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
+    "BackendName": "cache-kube-api-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "libvirt",
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.49999999999972",
-    "P99": "501.9"
+    "P95": "204.69999999999968",
+    "P99": "489.21999999999997"
   },
   {
-    "BackendName": "cache-kube-api-new-connections",
+    "BackendName": "cache-kube-api-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
     "Platform": "libvirt",
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.49999999999972",
-    "P99": "501.9"
+    "P95": "204.69999999999968",
+    "P99": "489.21999999999997"
   },
   {
-    "BackendName": "cache-kube-api-reused-connections",
+    "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.79"
+    "P95": "8.0",
+    "P99": "11.959999999999999"
   },
   {
-    "BackendName": "cache-kube-api-reused-connections",
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "658.59999999999991",
+    "P99": "718.92"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.75",
-    "P99": "3.95"
+    "P95": "5.3499999999999988",
+    "P99": "6.67"
   },
   {
-    "BackendName": "cache-kube-api-reused-connections",
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "5.5",
+    "P99": "5.9"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1132.75",
+    "P99": "1134.55"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "azure",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "7.699999999999978"
+    "P95": "18.349999999999998",
+    "P99": "243.48"
   },
   {
-    "BackendName": "cache-kube-api-reused-connections",
+    "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.9499999999999993",
-    "P99": "3.0"
+    "P95": "7.0",
+    "P99": "8.0"
   },
   {
-    "BackendName": "cache-kube-api-reused-connections",
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.749999999999998",
+    "P99": "11.75"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "10.0",
-    "P99": "11.28"
+    "P95": "10.299999999999997",
+    "P99": "31.52999999999999"
   },
   {
-    "BackendName": "cache-kube-api-reused-connections",
+    "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "11.799999999999997",
+    "P99": "27.079999999999991"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "9.0",
-    "P99": "10.0"
+    "P99": "17.06"
   },
   {
-    "BackendName": "cache-kube-api-reused-connections",
+    "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.75",
-    "P99": "3.95"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.2499999999999991",
-    "P99": "4.85"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "81.779999999999987"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "765.25",
-    "P99": "900.4799999999999"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.95",
-    "P99": "1.99"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "7.9999999999999982",
-    "P99": "8.8"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "5.8499999999999988",
-    "P99": "8.3099999999999987"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "48.35",
-    "P99": "50.339999999999996"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.9999999999999982",
-    "P99": "34.199999999999982"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "1.95",
-    "P99": "1.99"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "24.0",
-    "P99": "24.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.7499999999999956",
-    "P99": "7.9499999999999993"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
     "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.8499999999999979",
-    "P99": "6.1399999999999988"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "86.0",
-    "P99": "86.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "341.94999999999976",
-    "P99": "497.83"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "341.94999999999976",
-    "P99": "497.83"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "10.0",
-    "P99": "10.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.0",
-    "P99": "12.859999999999998"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "6.7499999999999982",
-    "P99": "9.6499999999999986"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "21.19999999999996",
-    "P99": "56.319999999999993"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "15.599999999999982",
-    "P99": "41.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "25.599999999999994",
-    "P99": "37.819999999999993"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "28.999999999999993",
-    "P99": "34.8"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "6.7499999999999982",
-    "P99": "9.6499999999999986"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.0",
-    "P99": "12.219999999999999"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "7.6499999999999977",
-    "P99": "26.489999999999988"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "10.549999999999997",
-    "P99": "96.46999999999997"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "951.4",
-    "P99": "1134.56"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "5.0",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "27.399999999999984",
-    "P99": "34.56"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "27.499999999999989",
-    "P99": "33.8"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.0",
-    "P99": "12.219999999999999"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
     "Topology": "ha",
     "P95": "9.25",
     "P99": "9.85"
@@ -893,10 +1047,153 @@
   {
     "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "5.3499999999999988",
+    "P99": "6.67"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "122.49999999999999",
+    "P99": "139.19"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "122.49999999999999",
+    "P99": "139.19"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.0",
+    "P99": "12.32"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "353.95",
+    "P99": "362.79"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "19.799999999999958",
+    "P99": "40.68"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "6.6499999999999986",
+    "P99": "9.19"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "953.49999999999989",
+    "P99": "1142.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "9.0999999999999517",
+    "P99": "53.019999999999989"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.9",
+    "P99": "4.98"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.8999999999999986",
+    "P99": "11.34"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.85",
+    "P99": "29.479999999999997"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.0",
+    "P99": "12.32"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
     "FromRelease": "",
     "Platform": "",
     "Architecture": "amd64",
-    "Network": "sdn",
+    "Network": "ovn",
     "Topology": "ha",
     "P95": "2.0",
     "P99": "2.0"
@@ -909,8 +1206,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "11.959999999999997"
+    "P95": "8.449999999999994",
+    "P99": "16.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -920,8 +1217,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "54.0",
-    "P99": "57.699999999999996"
+    "P95": "53.0",
+    "P99": "57.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -931,8 +1228,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "11.0"
+    "P95": "247.99999999999997",
+    "P99": "267.79999999999995"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -942,8 +1239,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "65.199999999999989",
-    "P99": "77.039999999999992"
+    "P95": "72.399999999999991",
+    "P99": "78.48"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -953,8 +1250,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "30.199999999999946",
-    "P99": "59.12"
+    "P95": "6.4999999999999982",
+    "P99": "15.249999999999998"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -964,8 +1261,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "6.0",
-    "P99": "6.0"
+    "P95": "5.2999999999999989",
+    "P99": "5.8599999999999994"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -975,8 +1272,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "10.699999999999996",
-    "P99": "32.799999999999983"
+    "P95": "6.7999999999999963",
+    "P99": "10.319999999999999"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -986,8 +1283,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "25.199999999999996",
-    "P99": "28.66"
+    "P95": "22.0",
+    "P99": "22.8"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -997,8 +1294,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "21.999999999999993",
-    "P99": "26.799999999999997"
+    "P95": "253.49999999999989",
+    "P99": "343.5"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1008,8 +1305,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "28.0",
-    "P99": "39.199999999999996"
+    "P95": "18.15",
+    "P99": "18.83"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.9",
+    "P99": "1.98"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1019,8 +1327,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.0499999999999989",
-    "P99": "5.81"
+    "P95": "3.0",
+    "P99": "3.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1030,8 +1338,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "9.7499999999999947",
-    "P99": "61.349999999999987"
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1052,8 +1360,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "11.959999999999997"
+    "P95": "8.449999999999994",
+    "P99": "16.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1063,8 +1371,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "54.0",
-    "P99": "57.699999999999996"
+    "P95": "53.0",
+    "P99": "57.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1074,19 +1382,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "11.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "182.49999999999994",
-    "P99": "243.7"
+    "P95": "247.99999999999997",
+    "P99": "267.79999999999995"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1096,8 +1393,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.39999999999975",
-    "P99": "501.52"
+    "P95": "252.34999999999985",
+    "P99": "490.94"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1107,8 +1404,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.39999999999975",
-    "P99": "501.52"
+    "P95": "252.34999999999985",
+    "P99": "490.94"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1118,8 +1415,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.75"
+    "P95": "2.9499999999999993",
+    "P99": "3.79"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "658.94999999999993",
+    "P99": "719.79"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1129,8 +1437,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.9499999999999957",
-    "P99": "13.19"
+    "P95": "6.1999999999999931",
+    "P99": "12.439999999999998"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1138,73 +1446,7 @@
     "FromRelease": "4.11",
     "Platform": "azure",
     "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "6.199999999999994",
-    "P99": "50.71999999999997"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "27.199999999999982",
-    "P99": "38.56"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "10.0",
-    "P99": "10.64"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "8.0",
-    "P99": "10.2"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "9.9499999999999957",
-    "P99": "13.19"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
     "P99": "2.0"
@@ -1212,409 +1454,629 @@
   {
     "BackendName": "cache-oauth-api-reused-connections",
     "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "6.5999999999999952",
-    "P99": "91.949999999999974"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
+    "FromRelease": "4.11",
     "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "931.5",
-    "P99": "1131.1999999999998"
+    "P95": "1137.2",
+    "P99": "1138.64"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "7.9999999999999982",
-    "P99": "8.8"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "6.0",
-    "P99": "8.3099999999999987"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.5999999999999996",
-    "P99": "3.92"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "56.0",
-    "P99": "57.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0499999999999989",
-    "P99": "3.8099999999999996"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "76.05",
-    "P99": "79.21"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "34.239999999999981"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "7.9999999999999947",
-    "P99": "12.799999999999999"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "22.599999999999994",
-    "P99": "26.919999999999998"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "22.799999999999955",
-    "P99": "63.759999999999991"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "10.599999999999998",
-    "P99": "34.559999999999988"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.5999999999999996",
-    "P99": "3.92"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "56.0",
-    "P99": "57.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0499999999999989",
-    "P99": "3.8099999999999996"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "182.19999999999993",
-    "P99": "243.64"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "341.94999999999976",
-    "P99": "497.2"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "341.94999999999976",
-    "P99": "497.2"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "7.0",
-    "P99": "9.1199999999999974"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "6.4999999999999982",
-    "P99": "7.75"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
     "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "19.899999999999974",
-    "P99": "35.659999999999982"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "10.0",
-    "P99": "25.429999999999996"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "27.799999999999994",
-    "P99": "37.4"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "28.999999999999993",
-    "P99": "31.4"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "6.4999999999999982",
-    "P99": "7.75"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "6.0",
-    "P99": "8.04"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "7.7999999999999963",
-    "P99": "38.519999999999989"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "14.999999999999993",
-    "P99": "109.19999999999999"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "901.94999999999993",
-    "P99": "1047.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "5.0",
-    "P99": "5.0"
+    "P99": "141.19999999999993"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.1499999999999986",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "6.8999999999999986",
+    "P99": "8.58"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "11.149999999999999",
+    "P99": "12.629999999999999"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.699999999999996",
+    "P99": "13.709999999999999"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "7.7499999999999956",
+    "P99": "11.95"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "9.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "6.1999999999999931",
+    "P99": "12.439999999999998"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "98.899999999999991",
+    "P99": "112.58"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "98.899999999999991",
+    "P99": "112.58"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "356.09999999999997",
+    "P99": "365.62"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "8.9999999999999947",
+    "P99": "13.799999999999999"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.75"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "947.49999999999989",
+    "P99": "1139.3"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "15.399999999999952",
+    "P99": "58.279999999999987"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "9.8"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "12.799999999999997",
+    "P99": "13.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0999999999999992",
+    "P99": "3.82"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "55.9",
+    "P99": "57.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "274.2",
+    "P99": "306.42"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "80.0",
+    "P99": "80.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.0",
+    "P99": "14.539999999999994"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.2499999999999991",
+    "P99": "2.8499999999999996"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "253.49999999999989",
+    "P99": "343.5"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0999999999999992",
+    "P99": "3.82"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "55.9",
+    "P99": "57.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "274.2",
+    "P99": "306.42"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "204.04999999999967",
+    "P99": "488.4"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "204.04999999999967",
+    "P99": "488.4"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "5.0",
+    "P99": "7.8599999999999994"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "593.9",
+    "P99": "601.18"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.1499999999999977",
+    "P99": "6.43"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.9",
+    "P99": "3.98"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1100.55",
+    "P99": "1144.11"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "96.7999999999997",
+    "P99": "231.76"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.2499999999999964",
+    "P99": "10.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "10.399999999999997",
+    "P99": "30.559999999999992"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.899999999999999",
+    "P99": "24.179999999999993"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "16.54"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "8.25",
+    "P99": "8.85"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.1499999999999977",
+    "P99": "6.43"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "121.94999999999997",
+    "P99": "139.29999999999998"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "121.94999999999997",
+    "P99": "139.29999999999998"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "5.0",
+    "P99": "7.7399999999999984"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "366.45",
+    "P99": "368.49"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "19.349999999999987",
+    "P99": "43.329999999999991"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "6.1999999999999975",
+    "P99": "8.44"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "909.1",
+    "P99": "1067.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "88.699999999999974",
+    "P99": "117.74"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.85",
+    "P99": "4.97"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1624,8 +2086,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "28.999999999999986",
-    "P99": "35.8"
+    "P95": "8.8999999999999986",
+    "P99": "12.12"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1635,8 +2097,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "25.649999999999995",
-    "P99": "32.68"
+    "P95": "11.0",
+    "P99": "29.719999999999995"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1646,8 +2108,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "6.0",
-    "P99": "8.04"
+    "P95": "5.0",
+    "P99": "7.7399999999999984"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1655,10 +2117,10 @@
     "FromRelease": "",
     "Platform": "",
     "Architecture": "amd64",
-    "Network": "ovn",
+    "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.9999999999999991",
-    "P99": "6.8"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1668,8 +2130,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.8999999999999986",
-    "P99": "10.739999999999998"
+    "P95": "9.0",
+    "P99": "11.879999999999999"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1679,8 +2141,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "54.65",
-    "P99": "56.06"
+    "P95": "53.949999999999996",
+    "P99": "282.73999999999984"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1690,8 +2152,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "12.439999999999996"
+    "P95": "285.0",
+    "P99": "314.52"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1701,8 +2163,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "5.1999999999999993",
-    "P99": "5.84"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1712,8 +2174,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "42.749999999999957",
-    "P99": "58.75"
+    "P95": "4.0",
+    "P99": "4.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1723,8 +2185,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "5.9999999999999991",
-    "P99": "6.0"
+    "P95": "5.1499999999999995",
+    "P99": "5.83"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1734,8 +2196,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "33.079999999999984"
+    "P95": "6.6999999999999975",
+    "P99": "8.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1745,8 +2207,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "28.299999999999997",
-    "P99": "29.66"
+    "P95": "21.9",
+    "P99": "23.58"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1756,8 +2218,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "24.799999999999997",
-    "P99": "27.36"
+    "P95": "88.5",
+    "P99": "92.9"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1767,8 +2229,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "31.999999999999993",
-    "P99": "34.4"
+    "P95": "20.0",
+    "P99": "20.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -1776,252 +2238,340 @@
     "FromRelease": "",
     "Platform": "ovirt",
     "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "14.299999999999944",
-    "P99": "64.46"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.8999999999999986",
-    "P99": "10.739999999999998"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "54.65",
-    "P99": "56.06"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "8.0",
-    "P99": "12.439999999999996"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "246.79999999999998",
-    "P99": "268.56"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "334.49999999999972",
-    "P99": "501.9"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "334.49999999999972",
-    "P99": "501.9"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.79"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "7.9999999999999956",
-    "P99": "12.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.5999999999999925",
-    "P99": "13.399999999999988"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "11.349999999999996",
-    "P99": "17.139999999999997"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "10.0",
-    "P99": "10.64"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "9.0",
-    "P99": "10.799999999999999"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "7.9999999999999956",
-    "P99": "12.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "11.549999999999907",
-    "P99": "95.909999999999982"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "900.0",
-    "P99": "1052.5"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "1.95",
     "P99": "1.99"
   },
   {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.4999999999999996",
+    "P99": "2.9"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "11.879999999999999"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "53.949999999999996",
+    "P99": "282.73999999999984"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "285.0",
+    "P99": "314.52"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "252.29999999999984",
+    "P99": "491.54999999999995"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "252.29999999999984",
+    "P99": "491.54999999999995"
+  },
+  {
     "BackendName": "cache-openshift-api-reused-connections",
     "Release": "4.12",
-    "FromRelease": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0999999999999992",
+    "P99": "2.82"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "594.85",
+    "P99": "600.57"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "5.9999999999999938",
+    "P99": "11.599999999999998"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1095.2",
+    "P99": "1139.84"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "8.5999999999999837",
+    "P99": "215.37999999999997"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.6999999999999997"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.9999999999999964",
+    "P95": "11.149999999999999",
+    "P99": "12.629999999999999"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.699999999999996",
+    "P99": "13.709999999999999"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "7.7499999999999956",
+    "P99": "11.95"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "9.0",
     "P99": "9.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "5.9999999999999938",
+    "P99": "11.599999999999998"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "95.999999999999986",
+    "P99": "111.2"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "95.999999999999986",
+    "P99": "111.2"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "366.9",
+    "P99": "370.98"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.3499999999999996",
+    "P99": "2.87"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "903.8",
+    "P99": "1070.11"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "37.799999999999926",
+    "P99": "102.75999999999999"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.95",
+    "P99": "1.99"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "9.8"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.8499999999999988",
-    "P99": "8.3099999999999987"
+    "P95": "12.799999999999997",
+    "P99": "13.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -2031,8 +2581,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "3.0999999999999992",
+    "P99": "3.82"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -2042,8 +2592,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "56.05",
-    "P99": "57.0"
+    "P95": "57.0",
+    "P99": "318.11999999999989"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -2053,8 +2603,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0999999999999992",
-    "P99": "3.82"
+    "P95": "308.59999999999997",
+    "P99": "319.48"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -2076,18 +2626,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "35.20999999999998"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
+    "P99": "6.1999999999999984"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -2107,20 +2646,9 @@
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
     "Topology": "single",
-    "P95": "24.799999999999997",
-    "P99": "27.36"
+    "P95": "85.399999999999991",
+    "P99": "90.679999999999993"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -2137,31 +2665,9 @@
     "BackendName": "cache-openshift-api-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
     "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "22.999999999999954",
-    "P99": "64.6"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
     "P99": "2.0"
@@ -2173,31 +2679,9 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "single",
-    "P95": "56.05",
-    "P99": "57.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "3.0999999999999992",
     "P99": "3.82"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "274.0",
-    "P99": "274.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -2207,8 +2691,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "341.94999999999976",
-    "P99": "497.2"
+    "P95": "206.49999999999969",
+    "P99": "488.79999999999995"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -2218,8 +2702,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "341.94999999999976",
-    "P99": "497.2"
+    "P95": "206.49999999999969",
+    "P99": "488.79999999999995"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2229,8 +2713,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
+    "P95": "19.0",
+    "P99": "19.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2240,8 +2724,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "13.0",
-    "P99": "24.15"
+    "P95": "16.0",
+    "P99": "25.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "8.85",
+    "P99": "8.97"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2251,8 +2746,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "14.0",
-    "P99": "34.739999999999974"
+    "P95": "15.899999999999997",
+    "P99": "36.579999999999977"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.7",
+    "P99": "8.94"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "4.9",
+    "P99": "4.98"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2262,8 +2779,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "11.149999999999995",
-    "P99": "18.149999999999995"
+    "P95": "14.0",
+    "P99": "19.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2273,8 +2790,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "9.4499999999999957",
-    "P99": "12.0"
+    "P95": "12.149999999999997",
+    "P99": "18.72"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "16.399999999999995",
+    "P99": "20.88"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2284,8 +2812,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.8999999999999986",
-    "P99": "10.58"
+    "P95": "16.099999999999998",
+    "P99": "16.82"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2295,8 +2823,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.0",
-    "P99": "7.0"
+    "P95": "15.65",
+    "P99": "15.93"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "15.949999999999992",
+    "P99": "18.54"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.9",
+    "P99": "2.98"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2306,8 +2856,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "14.0",
-    "P99": "34.739999999999974"
+    "P95": "15.899999999999997",
+    "P99": "36.579999999999977"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "21.7",
+    "P99": "22.74"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "21.7",
+    "P99": "22.74"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2317,8 +2889,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "12.799999999999986",
-    "P99": "18.479999999999993"
+    "P95": "18.0",
+    "P99": "21.61"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "8.7",
+    "P99": "8.94"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2328,8 +2911,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "10.0",
-    "P99": "10.35"
+    "P95": "16.999999999999996",
+    "P99": "18.799999999999997"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -2339,13 +2922,112 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "11.44"
+    "P95": "10.0",
+    "P99": "21.06"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
     "Release": "4.12",
     "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "8.3999999999999986",
+    "P99": "9.68"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "14.6",
+    "P99": "14.92"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "20.0",
+    "P99": "20.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "18.0",
+    "P99": "21.61"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.7499999999999982",
+    "P99": "4.1"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "13.849999999999982",
+    "P99": "29.969999999999995"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
@@ -2354,65 +3036,54 @@
     "P99": "5.0"
   },
   {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
+    "FromRelease": "4.11",
+    "Platform": "azure",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "1.9",
-    "P99": "1.98"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.4999999999999982",
-    "P99": "9.7"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "6.6",
-    "P99": "6.92"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "12.799999999999986",
-    "P99": "18.479999999999993"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "22.249999999999979",
-    "P99": "31.0"
+    "P95": "4.2999999999999989",
+    "P99": "4.8599999999999994"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "4.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.8499999999999996",
+    "P99": "3.9699999999999998"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -2423,67 +3094,23 @@
     "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
-    "Platform": "aws",
+    "Platform": "ovirt",
     "Architecture": "amd64",
-    "Network": "ovn",
+    "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
-    "P99": "3.4499999999999993"
+    "P99": "2.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
-    "Platform": "aws",
+    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
-    "Topology": "ha",
-    "P95": "15.399999999999984",
-    "P99": "30.279999999999998"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.1999999999999984",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.6999999999999988",
-    "P99": "5.4799999999999995"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
     "Topology": "ha",
     "P95": "1.0",
     "P99": "1.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "5.75",
-    "P99": "5.95"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -2493,81 +3120,15 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "15.399999999999984",
-    "P99": "30.279999999999998"
+    "P95": "13.849999999999982",
+    "P99": "29.969999999999995"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.4499999999999993",
-    "P99": "3.8899999999999997"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "1.9",
-    "P99": "1.98"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
     "P95": "1.95",
@@ -2578,11 +3139,77 @@
     "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "aws",
-    "Architecture": "arm64",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.7999999999999972",
+    "P99": "6.3599999999999994"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.5999999999999988",
+    "P99": "5.72"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.6999999999999997",
+    "P99": "3.94"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
     "P99": "3.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.8499999999999996",
+    "P99": "3.9699999999999998"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2603,8 +3230,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "70.0",
-    "P99": "91.199999999999989"
+    "P95": "75.0",
+    "P99": "94.96"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "408.5",
+    "P99": "423.3"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2614,8 +3252,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.6999999999999975",
-    "P99": "29.699999999999967"
+    "P95": "46.499999999999986",
+    "P99": "69.6"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "117.2",
+    "P99": "118.64"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "612.8",
+    "P99": "640.16"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2625,8 +3285,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "16.249999999999996",
-    "P99": "26.499999999999996"
+    "P95": "6.1999999999999957",
+    "P99": "10.04"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2636,8 +3296,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "156.0",
-    "P99": "163.46"
+    "P95": "157.0",
+    "P99": "165.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "140.79999999999998",
+    "P99": "146.56"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2647,8 +3318,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "46.949999999999996",
-    "P99": "57.08"
+    "P95": "47.05",
+    "P99": "56.539999999999992"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2658,8 +3329,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "159.99999999999994",
-    "P99": "176.0"
+    "P95": "156.09999999999994",
+    "P99": "175.25"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "294.45",
+    "P99": "354.9"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "45.249999999999993",
+    "P99": "50.65"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2669,8 +3362,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.6999999999999975",
-    "P99": "29.699999999999967"
+    "P95": "46.499999999999986",
+    "P99": "69.6"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "165.09999999999997",
+    "P99": "181.41"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "165.09999999999997",
+    "P99": "181.41"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2680,8 +3395,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "69.0",
-    "P99": "86.0"
+    "P95": "71.399999999999977",
+    "P99": "91.959999999999965"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "260.2",
+    "P99": "264.04"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2691,8 +3417,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.3499999999999961",
-    "P99": "7.0"
+    "P95": "5.0",
+    "P99": "5.6799999999999971"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2702,8 +3428,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "101.0",
-    "P99": "107.27999999999999"
+    "P95": "104.0",
+    "P99": "117.29999999999998"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2713,8 +3439,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "503.55",
-    "P99": "579.73"
+    "P95": "533.19999999999993",
+    "P99": "592.24"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "8.2",
+    "P99": "8.84"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2724,8 +3461,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "43.75",
-    "P99": "61.249999999999993"
+    "P95": "43.699999999999996",
+    "P99": "44.77"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2735,8 +3472,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "61.799999999999969",
-    "P99": "125.97999999999998"
+    "P95": "46.699999999999996",
+    "P99": "63.94"
   },
   {
     "BackendName": "image-registry-new-connections",
@@ -2746,30 +3483,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "69.0",
-    "P99": "86.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "50.599999999999916",
-    "P99": "71.759999999999991"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "12.85",
-    "P99": "12.97"
+    "P95": "71.399999999999977",
+    "P99": "91.959999999999965"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2779,8 +3494,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "32.44999999999991",
-    "P99": "62.82"
+    "P95": "19.849999999999994",
+    "P99": "61.97"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "367.0",
+    "P99": "375.0"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2790,8 +3516,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "15.249999999999989",
-    "P99": "25.45"
+    "P95": "16.099999999999991",
+    "P99": "25.619999999999997"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.1",
+    "P99": "8.82"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "579.15",
+    "P99": "598.23"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2801,8 +3549,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.35",
-    "P99": "5.87"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2813,7 +3561,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "8.0",
-    "P99": "10.099999999999996"
+    "P99": "11.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "5.0"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2823,8 +3582,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "27.299999999999969",
-    "P99": "55.859999999999992"
+    "P95": "27.0",
+    "P99": "53.279999999999994"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2834,8 +3593,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "140.14999999999998",
-    "P99": "157.63"
+    "P95": "137.65",
+    "P99": "155.32999999999998"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "259.34999999999997",
+    "P99": "290.02"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "21.9",
+    "P99": "22.78"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2845,8 +3626,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "15.249999999999989",
-    "P99": "25.45"
+    "P95": "16.099999999999991",
+    "P99": "25.619999999999997"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "111.69999999999997",
+    "P99": "132.03"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "111.69999999999997",
+    "P99": "132.03"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2856,8 +3659,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "15.0",
-    "P99": "64.44"
+    "P95": "57.0",
+    "P99": "68.449999999999989"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "232.0",
+    "P99": "235.2"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2867,8 +3681,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "6.3999999999999995",
-    "P99": "6.88"
+    "P95": "6.6",
+    "P99": "6.92"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2878,8 +3692,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "7.0",
-    "P99": "10.0"
+    "P95": "9.949999999999994",
+    "P99": "11.0"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2889,8 +3703,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "499.6",
-    "P99": "575.45999999999992"
+    "P95": "532.8",
+    "P99": "588.96"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2900,8 +3725,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.2999999999999994",
-    "P99": "2.86"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2911,8 +3736,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "43.299999999999983",
-    "P99": "58.26"
+    "P95": "33.999999999999993",
+    "P99": "39.6"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2922,8 +3747,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "47.999999999999986",
-    "P99": "126.39999999999998"
+    "P95": "41.349999999999994",
+    "P99": "46.67"
   },
   {
     "BackendName": "image-registry-reused-connections",
@@ -2933,19 +3758,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "15.0",
-    "P99": "64.44"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "18.249999999999989",
-    "P99": "48.749999999999993"
+    "P95": "57.0",
+    "P99": "68.449999999999989"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -2955,8 +3769,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.75",
-    "P99": "7.95"
+    "P95": "7.3999999999999995",
+    "P99": "7.88"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -2966,8 +3780,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "160.69999999999996",
-    "P99": "208.93999999999994"
+    "P95": "161.0",
+    "P99": "202.49999999999997"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "751.8",
+    "P99": "755.96"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -2977,8 +3802,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "10.049999999999995",
-    "P99": "21.049999999999994"
+    "P95": "87.299999999999926",
+    "P99": "126.47999999999999"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -2986,104 +3811,82 @@
     "FromRelease": "4.11",
     "Platform": "azure",
     "Architecture": "amd64",
-    "Network": "sdn",
+    "Network": "ovn",
     "Topology": "ha",
-    "P95": "33.799999999999976",
-    "P99": "49.48"
+    "P95": "226.35",
+    "P99": "232.47"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "308.0",
-    "P99": "319.38"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "26.799999999999997",
-    "P99": "30.96"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "28.599999999999998",
-    "P99": "30.52"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "10.049999999999995",
-    "P99": "21.049999999999994"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "164.19999999999996",
-    "P99": "188.32"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "11.799999999999994",
-    "P99": "21.36"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "195.85",
-    "P99": "209.88"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
     "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "1166.95",
-    "P99": "1335.97"
+    "P95": "1256.85",
+    "P99": "1259.37"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
     "Release": "4.12",
-    "FromRelease": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "103.59999999999992",
+    "P99": "218.64"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
     "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "304.0",
+    "P99": "317.08"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "271.84999999999997",
+    "P99": "288.77"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "19.599999999999987",
+    "P99": "29.519999999999996"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "20.399999999999995",
+    "P99": "25.68"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -3093,13 +3896,134 @@
   {
     "BackendName": "ingress-to-console-new-connections",
     "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "12.499999999999996",
+    "P99": "15.299999999999999"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "87.299999999999926",
+    "P99": "126.47999999999999"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "197.24999999999991",
+    "P99": "261.28999999999996"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "197.24999999999991",
+    "P99": "261.28999999999996"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "164.0",
+    "P99": "191.99999999999997"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "507.59999999999997",
+    "P99": "528.72"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "9.0",
+    "P99": "26.95999999999998"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "196.0",
+    "P99": "211.44"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1181.7999999999997",
+    "P99": "1353.1599999999999"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "12.199999999999998",
+    "P99": "14.44"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "11.2",
+    "P99": "11.84"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "28.699999999999996",
-    "P99": "33.74"
+    "P95": "7.6499999999999995",
+    "P99": "7.93"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3109,8 +4033,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "32.3",
-    "P99": "32.86"
+    "P95": "27.999999999999996",
+    "P99": "32.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3120,19 +4044,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "164.19999999999996",
-    "P99": "188.32"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "132.0",
-    "P99": "169.83999999999997"
+    "P95": "164.0",
+    "P99": "191.99999999999997"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3142,8 +4055,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "11.499999999999998",
-    "P99": "12.7"
+    "P95": "3.0",
+    "P99": "3.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3164,8 +4077,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "14.549999999999994",
-    "P99": "33.809999999999988"
+    "P95": "14.099999999999994",
+    "P99": "37.559999999999988"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3175,8 +4088,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "4.1999999999999984",
-    "P99": "5.64"
+    "P95": "2.4499999999999993",
+    "P99": "2.8899999999999997"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3186,8 +4099,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.0",
-    "P99": "25.899999999999991"
+    "P95": "659.74999999998965",
+    "P99": "2708.65"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3197,8 +4110,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "5.9999999999999991",
-    "P99": "6.8"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3208,8 +4121,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "37.0",
-    "P99": "50.919999999999987"
+    "P95": "41.39999999999997",
+    "P99": "77.559999999999988"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3219,8 +4132,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "8.77"
+    "P95": "8.7999999999999989",
+    "P99": "10.52"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3230,8 +4143,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "47.55",
-    "P99": "69.289999999999964"
+    "P95": "47.0",
+    "P99": "52.919999999999987"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3241,8 +4154,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "29.599999999999998",
-    "P99": "44.199999999999996"
+    "P95": "19.2",
+    "P99": "20.64"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3252,8 +4165,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "15.7",
-    "P99": "15.94"
+    "P95": "159.0",
+    "P99": "163.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3263,8 +4176,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "38.8",
-    "P99": "44.56"
+    "P95": "13.899999999999995",
+    "P99": "17.98"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3274,8 +4187,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.75",
-    "P99": "3.95"
+    "P95": "4.0",
+    "P99": "4.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3285,8 +4198,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "22.549999999999997",
-    "P99": "53.069999999999972"
+    "P95": "6.0",
+    "P99": "7.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3296,8 +4209,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.3999999999999995",
-    "P99": "4.88"
+    "P95": "2.9",
+    "P99": "2.98"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3307,8 +4220,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "14.549999999999994",
-    "P99": "33.809999999999988"
+    "P95": "14.099999999999994",
+    "P99": "37.559999999999988"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3318,8 +4231,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "4.1999999999999984",
-    "P99": "5.64"
+    "P95": "2.4499999999999993",
+    "P99": "2.8899999999999997"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3329,19 +4242,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.0",
-    "P99": "25.899999999999991"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "284.3",
-    "P99": "295.26"
+    "P95": "659.74999999998965",
+    "P99": "2708.65"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3351,8 +4253,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.39999999999975",
-    "P99": "502.14"
+    "P95": "252.99999999999986",
+    "P99": "491.79999999999995"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -3362,8 +4264,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.39999999999975",
-    "P99": "502.14"
+    "P95": "252.99999999999986",
+    "P99": "491.79999999999995"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3384,8 +4286,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "107.19999999999989",
-    "P99": "153.11999999999998"
+    "P95": "105.89999999999992",
+    "P99": "161.75999999999996"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "752.5",
+    "P99": "757.7"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3395,8 +4308,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "8.8999999999999968",
-    "P99": "29.849999999999994"
+    "P95": "34.949999999999996",
+    "P99": "110.89"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "37.499999999999993",
+    "P99": "41.1"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1252.05",
+    "P99": "1256.01"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3406,8 +4341,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "6.0999999999999925",
-    "P99": "17.099999999999991"
+    "P95": "25.099999999999845",
+    "P99": "153.50999999999996"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3417,8 +4352,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "59.299999999999983",
-    "P99": "80.979999999999947"
+    "P95": "56.0",
+    "P99": "64.16"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "30.65",
+    "P99": "36.11"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3428,8 +4374,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "5.0499999999999989",
+    "P99": "5.81"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3439,8 +4385,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "6.4499999999999975",
+    "P99": "8.49"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "12.0",
+    "P99": "12.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3450,8 +4407,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "8.8999999999999968",
-    "P99": "29.849999999999994"
+    "P95": "34.949999999999996",
+    "P99": "110.89"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "149.64999999999995",
+    "P99": "207.26"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "149.64999999999995",
+    "P99": "207.26"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3461,8 +4440,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "120.84999999999997",
-    "P99": "165.73999999999998"
+    "P95": "113.34999999999998",
+    "P99": "162.48"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "508.4",
+    "P99": "528.88"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3472,8 +4462,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.2499999999999982",
-    "P99": "11.45"
+    "P95": "8.9999999999999947",
+    "P99": "11.399999999999999"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3483,7 +4473,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "43.0",
+    "P95": "43.29999999999999",
     "P99": "45.0"
   },
   {
@@ -3494,8 +4484,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "1167.6",
-    "P99": "1332.8799999999999"
+    "P95": "1177.6",
+    "P99": "1347.52"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.8",
+    "P99": "3.96"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3505,8 +4506,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.9499999999999993",
-    "P99": "5.79"
+    "P95": "2.6999999999999997",
+    "P99": "2.94"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -3516,608 +4517,14 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.6",
-    "P99": "8.92"
+    "P95": "8.1",
+    "P99": "8.82"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
     "Release": "4.12",
     "FromRelease": "4.12",
     "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.95",
-    "P99": "2.99"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "120.84999999999997",
-    "P99": "165.73999999999998"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "64.349999999999838",
-    "P99": "157.91"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.7999999999999989",
-    "P99": "12.04"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "6.6999999999999993",
-    "P99": "6.9399999999999995"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "22.049999999999983",
-    "P99": "31.689999999999998"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "12.699999999999996",
-    "P99": "16.939999999999998"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "12.0",
-    "P99": "14.319999999999999"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "37.499999999999986",
-    "P99": "48.3"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "13.8",
-    "P99": "13.96"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "22.349999999999998",
-    "P99": "23.669999999999998"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.8",
-    "P99": "2.96"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "22.9",
-    "P99": "58.059999999999981"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.3999999999999995",
-    "P99": "3.88"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.7999999999999989",
-    "P99": "12.04"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "6.6999999999999993",
-    "P99": "6.9399999999999995"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "22.049999999999983",
-    "P99": "31.689999999999998"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "284.84999999999997",
-    "P99": "296.17"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "341.79999999999973",
-    "P99": "497.46"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "341.79999999999973",
-    "P99": "497.46"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "6.9",
-    "P99": "6.98"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "142.64999999999998",
-    "P99": "175.05999999999997"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "14.0",
-    "P99": "19.86"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "32.699999999999996",
-    "P99": "64.899999999999949"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "307.29999999999995",
-    "P99": "322.46"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "24.249999999999996",
-    "P99": "28.05"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "30.6",
-    "P99": "30.92"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "14.0",
-    "P99": "19.86"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "133.24999999999997",
-    "P99": "172.79999999999998"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "10.649999999999993",
-    "P99": "24.909999999999961"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "193.85",
-    "P99": "211.82"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "1083.2",
-    "P99": "1213.84"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "7.6999999999999993",
-    "P99": "7.9399999999999995"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "27.499999999999993",
-    "P99": "34.3"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "32.45",
-    "P99": "32.89"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "133.24999999999997",
-    "P99": "172.79999999999998"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "116.39999999999996",
-    "P99": "145.85999999999999"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "12.25",
-    "P99": "12.85"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "12.749999999999998",
-    "P99": "40.349999999999987"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "93.6",
-    "P99": "127.91999999999997"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "7.0",
-    "P99": "25.279999999999994"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "5.9999999999999991",
-    "P99": "6.8"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "37.0",
-    "P99": "56.749999999999986"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "6.8999999999999986",
-    "P99": "8.5599999999999987"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "43.9",
-    "P99": "81.69999999999996"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "30.199999999999992",
-    "P99": "33.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "19.0",
-    "P99": "19.8"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "35.199999999999996",
-    "P99": "39.04"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "7.0",
-    "P99": "49.399999999999977"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -4125,6 +4532,611 @@
     "P99": "4.92"
   },
   {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "113.34999999999998",
+    "P99": "162.48"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "13.0",
+    "P99": "13.41"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2662.0499999999997",
+    "P99": "2777.81"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "14.399999999999995",
+    "P99": "24.479999999999997"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.1499999999999995",
+    "P99": "3.83"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.79999999999999",
+    "P99": "18.879999999999995"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.5499999999999996",
+    "P99": "1.91"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "157.5",
+    "P99": "161.1"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "4.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "13.0",
+    "P99": "13.41"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "208.29999999999967",
+    "P99": "488.64"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "208.29999999999967",
+    "P99": "488.64"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.10",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "6.5",
+    "P99": "6.9"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "142.49999999999997",
+    "P99": "175.59999999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "809.59999999999991",
+    "P99": "849.12"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "76.749999999999957",
+    "P99": "131.39999999999998"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "226.75",
+    "P99": "235.75"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1140.05",
+    "P99": "1144.01"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "238.54999999999998",
+    "P99": "262.11"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "306.0",
+    "P99": "314.08"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "302.5",
+    "P99": "318.1"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "12.099999999999985",
+    "P99": "25.619999999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "25.399999999999995",
+    "P99": "29.88"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "14.499999999999996",
+    "P99": "17.3"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "76.749999999999957",
+    "P99": "131.39999999999998"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "213.49999999999989",
+    "P99": "284.59999999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "213.49999999999989",
+    "P99": "284.59999999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "132.0",
+    "P99": "175.80999999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "477.2",
+    "P99": "481.04"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.399999999999988",
+    "P99": "94.319999999999865"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "196.0",
+    "P99": "210.88"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1252.5",
+    "P99": "1260.1"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "12.399999999999997",
+    "P99": "15.28"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "8.85",
+    "P99": "8.97"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.5999999999999996",
+    "P99": "2.92"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "29.099999999999998",
+    "P99": "32.22"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "132.0",
+    "P99": "175.80999999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "11.0",
+    "P99": "41.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "88.25",
+    "P99": "89.65"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "7.4999999999999964",
+    "P99": "43.699999999999974"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "51.099999999999994",
+    "P99": "80.639999999999986"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.5999999999999979",
+    "P99": "9.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "43.0",
+    "P99": "46.989999999999988"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "18.799999999999997",
+    "P99": "22.16"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "156.8",
+    "P99": "159.36"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "19.849999999999998",
+    "P99": "22.37"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "5.3999999999999995",
+    "P99": "5.88"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "6.0",
+    "P99": "6.6"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
     "BackendName": "ingress-to-oauth-server-new-connections",
     "Release": "4.12",
     "FromRelease": "",
@@ -4132,8 +5144,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "12.749999999999998",
-    "P99": "40.349999999999987"
+    "P95": "11.0",
+    "P99": "41.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -4143,8 +5155,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "93.6",
-    "P99": "127.91999999999997"
+    "P95": "88.25",
+    "P99": "89.65"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -4154,19 +5166,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.0",
-    "P99": "25.279999999999994"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "261.0",
-    "P99": "283.4"
+    "P95": "7.4999999999999964",
+    "P99": "43.699999999999974"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -4176,8 +5177,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.29999999999973",
-    "P99": "501.76"
+    "P95": "256.99999999999989",
+    "P99": "491.2"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -4187,19 +5188,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.29999999999973",
-    "P99": "501.76"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "20.5",
-    "P99": "20.9"
+    "P95": "256.99999999999989",
+    "P99": "491.2"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4210,7 +5200,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "19.0",
-    "P99": "45.16"
+    "P99": "41.099999999999994"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "693.75",
+    "P99": "706.75"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4220,8 +5221,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "18.999999999999993",
-    "P99": "33.4"
+    "P95": "17.949999999999992",
+    "P99": "32.86"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "17.2",
+    "P99": "18.64"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1084.0",
+    "P99": "1091.2"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4231,8 +5254,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "39.199999999999967",
-    "P99": "69.44"
+    "P95": "204.1",
+    "P99": "212.02"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4242,8 +5265,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "14.0",
-    "P99": "20.0"
+    "P95": "13.0",
+    "P99": "17.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.0",
+    "P99": "6.2199999999999989"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4253,8 +5287,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4921.0",
-    "P99": "4921.0"
+    "P95": "5.1999999999999984",
+    "P99": "6.64"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4264,8 +5298,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "73.0",
-    "P99": "73.0"
+    "P95": "7.2999999999999989",
+    "P99": "8.66"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.0",
+    "P99": "10.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4275,8 +5320,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "18.999999999999993",
-    "P99": "33.4"
+    "P95": "17.949999999999992",
+    "P99": "32.86"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "175.64999999999995",
+    "P99": "215.92999999999998"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "175.64999999999995",
+    "P99": "215.92999999999998"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4286,8 +5353,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "13.0",
-    "P99": "44.72999999999999"
+    "P95": "20.699999999999985",
+    "P99": "40.019999999999989"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "422.6",
+    "P99": "424.52"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4297,8 +5375,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "8.8999999999999986",
-    "P99": "10.559999999999999"
+    "P95": "8.2999999999999989",
+    "P99": "8.86"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4308,8 +5386,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "11.0",
-    "P99": "13.399999999999999"
+    "P95": "12.0",
+    "P99": "16.519999999999996"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4319,8 +5397,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "1031.0",
-    "P99": "1156.99"
+    "P95": "1156.0",
+    "P99": "1192.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4341,41 +5430,30 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2752.0",
-    "P99": "2752.0"
+    "P95": "7.0",
+    "P99": "7.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
     "Release": "4.12",
     "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "13.0",
-    "P99": "44.72999999999999"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
+    "Platform": "metal",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "18.849999999999937",
-    "P99": "120.48999999999997"
+    "P95": "4.6",
+    "P99": "4.92"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
     "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.95",
-    "P99": "2.99"
+    "P95": "20.699999999999985",
+    "P99": "40.019999999999989"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4385,8 +5463,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "6.2499999999999991",
-    "P99": "6.85"
+    "P95": "5.0",
+    "P99": "5.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4396,8 +5474,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "17.749999999999993",
-    "P99": "25.15"
+    "P95": "14.399999999999995",
+    "P99": "16.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4407,8 +5485,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "23.2",
-    "P99": "23.84"
+    "P95": "39.749999999999993",
+    "P99": "43.949999999999996"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4418,8 +5496,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.7999999999999989",
-    "P99": "6.76"
+    "P95": "10.199999999999992",
+    "P99": "18.04"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4429,8 +5507,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.6999999999999997",
-    "P99": "2.94"
+    "P95": "2.55",
+    "P99": "2.91"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4441,7 +5519,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "8.0",
-    "P99": "9.54"
+    "P99": "9.32"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4450,6 +5528,28 @@
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.4999999999999996",
+    "P99": "1.9"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "145.0",
+    "P99": "147.4"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
     "Topology": "ha",
     "P95": "2.0",
     "P99": "2.0"
@@ -4458,23 +5558,12 @@
     "BackendName": "ingress-to-oauth-server-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "13.7",
-    "P99": "13.94"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
     "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "52.249999999999979",
-    "P99": "70.45"
+    "P95": "3.5999999999999996",
+    "P99": "3.92"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4484,19 +5573,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.55",
-    "P99": "3.91"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "6.2499999999999991",
-    "P99": "6.85"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4506,8 +5584,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "17.749999999999993",
-    "P99": "25.15"
+    "P95": "14.399999999999995",
+    "P99": "16.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4517,19 +5595,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.7999999999999963",
-    "P99": "8.16"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "288.0",
-    "P99": "288.0"
+    "P95": "39.749999999999993",
+    "P99": "43.949999999999996"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4539,8 +5606,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "341.94999999999976",
-    "P99": "498.46"
+    "P95": "207.39999999999969",
+    "P99": "489.64"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -4550,19 +5617,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "341.94999999999976",
-    "P99": "498.46"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.0",
-    "P99": "4.0"
+    "P95": "207.39999999999969",
+    "P99": "489.64"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4572,8 +5628,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "10.299999999999992",
-    "P99": "18.039999999999992"
+    "P95": "7.4499999999999948",
+    "P99": "16.559999999999995"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "565.69999999999993",
+    "P99": "577.14"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4583,8 +5650,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.7999999999999936",
-    "P99": "64.839999999999975"
+    "P95": "11.399999999999995",
+    "P99": "71.319999999999979"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.6999999999999997",
+    "P99": "3.94"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1580.2",
+    "P99": "1617.64"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4594,8 +5683,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "23.0",
-    "P99": "43.62"
+    "P95": "9.3499999999999943",
+    "P99": "158.58999999999983"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4605,8 +5694,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "10.899999999999993",
-    "P99": "20.93999999999998"
+    "P95": "7.0499999999999927",
+    "P99": "11.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.8999999999999955",
+    "P99": "6.9799999999999986"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4616,8 +5716,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "31.999999999999986",
-    "P99": "43.599999999999994"
+    "P95": "19.299999999999994",
+    "P99": "39.359999999999992"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4627,8 +5727,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "33.999999999999986",
-    "P99": "41.8"
+    "P95": "16.0",
+    "P99": "32.019999999999996"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "15.799999999999995",
+    "P99": "31.759999999999994"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "18.25",
+    "P99": "18.85"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4638,8 +5760,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.7999999999999936",
-    "P99": "64.839999999999975"
+    "P95": "11.399999999999995",
+    "P99": "71.319999999999979"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "222.19999999999993",
+    "P99": "266.92"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "222.19999999999993",
+    "P99": "266.92"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4649,8 +5793,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "10.249999999999996",
-    "P99": "12.249999999999996"
+    "P95": "8.0",
+    "P99": "13.899999999999997"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "512.8",
+    "P99": "520.96"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4660,8 +5815,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "12.799999999999995",
-    "P99": "45.279999999999973"
+    "P95": "24.049999999999965",
+    "P99": "64.46"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4671,8 +5826,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "14.999999999999986",
-    "P99": "134.99999999999989"
+    "P95": "8.2499999999999947",
+    "P99": "11.749999999999998"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4682,8 +5837,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "1611.1999999999998",
-    "P99": "1844.1"
+    "P95": "1388.0",
+    "P99": "1816.1999999999998"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.4499999999999993",
+    "P99": "4.89"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4693,8 +5859,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.55",
-    "P99": "4.91"
+    "P95": "4.6",
+    "P99": "4.92"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4704,8 +5870,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "31.299999999999979",
-    "P99": "39.22"
+    "P95": "14.0",
+    "P99": "15.559999999999999"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4715,8 +5881,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "27.999999999999993",
-    "P99": "30.7"
+    "P95": "19.999999999999993",
+    "P99": "27.839999999999996"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4726,30 +5892,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "10.249999999999996",
-    "P99": "12.249999999999996"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "11.549999999999997",
-    "P99": "13.54"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "6.5",
-    "P99": "6.9"
+    "P95": "8.0",
+    "P99": "13.899999999999997"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4758,42 +5902,31 @@
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "7.9499999999999984",
-    "P99": "12.36"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "48.85",
-    "P99": "50.71"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "9.0",
-    "P99": "10.7"
+    "P99": "11.47999999999999"
   },
   {
     "BackendName": "kube-api-new-connections",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "azure",
+    "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
+    "Topology": "single",
+    "P95": "48.0",
+    "P99": "48.62"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.6",
-    "P99": "5.92"
+    "P95": "242.74999999999997",
+    "P99": "258.5"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4803,8 +5936,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "50.149999999999963",
-    "P99": "66.22"
+    "P95": "3.4499999999999993",
+    "P99": "3.8899999999999997"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4825,8 +5958,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "34.599999999999987"
+    "P95": "6.9499999999999984",
+    "P99": "8.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4836,8 +5969,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "26.499999999999989",
-    "P99": "30.0"
+    "P95": "18.2",
+    "P99": "19.64"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4847,8 +5980,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "24.0",
-    "P99": "24.0"
+    "P95": "150.8",
+    "P99": "151.76"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4858,8 +5991,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "30.799999999999997",
-    "P99": "41.269999999999996"
+    "P95": "18.0",
+    "P99": "18.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4869,8 +6013,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "2.8",
+    "P99": "2.96"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4880,8 +6024,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4.2999999999999954",
-    "P99": "8.86"
+    "P95": "3.6999999999999997",
+    "P99": "3.94"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4891,8 +6035,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4901,31 +6045,20 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "7.9499999999999984",
-    "P99": "12.36"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "48.85",
-    "P99": "50.71"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "9.0",
-    "P99": "10.7"
+    "P99": "11.47999999999999"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "48.0",
+    "P99": "48.62"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4934,9 +6067,9 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "sdn",
-    "Topology": "single",
-    "P95": "81.8",
-    "P99": "85.16"
+    "Topology": "ha",
+    "P95": "242.74999999999997",
+    "P99": "258.5"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4946,8 +6079,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "326.74999999999972",
-    "P99": "501.45"
+    "P95": "254.99999999999986",
+    "P99": "492.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -4957,8 +6090,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "326.74999999999972",
-    "P99": "501.45"
+    "P95": "254.99999999999986",
+    "P99": "492.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -4979,8 +6112,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "7.4799999999999924"
+    "P95": "2.0",
+    "P99": "3.0099999999999989"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "559.55",
+    "P99": "566.31"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -4990,8 +6134,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.5999999999999979",
-    "P99": "30.599999999999994"
+    "P95": "3.0",
+    "P99": "28.919999999999991"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.9",
+    "P99": "2.98"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1567.3999999999999",
+    "P99": "1606.28"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5001,8 +6167,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.0",
-    "P99": "9.8899999999999935"
+    "P95": "6.9499999999999948",
+    "P99": "92.159999999999883"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5013,7 +6179,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "7.1599999999999957"
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5024,7 +6201,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "20.0",
-    "P99": "20.62"
+    "P99": "20.63"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5034,8 +6211,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "18.0",
-    "P99": "22.0"
+    "P95": "17.549999999999994",
+    "P99": "19.14"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "12.599999999999996",
+    "P99": "23.799999999999997"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "17.999999999999996",
+    "P99": "20.4"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5045,8 +6244,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.5999999999999979",
-    "P99": "30.599999999999994"
+    "P95": "3.0",
+    "P99": "28.919999999999991"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "175.99999999999997",
+    "P99": "212.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "175.99999999999997",
+    "P99": "212.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5056,8 +6277,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
+    "P95": "2.7499999999999973",
     "P99": "4.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "509.65",
+    "P99": "517.13"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5067,8 +6299,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "4.0",
+    "P99": "9.04"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5078,8 +6310,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "10.449999999999983",
-    "P99": "135.45999999999989"
+    "P95": "5.2999999999999954",
+    "P99": "12.339999999999998"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5089,8 +6321,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "1593.5",
-    "P99": "1818.34"
+    "P95": "1372.5",
+    "P99": "1803.1"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.7499999999999982",
+    "P99": "6.55"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5100,8 +6343,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "2.95",
+    "P99": "2.99"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5111,8 +6354,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "15.699999999999998",
-    "P99": "16.78"
+    "P95": "15.849999999999998",
+    "P99": "16.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5122,8 +6365,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.7999999999999989",
-    "P99": "15.319999999999999"
+    "P95": "16.399999999999995",
+    "P99": "22.389999999999997"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5133,19 +6376,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
+    "P95": "2.7499999999999973",
     "P99": "4.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "5.8499999999999988"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5155,8 +6387,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "3.7999999999999989",
+    "P99": "4.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5166,8 +6398,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "48.05",
-    "P99": "50.22"
+    "P95": "47.35",
+    "P99": "48.67"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5177,8 +6409,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.0",
-    "P99": "4.7299999999999995"
+    "P95": "223.0",
+    "P99": "223.7"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5199,8 +6431,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.5999999999999988",
-    "P99": "47.639999999999986"
+    "P95": "2.9999999999999982",
+    "P99": "4.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5210,8 +6442,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "2.8",
+    "P99": "2.96"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5231,20 +6463,9 @@
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "1.9",
-    "P99": "1.98"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
     "Topology": "single",
-    "P95": "24.0",
-    "P99": "24.0"
+    "P95": "151.5",
+    "P99": "151.9"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5254,19 +6475,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.4499999999999993",
-    "P99": "2.8899999999999997"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5276,19 +6486,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4.7999999999999963",
-    "P99": "8.16"
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "3.7999999999999989",
+    "P99": "4.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5298,19 +6508,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.0",
-    "P99": "4.7299999999999995"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "87.0",
-    "P99": "87.0"
+    "P95": "223.0",
+    "P99": "223.7"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5320,8 +6519,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.29999999999973",
-    "P99": "497.41999999999996"
+    "P95": "207.39999999999969",
+    "P99": "489.21999999999997"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -5331,8 +6530,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "334.29999999999973",
-    "P99": "497.41999999999996"
+    "P95": "207.39999999999969",
+    "P99": "489.21999999999997"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5342,8 +6541,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "6.0",
-    "P99": "6.0"
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5353,8 +6552,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "11.0",
-    "P99": "18.809999999999988"
+    "P95": "8.0",
+    "P99": "12.119999999999997"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1407.6499999999999",
+    "P99": "1521.53"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5364,8 +6574,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "18.599999999999994",
-    "P99": "69.319999999999965"
+    "P95": "12.699999999999987",
+    "P99": "73.119999999999976"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "5.0",
+    "P99": "5.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2160.2",
+    "P99": "2284.04"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5375,8 +6607,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "26.0",
-    "P99": "56.359999999999992"
+    "P95": "12.049999999999994",
+    "P99": "148.88999999999982"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5386,8 +6618,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "13.249999999999991",
-    "P99": "70.299999999999955"
+    "P95": "7.0",
+    "P99": "10.279999999999998"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "23.599999999999994"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5397,8 +6640,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "29.29999999999999",
-    "P99": "43.539999999999992"
+    "P95": "21.15",
+    "P99": "39.009999999999991"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5408,8 +6651,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "32.999999999999993",
-    "P99": "42.8"
+    "P95": "16.799999999999997",
+    "P99": "35.919999999999987"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "15.499999999999995",
+    "P99": "31.849999999999994"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "17.0",
+    "P99": "17.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5419,8 +6684,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "18.599999999999994",
-    "P99": "69.319999999999965"
+    "P95": "12.699999999999987",
+    "P99": "73.119999999999976"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "191.49999999999989",
+    "P99": "264.15"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "191.49999999999989",
+    "P99": "264.15"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5430,8 +6717,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "11.7"
+    "P95": "7.6499999999999959",
+    "P99": "10.519999999999996"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "808.55",
+    "P99": "820.11"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5441,8 +6739,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "13.999999999999988",
-    "P99": "44.91999999999998"
+    "P95": "17.599999999999987",
+    "P99": "56.289999999999992"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5452,8 +6750,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "13.099999999999996",
-    "P99": "93.759999999999835"
+    "P95": "9.0",
+    "P99": "13.469999999999999"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5463,8 +6761,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "1911.1",
-    "P99": "2250.2599999999998"
+    "P95": "1743.9999999999995",
+    "P99": "2245.4"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.6999999999999988",
+    "P99": "58.499999999999986"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5474,8 +6783,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "4.1",
+    "P99": "4.82"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5485,8 +6794,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "33.699999999999989",
-    "P99": "37.74"
+    "P95": "16.7",
+    "P99": "20.08"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5496,8 +6805,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "27.749999999999993",
-    "P99": "31.419999999999998"
+    "P95": "20.399999999999995",
+    "P99": "29.47"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5507,30 +6816,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.0",
-    "P99": "11.7"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "28.199999999999982",
-    "P99": "222.31999999999994"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "5.9999999999999991",
-    "P99": "6.8"
+    "P95": "7.6499999999999959",
+    "P99": "10.519999999999996"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5551,8 +6838,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "13.389999999999999"
+    "P95": "7.0",
+    "P99": "10.719999999999999"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5562,8 +6849,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "54.0",
-    "P99": "55.36"
+    "P95": "53.0",
+    "P99": "54.51"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5573,8 +6860,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "10.45"
+    "P95": "253.49999999999997",
+    "P99": "277.69999999999993"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5584,8 +6871,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "69.749999999999986",
-    "P99": "78.75"
+    "P95": "73.0",
+    "P99": "79.4"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5595,8 +6882,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "35.349999999999952",
-    "P99": "64.07"
+    "P95": "5.5999999999999979",
+    "P99": "13.599999999999998"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5606,7 +6893,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "5.7999999999999989",
+    "P95": "6.0",
     "P99": "6.0"
   },
   {
@@ -5617,8 +6904,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "10.599999999999998",
-    "P99": "36.239999999999981"
+    "P95": "7.8499999999999943",
+    "P99": "12.36"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5628,8 +6915,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "27.0",
-    "P99": "27.65"
+    "P95": "20.099999999999998",
+    "P99": "20.82"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5639,8 +6926,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "21.999999999999993",
-    "P99": "26.799999999999997"
+    "P95": "289.49999999999994",
+    "P99": "350.7"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5650,8 +6937,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "36.05",
-    "P99": "40.81"
+    "P95": "17.15",
+    "P99": "17.83"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.8499999999999999",
+    "P99": "1.97"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5661,8 +6959,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.1999999999999993",
-    "P99": "4.84"
+    "P95": "4.3999999999999995",
+    "P99": "4.88"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5672,19 +6970,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "17.499999999999947",
-    "P99": "64.299999999999983"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5694,8 +6981,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "13.389999999999999"
+    "P95": "7.0",
+    "P99": "10.719999999999999"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5705,8 +6992,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "54.0",
-    "P99": "55.36"
+    "P95": "53.0",
+    "P99": "54.51"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5716,19 +7003,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "10.45"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "182.49999999999994",
-    "P99": "243.7"
+    "P95": "253.49999999999997",
+    "P99": "277.69999999999993"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5738,8 +7014,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "326.69999999999976",
-    "P99": "501.06"
+    "P95": "247.49999999999986",
+    "P99": "490.47999999999996"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -5749,8 +7025,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "326.69999999999976",
-    "P99": "501.06"
+    "P95": "247.49999999999986",
+    "P99": "490.47999999999996"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5761,7 +7037,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "8.0499999999999936"
+    "P99": "4.8599999999999994"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1406.9999999999998",
+    "P99": "1521.3999999999999"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5771,8 +7058,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.7999999999999963",
-    "P99": "47.499999999999993"
+    "P95": "4.0",
+    "P99": "42.879999999999988"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "4.6999999999999993",
+    "P99": "4.9399999999999995"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2152.1",
+    "P99": "2275.22"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5782,8 +7091,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "10.0",
-    "P99": "19.469999999999953"
+    "P95": "10.199999999999987",
+    "P99": "139.07999999999979"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5793,8 +7102,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "5.0",
-    "P99": "42.599999999999994"
+    "P95": "3.7499999999999956",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.5499999999999989",
+    "P99": "21.749999999999993"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5804,8 +7124,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "19.999999999999993",
-    "P99": "21.6"
+    "P95": "20.049999999999997",
+    "P99": "21.61"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5815,8 +7135,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "17.0",
-    "P99": "23.199999999999996"
+    "P95": "17.549999999999994",
+    "P99": "19.57"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "13.0",
+    "P99": "22.159999999999997"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "17.999999999999996",
+    "P99": "20.4"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5826,8 +7168,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.7999999999999963",
-    "P99": "47.499999999999993"
+    "P95": "4.0",
+    "P99": "42.879999999999988"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "174.69999999999996",
+    "P99": "210.98"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "174.69999999999996",
+    "P99": "210.98"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5838,7 +7202,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "4.34"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "810.69999999999993",
+    "P99": "822.93999999999994"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5848,8 +7223,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.8499999999999988",
-    "P99": "4.0"
+    "P95": "3.899999999999999",
+    "P99": "21.159999999999997"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5859,8 +7234,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "8.6999999999999975",
-    "P99": "115.95999999999985"
+    "P95": "6.4499999999999975",
+    "P99": "11.919999999999996"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5870,8 +7245,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "1888.9",
-    "P99": "2243.42"
+    "P95": "1738.4999999999995",
+    "P99": "2240.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "8.59999999999994",
+    "P99": "63.319999999999986"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5892,8 +7278,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "15.499999999999998",
-    "P99": "16.75"
+    "P95": "16.549999999999997",
+    "P99": "17.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5903,8 +7289,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "10.0",
-    "P99": "14.559999999999999"
+    "P95": "15.899999999999999",
+    "P99": "22.24"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5915,18 +7301,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "75.9999999999998",
-    "P99": "251.19999999999996"
+    "P99": "4.34"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5936,8 +7311,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4.2499999999999991",
-    "P99": "4.85"
+    "P95": "3.899999999999999",
+    "P99": "6.34"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5947,7 +7322,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "56.0",
+    "P95": "55.85",
     "P99": "57.0"
   },
   {
@@ -5958,8 +7333,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.9999999999999991",
-    "P99": "3.8"
+    "P95": "265.59999999999997",
+    "P99": "308.48"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5980,8 +7355,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.0999999999999979",
-    "P99": "43.819999999999979"
+    "P95": "5.0",
+    "P99": "10.559999999999999"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -5991,8 +7366,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4.0",
-    "P99": "4.0"
+    "P95": "3.9",
+    "P99": "3.98"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -6002,19 +7377,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.7999999999999865",
-    "P99": "15.959999999999997"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "6.7999999999999989",
-    "P99": "7.76"
+    "P95": "3.0",
+    "P99": "10.799999999999997"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -6024,8 +7388,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "22.599999999999994",
-    "P99": "26.919999999999998"
+    "P95": "289.49999999999994",
+    "P99": "350.7"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -6042,34 +7406,12 @@
     "BackendName": "oauth-api-reused-connections",
     "Release": "4.12",
     "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
     "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "19.599999999999952",
-    "P99": "63.11999999999999"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "4.0",
-    "P99": "4.0"
+    "P95": "5.1999999999999993",
+    "P99": "5.84"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -6079,8 +7421,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "4.2499999999999991",
-    "P99": "4.85"
+    "P95": "3.899999999999999",
+    "P99": "6.34"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -6090,7 +7432,7 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "56.0",
+    "P95": "55.85",
     "P99": "57.0"
   },
   {
@@ -6101,19 +7443,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.9999999999999991",
-    "P99": "3.8"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "195.24999999999994",
-    "P99": "246.25"
+    "P95": "265.59999999999997",
+    "P99": "308.48"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -6123,8 +7454,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "342.79999999999973",
-    "P99": "497.2"
+    "P95": "207.49999999999969",
+    "P99": "488.79999999999995"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -6134,14 +7465,289 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "342.79999999999973",
-    "P99": "497.2"
+    "P95": "207.49999999999969",
+    "P99": "488.79999999999995"
   },
   {
     "BackendName": "openshift-api-new-connections",
     "Release": "4.12",
-    "FromRelease": "4.10",
+    "FromRelease": "4.11",
     "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "6.0",
+    "P99": "9.4399999999999959"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1378.85",
+    "P99": "1426.17"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.2",
+    "P99": "59.639999999999972"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "5.85",
+    "P99": "5.97"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2058.6",
+    "P99": "2113.32"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.0",
+    "P99": "169.15999999999985"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "7.0",
+    "P99": "11.309999999999999"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.8"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "21.15",
+    "P99": "42.159999999999989"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "16.0",
+    "P99": "33.019999999999996"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "16.599999999999991",
+    "P99": "32.279999999999994"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "17.5",
+    "P99": "18.7"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "10.2",
+    "P99": "59.639999999999972"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "189.39999999999989",
+    "P99": "267.8"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "189.39999999999989",
+    "P99": "267.8"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.0",
+    "P99": "10.25"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "924.35",
+    "P99": "930.47"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "17.199999999999982",
+    "P99": "55.899999999999984"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "7.1999999999999966",
+    "P99": "12.099999999999998"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1658.5",
+    "P99": "2099.8999999999996"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "66.69999999999996",
+    "P99": "107.74"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "15.0",
+    "P99": "15.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "19.999999999999993",
+    "P99": "31.639999999999997"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "8.0",
+    "P99": "10.25"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -6151,211 +7757,35 @@
   {
     "BackendName": "openshift-api-new-connections",
     "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "7.0",
-    "P99": "12.0"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "9.7499999999999982",
-    "P99": "52.799999999999969"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "23.399999999999977",
-    "P99": "48.679999999999978"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "10.999999999999984",
-    "P99": "42.399999999999963"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "33.05",
-    "P99": "46.199999999999996"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "34.999999999999986",
-    "P99": "42.8"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.11",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "9.7499999999999982",
-    "P99": "52.799999999999969"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.6999999999999957",
-    "P99": "11.94"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "18.749999999999989",
-    "P99": "49.969999999999978"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "17.999999999999932",
-    "P99": "135.55999999999986"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "1836.9999999999998",
-    "P99": "2116.1"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.2999999999999994",
-    "P99": "3.86"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "31.699999999999974",
-    "P99": "40.96"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "31.499999999999989",
-    "P99": "35.0"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "8.6999999999999957",
-    "P99": "11.94"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "6.2499999999999991",
-    "P99": "6.85"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
     "FromRelease": "",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "9.7999999999999972",
-    "P99": "32.279999999999987"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "54.5",
-    "P99": "56.0"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "9.0",
-    "P99": "13.589999999999998"
+    "P99": "23.29999999999999"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "54.0",
+    "P99": "271.15999999999985"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "291.4",
+    "P99": "317.84999999999997"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6365,8 +7795,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "5.6",
-    "P99": "5.92"
+    "P95": "4.0",
+    "P99": "4.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6376,8 +7806,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "39.049999999999955",
-    "P99": "64.41"
+    "P95": "6.0",
+    "P99": "34.079999999999991"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6387,7 +7817,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "7.9999999999999973",
+    "P95": "8.0",
     "P99": "8.0"
   },
   {
@@ -6398,8 +7828,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.5999999999999979",
-    "P99": "36.599999999999987"
+    "P95": "6.3999999999999968",
+    "P99": "16.319999999999997"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6409,8 +7839,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "25.499999999999996",
-    "P99": "29.599999999999998"
+    "P95": "21.099999999999998",
+    "P99": "22.62"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6420,8 +7850,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "24.799999999999997",
-    "P99": "27.36"
+    "P95": "177.5",
+    "P99": "182.7"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6431,8 +7861,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "30.399999999999991",
-    "P99": "42.64"
+    "P95": "17.15",
+    "P99": "17.83"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6442,8 +7883,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "1.7499999999999998",
+    "P99": "1.95"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6453,19 +7894,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "23.199999999999953",
-    "P99": "65.44"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "5.0",
-    "P99": "5.0"
+    "P95": "3.8",
+    "P99": "3.96"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6474,31 +7904,20 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
-    "Topology": "ha",
-    "P95": "9.7999999999999972",
-    "P99": "32.279999999999987"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "54.5",
-    "P99": "56.0"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
     "Topology": "ha",
     "P95": "9.0",
-    "P99": "13.589999999999998"
+    "P99": "23.29999999999999"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.12",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "54.0",
+    "P99": "271.15999999999985"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6507,9 +7926,9 @@
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "sdn",
-    "Topology": "single",
-    "P95": "246.79999999999998",
-    "P99": "268.56"
+    "Topology": "ha",
+    "P95": "291.4",
+    "P99": "317.84999999999997"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6519,8 +7938,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "326.74999999999972",
-    "P99": "501.45"
+    "P95": "254.09999999999985",
+    "P99": "491.54999999999995"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -6530,19 +7949,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "326.74999999999972",
-    "P99": "501.45"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
+    "P95": "254.09999999999985",
+    "P99": "491.54999999999995"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6553,7 +7961,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "3.9599999999999991"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "1379.5",
+    "P99": "1426.3"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6563,8 +7982,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.8999999999999986",
-    "P99": "34.22999999999999"
+    "P95": "4.6999999999999975",
+    "P99": "33.489999999999995"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "4.3999999999999995",
+    "P99": "4.88"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "2047.6499999999999",
+    "P99": "2099.13"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6574,8 +8015,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "5.5499999999999892",
-    "P99": "20.569999999999986"
+    "P95": "5.3999999999999941",
+    "P99": "69.879999999999953"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6585,8 +8026,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "6.9999999999999911",
-    "P99": "21.999999999999993"
+    "P95": "3.0",
+    "P99": "6.8799999999999981"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "2.7999999999999989",
+    "P99": "3.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6596,7 +8048,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "19.999999999999993",
+    "P95": "20.0",
     "P99": "20.0"
   },
   {
@@ -6607,8 +8059,30 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "17.999999999999996",
-    "P99": "21.4"
+    "P95": "17.549999999999994",
+    "P99": "20.14"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "12.649999999999999",
+    "P99": "22.119999999999997"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "18.249999999999996",
+    "P99": "21.25"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6618,8 +8092,30 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "4.8999999999999986",
-    "P99": "34.22999999999999"
+    "P95": "4.6999999999999975",
+    "P99": "33.489999999999995"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "176.24999999999997",
+    "P99": "210.45"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "176.24999999999997",
+    "P99": "210.45"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6630,7 +8126,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "3.9099999999999993"
+    "P99": "3.2199999999999993"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "P95": "922.5",
+    "P99": "929.3"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6641,7 +8148,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "2.899999999999999",
-    "P99": "3.0"
+    "P99": "9.2399999999999984"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6651,8 +8158,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "121.69999999999987"
+    "P95": "5.1999999999999975",
+    "P99": "11.639999999999997"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6662,8 +8169,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "1828.9999999999998",
-    "P99": "2106.94"
+    "P95": "1650.5",
+    "P99": "2090.7999999999997"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "23.69999999999991",
+    "P99": "103.93999999999998"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6684,8 +8202,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "15.549999999999997",
-    "P99": "16.77"
+    "P95": "16.599999999999994",
+    "P99": "17.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6695,8 +8213,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.7999999999999989",
-    "P99": "14.559999999999999"
+    "P95": "15.85",
+    "P99": "22.159999999999997"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6707,7 +8225,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "3.9099999999999993"
+    "P99": "3.2199999999999993"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6717,8 +8235,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "37.149999999999991",
-    "P99": "45.83"
+    "P95": "21.249999999999996",
+    "P99": "30.47"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6728,8 +8246,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "56.0",
-    "P99": "57.0"
+    "P95": "57.0",
+    "P99": "298.91999999999985"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6739,8 +8257,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.78"
+    "P95": "315.8",
+    "P99": "341.46"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6762,7 +8280,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "4.0",
-    "P99": "40.769999999999975"
+    "P99": "16.949999999999992"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6783,19 +8301,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "6.7999999999999865",
-    "P99": "18.959999999999997"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "P95": "4.3999999999999995",
-    "P99": "4.88"
+    "P95": "10.099999999999989",
+    "P99": "19.619999999999997"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6805,8 +8312,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "P95": "24.799999999999997",
-    "P99": "27.36"
+    "P95": "177.0",
+    "P99": "182.6"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6816,19 +8323,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "1.6499999999999997",
+    "P99": "1.93"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6838,17 +8334,6 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "9.5999999999999925",
-    "P99": "62.139999999999986"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
     "P95": "2.0",
     "P99": "2.0"
   },
@@ -6860,19 +8345,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "37.149999999999991",
-    "P99": "45.83"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "P95": "56.0",
-    "P99": "57.0"
+    "P95": "21.249999999999996",
+    "P99": "30.47"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6882,19 +8356,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "3.0",
-    "P99": "3.78"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "single",
-    "P95": "274.0",
-    "P99": "274.0"
+    "P95": "315.8",
+    "P99": "341.46"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6904,8 +8367,8 @@
     "Architecture": "ppc64le",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "349.59999999999974",
-    "P99": "498.88"
+    "P95": "212.74999999999969",
+    "P99": "490.06"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -6915,8 +8378,8 @@
     "Architecture": "s390x",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "349.59999999999974",
-    "P99": "498.88"
+    "P95": "212.74999999999969",
+    "P99": "490.06"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -6937,8 +8400,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "16.149999999999967",
-    "P99": "36.519999999999975"
+    "P95": "17.0",
+    "P99": "40.159999999999982"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -6948,8 +8411,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "12.209999999999999"
+    "P95": "10.849999999999993",
+    "P99": "15.339999999999996"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "6.0",
+    "P99": "6.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -6960,7 +8434,7 @@
     "Network": "sdn",
     "Topology": "ha",
     "P95": "7.0",
-    "P99": "9.0"
+    "P99": "10.109999999999998"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -6970,8 +8444,19 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "46.299999999999983",
-    "P99": "57.459999999999994"
+    "P95": "48.0",
+    "P99": "57.08"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "25.799999999999997",
+    "P99": "27.56"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -6981,8 +8466,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "9.0",
-    "P99": "12.209999999999999"
+    "P95": "10.849999999999993",
+    "P99": "15.339999999999996"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -7003,8 +8488,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "12.0",
-    "P99": "14.789999999999997"
+    "P95": "11.0",
+    "P99": "13.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -7015,7 +8500,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "8.0",
-    "P99": "14.119999999999989"
+    "P99": "10.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "6.4499999999999975",
+    "P99": "10.939999999999998"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -7025,8 +8521,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "7.2999999999999989",
-    "P99": "7.8599999999999994"
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -7040,28 +8536,6 @@
     "P99": "17.0"
   },
   {
-    "BackendName": "service-load-balancer-with-pdb-new-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "13.0",
-    "P99": "18.0"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.10",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
     "Release": "4.12",
     "FromRelease": "4.11",
@@ -7070,7 +8544,7 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.349999999999997"
+    "P99": "3.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -7080,8 +8554,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.1499999999999959",
-    "P99": "9.03"
+    "P95": "2.0",
+    "P99": "6.1999999999999966"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -7103,7 +8588,18 @@
     "Network": "ovn",
     "Topology": "ha",
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "3.6099999999999968"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.11",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "P95": "4.0",
+    "P99": "4.9699999999999989"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -7113,8 +8609,8 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.1499999999999959",
-    "P99": "9.03"
+    "P95": "2.0",
+    "P99": "6.1999999999999966"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -7124,8 +8620,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.7999999999999838",
-    "P99": "3.0"
+    "P95": "2.0",
+    "P99": "4.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -7135,8 +8631,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "P95": "2.4499999999999948",
-    "P99": "4.7799999999999976"
+    "P95": "3.0",
+    "P99": "3.0999999999999956"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -7145,6 +8641,17 @@
     "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
+    "Topology": "ha",
+    "P95": "3.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.12",
+    "FromRelease": "4.12",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
     "Topology": "ha",
     "P95": "3.0",
     "P99": "4.0"
@@ -7168,18 +8675,7 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "P95": "2.7999999999999838",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-reused-connections",
-    "Release": "4.12",
-    "FromRelease": "4.12",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "P95": "3.0",
+    "P95": "2.0",
     "P99": "4.0"
   }
 ]


### PR DESCRIPTION
/hold

## alerts Information

There were (165) added jobs and (30) were removed.

### Comparisons were above allowed leeway of `1m0s`

Note: alerts had `4` jobs increased and `86` jobs decreased.

| Name | Release | From | Arch | Network | Platform | Topology | Time Increase |
| ---- | ------- | ---- | ---- | ------- | -------- |--------- | ------------- |
| KubePersistentVolumeErrors | 4.12 |  | amd64 | sdn | azure |ha | 29m20.76s |
| etcdGRPCRequestsSlow | 4.12 |  | ppc64le | sdn | libvirt |ha | 10m57.3s |
| etcdGRPCRequestsSlow | 4.12 |  | s390x | sdn | libvirt |ha | 10m57.3s |
| etcdGRPCRequestsSlow | 4.12 |  | amd64 | ovn | vsphere |ha | 3m16.96s |


### Missing Data

Note: Jobs were missing from the new data set but was present in the previous dataset.

| Name | Release | From | Arch | Network | Platform | Topology | Time Increase |
| ---- | ------- | ---- | ---- | ------- | -------- |--------- | ------------- |
| PrometheusOperatorWatchErrors | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdInsufficientMembers | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdHighNumberOfLeaderChanges | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdMembersDown | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdGRPCRequestsSlow | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| KubeClientErrors | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| KubeAPIErrorBudgetBurn | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdNoLeader | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdMemberCommunicationSlow | 4.12 |  | arm64 | sdn | aws |single | 0s |
| KubeAPIErrorBudgetBurn | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdHighNumberOfFailedGRPCRequests | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdHighNumberOfLeaderChanges | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdInsufficientMembers | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| MCDDrainError | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdHighFsyncDurations | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| KubeClientErrors | 4.12 |  | arm64 | sdn | aws |single | 0s |
| KubePersistentVolumeErrors | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| KubePersistentVolumeErrors | 4.12 |  | arm64 | sdn | aws |single | 0s |
| VSphereOpenshiftNodeHealthFail | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdHighFsyncDurations | 4.12 |  | arm64 | sdn | aws |single | 0s |
| MCDDrainError | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| PrometheusOperatorWatchErrors | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdNoLeader | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdHighCommitDurations | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdMembersDown | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdGRPCRequestsSlow | 4.12 |  | arm64 | sdn | aws |single | 0s |
| VSphereOpenshiftNodeHealthFail | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdHighCommitDurations | 4.12 |  | arm64 | sdn | aws |single | 0s |
| etcdMemberCommunicationSlow | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| etcdHighNumberOfFailedGRPCRequests | 4.12 |  | arm64 | sdn | aws |single | 0s |



## disruptions Information

There were (215) added jobs and (79) were removed.

### Comparisons were above allowed leeway of `1m0s`

Note: disruptions had `67` jobs increased and `305` jobs decreased.

| Name | Release | From | Arch | Network | Platform | Topology | Time Increase |
| ---- | ------- | ---- | ---- | ------- | -------- |--------- | ------------- |
| ingress-to-console-reused-connections | 4.12 |  | amd64 | sdn | aws |ha | 45m46.12s |
| ingress-to-console-new-connections | 4.12 |  | arm64 | sdn | aws |ha | 44m42.75s |
| ingress-to-console-new-connections | 4.12 |  | amd64 | sdn | aws |ha | 44m42.75s |
| openshift-api-reused-connections | 4.12 |  | amd64 | sdn | aws |ha | 5m37.68s |
| openshift-api-reused-connections | 4.12 |  | arm64 | sdn | aws |ha | 5m37.68s |
| oauth-api-new-connections | 4.12 |  | amd64 | ovn | metal |single | 5m23.9s |
| oauth-api-reused-connections | 4.12 |  | amd64 | ovn | metal |single | 5m23.78s |
| cache-oauth-api-new-connections | 4.12 |  | amd64 | ovn | metal |single | 5m16.7s |
| cache-oauth-api-reused-connections | 4.12 |  | amd64 | ovn | metal |single | 5m16.58s |
| cache-openshift-api-reused-connections | 4.12 |  | amd64 | sdn | aws |ha | 5m15.66s |
| oauth-api-reused-connections | 4.12 |  | amd64 | sdn | aws |ha | 5m4.68s |
| oauth-api-reused-connections | 4.12 |  | arm64 | sdn | aws |ha | 5m4.68s |
| openshift-api-new-connections | 4.12 |  | arm64 | sdn | aws |ha | 5m4.26s |
| openshift-api-new-connections | 4.12 |  | amd64 | sdn | aws |ha | 5m4.26s |
| cache-oauth-api-reused-connections | 4.12 |  | amd64 | sdn | aws |ha | 5m2.61s |
| cache-oauth-api-reused-connections | 4.12 |  | arm64 | sdn | aws |ha | 5m2.61s |
| cache-openshift-api-new-connections | 4.12 |  | arm64 | sdn | aws |ha | 5m2.08s |
| cache-openshift-api-new-connections | 4.12 |  | amd64 | sdn | aws |ha | 5m2.08s |
| oauth-api-new-connections | 4.12 |  | amd64 | sdn | aws |ha | 4m27.25s |
| oauth-api-new-connections | 4.12 |  | arm64 | sdn | aws |ha | 4m27.25s |
| cache-openshift-api-reused-connections | 4.12 |  | amd64 | ovn | aws |single | 4m21.12s |
| cache-oauth-api-new-connections | 4.12 |  | arm64 | sdn | aws |ha | 4m16.8s |
| cache-oauth-api-new-connections | 4.12 |  | amd64 | sdn | aws |ha | 4m16.8s |
| kube-api-new-connections | 4.12 |  | arm64 | sdn | aws |ha | 4m7.8s |
| kube-api-new-connections | 4.12 |  | amd64 | sdn | aws |ha | 4m7.8s |
| cache-kube-api-new-connections | 4.12 |  | amd64 | sdn | aws |ha | 4m7.46s |
| cache-kube-api-new-connections | 4.12 |  | arm64 | sdn | aws |ha | 4m7.46s |
| openshift-api-reused-connections | 4.12 |  | amd64 | ovn | aws |single | 4m1.92s |
| cache-openshift-api-new-connections | 4.12 |  | arm64 | ovn | aws |single | 3m46.68s |
| cache-openshift-api-new-connections | 4.12 |  | amd64 | ovn | aws |single | 3m46.68s |
| kube-api-reused-connections | 4.12 |  | arm64 | sdn | aws |ha | 3m38.97s |
| kube-api-reused-connections | 4.12 |  | amd64 | sdn | aws |ha | 3m38.97s |
| cache-kube-api-reused-connections | 4.12 |  | amd64 | sdn | aws |ha | 3m35.54s |
| openshift-api-new-connections | 4.12 |  | amd64 | ovn | aws |single | 3m35.16s |
| openshift-api-new-connections | 4.12 |  | arm64 | ovn | aws |single | 3m35.16s |
| cache-kube-api-reused-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 3m28.42s |
| cache-openshift-api-reused-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 3m21.98s |
| ingress-to-oauth-server-new-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 3m17.21s |
| cache-openshift-api-new-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 3m16.1s |
| cache-oauth-api-new-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 3m7.16s |
| cache-kube-api-new-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 3m6.72s |
| ingress-to-console-new-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 2m49.16s |
| openshift-api-new-connections | 4.12 |  | amd64 | ovn | metal |single | 2m35.34s |
| openshift-api-reused-connections | 4.12 |  | amd64 | ovn | metal |single | 2m35.24s |
| ingress-to-console-reused-connections | 4.12 |  | amd64 | ovn | metal |single | 2m27.14s |
| ingress-to-console-new-connections | 4.12 |  | amd64 | ovn | metal |single | 2m27.06s |
| ingress-to-oauth-server-reused-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 2m22.58s |
| ingress-to-oauth-server-new-connections | 4.12 |  | amd64 | ovn | metal |single | 2m19.56s |
| ingress-to-console-reused-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 2m16.41s |
| ingress-to-oauth-server-reused-connections | 4.12 |  | amd64 | ovn | metal |single | 2m13.46s |
| kube-api-reused-connections | 4.12 |  | amd64 | ovn | metal |single | 2m7.9s |
| kube-api-new-connections | 4.12 |  | amd64 | ovn | metal |single | 2m7.76s |
| openshift-api-new-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 2m0.48s |
| oauth-api-reused-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 1m59.61s |
| kube-api-new-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 1m54.97s |
| ingress-to-oauth-server-new-connections | 4.12 | 4.11 | amd64 | sdn | aws |ha | 1m51.54s |
| ingress-to-oauth-server-new-connections | 4.12 | 4.11 | arm64 | sdn | aws |ha | 1m51.54s |
| ingress-to-console-new-connections | 4.12 | 4.11 | amd64 | sdn | aws |ha | 1m45.43s |
| ingress-to-console-new-connections | 4.12 | 4.11 | arm64 | sdn | aws |ha | 1m45.43s |
| oauth-api-new-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 1m32.53s |
| cache-oauth-api-reused-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 1m30.48s |
| kube-api-reused-connections | 4.12 | 4.11 | amd64 | sdn | azure |ha | 1m22.27s |
| ingress-to-console-reused-connections | 4.12 | 4.11 | arm64 | sdn | aws |ha | 1m21.04s |
| ingress-to-console-reused-connections | 4.12 | 4.11 | amd64 | sdn | aws |ha | 1m21.04s |
| ingress-to-oauth-server-new-connections | 4.12 | 4.12 | amd64 | sdn | aws |ha | 1m9.41s |
| cache-openshift-api-new-connections | 4.12 |  | amd64 | ovn | metal |single | 1m5.54s |
| cache-openshift-api-reused-connections | 4.12 |  | amd64 | ovn | metal |single | 1m3.32s |


### Missing Data

Note: Jobs were missing from the new data set but was present in the previous dataset.

| Name | Release | From | Arch | Network | Platform | Topology | Time Increase |
| ---- | ------- | ---- | ---- | ------- | -------- |--------- | ------------- |
| cache-openshift-api-reused-connections | 4.12 |  | arm64 | ovn | aws |single | 0s |
| kube-api-new-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| kube-api-reused-connections | 4.12 |  | amd64 | ovn | metal |ha | 0s |
| oauth-api-new-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| oauth-api-new-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| openshift-api-new-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| oauth-api-new-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| openshift-api-new-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| oauth-api-reused-connections | 4.12 |  | amd64 | ovn | metal |ha | 0s |
| ingress-to-oauth-server-reused-connections | 4.12 |  | arm64 | ovn | aws |ha | 0s |
| ingress-to-console-reused-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| openshift-api-reused-connections | 4.12 |  | amd64 | sdn | ovirt |ha | 0s |
| image-registry-reused-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| openshift-api-reused-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| ingress-to-oauth-server-new-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| ingress-to-console-reused-connections | 4.12 |  | arm64 | ovn | aws |single | 0s |
| kube-api-new-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| cache-oauth-api-reused-connections | 4.12 |  | amd64 | ovn | metal |ha | 0s |
| service-load-balancer-with-pdb-reused-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| cache-openshift-api-reused-connections | 4.12 |  | arm64 | sdn | aws |ha | 0s |
| ingress-to-oauth-server-reused-connections | 4.12 | 4.10 | amd64 | sdn | aws |ha | 0s |
| cache-kube-api-reused-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| cache-oauth-api-reused-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| ingress-to-oauth-server-reused-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| image-registry-new-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| cache-oauth-api-new-connections | 4.12 |  | amd64 | sdn |  |ha | 0s |
| ingress-to-oauth-server-new-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| oauth-api-reused-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| kube-api-new-connections | 4.12 | 4.10 | amd64 | sdn | aws |ha | 0s |
| cache-openshift-api-reused-connections | 4.12 |  | amd64 | sdn | ovirt |ha | 0s |
| openshift-api-reused-connections | 4.12 |  | amd64 | ovn | metal |ha | 0s |
| cache-oauth-api-reused-connections | 4.12 |  | amd64 | sdn | ovirt |ha | 0s |
| ingress-to-console-new-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| openshift-api-reused-connections | 4.12 | 4.10 | amd64 | sdn | aws |ha | 0s |
| ingress-to-console-new-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| cache-kube-api-new-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| cache-openshift-api-new-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| cache-openshift-api-new-connections | 4.12 |  | amd64 | ovn |  |ha | 0s |
| ci-cluster-network-liveness-reused-connections | 4.12 | 4.12 | amd64 | ovn | azure |single | 0s |
| cache-oauth-api-new-connections | 4.12 | 4.10 | amd64 | sdn | aws |ha | 0s |
| cache-openshift-api-reused-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| kube-api-reused-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| cache-kube-api-reused-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| ci-cluster-network-liveness-new-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| cache-kube-api-reused-connections | 4.12 |  | arm64 | sdn | aws |ha | 0s |
| openshift-api-reused-connections | 4.12 |  | arm64 | ovn | aws |single | 0s |
| openshift-api-reused-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| ingress-to-console-reused-connections | 4.12 |  | amd64 | ovn |  |ha | 0s |
| cache-openshift-api-new-connections | 4.12 | 4.10 | amd64 | sdn | aws |ha | 0s |
| ingress-to-console-reused-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| openshift-api-new-connections | 4.12 | 4.10 | amd64 | sdn | aws |ha | 0s |
| ingress-to-oauth-server-reused-connections | 4.12 |  | amd64 | ovn |  |ha | 0s |
| cache-oauth-api-new-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| cache-oauth-api-reused-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| openshift-api-new-connections | 4.12 |  | amd64 | ovn |  |ha | 0s |
| ingress-to-console-reused-connections | 4.12 |  | amd64 | sdn | ovirt |ha | 0s |
| kube-api-reused-connections | 4.12 |  | amd64 | sdn | ovirt |ha | 0s |
| image-registry-reused-connections | 4.12 | 4.10 | amd64 | sdn | aws |ha | 0s |
| cache-openshift-api-new-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| oauth-api-reused-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| kube-api-new-connections | 4.12 |  | amd64 | ovn |  |ha | 0s |
| ci-cluster-network-liveness-reused-connections | 4.12 | 4.12 | arm64 | ovn | aws |ha | 0s |
| cache-openshift-api-reused-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| service-load-balancer-with-pdb-new-connections | 4.12 | 4.12 | arm64 | sdn | aws |ha | 0s |
| cache-kube-api-new-connections | 4.12 |  | amd64 | ovn |  |ha | 0s |
| cache-kube-api-reused-connections | 4.12 |  | amd64 | ovn | metal |ha | 0s |
| ingress-to-console-reused-connections | 4.12 |  | arm64 | sdn | aws |ha | 0s |
| ingress-to-oauth-server-reused-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| oauth-api-new-connections | 4.12 |  | amd64 | ovn |  |ha | 0s |
| cache-openshift-api-reused-connections | 4.12 |  | amd64 | ovn | metal |ha | 0s |
| cache-openshift-api-reused-connections | 4.12 |  | amd64 | ovn | gcp |ha | 0s |
| oauth-api-reused-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| service-load-balancer-with-pdb-reused-connections | 4.12 | 4.10 | amd64 | sdn | aws |ha | 0s |
| kube-api-reused-connections | 4.12 |  | amd64 | sdn | vsphere |ha | 0s |
| ingress-to-oauth-server-new-connections | 4.12 |  | amd64 | sdn |  |ha | 0s |
| ingress-to-console-reused-connections | 4.12 |  | amd64 | ovn | azure |ha | 0s |
| oauth-api-reused-connections | 4.12 |  | amd64 | sdn | ovirt |ha | 0s |
| kube-api-reused-connections | 4.12 |  | arm64 | sdn | aws |single | 0s |
| kube-api-new-connections | 4.12 |  | amd64 | ovn | azure |ha | 0s |


Signed-off-by: ehila <ehila@redhat.com>