### PR TITLE
Add Invariant test to look for probe errors for openshift-config-operator

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -46,6 +46,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testBackoffStartingFailedContainerForE2ENamespaces(events)...)
 	tests = append(tests, testAPIQuotaEvents(events)...)
 	tests = append(tests, testErrorUpdatingEndpointSlices(events)...)
+	tests = append(tests, testConfigOperatorReadinessProbe(events)...)
 
 	return tests
 }
@@ -89,6 +90,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 
 	tests = append(tests, testNoExcessiveSecretGrowthDuringUpgrade()...)
 	tests = append(tests, testNoExcessiveConfigMapGrowthDuringUpgrade()...)
+	tests = append(tests, testConfigOperatorReadinessProbe(events)...)
 
 	return tests
 }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/TRT-566

Looking for events like this on openshift-config-operator pods:

```
{
  "level": "Info",
  "locator": "ns/openshift-config-operator pod/openshift-config-operator-6fb5684645-wx5bt uid/b7869874-df1a-4ecc-bada-59fa9c7d5e64 container/openshift-config-operator",
  "message": "constructed/true reason/ReadinessFailed Get \"https://10.130.0.16:8443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
  "from": "2022-08-29T10:41:23Z",
  "to": "2022-08-29T10:41:24Z"
}
```

I also augmented the ReadinessFailed and ReadinessErrored messages with the timestamp so I don't have to search an events.json file to get the timestamp when looking at the failure output in the prow job.

If the failure output looks too weird, I can be convinced to remove `"failureTime="+failureTime.Format("15:04:05")`.

[Example failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27436/pull-ci-openshift-origin-master-e2e-gcp-ovn-upgrade/1574500025503846400)