### PR TITLE
Unrevert etcd vertical scaling test

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -122,8 +122,7 @@ var staticSuites = testSuites{
 				}
 				return strings.Contains(name, "[Suite:openshift/conformance/serial") || isStandardEarlyOrLateTest(name)
 			},
-			// etcd's vertical scaling test is expensive
-			TestTimeout:         60 * time.Minute,
+			TestTimeout:         40 * time.Minute,
 			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.StableSystemEventInvariants),
 		},
 		PreSuite: suiteWithProviderPreSuite,
@@ -426,6 +425,24 @@ var staticSuites = testSuites{
 			},
 		},
 		PreSuite: suiteWithInitializedProviderPreSuite,
+	},
+	{
+		TestSuite: ginkgo.TestSuite{
+			Name: "openshift/etcd/scaling",
+			Description: templates.LongDesc(`
+		This test suite runs vertical scaling tests to exercise the safe scale-up and scale-down of etcd members.
+		`),
+			Matches: func(name string) bool {
+				if isDisabled(name) {
+					return false
+				}
+				return strings.Contains(name, "[Suite:openshift/etcd/scaling") || strings.Contains(name, "[Feature:EtcdVerticalScaling]") || isStandardEarlyOrLateTest(name)
+			},
+			// etcd's vertical scaling test can take a while for apiserver rollouts to stabilize on the same revision
+			TestTimeout:         60 * time.Minute,
+			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.StableSystemEventInvariants),
+		},
+		PreSuite: suiteWithProviderPreSuite,
 	},
 }
 

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -364,7 +364,6 @@ func SkipIfUnsupportedPlatform(ctx context.Context, oc *exutil.CLI) {
 	skipUnlessFunctionalMachineAPI(ctx, machineClient)
 	skipIfSingleNode(oc)
 	skipIfBareMetal(oc)
-	skipIfVsphere(oc)
 }
 
 func skipUnlessFunctionalMachineAPI(ctx context.Context, machineClient machinev1beta1client.MachineInterface) {

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling] etcd [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-scaling").AsAdmin()
 

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -10,6 +10,7 @@ import (
 
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	testlibraryapi "github.com/openshift/library-go/test/library/apiserver"
+
 	scalingtestinglibrary "github.com/openshift/origin/test/extended/etcd/helpers"
 	exutil "github.com/openshift/origin/test/extended/util"
 
@@ -17,7 +18,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling] etcd [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling] etcd [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-scaling").AsAdmin()
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2049,7 +2049,7 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io]": " [Serial]",
 
-	"[sig-etcd][Serial] etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": " [Suite:openshift/conformance/serial]",
+	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling] etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "",
 
 	"[sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
I had to revert https://github.com/openshift/origin/pull/27463 because the etcd tes was mistakenly running in all parallel conformance jobs.  In order to make this test only part of the etcd scaling test, we need to mark it so -- but this requires a change to openshift/kubernetes to allow that behavior.

