### PR TITLE
Trt 579 http2 connection lost

### DIFF
--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -165,6 +165,10 @@ func eventsFromKubeletLogs(nodeName string, kubeletLog []byte) monitorapi.Interv
 		currLine := scanner.Text()
 		ret = append(ret, readinessFailure(currLine)...)
 		ret = append(ret, readinessError(currLine)...)
+		ret = append(ret, statusHttpClientConnectionLostError(currLine)...)
+		ret = append(ret, reflectorHttpClientConnectionLostError(currLine)...)
+		ret = append(ret, kubeletNodeHttpClientConnectionLostError(currLine)...)
+
 	}
 
 	return ret
@@ -245,14 +249,18 @@ var failureOutputRegex = regexp.MustCompile(`"Probe failed" probeType="Readiness
 var errorOutputRegex = regexp.MustCompile(`"Probe errored" err="(?P<OUTPUT>.+)" probeType="Readiness"`)
 
 func probeProblemToContainerReference(logLine string) monitorapi.ContainerReference {
+	return regexToContainerReference(logLine, containerRefRegex)
+}
+
+func regexToContainerReference(logLine string, containerReferenceMatch *regexp.Regexp) monitorapi.ContainerReference {
 	ret := monitorapi.ContainerReference{}
-	containerRefRegex.MatchString(logLine)
-	if !containerRefRegex.MatchString(logLine) {
+	containerReferenceMatch.MatchString(logLine)
+	if !containerReferenceMatch.MatchString(logLine) {
 		return ret
 	}
 
-	subMatches := containerRefRegex.FindStringSubmatch(logLine)
-	subNames := containerRefRegex.SubexpNames()
+	subMatches := containerReferenceMatch.FindStringSubmatch(logLine)
+	subNames := containerReferenceMatch.SubexpNames()
 	for i, name := range subNames {
 		switch name {
 		case "NS":
@@ -267,6 +275,90 @@ func probeProblemToContainerReference(logLine string) monitorapi.ContainerRefere
 	}
 
 	return ret
+}
+
+var reflectorRefRegex = regexp.MustCompile(`object-"(?P<NS>[a-z0-9.-]+)"\/"(?P<POD>[a-z0-9.-]+)"`)
+var reflectorOutputRegex = regexp.MustCompile(`error on the server \("(?P<OUTPUT>.+)"\)`)
+var statusRefRegex = regexp.MustCompile(`podUID=(?P<PODUID>[a-z0-9.-]+) pod="(?P<NS>[a-z0-9.-]+)\/(?P<POD>[a-z0-9.-]+)"`)
+var statusOutputRegex = regexp.MustCompile(`err="(?P<OUTPUT>.+)"`)
+var nodeRefRegex = regexp.MustCompile(`error getting node \\"(?P<NODEID>[a-z0-9.-]+)\\"`)
+var nodeOutputRegex = regexp.MustCompile(`err="(?P<OUTPUT>.+)"`)
+
+func reflectorHttpClientConnectionLostError(logLine string) monitorapi.Intervals {
+	if !strings.Contains(logLine, `http2: client connection lost`) {
+		return nil
+	}
+
+	if !strings.Contains(logLine, `watch of`) {
+		return nil
+	}
+
+	return commonErrorInterval(logLine, reflectorOutputRegex, "HttpClientConnectionLost", func() string {
+		containerRef := regexToContainerReference(logLine, reflectorRefRegex)
+		return containerRef.ToLocator()
+	})
+}
+
+func statusHttpClientConnectionLostError(logLine string) monitorapi.Intervals {
+	if !strings.Contains(logLine, `http2: client connection lost`) {
+		return nil
+	}
+
+	if !strings.Contains(logLine, `Failed to get status for pod`) {
+		return nil
+	}
+
+	return commonErrorInterval(logLine, nodeOutputRegex, "HttpClientConnectionLost", func() string {
+		containerRef := regexToContainerReference(logLine, statusRefRegex)
+		return containerRef.ToLocator()
+	})
+}
+
+func kubeletNodeHttpClientConnectionLostError(logLine string) monitorapi.Intervals {
+	if !strings.Contains(logLine, `http2: client connection lost`) {
+		return nil
+	}
+
+	if !strings.Contains(logLine, `Error updating node status`) {
+		return nil
+	}
+
+	return commonErrorInterval(logLine, statusOutputRegex, "HttpClientConnectionLost", func() string {
+		nodeRefRegex.MatchString(logLine)
+		if !nodeRefRegex.MatchString(logLine) {
+			return ""
+		}
+		return nodeRefRegex.FindStringSubmatch(logLine)[1]
+	})
+
+}
+
+func commonErrorInterval(logLine string, messageExp *regexp.Regexp, reason string, locator func() string) monitorapi.Intervals {
+
+	messageExp.MatchString(logLine)
+	if !messageExp.MatchString(logLine) {
+		return nil
+	}
+	outputSubmatches := messageExp.FindStringSubmatch(logLine)
+	message := outputSubmatches[1]
+	// message contains many \", this removes the escaping to result in message containing "
+	// if we have an error, just use the original message, we don't really care that much.
+	if unquotedMessage, err := strconv.Unquote(`"` + message + `"`); err == nil {
+		message = unquotedMessage
+	}
+
+	failureTime := kubeletLogTime(logLine)
+	return monitorapi.Intervals{
+		{
+			Condition: monitorapi.Condition{
+				Level:   monitorapi.Info,
+				Locator: locator(),
+				Message: monitorapi.ReasonedMessage(reason, message),
+			},
+			From: failureTime,
+			To:   failureTime,
+		},
+	}
 }
 
 var kubeletTimeRegex = regexp.MustCompile(`^(?P<MONTH>\S+)\s(?P<DAY>\S+)\s(?P<TIME>\S+)`)

--- a/pkg/monitor/intervalcreation/node_test.go
+++ b/pkg/monitor/intervalcreation/node_test.go
@@ -23,12 +23,12 @@ func TestMonitorApiIntervals(t *testing.T) {
 			logLine: `Sep 27 08:59:59.857303 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: I0927 08:59:59.850662    2397 status_manager.go:667] "Failed to get status for pod" podUID=a1947638-25c2-4fd8-b3c8-4dbaa666bc61 pod="openshift-monitoring/prometheus-k8s-0" err="Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost"`,
 			want: monitorapi.EventInterval{
 				Condition: monitorapi.Condition{
-					Level:   0,
+					Level:   monitorapi.Info,
 					Locator: "ns/openshift-monitoring pod/prometheus-k8s-0 uid/a1947638-25c2-4fd8-b3c8-4dbaa666bc61 container/",
 					Message: "reason/HttpClientConnectionLost Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost",
 				},
-				From: time.UnixMicro(1664269199857303).In(time.UTC),
-				To:   time.UnixMicro(1664269199857303).In(time.UTC),
+				From: kubeletLogTime("Sep 27 08:59:59.857303"),
+				To:   kubeletLogTime("Sep 27 08:59:59.857303"),
 			},
 		},
 		{
@@ -36,12 +36,12 @@ func TestMonitorApiIntervals(t *testing.T) {
 			logLine: `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: W0927 08:59:59.849136    2397 reflector.go:347] object-"openshift-monitoring"/"prometheus-adapter-7m6srg4dfreoi": watch of *v1.Secret ended with: an error on the server ("unable to decode an event from the watch stream: http2: client connection lost") has prevented the request from succeeding`,
 			want: monitorapi.EventInterval{
 				Condition: monitorapi.Condition{
-					Level:   0,
+					Level:   monitorapi.Info,
 					Locator: "ns/openshift-monitoring pod/prometheus-adapter-7m6srg4dfreoi uid/ container/",
 					Message: "reason/HttpClientConnectionLost unable to decode an event from the watch stream: http2: client connection lost",
 				},
-				From: time.UnixMicro(1664269199853216).In(time.UTC),
-				To:   time.UnixMicro(1664269199853216).In(time.UTC),
+				From: kubeletLogTime("Sep 27 08:59:59.853216"),
+				To:   kubeletLogTime("Sep 27 08:59:59.853216"),
 			},
 		},
 		{
@@ -49,12 +49,12 @@ func TestMonitorApiIntervals(t *testing.T) {
 			logLine: `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: E0927 08:59:59.849143    2397 kubelet_node_status.go:487] "Error updating node status, will retry" err="error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost"`,
 			want: monitorapi.EventInterval{
 				Condition: monitorapi.Condition{
-					Level:   0,
-					Locator: "ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s",
+					Level:   monitorapi.Info,
+					Locator: "node/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s",
 					Message: "reason/HttpClientConnectionLost error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost",
 				},
-				From: time.UnixMicro(1664269199853216).In(time.UTC),
-				To:   time.UnixMicro(1664269199853216).In(time.UTC),
+				From: kubeletLogTime("Sep 27 08:59:59.853216"),
+				To:   kubeletLogTime("Sep 27 08:59:59.853216"),
 			},
 		},
 		{
@@ -62,12 +62,12 @@ func TestMonitorApiIntervals(t *testing.T) {
 			logLine: `Jul 05 17:47:52.807876 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: I0606 17:47:52.807876    1599 prober.go:121] "Probe failed" probeType="Readiness" pod="openshift-authentication/oauth-openshift-77f7b95df5-r4xf7" podUID=1af660b3-ac3a-4182-86eb-2f74725d8415 containerName="oauth-openshift" probeResult=failure output="Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"`,
 			want: monitorapi.EventInterval{
 				Condition: monitorapi.Condition{
-					Level:   0,
+					Level:   monitorapi.Info,
 					Locator: "ns/openshift-authentication pod/oauth-openshift-77f7b95df5-r4xf7 uid/1af660b3-ac3a-4182-86eb-2f74725d8415 container/oauth-openshift",
 					Message: "reason/ReadinessFailed Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
 				},
-				From: time.UnixMicro(1657043272807876).In(time.UTC),
-				To:   time.UnixMicro(1657043272807876).In(time.UTC),
+				From: kubeletLogTime("Jul 05 17:47:52.807876"),
+				To:   kubeletLogTime("Jul 05 17:47:52.807876"),
 			},
 		},
 		{
@@ -75,19 +75,18 @@ func TestMonitorApiIntervals(t *testing.T) {
 			logLine: `Jul 05 17:43:12.908344 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: E0606 17:43:12.908344    1500 prober.go:118] "Probe errored" err="rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found" probeType="Readiness" pod="openshift-marketplace/redhat-operators-4jpg4" podUID=0bac4741-a3bd-483c-b119-e97663d64024 containerName="registry-server"`,
 			want: monitorapi.EventInterval{
 				Condition: monitorapi.Condition{
-					Level:   0,
+					Level:   monitorapi.Info,
 					Locator: "ns/openshift-marketplace pod/redhat-operators-4jpg4 uid/0bac4741-a3bd-483c-b119-e97663d64024 container/registry-server",
 					Message: "reason/ReadinessErrored rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found",
 				},
-				From: time.UnixMicro(1657042992908344).In(time.UTC),
-				To:   time.UnixMicro(1657042992908344).In(time.UTC),
+				From: kubeletLogTime("Jul 05 17:43:12.908344"),
+				To:   kubeletLogTime("Jul 05 17:43:12.908344"),
 			},
 		},
 	}
 
 	logString := ""
 	for i := range testcase {
-
 		logString += testcase[i].logLine + "\n"
 	}
 

--- a/pkg/monitor/intervalcreation/node_test.go
+++ b/pkg/monitor/intervalcreation/node_test.go
@@ -2,6 +2,7 @@ package intervalcreation
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 
@@ -9,6 +10,191 @@ import (
 
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 )
+
+func TestMonitorApiIntervals(t *testing.T) {
+
+	testcase := []struct {
+		name    string
+		logLine string
+		want    monitorapi.EventInterval
+	}{
+		{
+			name:    "status",
+			logLine: `Sep 27 08:59:59.857303 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: I0927 08:59:59.850662    2397 status_manager.go:667] "Failed to get status for pod" podUID=a1947638-25c2-4fd8-b3c8-4dbaa666bc61 pod="openshift-monitoring/prometheus-k8s-0" err="Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost"`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   0,
+					Locator: "ns/openshift-monitoring pod/prometheus-k8s-0 uid/a1947638-25c2-4fd8-b3c8-4dbaa666bc61 container/",
+					Message: "reason/HttpClientConnectionLost Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost",
+				},
+				From: time.UnixMicro(1664269199857303).In(time.UTC),
+				To:   time.UnixMicro(1664269199857303).In(time.UTC),
+			},
+		},
+		{
+			name:    "reflector",
+			logLine: `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: W0927 08:59:59.849136    2397 reflector.go:347] object-"openshift-monitoring"/"prometheus-adapter-7m6srg4dfreoi": watch of *v1.Secret ended with: an error on the server ("unable to decode an event from the watch stream: http2: client connection lost") has prevented the request from succeeding`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   0,
+					Locator: "ns/openshift-monitoring pod/prometheus-adapter-7m6srg4dfreoi uid/ container/",
+					Message: "reason/HttpClientConnectionLost unable to decode an event from the watch stream: http2: client connection lost",
+				},
+				From: time.UnixMicro(1664269199853216).In(time.UTC),
+				To:   time.UnixMicro(1664269199853216).In(time.UTC),
+			},
+		},
+		{
+			name:    "kubelet",
+			logLine: `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: E0927 08:59:59.849143    2397 kubelet_node_status.go:487] "Error updating node status, will retry" err="error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost"`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   0,
+					Locator: "ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s",
+					Message: "reason/HttpClientConnectionLost error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost",
+				},
+				From: time.UnixMicro(1664269199853216).In(time.UTC),
+				To:   time.UnixMicro(1664269199853216).In(time.UTC),
+			},
+		},
+		{
+			name:    "simple failure",
+			logLine: `Jul 05 17:47:52.807876 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: I0606 17:47:52.807876    1599 prober.go:121] "Probe failed" probeType="Readiness" pod="openshift-authentication/oauth-openshift-77f7b95df5-r4xf7" podUID=1af660b3-ac3a-4182-86eb-2f74725d8415 containerName="oauth-openshift" probeResult=failure output="Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   0,
+					Locator: "ns/openshift-authentication pod/oauth-openshift-77f7b95df5-r4xf7 uid/1af660b3-ac3a-4182-86eb-2f74725d8415 container/oauth-openshift",
+					Message: "reason/ReadinessFailed Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+				},
+				From: time.UnixMicro(1657043272807876).In(time.UTC),
+				To:   time.UnixMicro(1657043272807876).In(time.UTC),
+			},
+		},
+		{
+			name:    "simple error",
+			logLine: `Jul 05 17:43:12.908344 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: E0606 17:43:12.908344    1500 prober.go:118] "Probe errored" err="rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found" probeType="Readiness" pod="openshift-marketplace/redhat-operators-4jpg4" podUID=0bac4741-a3bd-483c-b119-e97663d64024 containerName="registry-server"`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   0,
+					Locator: "ns/openshift-marketplace pod/redhat-operators-4jpg4 uid/0bac4741-a3bd-483c-b119-e97663d64024 container/registry-server",
+					Message: "reason/ReadinessErrored rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found",
+				},
+				From: time.UnixMicro(1657042992908344).In(time.UTC),
+				To:   time.UnixMicro(1657042992908344).In(time.UTC),
+			},
+		},
+	}
+
+	logString := ""
+	for i := range testcase {
+
+		logString += testcase[i].logLine + "\n"
+	}
+
+	intervals := eventsFromKubeletLogs("testName", []byte(logString))
+
+	if intervals == nil {
+		t.Fatal("Invalid intervals")
+	}
+
+	if intervals.Len() != len(testcase) {
+		t.Fatal("Mismatched interval count")
+	}
+
+	for i := range intervals {
+		if !reflect.DeepEqual(intervals[i], testcase[i].want) {
+			t.Errorf("Interval compare for %s = %v, want %v", testcase[i].name, intervals[i], testcase[i])
+		}
+	}
+}
+
+func TestRegexToContainerReference(t *testing.T) {
+	type args struct {
+		logLine                 string
+		containerReferenceMatch *regexp.Regexp
+	}
+	tests := []struct {
+		name string
+		args args
+		want monitorapi.ContainerReference
+	}{
+		{
+			name: "statusManager http connection failure",
+			args: args{
+				logLine:                 `Sep 27 08:59:59.857303 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: I0927 08:59:59.850662    2397 status_manager.go:667] "Failed to get status for pod" podUID=a1947638-25c2-4fd8-b3c8-4dbaa666bc61 pod="openshift-monitoring/prometheus-k8s-0" err="Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost"`,
+				containerReferenceMatch: statusRefRegex,
+			},
+			want: monitorapi.ContainerReference{
+				Pod: monitorapi.PodReference{
+					NamespacedReference: monitorapi.NamespacedReference{
+						Namespace: "openshift-monitoring",
+						Name:      "prometheus-k8s-0",
+						UID:       "a1947638-25c2-4fd8-b3c8-4dbaa666bc61",
+					},
+				},
+				ContainerName: "",
+			},
+		},
+		{
+			name: "reflector http connection failure",
+			args: args{
+				logLine:                 `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: W0927 08:59:59.849136    2397 reflector.go:347] object-"openshift-monitoring"/"prometheus-adapter-7m6srg4dfreoi": watch of *v1.Secret ended with: an error on the server ("unable to decode an event from the watch stream: http2: client connection lost") has prevented the request from succeeding`,
+				containerReferenceMatch: reflectorRefRegex,
+			},
+			want: monitorapi.ContainerReference{
+				Pod: monitorapi.PodReference{
+					NamespacedReference: monitorapi.NamespacedReference{
+						Namespace: "openshift-monitoring",
+						Name:      "prometheus-adapter-7m6srg4dfreoi",
+						UID:       "",
+					},
+				},
+				ContainerName: "",
+			},
+		},
+		{
+			name: "simple failure",
+			args: args{
+				logLine:                 `Jul 05 17:47:52.807876 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: I0606 17:47:52.807876    1599 prober.go:121] "Probe failed" probeType="Readiness" pod="openshift-authentication/oauth-openshift-77f7b95df5-r4xf7" podUID=1af660b3-ac3a-4182-86eb-2f74725d8415 containerName="oauth-openshift" probeResult=failure output="Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"`,
+				containerReferenceMatch: containerRefRegex,
+			},
+			want: monitorapi.ContainerReference{
+				Pod: monitorapi.PodReference{
+					NamespacedReference: monitorapi.NamespacedReference{
+						Namespace: "openshift-authentication",
+						Name:      "oauth-openshift-77f7b95df5-r4xf7",
+						UID:       "1af660b3-ac3a-4182-86eb-2f74725d8415",
+					},
+				},
+				ContainerName: "oauth-openshift",
+			},
+		},
+		{
+			name: "simple error",
+			args: args{
+				logLine:                 `Jul 05 17:43:12.908344 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: E0606 17:43:12.908344    1500 prober.go:118] "Probe errored" err="rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found" probeType="Readiness" pod="openshift-marketplace/redhat-operators-4jpg4" podUID=0bac4741-a3bd-483c-b119-e97663d64024 containerName="registry-server"`,
+				containerReferenceMatch: containerRefRegex,
+			},
+			want: monitorapi.ContainerReference{
+				Pod: monitorapi.PodReference{
+					NamespacedReference: monitorapi.NamespacedReference{
+						Namespace: "openshift-marketplace",
+						Name:      "redhat-operators-4jpg4",
+						UID:       "0bac4741-a3bd-483c-b119-e97663d64024",
+					},
+				},
+				ContainerName: "registry-server",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := regexToContainerReference(tt.args.logLine, tt.args.containerReferenceMatch); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("regexToContainerReference() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 	intervals, err := monitorserialization.EventsFromFile("testdata/node.json")
@@ -99,6 +285,27 @@ func Test_messageTime(t *testing.T) {
 		args args
 		want time.Time
 	}{
+		{
+			name: "kubelet_node failure",
+			args: args{
+				logLine: `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: E0927 08:59:59.849143    2397 kubelet_node_status.go:487] "Error updating node status, will retry" err="error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost"`,
+			},
+			want: mustTime("27 Sep 2022 08:59:59.853216 UTC"),
+		},
+		{
+			name: "reflector failure",
+			args: args{
+				logLine: `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: W0927 08:59:59.849136    2397 reflector.go:347] object-"openshift-monitoring"/"prometheus-adapter-7m6srg4dfreoi": watch of *v1.Secret ended with: an error on the server ("unable to decode an event from the watch stream: http2: client connection lost") has prevented the request from succeeding`,
+			},
+			want: mustTime("27 Sep 2022 08:59:59.853216 UTC"),
+		},
+		{
+			name: "status failure",
+			args: args{
+				logLine: `Sep 27 08:59:59.857303 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: I0927 08:59:59.850662    2397 status_manager.go:667] "Failed to get status for pod" podUID=a1947638-25c2-4fd8-b3c8-4dbaa666bc61 pod="openshift-monitoring/prometheus-k8s-0" err="Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost"`,
+			},
+			want: mustTime("27 Sep 2022 08:59:59.857303 UTC"),
+		},
 		{
 			name: "simple failure",
 			args: args{

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -47,6 +47,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testAPIQuotaEvents(events)...)
 	tests = append(tests, testErrorUpdatingEndpointSlices(events)...)
 	tests = append(tests, testConfigOperatorReadinessProbe(events)...)
+	tests = append(tests, testHttpConnectionLost(events)...)
 
 	return tests
 }
@@ -91,6 +92,8 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testNoExcessiveSecretGrowthDuringUpgrade()...)
 	tests = append(tests, testNoExcessiveConfigMapGrowthDuringUpgrade()...)
 	tests = append(tests, testConfigOperatorReadinessProbe(events)...)
+
+	tests = append(tests, testHttpConnectionLost(events)...)
 
 	return tests
 }

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -54,7 +54,8 @@ func testKubeletToAPIServerGracefulTermination(events monitorapi.Intervals) []*j
 }
 
 func testHttpConnectionLost(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
-	const testName = "[sig-node] http client connection lost"
+	const testName = "[sig-node] kubelet logs do not contain http client connection lost errors"
+	success := &junitapi.JUnitTestCase{Name: testName}
 
 	var failures []string
 	for _, event := range events {
@@ -63,23 +64,19 @@ func testHttpConnectionLost(events monitorapi.Intervals) []*junitapi.JUnitTestCa
 		}
 	}
 
-	// failures during a run always fail the test suite
-	var tests []*junitapi.JUnitTestCase
-	if len(failures) > 0 {
-		tests = append(tests, &junitapi.JUnitTestCase{
-			Name:      testName,
-			SystemOut: strings.Join(failures, "\n"),
-			FailureOutput: &junitapi.FailureOutput{
-				Output: fmt.Sprintf("%d kubelet logs contain errors from http client connections lost unexpectedly.\n\n%v", len(failures), strings.Join(failures, "\n")),
-			},
-		})
+	if len(failures) == 0 {
+		return []*junitapi.JUnitTestCase{success}
 	}
 
-	// do we want this to fail completely or flake?
-	// for now we flake
-	tests = append(tests, &junitapi.JUnitTestCase{Name: testName})
-
-	return tests
+	failure := &junitapi.JUnitTestCase{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &junitapi.FailureOutput{
+			Output: fmt.Sprintf("%d kubelet logs contain errors from http client connections lost unexpectedly.\n\n%v", len(failures), strings.Join(failures, "\n")),
+		},
+	}
+	// TODO: marked flaky until we have monitored it for consistency
+	return []*junitapi.JUnitTestCase{failure, success}
 }
 
 func testKubeAPIServerGracefulTermination(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
@@ -277,7 +274,7 @@ func testPodTransitions(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 			Output: fmt.Sprintf("Marked as flake until https://bugzilla.redhat.com/show_bug.cgi?id=1933760 is fixed\n\n%d pods illegally transitioned to Pending\n\n%v", len(failures), strings.Join(failures, "\n")),
 		},
 	}
-	// TODO: temporarily marked flaky since it is continously failing
+	// TODO: temporarily marked flaky since it is continuously failing
 	return []*junitapi.JUnitTestCase{failure, success}
 }
 


### PR DESCRIPTION
Adds support for extracting `http2: client connection lost` errors from kubelet logs