### PR TITLE
Drastically reduce the jobs we enforce disruption on.

### DIFF
--- a/pkg/synthetictests/disruption.go
+++ b/pkg/synthetictests/disruption.go
@@ -57,6 +57,26 @@ func testServerAvailability(
 			},
 		}
 	}
+
+	// Check if we got an empty result, which signals we did not have historical data for this NURP and thus
+	// do not want to run the test.
+	if allowedDisruption == nil {
+		// An empty StatisticalDuration implies we did not find any data and thus do not want to run the disruption
+		// test. We'll mark it as a flake and explain why so we can find these tests should anyone need to look.
+		return []*junitapi.JUnitTestCase{
+			{
+				Name:     testName,
+				Duration: jobRunDuration.Seconds(),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: fmt.Sprintf("skipping test due to no historical disruption data: %s", disruptionDetails),
+				},
+			},
+			{
+				Name: testName,
+			},
+		}
+	}
+
 	roundedAllowedDisruption := allowedDisruption.Round(time.Second)
 	if allowedDisruption.Milliseconds() == disruption.DefaultAllowedDisruption {
 		// don't round if we're using the default value so we can find this.


### PR DESCRIPTION
Our operating assumption was that we were only enforcing disruption
using P99 values, thus would expect to only fail 1% of jobs, and if you
violate that test then you likely have regressed.

We have discovered that the vast majority of job platform combinations
do not have the 100 minimum runs required to get a P99, and thus we're
actually failing jobs on as low as P50's, which causes very erratic
failures and retests.

We are now limiting the data going into the historical
query_results.json in openshift/ci-tools repo. Here we now assume that
if we do not have disruption data for the platform under test, we flake
and report why. Previously this was a failure. The flake will allow us
to find instances where this is occurring if anyone needs to.

OCPBUGS-1459
[TRT-583](https://issues.redhat.com//browse/TRT-583)
