### PR TITLE
OCPBUGS-1052: allow frontends to tolerate 2.5% disruption during upgrades

### DIFF
--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -130,8 +130,8 @@ func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgra
 	// framework.ProviderIs("gce") removed here in 4.9 due to regression. BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1983758
 	case framework.ProviderIs("azure"), framework.ProviderIs("aws"):
 		if hasAllFixes {
-			framework.Logf("Cluster contains no versions older than 4.8, tolerating no disruption")
-			toleratedDisruption = 0
+			framework.Logf("Cluster contains no versions older than 4.8, tolerating 2.5% disruption")
+			toleratedDisruption = 0.025
 		}
 	}
 	disruption.ExpectNoDisruption(f, toleratedDisruption, end.Sub(start), m.Intervals(time.Time{}, time.Time{}), "Frontends were unreachable during disruption")


### PR DESCRIPTION
Recent 4.8 to 4.9 upgrade tests fail fairly consistently due to cluster frontend ingress being unavailable. Currently the upgrade test tolerates no disruption whatsoever. This PR makes the test more lenient, allowing 2.5% disruption, which is the minimum that would have resulted in passes for the string of recent failures.

Note for reviewer: this is outside my typical domain, so if there's a more targeted fix we could make (e.g. do this only on AWS upgrades), or we think its worth root-causing and/or adding a link in the test output to help our future selves understand this decision, let me know what's appropriate.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>