### PR TITLE
OCPBUGS-1079: Use kubeconfig from secret mount instead of /tmp

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -49,6 +49,7 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster
 	context.AllowedNotReadyNodes = -1
 	context.MinStartupPods = -1
 	context.MaxNodesToGather = 0
+	context.KubeConfig = os.Getenv("KUBECONFIG")
 
 	// allow the CSI tests to access test data, but only briefly
 	// TODO: ideally CSI would not use any of these test methods

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -36,6 +36,7 @@ import (
 
 	projectv1 "github.com/openshift/api/project/v1"
 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
+
 	"github.com/openshift/origin/pkg/version"
 )
 
@@ -67,7 +68,6 @@ func InitTest(dryRun bool) error {
 	testfiles.AddFileSource(conformancetestdata.GetConformanceTestdataFS())
 	TestContext.KubectlPath = "kubectl"
 	TestContext.KubeConfig = KubeConfigPath()
-	os.Setenv("KUBECONFIG", TestContext.KubeConfig)
 
 	// "debian" is used when not set. At least GlusterFS tests need "custom".
 	// (There is no option for "rhel" or "centos".)


### PR DESCRIPTION
Every now and then we get catastrophic runs where hundreds of tests fail with this error:

```
error: stat /tmp/kubeconfig-2448219175: no such file or directory
```

Example run at [1].

Typically we use the `KUBECONFIG` from a read-only mounted secret. However there is code in `initializeTestFramework` that causes this temp file to be created in certain cases. The file is written by a vendored kube function, which does this because the context it's given doesn't specify any `KUBECONFIG` so it gets one via a service account.  By setting it in the context, we can avoid writing one to /tmp.

The benefit to this is the secret is mounted read only, so it shouldn't be modifiable or removable.  I dug around and I cannot figure *what* exactly caused the /tmp/kubeconfig- to be deleted, but I am hoping this guards against it.

This also remove a meaningless call that's effectively doing os.Setenv(os.Getenv("KUBECONFIG")).

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-sdn-upgrade/1572280613627498496

[2] https://github.com/openshift/origin/blob/199ad942ed2d5998b83da2a609e0a11e70e5475a/vendor/k8s.io/kubernetes/test/e2e/framework/test_context.go#L453