### PR TITLE
disruption checking is disabled for prior releases because we lack a good baseline

### DIFF
--- a/pkg/synthetictests/allowedbackenddisruption/matches.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches.go
@@ -9,5 +9,6 @@ import (
 // GetAllowedDisruption uses the backend and information about the cluster to choose the best historical p95 to operate against.
 // We enforce "don't get worse" for disruption by watching the aggregate data in CI over many runs.
 func GetAllowedDisruption(backendName string, jobType platformidentification.JobType) (*time.Duration, string, error) {
-	return getCurrentResults().BestMatchP99(backendName, jobType)
+	t := 6 * time.Hour
+	return &t, "disruption checking is disabled for prior releases because we lack a good baseline", nil
 }


### PR DESCRIPTION
After checking, I think this is the minimal change to disable disruption on prior releases.  We can try to remove all the code, but I think this allows us to retain data collection (such as it is), while disabling test failures.

/assign @dgoodwin 