### PR TITLE
IR-258: add dockerImageLayers to all Image objects

### DIFF
--- a/test/extended/builds/controllers.go
+++ b/test/extended/builds/controllers.go
@@ -270,6 +270,7 @@ WaitLoop2:
 				Name: "ref-2-random",
 			},
 			DockerImageReference: registryHostname + "/openshift/test-image-trigger:ref-2-random",
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		},
 	}, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -625,6 +626,7 @@ func mockImageStreamMapping(stream, image, tag, reference string) *imagev1.Image
 				Name: image,
 			},
 			DockerImageReference: reference,
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		},
 	}
 }

--- a/test/extended/builds/webhook.go
+++ b/test/extended/builds/webhook.go
@@ -153,6 +153,7 @@ func TestWebhookGitHubPushWithImage(t g.GinkgoTInterface, oc *exutil.CLI) {
 				Name: "myimage",
 			},
 			DockerImageReference: registryHostname + "/" + oc.Namespace() + "/imagestream:success",
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		},
 	}
 	if _, err := clusterAdminImageClient.ImageStreamMappings(oc.Namespace()).Create(context.Background(), ism, metav1.CreateOptions{}); err != nil {
@@ -243,6 +244,7 @@ func TestWebhookGitHubPushWithImageStream(t g.GinkgoTInterface, oc *exutil.CLI) 
 				Name: "myimage",
 			},
 			DockerImageReference: registryHostname + "/" + oc.Namespace() + "/imagestream:success",
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		},
 	}
 	if _, err := clusterAdminImageClient.ImageStreamMappings(oc.Namespace()).Create(context.Background(), ism, metav1.CreateOptions{}); err != nil {

--- a/test/extended/controller_manager/deploy_trigger.go
+++ b/test/extended/controller_manager/deploy_trigger.go
@@ -138,6 +138,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 						Name: updatedImage,
 					},
 					DockerImageReference: updatedPullSpec,
+					DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 				},
 			}
 			if _, err := projectAdminImageClient.ImageStreamMappings(oc.Namespace()).Create(context.Background(), mapping, metav1.CreateOptions{}); err != nil {
@@ -229,6 +230,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 					Name: image,
 				},
 				DockerImageReference: pullSpec,
+				DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 			},
 		}
 
@@ -430,6 +432,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 						Name: image,
 					},
 					DockerImageReference: pullSpec,
+					DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 				},
 			}
 			if _, err := adminImageClient.ImageStreamMappings(oc.Namespace()).Create(context.Background(), mapping, metav1.CreateOptions{}); err != nil {

--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -85,7 +85,7 @@ func GetOpenshiftEtcdStorageData(namespace string) map[schema.GroupVersionResour
 			ExpectedEtcdPath: "openshift.io/imagestreams/" + namespace + "/is1g",
 		},
 		gvr("image.openshift.io", "v1", "images"): {
-			Stub:             `{"dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "metadata": {"name": "image1g"}}`,
+			Stub:             `{"dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "metadata": {"name": "image1g"}, dockerImageLayers: [{"name": "test", "layerSize": 10}]}`,
 			ExpectedEtcdPath: "openshift.io/images/image1g",
 		},
 		// --

--- a/test/extended/imageapis/quota_admission.go
+++ b/test/extended/imageapis/quota_admission.go
@@ -287,6 +287,7 @@ func createImageStreamMapping(oc *exutil.CLI, namespace, name, tag string) error
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			},
+			DockerImageLayers: []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		},
 		Tag: tag,
 	}, metav1.CreateOptions{})

--- a/test/extended/images/imagechange_buildtrigger.go
+++ b/test/extended/images/imagechange_buildtrigger.go
@@ -247,6 +247,7 @@ func mockImageStreamMapping(stream, image, tag, reference string) *imagev1.Image
 				Name: image,
 			},
 			DockerImageReference: reference,
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		},
 	}
 }
@@ -328,6 +329,7 @@ func runTest(t g.GinkgoTInterface, oc *exutil.CLI, testname string, projectAdmin
 					Name: "ref-2-random",
 				},
 				DockerImageReference: registryHostname + "/openshift/test-image-trigger:ref-2-random",
+				DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 			},
 		}, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -414,6 +416,7 @@ func TestMultipleImageChangeBuildTriggers(t g.GinkgoTInterface, oc *exutil.CLI) 
 					Name: name,
 				},
 				DockerImageReference: "registry:5000/openshift/" + name + ":" + tag,
+				DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 			},
 		}
 

--- a/test/extended/images/imagestream.go
+++ b/test/extended/images/imagestream.go
@@ -59,6 +59,7 @@ func TestImageStreamMappingCreate(t g.GinkgoTInterface, oc *exutil.CLI) {
 				Name: "image1",
 			},
 			DockerImageReference: "some/other/name",
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		},
 	}
 	_, err = clusterAdminImageClient.ImageStreamMappings(oc.Namespace()).Create(ctx, mapping, metav1.CreateOptions{})
@@ -79,6 +80,7 @@ func TestImageStreamMappingCreate(t g.GinkgoTInterface, oc *exutil.CLI) {
 				},
 			},
 		},
+		DockerImageLayers: []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 	}
 	if _, err := clusterAdminImageClient.Images().Create(ctx, image, metav1.CreateOptions{}); err == nil {
 		t.Fatalf("unexpected non-error")
@@ -228,6 +230,7 @@ func TestImageStreamWithoutDockerImageConfig(t g.GinkgoTInterface, oc *exutil.CL
 		},
 		DockerImageConfig:    string(imageConfigBytes),
 		DockerImageReference: "some/namespace/name",
+		DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 	}
 
 	// create a mapping to an image that doesn't exist

--- a/test/extended/images/imagestream_admission.go
+++ b/test/extended/images/imagestream_admission.go
@@ -60,6 +60,7 @@ func TestImageStreamTagsAdmission(t g.GinkgoTInterface, oc *exutil.CLI) {
 				Name: name,
 			},
 			DockerImageReference: imageReference,
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		}
 		tag := fmt.Sprintf("tag%d", i+1)
 
@@ -245,6 +246,7 @@ func TestImageStreamAdmitSpecUpdate(t g.GinkgoTInterface, oc *exutil.CLI) {
 				Name: name,
 			},
 			DockerImageReference: imageReference,
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		}
 		tag := fmt.Sprintf("tag%d", i+1)
 
@@ -378,6 +380,7 @@ func TestImageStreamAdmitStatusUpdate(t g.GinkgoTInterface, oc *exutil.CLI) {
 				Name: name,
 			},
 			DockerImageReference: imageReference,
+			DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 		}
 		images = append(images, image)
 

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -58,6 +58,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 					Name: "an_image_to_be_deleted",
 				},
 				DockerImageReference: "example.com/random/image:latest",
+				DockerImageLayers:    []imagev1.ImageLayer{{Name: "test", LayerSize: 10}},
 			},
 			Tag: "missing",
 		}, metav1.CreateOptions{})

--- a/test/extended/testdata/image/test-image.json
+++ b/test/extended/testdata/image/test-image.json
@@ -13,6 +13,6 @@
     "ContainerConfig": {},
     "Config": {}
   },
-  "dockerImageLayers": [],
+  "dockerImageLayers": [{"name": "test", "layerSize": 10}],
   "dockerImageMetadataVersion": "1.0"
 }


### PR DESCRIPTION
openshift/openshift-apiserver#290 added validation for the presence of dockerImageLayers field.