### PR TITLE
ETCD-330: Regression Test: ensure healthy quorum before config update

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2021,6 +2021,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io]": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io] [Serial]",
 
+	"[Top Level] [sig-etcd][Feature:EtcdVerticalScaling] etcd [apigroup:config.openshift.io] is able to scale to two members without interruption [Timeout:60m][apigroup:machine.openshift.io]": "is able to scale to two members without interruption [Timeout:60m][apigroup:machine.openshift.io] [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-etcd][Feature:EtcdVerticalScaling] etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io] [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": "should redirect on blob pull [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This is building upon the new jobs that @hasbro17 introduced in #27444.
Waiting for https://github.com/openshift/release/pull/32623 to merge first.
/hold