### PR TITLE
update skip openshift-controller-manager scaling events in build testsuite

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -199,7 +199,7 @@ var knownEventsBugs = []knownProblem{
 	// builds tests trigger many changes in the config which creates new rollouts -> event for each pod
 	// working as intended (not a bug) and needs to be tolerated
 	{
-		Regexp:    regexp.MustCompile(`ns/openshift-controller-manager daemonset/controller-manager - reason/SuccessfulDelete \(combined from similar events\): Deleted pod: controller-manager-[a-z0-9-]+`),
+		Regexp:    regexp.MustCompile(`ns/openshift-controller-manager deployment/controller-manager - reason/ScalingReplicaSet \(combined from similar events\): Scaled (down|up) replica set controller-manager-[a-z0-9-]+ to [0-9]+`),
 		TestSuite: stringPointer("openshift/build"),
 	},
 	//{ TODO this should only be skipped for single-node


### PR DESCRIPTION
after a recent change of OCM being managed by a deployment instead of a daemonset: https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/264

similar change was done in RCM as well: https://github.com/openshift/origin/pull/27394

was caught for example here: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_openshift-controller-manager/242/pull-ci-openshift-openshift-controller-manager-master-e2e-gcp-builds/1582378124010590208