### PR TITLE
ignore kubepodnotready alerts firing when it happens during node upgrade

### DIFF
--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -99,6 +99,10 @@ func NamespaceFromLocator(locator string) string {
 	return ""
 }
 
+func AlertFromLocator(locator string) string {
+	return AlertFrom(LocatorParts(locator))
+}
+
 func AlertFrom(locatorParts map[string]string) string {
 	return locatorParts["alert"]
 }


### PR DESCRIPTION
I think this does what I mentioned.  It doesn't address the test variant in https://github.com/openshift/origin/blob/master/test/extended/prometheus/alerts.go#L24 .  Do we still need to actually run that test or do we only use it to properly wire ignores?

/assign @dgoodwin @neisw 