### PR TITLE
Write out cluster state and config to disk for later inspection

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/kubectl/pkg/util/templates"
+
 	"github.com/openshift/origin/pkg/synthetictests"
 	"github.com/openshift/origin/pkg/test/ginkgo"
 	exutil "github.com/openshift/origin/test/extended/util"
-	"k8s.io/kubectl/pkg/util/templates"
 
 	_ "github.com/openshift/origin/test/extended"
 	_ "github.com/openshift/origin/test/extended/util/annotate/generated"
@@ -448,7 +449,7 @@ func isStandardEarlyOrLateTest(name string) bool {
 // suiteWithInitializedProviderPreSuite loads the provider info, but does not
 // exclude any tests specific to that provider.
 func suiteWithInitializedProviderPreSuite(opt *runOptions) error {
-	config, err := decodeProvider(opt.Provider, opt.DryRun, true, nil)
+	config, err := decodeProvider(opt.Provider, opt.DryRun, true, opt.JUnitDir, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -430,7 +430,7 @@ func newRunTestCommand() *cobra.Command {
 			ginkgo.GlobalSuite().ClearBeforeSuiteNode()
 			ginkgo.GlobalSuite().ClearAfterSuiteNode()
 
-			config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
+			config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, os.Getenv("TEST_JUNIT_DIR"), nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/openshift-tests/provider_test.go
+++ b/cmd/openshift-tests/provider_test.go
@@ -6,6 +6,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	exutilcluster "github.com/openshift/origin/test/extended/util/cluster"
 
 	corev1 "k8s.io/api/core/v1"
@@ -272,7 +273,7 @@ func TestDecodeProvider(t *testing.T) {
 					NetworkSpec:    tc.discoveredNetwork,
 				}
 			}
-			config, err := decodeProvider(tc.provider, false, discover, testState)
+			config, err := decodeProvider(tc.provider, false, discover, "", testState)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/origin/pkg/synthetictests"
-	"github.com/openshift/origin/pkg/test/ginkgo"
-	"github.com/openshift/origin/test/e2e/upgrade"
-	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/kubernetes/test/e2e/upgrades"
+
+	"github.com/openshift/origin/pkg/synthetictests"
+	"github.com/openshift/origin/pkg/test/ginkgo"
+	"github.com/openshift/origin/test/e2e/upgrade"
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 // upgradeSuites are all known upgrade test suites this binary should run
@@ -78,7 +79,7 @@ var upgradeSuites = testSuites{
 func upgradeTestPreSuite(opt *runOptions) error {
 	if !opt.DryRun {
 		testOpt := ginkgo.NewTestOptions(os.Stdout, os.Stderr)
-		config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
+		config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, true, opt.JUnitDir, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
origin already examines the cluster under test and generates configuration and state information that contains useful things that can be looked at for debugging later (was this cluster ipv4? what versions are in the CVO history? did it run on AWS? etc).