### PR TITLE
Remove must-gather pod from lack priorityclass exception list

### DIFF
--- a/test/extended/pods/priorityclasses.go
+++ b/test/extended/pods/priorityclasses.go
@@ -37,7 +37,6 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 			"migrator":             "https://bugzilla.redhat.com/show_bug.cgi?id=1954868",
 			"downloads":            "https://bugzilla.redhat.com/show_bug.cgi?id=1954866",
 			"pod-identity-webhook": "https://bugzilla.redhat.com/show_bug.cgi?id=1954865",
-			"must-gather":          "https://bugzilla.redhat.com/show_bug.cgi?id=2093046",
 		}
 		// list of pods that use images not in the release payload
 		invalidPodPriority := sets.NewString()


### PR DESCRIPTION
must-gather pod was added exception list because `oc debug node` does not include priorityClassName. After this PR [openshift/oc/pull/1263](https://github.com/openshift/oc/pull/1263) adds priorityClassName statically, we can remove must-gather pod from priorityclass exception list.