### PR TITLE
Bug 2033167: Remove deprecated oc extract missing dir test

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -32352,7 +32352,6 @@ os::cmd::expect_failure_and_text "oc extract secret/dockerconfigjson secret/dock
 os::cmd::expect_success_and_text "oc extract secret/dockerconfigjson secret/dockerconfigjson --to '${workingdir}' --confirm" '.dockerconfigjson'
 os::cmd::expect_success_and_text "oc extract secret/dockerconfigjson --to '${workingdir}' --confirm" '.dockerconfigjson'
 os::cmd::expect_success "oc extract secret/dockerconfigjson --to '${workingdir}' --confirm | xargs rm"
-os::cmd::expect_failure_and_text "oc extract secret/dockerconfigjson --to missing-dir" "stat missing-dir: no such file or directory"
 
 # attach secrets to service account
 # single secret with prefix

--- a/test/extended/testdata/cmd/test/cmd/secrets.sh
+++ b/test/extended/testdata/cmd/test/cmd/secrets.sh
@@ -41,7 +41,6 @@ os::cmd::expect_failure_and_text "oc extract secret/dockerconfigjson secret/dock
 os::cmd::expect_success_and_text "oc extract secret/dockerconfigjson secret/dockerconfigjson --to '${workingdir}' --confirm" '.dockerconfigjson'
 os::cmd::expect_success_and_text "oc extract secret/dockerconfigjson --to '${workingdir}' --confirm" '.dockerconfigjson'
 os::cmd::expect_success "oc extract secret/dockerconfigjson --to '${workingdir}' --confirm | xargs rm"
-os::cmd::expect_failure_and_text "oc extract secret/dockerconfigjson --to missing-dir" "stat missing-dir: no such file or directory"
 
 # attach secrets to service account
 # single secret with prefix


### PR DESCRIPTION
Currently `oc extract` command fails when target directory is absent. However, with this PR https://github.com/openshift/oc/pull/1248, we are changing functionality and we are creating nested directories
if they are absent. 

Thus, this test becomes obsolete and this PR removes it.