### PR TITLE
microshift: avoid oauth and console disruption monitoring

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -122,7 +122,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 		// A supported version of OpenShift must hold the CloudPrivateIPConfig CRD.
 		// Otherwise, skip this test.
 		g.By("Verifying that this is a supported version of OpenShift")
-		isSupportedOcpVersion, err := exutil.DoesApiResourceExist(oc, "cloudprivateipconfigs")
+		isSupportedOcpVersion, err := exutil.DoesApiResourceExist(oc.AdminConfig(), "cloudprivateipconfigs")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if !isSupportedOcpVersion {
 			skipper.Skipf("This OCP version is not supported for this test (api-resource cloudprivateipconfigs not found)")

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -258,7 +258,7 @@ func (c CLI) WithToken(token string) *CLI {
 // All resources will be then created within this project.
 // Returns the name of the new project.
 func (c *CLI) SetupProject() string {
-	exist, err := DoesApiResourceExist(c, "projects")
+	exist, err := DoesApiResourceExist(c.AdminConfig(), "projects")
 	o.Expect(err).ToNot(o.HaveOccurred())
 	if exist {
 		return c.setupProject()
@@ -941,7 +941,7 @@ func (c *CLI) CreateUser(prefix string) *userv1.User {
 
 func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
 
-	userAPIExists, err := DoesApiResourceExist(c, "users")
+	userAPIExists, err := DoesApiResourceExist(c.AdminConfig(), "users")
 	if err != nil {
 		FatalErr(err)
 	}

--- a/test/extended/util/disruption/frontends/known_backends.go
+++ b/test/extended/util/disruption/frontends/known_backends.go
@@ -4,46 +4,83 @@ import (
 	"context"
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/cluster"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-func StartAllIngressMonitoring(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
-	if err := createOAuthRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
-		return err
-	}
-	if err := createOAuthRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
-		return err
-	}
+const (
+	oauthRouteNamespace = "openshift-authentication"
+	oauthRouteName      = "oauth-openshift"
+)
 
-	// Some jobs explicitly disable the console and other features. Check if it's disabled and if so,
-	// do not run a disruption monitoring backend for it.
-	configClient, err := configclient.NewForConfig(clusterConfig)
+func StartAllIngressMonitoring(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+	// Ingress monitoring checks for oauth and console routes to monitor healthz endpoints. Check availability
+	// before setting up any monitors.
+	routeAvailable, err := isRouteAvailable(ctx, clusterConfig, oauthRouteNamespace, oauthRouteName)
 	if err != nil {
 		return err
 	}
-	clusterVersion, err := configClient.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
-	if err != nil {
-		e2e.Failf("Failed to get cluster version: %v", err)
-	}
-	// If the cluster does not know about the Console capability, it likely predates 4.12 and we can assume
-	// it has it by default. This is to catch possible future scenarios where we upgrade 4.11 no cap to 4.12 no cap.
-	if !cluster.KnowsCapability(clusterVersion, "Console") ||
-		cluster.HasCapability(clusterVersion, "Console") {
-		if err := createConsoleRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
+	if routeAvailable {
+		if err := createOAuthRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
 			return err
 		}
-		if err := createConsoleRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
+		if err := createOAuthRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
 			return err
+		}
+	}
+
+	configAvailable, err := exutil.DoesApiResourceExist(clusterConfig, "clusterversions")
+	if err != nil {
+		return err
+	}
+	if configAvailable {
+		// Some jobs explicitly disable the console and other features. Check if it's disabled and if so,
+		// do not run a disruption monitoring backend for it.
+		configClient, err := configclient.NewForConfig(clusterConfig)
+		if err != nil {
+			return err
+		}
+		clusterVersion, err := configClient.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
+		if err != nil {
+			e2e.Failf("Failed to get cluster version: %v", err)
+		}
+		// If the cluster does not know about the Console capability, it likely predates 4.12 and we can assume
+		// it has it by default. This is to catch possible future scenarios where we upgrade 4.11 no cap to 4.12 no cap.
+		if !cluster.KnowsCapability(clusterVersion, "Console") ||
+			cluster.HasCapability(clusterVersion, "Console") {
+			if err := createConsoleRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
+				return err
+			}
+			if err := createConsoleRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
+}
+
+func isRouteAvailable(ctx context.Context, config *rest.Config, namespace, name string) (bool, error) {
+	routeClient, err := routeclient.NewForConfig(config)
+	if err != nil {
+		return false, err
+	}
+	_, err = routeClient.RouteV1().Routes(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func createOAuthRouteAvailableWithNewConnections() *backenddisruption.BackendSampler {
@@ -51,8 +88,8 @@ func createOAuthRouteAvailableWithNewConnections() *backenddisruption.BackendSam
 	utilruntime.Must(err)
 	return backenddisruption.NewRouteBackend(
 		restConfig,
-		"openshift-authentication",
-		"oauth-openshift",
+		oauthRouteNamespace,
+		oauthRouteName,
 		"ingress-to-oauth-server",
 		"/healthz",
 		backenddisruption.NewConnectionType).
@@ -64,8 +101,8 @@ func createOAuthRouteAvailableWithConnectionReuse() *backenddisruption.BackendSa
 	utilruntime.Must(err)
 	return backenddisruption.NewRouteBackend(
 		restConfig,
-		"openshift-authentication",
-		"oauth-openshift",
+		oauthRouteNamespace,
+		oauthRouteName,
 		"ingress-to-oauth-server",
 		"/healthz",
 		backenddisruption.ReusedConnectionType).

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -2044,8 +2045,8 @@ func SkipIfExternalControlplaneTopology(oc *CLI, reason string) {
 
 // DoesApiResourceExist searches the list of ApiResources and returns "true" if a given
 // apiResourceName Exists. Valid search strings are for example "cloudprivateipconfigs" or "machines".
-func DoesApiResourceExist(oc *CLI, apiResourceName string) (bool, error) {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(oc.AdminConfig())
+func DoesApiResourceExist(config *rest.Config, apiResourceName string) (bool, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
When https://github.com/openshift/origin/pull/27460 was introduced the tests in MicroShift stopped working because of checking `clusterversion.config.openshift.io`. Since this API group/resource is not available in MicroShift, we need to skip it.

/cc @dgoodwin