### PR TITLE
Kubevirt network connectivity tests

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -50,3 +50,5 @@ aliases:
   - sttts # API Server
   - trozet # Networking
   - umohnani8 # Container Engine Tools
+  - davidvossel # HyperShift on KubeVirt Platform
+  - orenc1 # HyperShift on KubeVirt Platform

--- a/test/extended/kubevirt/OWNERS
+++ b/test/extended/kubevirt/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - davidvossel
+  - nunnatsa
+  - orenc1
+
+approvers:
+  - davidvossel
+  - nunnatsa
+  - orenc1

--- a/test/extended/kubevirt/services.go
+++ b/test/extended/kubevirt/services.go
@@ -1,0 +1,76 @@
+package kubevirt
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = Describe("[sig-kubevirt] services", func() {
+	oc := exutil.NewCLIWithPodSecurityLevel("ns-global", admissionapi.LevelBaseline)
+
+	InKubeVirtClusterContext(oc, func() {
+
+		mgmtFramework := e2e.NewDefaultFramework("mgmt-framework")
+		mgmtFramework.SkipNamespaceCreation = true
+
+		f1 := e2e.NewDefaultFramework("server-framework")
+		f1.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+		It("should allow connections to pods from infra cluster pod via NodePort across different infra nodes", func() {
+			// This tests connectivity from the infra cluster's pod network to a NodePort
+			// within a nested KubeVirt Hypershift guest cluster.
+			//
+			// This exercises the back half of the network flow used to pass ingress
+			// through the ingress cluster into the nested guest cluster.
+			//
+			// client pod (on infra cluster) -> guest node IP -> NodePort -> server pod (on guest cluster)
+			//
+			_, hcpNamespace, err := exutil.GetHypershiftManagementClusterConfigAndNamespace()
+			Expect(err).NotTo(HaveOccurred())
+
+			oc = exutil.NewHypershiftManagementCLI(hcpNamespace).AsAdmin()
+
+			mgmtClientSet := oc.KubeClient()
+			mgmtFramework.Namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: hcpNamespace,
+				},
+			}
+			mgmtFramework.ClientSet = mgmtClientSet
+
+			Expect(checkKubeVirtInfraClusterNodePortConnectivity(f1, mgmtFramework, oc)).To(Succeed())
+		})
+
+		It("should allow connections to pods from guest hostNetwork pod via NodePort across different guest nodes", func() {
+			// Within a nested KubeVirt guest cluster, this tests the ability for
+			// NodePort services to route from hostnet to pods across guest nodes.
+			Expect(checkKubeVirtGuestClusterHostNetworkNodePortConnectivity(f1, f1)).To(Succeed())
+		})
+
+		It("should allow connections to pods from guest podNetwork pod via NodePort across different guest nodes", func() {
+			// Within a nested KubeVirt guest cluster, this tests the ability for
+			// NodePort services to route from pod network to pods across guest nodes.
+			Expect(checkKubeVirtGuestClusterPodNetworkNodePortConnectivity(f1, f1)).To(Succeed())
+		})
+
+		It("should allow direct connections to pods from guest cluster pod in pod network across different guest nodes", func() {
+			// Within a nested KubeVirt guest cluster, this tests the ability for different pods within the
+			// guest cluster to communicate each other, across different guest cluster nodes, via PodNetwork.
+			Expect(checkKubeVirtGuestClusterPodNetworkConnectivity(f1, f1)).To(Succeed())
+		})
+
+		It("should allow direct connections to pods from guest cluster pod in host network across different guest nodes", func() {
+			// Within a nested KubeVirt guest cluster, this tests the ability for different pods within the
+			// guest cluster to communicate each other, across different guest cluster nodes, via HostNetwork.
+			Expect(checkKubeVirtGuestClusterHostNetworkConnectivity(f1, f1)).To(Succeed())
+		})
+	})
+
+})

--- a/test/extended/kubevirt/util.go
+++ b/test/extended/kubevirt/util.go
@@ -1,0 +1,338 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
+	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	"k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type NodeType int
+
+type IPFamily string
+
+func launchWebserverNodePortService(client k8sclient.Interface, namespace, serviceName string, nodeName string) int32 {
+	labelSelector := make(map[string]string)
+	labelSelector["name"] = "web"
+	createPodForService(client, namespace, serviceName, nodeName, labelSelector)
+
+	servicePort := 8080
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+			Ports: []corev1.ServicePort{
+				{
+					Protocol: corev1.ProtocolTCP,
+					Port:     int32(servicePort),
+				},
+			},
+			Selector: labelSelector,
+		},
+	}
+	serviceClient := client.CoreV1().Services(namespace)
+	_, err := serviceClient.Create(context.Background(), service, metav1.CreateOptions{})
+	expectNoError(err)
+	expectNoError(exutil.WaitForEndpoint(client, namespace, serviceName))
+	service, err = serviceClient.Get(context.Background(), serviceName, metav1.GetOptions{})
+	expectNoError(err)
+
+	Expect(service.Spec.Ports[0].NodePort).ToNot(Equal(0))
+	return service.Spec.Ports[0].NodePort
+
+}
+
+func launchWebserverLoadBalancerService(client k8sclient.Interface, namespace, serviceName string, nodeName string, externalIPs []string) int32 {
+	labelSelector := make(map[string]string)
+	labelSelector["name"] = "web"
+	createPodForService(client, namespace, serviceName, nodeName, labelSelector)
+
+	servicePort := 8080
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
+				{
+					Protocol: corev1.ProtocolTCP,
+					Port:     int32(servicePort),
+				},
+			},
+			Selector:    labelSelector,
+			ExternalIPs: externalIPs,
+		},
+	}
+	serviceClient := client.CoreV1().Services(namespace)
+	_, err := serviceClient.Create(context.Background(), service, metav1.CreateOptions{})
+	expectNoError(err)
+	expectNoError(exutil.WaitForEndpoint(client, namespace, serviceName))
+	service, err = serviceClient.Get(context.Background(), serviceName, metav1.GetOptions{})
+	expectNoError(err)
+
+	return int32(servicePort)
+
+}
+
+func checkConnectivityToHostWithCLI(f *e2e.Framework, oc *exutil.CLI, nodeName string, podName string, host string, timeout time.Duration, hostNetwork bool) error {
+	namespace := f.Namespace.Name
+
+	e2e.Logf("Creating an exec pod on node %v", nodeName)
+	execPod := pod.CreateExecPodOrFail(f.ClientSet, namespace, fmt.Sprintf("execpod-sourceip-%s", nodeName), func(pod *corev1.Pod) {
+		pod.Spec.NodeName = nodeName
+		pod.Spec.HostNetwork = hostNetwork
+	})
+	defer func() {
+		e2e.Logf("Cleaning up the exec pod")
+		err := f.ClientSet.CoreV1().Pods(namespace).Delete(context.Background(), execPod.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	var stdout string
+	e2e.Logf("Waiting up to %v to wget %s", timeout, host)
+	cmd := fmt.Sprintf("wget -T 30 -qO- %s", host)
+	var err error
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(2) {
+		stdout, err = oc.Run("exec").Args(execPod.Name, "-n", namespace, "--", "/bin/sh", "-x", "-c", cmd).Output()
+		if err != nil {
+			e2e.Logf("got err: %v, retry until timeout", err)
+			continue
+		}
+		// Need to check output because wget -q might omit the error.
+		if strings.TrimSpace(stdout) == "" {
+			e2e.Logf("got empty stdout, retry until timeout")
+			continue
+		}
+		break
+	}
+	return err
+}
+
+func createPodForService(client k8sclient.Interface, namespace, serviceName string, nodeName string, labelMap map[string]string) {
+	exutil.LaunchWebserverPod(client, namespace, serviceName, nodeName)
+	// FIXME: make e2e.LaunchWebserverPod() set the label when creating the pod
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		podClient := client.CoreV1().Pods(namespace)
+		pod, err := podClient.Get(context.Background(), serviceName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if pod.ObjectMeta.Labels == nil {
+			pod.ObjectMeta.Labels = labelMap
+		} else {
+			for key, value := range labelMap {
+				pod.ObjectMeta.Labels[key] = value
+			}
+		}
+		_, err = podClient.Update(context.Background(), pod, metav1.UpdateOptions{})
+		return err
+	})
+	expectNoError(err)
+}
+
+func platformType(configClient configv1client.Interface) (configv1.PlatformType, error) {
+	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return infrastructure.Status.PlatformStatus.Type, nil
+}
+
+func checkConnectivityToHost(f *e2e.Framework, nodeName string, podName string, host string, timeout time.Duration, hostNetwork bool) error {
+	e2e.Logf("Creating an exec pod on node %v", nodeName)
+	execPod := pod.CreateExecPodOrFail(f.ClientSet, f.Namespace.Name, fmt.Sprintf("execpod-sourceip-%s", nodeName), func(pod *corev1.Pod) {
+		pod.Spec.NodeName = nodeName
+		pod.Spec.HostNetwork = hostNetwork
+	})
+	defer func() {
+		e2e.Logf("Cleaning up the exec pod")
+		err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.Background(), execPod.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	var stdout string
+	e2e.Logf("Waiting up to %v to wget %s", timeout, host)
+	cmd := fmt.Sprintf("wget -T 30 -qO- %s", host)
+	var err error
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(2) {
+		stdout, err = e2e.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
+		if err != nil {
+			e2e.Logf("got err: %v, retry until timeout", err)
+			continue
+		}
+		// Need to check output because wget -q might omit the error.
+		if strings.TrimSpace(stdout) == "" {
+			e2e.Logf("got empty stdout, retry until timeout")
+			continue
+		}
+		break
+	}
+	return err
+}
+
+func getKubeVirtPodFromGuestNode(framework *e2e.Framework, node v1.Node) (*corev1.Pod, error) {
+
+	podList, err := framework.ClientSet.CoreV1().Pods(framework.Namespace.Name).List(context.Background(), metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	for _, pod := range podList.Items {
+		if strings.Contains(pod.Name, node.Name) {
+			return &pod, nil
+		}
+	}
+
+	return nil, fmt.Errorf("kubevirt node's infra pod not found")
+}
+
+func getSchedulableInfraNode(framework *e2e.Framework, serverInfraNode string) (string, error) {
+
+	// find an infra node to schedule the client on
+	nodes, err := e2enode.GetReadySchedulableNodes(framework.ClientSet)
+	if err != nil {
+		e2e.Logf("Unable to get schedulable nodes due to %v", err)
+		return "", err
+	}
+
+	for _, node := range nodes.Items {
+		if node.Name != serverInfraNode {
+			return node.Name, nil
+		}
+	}
+	return "", fmt.Errorf("infra node not found")
+}
+
+func getNodeInternalAddress(node *v1.Node) (string, error) {
+
+	for _, addr := range node.Status.Addresses {
+
+		if addr.Type == v1.NodeInternalIP {
+			return addr.Address, nil
+		}
+	}
+	return "", fmt.Errorf("no internal node ip found for node %s", node.Name)
+}
+
+func checkKubeVirtGuestClusterHostNetworkNodePortConnectivity(serverFramework, clientFramework *e2e.Framework) error {
+	return checkKubeVirtGuestClusterConnectivity(serverFramework, clientFramework, true, v1.ServiceTypeNodePort)
+}
+
+func checkKubeVirtGuestClusterPodNetworkNodePortConnectivity(serverFramework, clientFramework *e2e.Framework) error {
+	return checkKubeVirtGuestClusterConnectivity(serverFramework, clientFramework, false, v1.ServiceTypeNodePort)
+}
+
+func checkKubeVirtInfraClusterConnectivity(serverFramework, clientFramework *e2e.Framework, oc *exutil.CLI, serviceType v1.ServiceType) error {
+	serverGuestNode, err := e2enode.GetRandomReadySchedulableNode(serverFramework.ClientSet)
+	Expect(err).NotTo(HaveOccurred())
+
+	serverVMPod, err := getKubeVirtPodFromGuestNode(clientFramework, *serverGuestNode)
+	Expect(err).NotTo(HaveOccurred())
+
+	serverInfraNode := serverVMPod.Spec.NodeName
+	serverGuestNodeIP := serverVMPod.Status.PodIP
+
+	infraClientNode, err := getSchedulableInfraNode(clientFramework, serverInfraNode)
+	Expect(err).NotTo(HaveOccurred())
+
+	podName := names.SimpleNameGenerator.GenerateName("service-")
+
+	serviceAddr := ""
+	if serviceType == v1.ServiceTypeNodePort {
+		serverGuestNodePort := launchWebserverNodePortService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverGuestNode.Name)
+		serviceAddr = net.JoinHostPort(serverGuestNodeIP, strconv.Itoa(int(serverGuestNodePort)))
+	}
+	if serviceType == v1.ServiceTypeLoadBalancer {
+		hostUrl, err := url.Parse(serverFramework.ClientConfig().Host)
+		if err != nil {
+			return err
+		}
+		externalIP := hostUrl.Host
+		serverLBPort := launchWebserverLoadBalancerService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverGuestNode.Name, []string{externalIP})
+		serviceAddr = net.JoinHostPort(externalIP, strconv.Itoa(int(serverLBPort)))
+	}
+
+	return checkConnectivityToHostWithCLI(clientFramework, oc, infraClientNode, "service-wget", serviceAddr, 10*time.Second, false)
+}
+
+func checkKubeVirtInfraClusterNodePortConnectivity(serverFramework, clientFramework *e2e.Framework, oc *exutil.CLI) error {
+	return checkKubeVirtInfraClusterConnectivity(serverFramework, clientFramework, oc, v1.ServiceTypeNodePort)
+}
+
+func checkKubeVirtGuestClusterConnectivity(serverFramework, clientFramework *e2e.Framework, hostNetwork bool, serviceType v1.ServiceType) error {
+	nodes, err := e2enode.GetBoundedReadySchedulableNodes(serverFramework.ClientSet, 2)
+	if err != nil {
+		return err
+	}
+
+	clientNode := nodes.Items[0]
+	serverNode := nodes.Items[1]
+	podName := names.SimpleNameGenerator.GenerateName("service-")
+	serviceAddr := ""
+	if serviceType == v1.ServiceTypeNodePort {
+		serverNodePort := launchWebserverNodePortService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverNode.Name)
+
+		ip, err := getNodeInternalAddress(&clientNode)
+		Expect(err).NotTo(HaveOccurred())
+
+		serviceAddr = net.JoinHostPort(ip, strconv.Itoa(int(serverNodePort)))
+
+	}
+	if serviceType == v1.ServiceTypeClusterIP {
+		serviceAddr = exutil.LaunchWebserverPod(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverNode.Name)
+	}
+	if serviceType == v1.ServiceTypeLoadBalancer {
+		externalIP := strings.TrimLeft(strings.Split(serverFramework.ClientConfig().Host, ":")[1], "/")
+		serverLBPort := launchWebserverLoadBalancerService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverNode.Name, []string{externalIP})
+		serviceAddr = net.JoinHostPort(externalIP, strconv.Itoa(int(serverLBPort)))
+
+	}
+	return checkConnectivityToHost(clientFramework, clientNode.Name, "service-wget", serviceAddr, 10*time.Second, hostNetwork)
+}
+
+func checkKubeVirtGuestClusterPodNetworkConnectivity(serverFramework, clientFramework *e2e.Framework) error {
+	return checkKubeVirtGuestClusterConnectivity(serverFramework, clientFramework, false, v1.ServiceTypeClusterIP)
+
+}
+
+func checkKubeVirtGuestClusterHostNetworkConnectivity(serverFramework, clientFramework *e2e.Framework) error {
+	return checkKubeVirtGuestClusterConnectivity(serverFramework, clientFramework, true, v1.ServiceTypeClusterIP)
+}
+
+func InKubeVirtClusterContext(oc *exutil.CLI, body func()) {
+	Context("when running openshift cluster on KubeVirt virtual machines",
+		func() {
+			BeforeEach(func() {
+				pType, err := platformType(oc.AdminConfigClient())
+				expectNoError(err)
+				if pType != configv1.KubevirtPlatformType {
+					e2eskipper.Skipf("Not running in KubeVirt cluster")
+				}
+			})
+
+			body()
+		},
+	)
+}
+
+func expectNoError(err error, explain ...interface{}) {
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), explain...)
+}


### PR DESCRIPTION
This PR is a continuation of PR #27308 by @davidvossel 

Introducing 6 test cases to cover pods ability to communicate each other in several scenarios:
* Direct connection between pods on the guest cluster, via Pod Network and Host Network
* Connection between pods in guest cluster to a NodePort service configured on the guest cluster via Pod Network and Host Network.
* Connection between pods in infra cluster to a NodePort service configured on the guest cluster
* ~~Connection between pods in guest cluster to a LoadBalancer service configured on the guest cluster~~
* ~~Connection between pods in infra cluster to a LoadBalancer service configured on the guest cluster~~