### PR TITLE
Add Kuryr exception to "pods should successfully create sandboxes" test

### DIFF
--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -109,6 +109,12 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 				continue
 			}
 		}
+		if strings.Contains(event.Message, "kuryr") && strings.Contains(event.Message, "deleted while processing the CNI ADD request") {
+			// This happens from time to time with Kuryr. Creating ports in Neutron for pod can take long and a controller might delete the pod before,
+			// effectively cancelling Kuryr CNI ADD request.
+			flakes = append(flakes, fmt.Sprintf("%v - pod got deleted while kuryr was still processing its creation - %v", event.Locator, event.Message))
+			continue
+		}
 
 		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.Locator)
 		if deletionTime := getPodDeletionTime(eventsForPods[partialLocator], event.Locator); deletionTime == nil {


### PR DESCRIPTION
Kuryr can take long to create Pods as it needs to create ports for these pods in Neutron. If a pod gets deleted while this is being processed, a warning Event will be generated. This causes the `[sig-network] pods should successfully create sandboxes by adding pod to network` to fail.

This commit adds this case as a flake.