### PR TITLE
Fix flaky cli tests

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -24,7 +24,9 @@ func isDisabled(name string) bool {
 
 // shouldSkipUntil allows a test to be skipped with a time limit.
 // the test should be annotated with the 'SkippedUntil' tag, as shown below.
-//   [SkippedUntil:05092022:blocker-bz/123456]
+//
+//	[SkippedUntil:05092022:blocker-bz/123456]
+//
 // - the specified date should conform to the 'MMDDYYYY' format.
 // - a valid blocker BZ must be specified
 // if the specified date in the tag has not passed yet, the test

--- a/pkg/monitor/intervalcreation/rendering_per_namespace.go
+++ b/pkg/monitor/intervalcreation/rendering_per_namespace.go
@@ -164,7 +164,6 @@ func NewIngressServicePodIntervalRenderer() ingressServicePodRendering {
 // WriteEventData for ingressServicePodRendering writes out a custom spyglass chart to help debug TRT-364 and BZ2101622 where
 // image-registry, console, and oauth pods were experiencing disruption during upgrades.  We wanted one chart that
 // showed those pods, router-default pods, node changes, and disruption.
-//
 func (r ingressServicePodRendering) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, timeSuffix string) error {
 	errs := []error{}
 	disruptionReasons := sets.NewString(backenddisruption.DisruptionBeganEventReason,

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -285,7 +285,8 @@ func (m *Monitor) Intervals(from, to time.Time) monitorapi.Intervals {
 // filterSamples converts the sorted samples that are within [from,to) to a set of
 // intervals.
 // TODO: simplify this by having the monitor samplers produce intervals themselves
-//   and make the streaming print logic simply show transitions.
+//
+//	and make the streaming print logic simply show transitions.
 func filterSamples(samples []*sample, from, to time.Time) monitorapi.Intervals {
 	if len(samples) == 0 {
 		return nil

--- a/pkg/synthetictests/allowedalerts/basic_alert.go
+++ b/pkg/synthetictests/allowedalerts/basic_alert.go
@@ -293,7 +293,6 @@ var imagePullBackoffRegEx = regexp.MustCompile("Back-off pulling image .*registr
 
 // kubePodNotReadyDueToImagePullBackoff returns true if we searched pod events and determined that the
 // KubePodNotReady alert for this pod fired due to an imagePullBackoff event on registry.redhat.io.
-//
 func kubePodNotReadyDueToImagePullBackoff(trackedEventResources monitorapi.InstanceMap, firingIntervals monitorapi.Intervals) bool {
 
 	// Run the check for all firing intervals.

--- a/pkg/synthetictests/allowedalerts/types.go
+++ b/pkg/synthetictests/allowedalerts/types.go
@@ -42,6 +42,7 @@ order by
 //  2. it allows external people (recall we ship this binary) without access to ocp credentials to have a sense of what is normal on their platform
 //  3. it gives a spot to wire in a dynamic look *if* someone desired to do so and made it conditional to avoid breaking
 //     1 and 2
+//
 //go:embed query_results.json
 var queryResults []byte
 

--- a/pkg/synthetictests/duplicated_events_special.go
+++ b/pkg/synthetictests/duplicated_events_special.go
@@ -44,7 +44,6 @@ type singleEventCheckRegex struct {
 // if a match is found, marks it as failure or flake depending on if the pattern occurs
 // above the fail/flake thresholds (this allows us to track the occurence as a specific
 // test. If the fail threshold is set to -1, the test will only flake.
-//
 func (s *singleEventCheckRegex) test(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	success := &junitapi.JUnitTestCase{Name: s.testName}
 	var failureOutput, flakeOutput []string
@@ -97,27 +96,30 @@ func newSingleEventCheckRegex(testName, regex string, failThreshold, flakeThresh
 }
 
 // testBackoffPullingRegistryRedhatImage looks for this symptom:
-//   reason/ContainerWait ... Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
-//   reason/BackOff Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
-// to happen over a certain threshold and marks it as a failure or flake accordingly.
 //
+//	reason/ContainerWait ... Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
+//	reason/BackOff Back-off pulling image "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
+//
+// to happen over a certain threshold and marks it as a failure or flake accordingly.
 func testBackoffPullingRegistryRedhatImage(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[sig-arch] should not see excessive pull back-off on registry.redhat.io"
 	return newSingleEventCheckRegex(testName, imagePullRedhatRegEx, math.MaxInt, imagePullRedhatFlakeThreshold).test(events)
 }
 
 // testRequiredInstallerResourcesMissing looks for this symptom:
-//   reason/RequiredInstallerResourcesMissing secrets: etcd-all-certs-3
+//
+//	reason/RequiredInstallerResourcesMissing secrets: etcd-all-certs-3
+//
 // and fails if it happens more than the failure threshold count of 20 and flakes more than the
 // flake threshold.  See https://bugzilla.redhat.com/show_bug.cgi?id=2031564.
-//
 func testRequiredInstallerResourcesMissing(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[bz-etcd] should not see excessive RequiredInstallerResourcesMissing secrets"
 	return newSingleEventCheckRegex(testName, requiredResourcesMissingRegEx, duplicateEventThreshold, requiredResourceMissingFlakeThreshold).test(events)
 }
 
 // testBackoffStartingFailedContainer looks for this symptom in core namespaces:
-//   reason/BackOff Back-off restarting failed container
+//
+//	reason/BackOff Back-off restarting failed container
 func testBackoffStartingFailedContainer(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[sig-cluster-lifecycle] should not see excessive Back-off restarting failed containers"
 
@@ -126,7 +128,8 @@ func testBackoffStartingFailedContainer(events monitorapi.Intervals) []*junitapi
 }
 
 // testBackoffStartingFailedContainerForE2ENamespaces looks for this symptom in e2e namespaces:
-//   reason/BackOff Back-off restarting failed container
+//
+//	reason/BackOff Back-off restarting failed container
 func testBackoffStartingFailedContainerForE2ENamespaces(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[sig-cluster-lifecycle] should not see excessive Back-off restarting failed containers in e2e namespaces"
 

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -114,7 +114,6 @@ func SetUpgradeDisruptReboot(policy string) error {
 //
 // * empty string - do not abort
 // * integer between 0-100 - once this percentage of operators have updated, rollback to the previous version
-//
 func SetUpgradeAbortAt(policy string) error {
 	if len(policy) == 0 {
 		upgradeAbortAt = 0

--- a/test/extended/authorization/scopes.go
+++ b/test/extended/authorization/scopes.go
@@ -589,7 +589,7 @@ var scopeDiscoveryRule = rbacv1.PolicyRule{
 	},
 }
 
-//convert SSRR result.  This works well enough for the test
+// convert SSRR result.  This works well enough for the test
 func authzv1_To_rbacv1_PolicyRules(authzv1Rules []authorizationv1.PolicyRule) ([]rbacv1.PolicyRule, error) {
 	ret := []rbacv1.PolicyRule{}
 

--- a/test/extended/cli/project.go
+++ b/test/extended/cli/project.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-cli] oc project", func() {
 		o.Expect(out).To(o.ContainSubstring("foo=bar"))
 	})
 
-	g.It("can switch between different projects [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io]", func() {
+	g.It("can switch between different projects [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io][Serial]", func() {
 		g.By("check auth usage is correct")
 		_, err := oc.Run("policy", "who-can").Args("get", "pods", "-n", "missing-ns").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -285,7 +285,7 @@ func EnsureHealthyMember(t TestingT, etcdClientFactory EtcdClientCreator, member
 // first it looks up a node that corresponds to the machine by comparing the ProviderID field
 // next, it returns the node name as it is used to name an etcd member.
 //
-// In cases the ProviderID is empty it will try to find a node that matches an internal IP address
+// # In cases the ProviderID is empty it will try to find a node that matches an internal IP address
 //
 // note:
 // it will exit and report an error in case the node was not found

--- a/test/extended/images/oc_copy.go
+++ b/test/extended/images/oc_copy.go
@@ -182,9 +182,9 @@ func (e *hookExecutor) tagImages(hook *appsv1.LifecycleHook, rc *corev1.Replicat
 //
 // The hook pod inherits the following from the container the hook refers to:
 //
-//   * Environment (hook keys take precedence)
-//   * Working directory
-//   * Resources
+//   - Environment (hook keys take precedence)
+//   - Working directory
+//   - Resources
 func (e *hookExecutor) executeExecNewPod(hook *appsv1.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error {
 	config, err := appsserialization.DecodeDeploymentConfig(rc)
 	if err != nil {

--- a/test/extended/templates/helpers.go
+++ b/test/extended/templates/helpers.go
@@ -178,7 +178,7 @@ var readinessCheckers = map[schema.GroupVersionKind]func(runtime.Object) (bool, 
 	groupVersionKind(batchv1.SchemeGroupVersion, "Job"):         checkJobReadiness,
 }
 
-//TODO candidate for openshift/library-go
+// TODO candidate for openshift/library-go
 func isTerminalPhase(phase buildv1.BuildPhase) bool {
 	switch phase {
 	case buildv1.BuildPhaseNew,
@@ -189,7 +189,7 @@ func isTerminalPhase(phase buildv1.BuildPhase) bool {
 	return true
 }
 
-//TODO candidate for openshift/library-go
+// TODO candidate for openshift/library-go
 func checkBuildReadiness(obj runtime.Object) (bool, bool, error) {
 	b, ok := obj.(*buildv1.Build)
 	if !ok {
@@ -205,7 +205,7 @@ func checkBuildReadiness(obj runtime.Object) (bool, bool, error) {
 	return ready, failed, nil
 }
 
-//TODO candidate for openshift/library-go
+// TODO candidate for openshift/library-go
 func labelValue(name string) string {
 	if len(name) <= validation.DNS1123LabelMaxLength {
 		return name
@@ -213,7 +213,7 @@ func labelValue(name string) string {
 	return name[:validation.DNS1123LabelMaxLength]
 }
 
-//TODO candidate for openshift/library-go
+// TODO candidate for openshift/library-go
 func buildConfigSelector(name string) labels.Selector {
 	return labels.Set{buildv1.BuildConfigLabel: labelValue(name)}.AsSelector()
 }
@@ -286,7 +286,7 @@ func checkDeploymentReadiness(obj runtime.Object) (bool, bool, error) {
 	return ready, failed, nil
 }
 
-//TODO candidate for openshift/library-go
+// TODO candidate for openshift/library-go
 func checkDeploymentConfigReadiness(obj runtime.Object) (bool, bool, error) {
 	dc, ok := obj.(*appsv1.DeploymentConfig)
 	if !ok {

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1751,7 +1751,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] oc project --show-labels works for projects [apigroup:project.openshift.io]": "--show-labels works for projects [apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-cli] oc project can switch between different projects [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io]": "can switch between different projects [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-cli] oc project can switch between different projects [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io][Serial]": "can switch between different projects [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io][Serial] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-cli] oc rsh specific flags should work well when access to a remote shell": "should work well when access to a remote shell [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -286,7 +286,6 @@ func filesystemSafeName(s string) string {
 //
 // historically: ".../vendor/k8s.io/kubernetes/test/e2e"
 // go.mod:       "k8s.io/kubernetes@0.18.4/test/e2e"
-//
 func isGoModulePath(packagePath, module, modulePath string) bool {
 	return regexp.MustCompile(fmt.Sprintf(`\b%s(@[^/]*|)/%s\b`, regexp.QuoteMeta(module), regexp.QuoteMeta(modulePath))).MatchString(packagePath)
 }

--- a/test/extended/util/docker.go
+++ b/test/extended/util/docker.go
@@ -6,7 +6,7 @@ import (
 	dockerClient "github.com/fsouza/go-dockerclient"
 )
 
-//ListImages initiates the equivalent of a `docker images`
+// ListImages initiates the equivalent of a `docker images`
 func ListImages() ([]string, error) {
 	client, err := dockerClient.NewClientFromEnv()
 	if err != nil {
@@ -33,7 +33,7 @@ func (mte MissingTagError) Error() string {
 	return fmt.Sprintf("the tag %s passed in was invalid, and not found in the list of images returned from docker", mte.Tags)
 }
 
-//GetImageIDForTags will obtain the hexadecimal IDs for the array of human readible image tags IDs provided
+// GetImageIDForTags will obtain the hexadecimal IDs for the array of human readible image tags IDs provided
 func GetImageIDForTags(comps []string) ([]string, error) {
 	client, dcerr := dockerClient.NewClientFromEnv()
 	if dcerr != nil {

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1388,7 +1388,7 @@ func KubeConfigPath() string {
 	return os.Getenv("KUBECONFIG")
 }
 
-//ArtifactDirPath returns the value of ARTIFACT_DIR environment variable
+// ArtifactDirPath returns the value of ARTIFACT_DIR environment variable
 func ArtifactDirPath() string {
 	path := os.Getenv("ARTIFACT_DIR")
 	o.Expect(path).NotTo(o.BeNil())
@@ -1396,8 +1396,8 @@ func ArtifactDirPath() string {
 	return path
 }
 
-//ArtifactPath returns the absolute path to the fix artifact file
-//The path is relative to ARTIFACT_DIR
+// ArtifactPath returns the absolute path to the fix artifact file
+// The path is relative to ARTIFACT_DIR
 func ArtifactPath(elem ...string) string {
 	return filepath.Join(append([]string{ArtifactDirPath()}, elem...)...)
 }

--- a/test/extended/util/image_helpers.go
+++ b/test/extended/util/image_helpers.go
@@ -6,7 +6,7 @@ import (
 	g "github.com/onsi/ginkgo"
 )
 
-//DumpAndReturnTagging takes and array of tags and obtains the hex image IDs, dumps them to ginkgo for printing, and then returns them
+// DumpAndReturnTagging takes and array of tags and obtains the hex image IDs, dumps them to ginkgo for printing, and then returns them
 func DumpAndReturnTagging(tags []string) ([]string, error) {
 	hexIDs, err := GetImageIDForTags(tags)
 	if err != nil {
@@ -18,7 +18,7 @@ func DumpAndReturnTagging(tags []string) ([]string, error) {
 	return hexIDs, nil
 }
 
-//CreateResource creates the resources from the supplied json file (not a template); ginkgo error checking included
+// CreateResource creates the resources from the supplied json file (not a template); ginkgo error checking included
 func CreateResource(jsonFilePath string, oc *CLI) error {
 	err := oc.Run("create").Args("-f", jsonFilePath).Execute()
 	return err

--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -464,7 +464,7 @@ func newSessionSecretsJSON() ([]byte, error) {
 	return secretsBytes, nil
 }
 
-//randomString - random string of A-Z chars with len size
+// randomString - random string of A-Z chars with len size
 func randomString(size int) string {
 	buffer := make([]byte, size)
 	for i := 0; i < size; i++ {

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -183,7 +183,6 @@ func InitDefaultEnvironmentVariables() {
 //
 // historically: ".../vendor/k8s.io/kubernetes/test/e2e"
 // go.mod:       "k8s.io/kubernetes@0.18.4/test/e2e"
-//
 func isGoModulePath(packagePath, module, modulePath string) bool {
 	return regexp.MustCompile(fmt.Sprintf(`\b%s(@[^/]*|)/%s\b`, regexp.QuoteMeta(module), regexp.QuoteMeta(modulePath))).MatchString(packagePath)
 }

--- a/tools/junitreport/pkg/parser/stack/parser.go
+++ b/tools/junitreport/pkg/parser/stack/parser.go
@@ -22,15 +22,16 @@ func NewParser(builder builder.TestSuitesBuilder, testParser TestDataParser, sui
 }
 
 // testOutputParser uses a stack to parse test output. Critical assumptions that this parser makes are:
-//   1 - packages may be nested but tests may not
-//   2 - no package declarations will occur within the boundaries of a test
-//   3 - all tests and packages are fully bounded by a start and result line
-//   4 - if a package or test declaration occurs after the start of a package but before its result,
-//       the sub-package's or member test's result line will occur before that of the parent package
-//       i.e. any test or package overlap will necessarily mean that one package's lines are a superset
-//       of any lines of tests or other packages overlapping with it
-//   5 - any text in the input file that doesn't match the parser regex is necessarily the output of the
-//       current test being built
+//
+//	1 - packages may be nested but tests may not
+//	2 - no package declarations will occur within the boundaries of a test
+//	3 - all tests and packages are fully bounded by a start and result line
+//	4 - if a package or test declaration occurs after the start of a package but before its result,
+//	    the sub-package's or member test's result line will occur before that of the parent package
+//	    i.e. any test or package overlap will necessarily mean that one package's lines are a superset
+//	    of any lines of tests or other packages overlapping with it
+//	5 - any text in the input file that doesn't match the parser regex is necessarily the output of the
+//	    current test being built
 type testOutputParser struct {
 	builder builder.TestSuitesBuilder
 


### PR DESCRIPTION
This PR adds;

- proper project cleanup in `oc adm storage-admin`, `oc adm new-project` tests.
These tests are precisely failing in second run, because projects which
trying to be created are already existed.
- moving  `oc project can switch between different projects` to serial suite.
Because `oc new-project` without `--skip-config-write` flag can make changes on
global kubeconfig and might cause other tests fail. We can not use `skip-config-write`
flag, since all purpose of this test is testing actual `new-project`. Therefore,
this test can be better run in serial suite(more detail https://github.com/openshift/origin/pull/26610).