### PR TITLE
OCPBUGS-2155: Revert "Add etcd vertical scaling test suite"

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -120,7 +120,8 @@ var staticSuites = testSuites{
 				}
 				return strings.Contains(name, "[Suite:openshift/conformance/serial") || isStandardEarlyOrLateTest(name)
 			},
-			TestTimeout:         40 * time.Minute,
+			// etcd's vertical scaling test is expensive
+			TestTimeout:         60 * time.Minute,
 			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.StableSystemEventInvariants),
 		},
 		PreSuite: suiteWithProviderPreSuite,
@@ -423,24 +424,6 @@ var staticSuites = testSuites{
 			},
 		},
 		PreSuite: suiteWithInitializedProviderPreSuite,
-	},
-	{
-		TestSuite: ginkgo.TestSuite{
-			Name: "openshift/etcd/scaling",
-			Description: templates.LongDesc(`
-		This test suite runs vertical scaling tests to exercise the safe scale-up and scale-down of etcd members.
-		`),
-			Matches: func(name string) bool {
-				if isDisabled(name) {
-					return false
-				}
-				return strings.Contains(name, "[Suite:openshift/etcd/scaling") || strings.Contains(name, "[Feature:EtcdVerticalScaling]") || isStandardEarlyOrLateTest(name)
-			},
-			// etcd's vertical scaling test can take a while for apiserver rollouts to stabilize on the same revision
-			TestTimeout:         60 * time.Minute,
-			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.StableSystemEventInvariants),
-		},
-		PreSuite: suiteWithProviderPreSuite,
 	},
 }
 

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -364,6 +364,7 @@ func SkipIfUnsupportedPlatform(ctx context.Context, oc *exutil.CLI) {
 	skipUnlessFunctionalMachineAPI(ctx, machineClient)
 	skipIfSingleNode(oc)
 	skipIfBareMetal(oc)
+	skipIfVsphere(oc)
 }
 
 func skipUnlessFunctionalMachineAPI(ctx context.Context, machineClient machinev1beta1client.MachineInterface) {

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling] etcd [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-scaling").AsAdmin()
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2021,7 +2021,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io]": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io] [Serial]",
 
-	"[Top Level] [sig-etcd][Feature:EtcdVerticalScaling] etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-etcd][Serial] etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": "should redirect on blob pull [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
Reverts #openshift/origin#27444 ; tracked by OCPBUGS-2155

Per TRT policy, we are reverting this breaking change to get ci and/or nightly payloads flowing again. This change made this test run in `[Suite:openshift/conformance/parallel]` instead of the intended new etcd suite. It's causing jobs to fail, so I'm going to have to revert this change.

To unrevert this revert, revert this PR, and layer an additional separate commit on top that addresses the problem, and ensure the test does not run in either serial or parallel conformance runs.


CC: @hasbro17 