### PR TITLE
Check for console capability before launching it's disruption monitoring.

### DIFF
--- a/test/extended/util/cluster/cluster.go
+++ b/test/extended/util/cluster/cluster.go
@@ -290,3 +290,20 @@ func (c *ClusterConfiguration) MatchFn() func(string) bool {
 	}
 	return matchFn
 }
+
+func HasCapability(clusterVersion *configv1.ClusterVersion, desiredCapability string) bool {
+	for _, ec := range clusterVersion.Status.Capabilities.EnabledCapabilities {
+		if string(ec) == desiredCapability {
+			return true
+		}
+	}
+	return false
+}
+func KnowsCapability(clusterVersion *configv1.ClusterVersion, desiredCapability string) bool {
+	for _, ec := range clusterVersion.Status.Capabilities.KnownCapabilities {
+		if string(ec) == desiredCapability {
+			return true
+		}
+	}
+	return false
+}

--- a/test/extended/util/disruption/frontends/known_backends.go
+++ b/test/extended/util/disruption/frontends/known_backends.go
@@ -3,11 +3,14 @@ package frontends
 import (
 	"context"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/test/extended/util/cluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
 func StartAllIngressMonitoring(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
@@ -17,12 +20,29 @@ func StartAllIngressMonitoring(ctx context.Context, m monitor.Recorder, clusterC
 	if err := createOAuthRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
 		return err
 	}
-	if err := createConsoleRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
+
+	// Some jobs explicitly disable the console and other features. Check if it's disabled and if so,
+	// do not run a disruption monitoring backend for it.
+	configClient, err := configclient.NewForConfig(clusterConfig)
+	if err != nil {
 		return err
 	}
-	if err := createConsoleRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
-		return err
+	clusterVersion, err := configClient.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
+	if err != nil {
+		e2e.Failf("Failed to get cluster version: %v", err)
 	}
+	// If the cluster does not know about the Console capability, it likely predates 4.12 and we can assume
+	// it has it by default. This is to catch possible future scenarios where we upgrade 4.11 no cap to 4.12 no cap.
+	if !cluster.KnowsCapability(clusterVersion, "Console") ||
+		cluster.HasCapability(clusterVersion, "Console") {
+		if err := createConsoleRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
+			return err
+		}
+		if err := createConsoleRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Adds new utilities to check for enabled and known capabilities. Check
also assumes that if the cluster doesn't know about the console
capability, it predates 4.12 and thus we should assume to do monitoring
for console as it was default then.

The test should then see no ingress- backends for console, and not fail.

[TRT-573](https://issues.redhat.com//browse/TRT-573)
