### PR TITLE
Fix rare race condition in ImageStream admission tests.

### DIFF
--- a/test/extended/images/imagestream_admission.go
+++ b/test/extended/images/imagestream_admission.go
@@ -434,6 +434,7 @@ func TestImageStreamAdmitStatusUpdate(t g.GinkgoTInterface, oc *exutil.CLI) {
 			},
 		},
 	})
+
 	_, err = client.ImageV1().ImageStreams(oc.Namespace()).UpdateStatus(ctx, is, metav1.UpdateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -559,6 +560,13 @@ func bumpLimit(t g.GinkgoTInterface, oc *exutil.CLI, lrClient corev1client.Limit
 	}
 	_, err = lrClient.Update(context.Background(), lr, metav1.UpdateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// In very rare circumstances, this change is not honored when we immediately make requests that will
+	// violate the new limit. A sleep should help these test failures from ever occurring. I'd prefer
+	// we wait until some observed state is validated, but LimitRange has no Status.
+	// Using same value as pre-existing Sleep above.
+	time.Sleep(5 * time.Second)
+
 	return res
 }
 


### PR DESCRIPTION
Details in TRT-577. Essentially we bump the limit from 0 to 1,
immediately try to create an ImageStream expecting it to pass, but get
rejected as the old limit of 0 appears to still be in effect.

There is no observed Status on LimitRange to wait for, so I think the
best we can do here is a sleep.
