### PR TITLE
Add jUnitSuite and status to e2e-test interval locators.

### DIFF
--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-func E2ETestLocator(testName string) string {
-	return fmt.Sprintf("e2e-test/%q", testName)
+func E2ETestLocator(testName, jUnitSuiteName string) string {
+	return fmt.Sprintf("e2e-test/%q jUnitSuite/%s", testName, jUnitSuiteName)
 }
 
 func IsE2ETest(locator string) bool {
@@ -16,16 +16,15 @@ func IsE2ETest(locator string) bool {
 }
 
 func E2ETestFromLocator(locator string) (string, bool) {
-	if !strings.HasPrefix(locator, "e2e-test/") {
-		return "", false
+	locatorParts := LocatorParts(locator)
+	if quotedTestName, ok := locatorParts["e2e-test"]; ok {
+		testName, err := strconv.Unquote(quotedTestName)
+		if err != nil {
+			return "", false
+		}
+		return testName, true
 	}
-	parts := strings.SplitN(locator, "/", 2)
-	quotedTestName := parts[1]
-	testName, err := strconv.Unquote(quotedTestName)
-	if err != nil {
-		return "", false
-	}
-	return testName, true
+	return "", false
 }
 
 func NodeLocator(testName string) string {

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -151,7 +151,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 		suite.SyntheticEventTests,
 	}
 
-	tests, err := testsForSuite(config.GinkgoConfig)
+	tests, err := testsForSuite(config.GinkgoConfig, junitSuiteName)
 	if err != nil {
 		return err
 	}

--- a/pkg/test/ginkgo/cmd_runtest.go
+++ b/pkg/test/ginkgo/cmd_runtest.go
@@ -51,7 +51,7 @@ func (opt *TestOptions) Run(args []string) error {
 		return fmt.Errorf("only a single test name may be passed")
 	}
 
-	tests, err := testsForSuite(config.GinkgoConfig)
+	tests, err := testsForSuite(config.GinkgoConfig, "") // no junitsuitename known when we run individual tests
 	if err != nil {
 		return err
 	}

--- a/pkg/test/ginkgo/ginkgo.go
+++ b/pkg/test/ginkgo/ginkgo.go
@@ -10,7 +10,7 @@ import (
 	"github.com/onsi/ginkgo/types"
 )
 
-func testsForSuite(cfg config.GinkgoConfigType) ([]*testCase, error) {
+func testsForSuite(cfg config.GinkgoConfigType, jUnitSuiteName string) ([]*testCase, error) {
 	iter := ginkgo.GlobalSuite().Iterator(cfg)
 	var tests []*testCase
 	for {
@@ -21,7 +21,7 @@ func testsForSuite(cfg config.GinkgoConfigType) ([]*testCase, error) {
 			}
 			return nil, err
 		}
-		tc, err := newTestCase(spec)
+		tc, err := newTestCase(spec, jUnitSuiteName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -121,7 +121,7 @@ func (s *testStatus) finalizeTest(test *testCase) {
 
 	s.monitorRecorder.Record(monitorapi.Condition{
 		Level:   eventLevel,
-		Locator: monitorapi.E2ETestLocator(test.name),
+		Locator: monitorapi.E2ETestLocator(test.name, test.jUnitSuiteName),
 		Message: eventMessage,
 	})
 }
@@ -140,7 +140,7 @@ func (s *testStatus) OutputCommand(ctx context.Context, test *testCase) {
 func (s *testStatus) Run(ctx context.Context, test *testCase) {
 	s.monitorRecorder.Record(monitorapi.Condition{
 		Level:   monitorapi.Info,
-		Locator: monitorapi.E2ETestLocator(test.name),
+		Locator: monitorapi.E2ETestLocator(test.name, test.jUnitSuiteName),
 		Message: "started",
 	})
 	// if the test was already marked as skipped, skip it.

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type testCase struct {
-	name      string
-	spec      ginkgoSpec
-	location  types.CodeLocation
-	apigroups []string
+	name           string
+	jUnitSuiteName string
+	spec           ginkgoSpec
+	location       types.CodeLocation
+	apigroups      []string
 
 	// identifies which tests can be run in parallel (ginkgo runs suites linearly)
 	testExclusion string
@@ -39,15 +40,16 @@ type testCase struct {
 	previous *testCase
 }
 
-func newTestCase(spec ginkgoSpec) (*testCase, error) {
+func newTestCase(spec ginkgoSpec, jUnitSuiteName string) (*testCase, error) {
 	name := spec.ConcatenatedString()
 	name = strings.TrimPrefix(name, "[Top Level] ")
 
 	summary := spec.Summary("")
 	tc := &testCase{
-		name:     name,
-		spec:     spec,
-		location: summary.ComponentCodeLocations[len(summary.ComponentCodeLocations)-1],
+		name:           name,
+		jUnitSuiteName: jUnitSuiteName,
+		spec:           spec,
+		location:       summary.ComponentCodeLocations[len(summary.ComponentCodeLocations)-1],
 	}
 
 	matches := regexp.MustCompile(`\[apigroup:([^]]*)\]`).FindAllStringSubmatch(name, -1)


### PR DESCRIPTION
Today there is no clear way to search for failed tests in the regex
search in spyglass or the html files it uses because the status of the
test is not in the locator. Searching the messages is non-trivial and
probably too slow as there can be many per row.

There are typically 3 intervals for each e2e test, start, finish, and
the end result with proper start/stop time. This change adds
status/Passed or Failed or Flakes to the latter.

In addition, I have added the jUnitSuite to the locator as well, this
will make it a little more clear what invocation of openshift-tests
we're running when we view intervals html. (today we sort of just know
instinctively by its ordering or what tests it runs) This will be useful
for a coming PR where I plan to extract the failed test names
from intervals.
