### PR TITLE
Bump api-requests for console-operator on vsphere

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -241,7 +241,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"cluster-node-tuning-operator":           97.0,
 				"cluster-samples-operator":               25.0,
 				"cluster-storage-operator":               195.0,
-				"console-operator":                       106.0,
+				"console-operator":                       110.0,
 				"csi-snapshot-controller-operator":       80.0,
 				"dns-operator":                           49.0,
 				"etcd-operator":                          147.0,


### PR DESCRIPTION
Found in:
- https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-kubernetes-1360-nightly-4.12-e2e-vsphere-ovn-techpreview-serial/1572344489270317056 
- https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-kubernetes-1360-nightly-4.12-e2e-vsphere-ovn-serial/1572344487600984064

/assign @ingvagabund 