### PR TITLE
Add monitor store to resource watch

### DIFF
--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -18,6 +18,7 @@ import (
 
 var reMatchFirstQuote = regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`)
 
+// EventAddOrUpdateFunc processes add and update for events
 func EventAddOrUpdateFunc(
 	ctx context.Context,
 	m Recorder,

--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -16,9 +16,18 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Interface) {
-	reMatchFirstQuote := regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`)
+var reMatchFirstQuote = regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`)
 
+func EventAddOrUpdateFunc(
+	ctx context.Context,
+	m Recorder,
+	client kubernetes.Interface,
+	significantlyBeforeNow time.Time,
+	obj *corev1.Event) {
+	recordAddOrUpdateEvent(ctx, m, client, reMatchFirstQuote, significantlyBeforeNow, obj)
+}
+
+func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Interface) {
 	// filter out events written "now" but with significantly older start times (events
 	// created in test jobs are the most common)
 	significantlyBeforeNow := time.Now().UTC().Add(-15 * time.Minute)

--- a/pkg/monitor/node.go
+++ b/pkg/monitor/node.go
@@ -15,89 +15,103 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func startNodeMonitoring(ctx context.Context, m Recorder, client kubernetes.Interface) {
-	nodeChangeFns := []func(node, oldNode *corev1.Node) []monitorapi.Condition{
-		func(node, oldNode *corev1.Node) []monitorapi.Condition {
-			var conditions []monitorapi.Condition
-			roles := nodeRoles(node)
+var nodeChangeFns = []func(node, oldNode *corev1.Node) []monitorapi.Condition{
+	func(node, oldNode *corev1.Node) []monitorapi.Condition {
+		var conditions []monitorapi.Condition
+		roles := nodeRoles(node)
 
-			for i := range node.Status.Conditions {
-				c := &node.Status.Conditions[i]
-				previous := findNodeCondition(oldNode.Status.Conditions, c.Type, i)
-				if previous == nil {
-					continue
-				}
-				if c.Status != previous.Status {
-					conditions = append(conditions, monitorapi.Condition{
-						Level:   monitorapi.Warning,
-						Locator: monitorapi.NodeLocator(node.Name),
-						Message: fmt.Sprintf("condition/%s status/%s reason/%s roles/%s changed", c.Type, c.Status, c.Reason, roles),
-					})
-				}
+		for i := range node.Status.Conditions {
+			c := &node.Status.Conditions[i]
+			previous := findNodeCondition(oldNode.Status.Conditions, c.Type, i)
+			if previous == nil {
+				continue
 			}
-			if node.UID != oldNode.UID {
+			if c.Status != previous.Status {
 				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Error,
+					Level:   monitorapi.Warning,
 					Locator: monitorapi.NodeLocator(node.Name),
-					Message: fmt.Sprintf("roles/%s node was deleted and recreated", roles),
+					Message: fmt.Sprintf("condition/%s status/%s reason/%s roles/%s changed", c.Type, c.Status, c.Reason, roles),
 				})
 			}
-			return conditions
-		},
-		func(node, oldNode *corev1.Node) []monitorapi.Condition {
-			var conditions []monitorapi.Condition
-			roles := nodeRoles(node)
+		}
+		if node.UID != oldNode.UID {
+			conditions = append(conditions, monitorapi.Condition{
+				Level:   monitorapi.Error,
+				Locator: monitorapi.NodeLocator(node.Name),
+				Message: fmt.Sprintf("roles/%s node was deleted and recreated", roles),
+			})
+		}
+		return conditions
+	},
+	func(node, oldNode *corev1.Node) []monitorapi.Condition {
+		var conditions []monitorapi.Condition
+		roles := nodeRoles(node)
 
-			oldConfig := oldNode.Annotations["machineconfiguration.openshift.io/currentConfig"]
-			newConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
-			oldDesired := oldNode.Annotations["machineconfiguration.openshift.io/desiredConfig"]
-			newDesired := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+		oldConfig := oldNode.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		newConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		oldDesired := oldNode.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+		newDesired := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
 
-			if newDesired != oldDesired {
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.NodeLocator(node.Name),
-					Message: fmt.Sprintf("reason/MachineConfigChange config/%s roles/%s config change requested", newDesired, roles),
-				})
-			}
-			if oldConfig != newConfig && newDesired == newConfig {
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.NodeLocator(node.Name),
-					Message: fmt.Sprintf("reason/MachineConfigReached config/%s roles/%s reached desired config", newDesired, roles),
-				})
-			}
-			return conditions
-		},
+		if newDesired != oldDesired {
+			conditions = append(conditions, monitorapi.Condition{
+				Level:   monitorapi.Info,
+				Locator: monitorapi.NodeLocator(node.Name),
+				Message: fmt.Sprintf("reason/MachineConfigChange config/%s roles/%s config change requested", newDesired, roles),
+			})
+		}
+		if oldConfig != newConfig && newDesired == newConfig {
+			conditions = append(conditions, monitorapi.Condition{
+				Level:   monitorapi.Info,
+				Locator: monitorapi.NodeLocator(node.Name),
+				Message: fmt.Sprintf("reason/MachineConfigReached config/%s roles/%s reached desired config", newDesired, roles),
+			})
+		}
+		return conditions
+	},
+}
+
+// NodeAddFunc processes add event for node
+func NodeAddFunc(obj interface{}) {
+}
+
+// NodeDeleteFunc processes delete event for node
+func NodeDeleteFunc(m Recorder, obj interface{}) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return
 	}
+	m.Record(monitorapi.Condition{
+		Level:   monitorapi.Warning,
+		Locator: monitorapi.NodeLocator(node.Name),
+		Message: fmt.Sprintf("roles/%s deleted", nodeRoles(node)),
+	})
+}
 
+// NodeUpdateFunc processes update event for node
+func NodeUpdateFunc(m Recorder, old, obj interface{}) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return
+	}
+	oldNode, ok := old.(*corev1.Node)
+	if !ok {
+		return
+	}
+	for _, fn := range nodeChangeFns {
+		m.Record(fn(node, oldNode)...)
+	}
+}
+
+func startNodeMonitoring(ctx context.Context, m Recorder, client kubernetes.Interface) {
 	nodeInformer := informercorev1.NewNodeInformer(client, time.Hour, nil)
 	nodeInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {},
+			AddFunc: NodeAddFunc,
 			DeleteFunc: func(obj interface{}) {
-				node, ok := obj.(*corev1.Node)
-				if !ok {
-					return
-				}
-				m.Record(monitorapi.Condition{
-					Level:   monitorapi.Warning,
-					Locator: monitorapi.NodeLocator(node.Name),
-					Message: fmt.Sprintf("roles/%s deleted", nodeRoles(node)),
-				})
+				NodeDeleteFunc(m, obj)
 			},
 			UpdateFunc: func(old, obj interface{}) {
-				node, ok := obj.(*corev1.Node)
-				if !ok {
-					return
-				}
-				oldNode, ok := old.(*corev1.Node)
-				if !ok {
-					return
-				}
-				for _, fn := range nodeChangeFns {
-					m.Record(fn(node, oldNode)...)
-				}
+				NodeUpdateFunc(m, old, obj)
 			},
 		},
 	)

--- a/pkg/monitor/resourcewatch/cmd/resourcewatch.go
+++ b/pkg/monitor/resourcewatch/cmd/resourcewatch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -10,11 +11,21 @@ import (
 )
 
 func NewRunResourceWatchCommand() *cobra.Command {
-	cmd := controllercmd.
-		NewControllerCommandConfig("run-resourcewatch", version.Get(), operator.RunOperator).
-		NewCommand()
+	cmdCfg := controllercmd.NewControllerCommandConfig("run-resourcewatch", version.Get(), operator.RunOperator)
+	cmdCfg.DisableServing = true
+	cmdCfg.DisableLeaderElection = true
+	cmd := cmdCfg.NewCommandWithContext(context.TODO())
 	cmd.Use = "run-resourcewatch"
-	cmd.Short = "Run watching resource changes"
-
+	cmd.Short = "Run watch for resource changes and commit each to a git repository"
+	cmd.Long = `
+Watches specific resources using the given kubeconfig for create/update/delete,
+and commits the latest state of the resource to a git repo. This allows you to
+see precisely how a resource changed over time.
+By default /repository will be used, specify REPOSITORY_PATH env var to 
+override.
+Sample invocation against an external cluster:
+  $ REPOSITORY_PATH="/tmp/resource-watch-repo" openshift-tests run-resourcewatch --kubeconfig /path/to/kubeconfig --namespace default
+`
+	operator.AddFlags(cmd)
 	return cmd
 }

--- a/pkg/monitor/resourcewatch/controller/clusteroperatormetric/controller.go
+++ b/pkg/monitor/resourcewatch/controller/clusteroperatormetric/controller.go
@@ -32,11 +32,15 @@ type ClusterOperatorMetricController struct {
 	clusterOperatorClient configv1client.ClusterOperatorsGetter
 }
 
-func NewClusterOperatorMetricController(clusterOperatorInformer cache.SharedInformer, clusterOperatorGetter configv1client.ClusterOperatorsGetter, recorder events.Recorder) factory.Controller {
+func NewClusterOperatorMetricController(
+	clusterOperatorInformer cache.SharedInformer,
+	clusterOperatorGetter configv1client.ClusterOperatorsGetter,
+	recorder events.Recorder) factory.Controller {
 	c := &ClusterOperatorMetricController{
 		clusterOperatorClient: clusterOperatorGetter,
 	}
-	return factory.New().WithInformers(clusterOperatorInformer).WithSync(c.sync).ResyncEvery(1*time.Minute).ToController("ClusterOperatorMetricController", recorder.WithComponentSuffix("cluster-operator-metric"))
+	return factory.New().WithInformers(clusterOperatorInformer).WithSync(c.sync).ResyncEvery(1*time.Minute).
+		ToController("ClusterOperatorMetricController", recorder.WithComponentSuffix("cluster-operator-metric"))
 }
 
 func (c *ClusterOperatorMetricController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
@@ -46,7 +50,8 @@ func (c *ClusterOperatorMetricController) sync(ctx context.Context, syncCtx fact
 	}
 	for _, operator := range clusterOperators.Items {
 		for _, condition := range operator.Status.Conditions {
-			clusterOperatorStateMetric.WithLabelValues(operator.Name, string(condition.Type), string(condition.Status)).Set(float64(condition.LastTransitionTime.Unix()))
+			clusterOperatorStateMetric.WithLabelValues(operator.Name, string(condition.Type),
+				string(condition.Status)).Set(float64(condition.LastTransitionTime.Unix()))
 		}
 	}
 	return nil

--- a/pkg/monitor/resourcewatch/controller/configmonitor/crd_controller.go
+++ b/pkg/monitor/resourcewatch/controller/configmonitor/crd_controller.go
@@ -26,13 +26,16 @@ var (
 )
 
 type ConfigObserverController struct {
-	crdLister          apiextensionsv1lister.CustomResourceDefinitionLister
-	crdInformer        cache.SharedIndexInformer
-	dynamicClient      dynamic.Interface
-	dynamicInformers   []*dynamicConfigInformer
-	cachedDiscovery    discovery.CachedDiscoveryInterface
-	monitoredResources []schema.GroupVersion
-	storageHandler     cache.ResourceEventHandler
+	crdLister        apiextensionsv1lister.CustomResourceDefinitionLister
+	crdInformer      cache.SharedIndexInformer
+	dynamicClient    dynamic.Interface
+	dynamicInformers []*dynamicConfigInformer
+	cachedDiscovery  discovery.CachedDiscoveryInterface
+	// monitoredResourceGVs are group+versions we want to monitor all resources beneath.
+	monitoredResourceGVs []schema.GroupVersion
+	// monitoredResourceGVKs are specific group+version+kinds we want to monitor for. (as opposed to everything in the group)
+	monitoredResourceGVKs []schema.GroupVersionKind
+	storageHandler        cache.ResourceEventHandler
 }
 
 func NewConfigObserverController(
@@ -40,33 +43,40 @@ func NewConfigObserverController(
 	crdInformer cache.SharedIndexInformer,
 	discoveryClient *discovery.DiscoveryClient,
 	configStorage cache.ResourceEventHandler,
-	monitoredResources []schema.GroupVersion,
+	monitoredResourceGVs []schema.GroupVersion,
+	monitoredResourceGVKs []schema.GroupVersionKind,
 	recorder events.Recorder,
 ) factory.Controller {
 	c := &ConfigObserverController{
-		dynamicClient:      dynamicClient,
-		crdInformer:        crdInformer,
-		storageHandler:     configStorage,
-		monitoredResources: monitoredResources,
-		cachedDiscovery:    memory.NewMemCacheClient(discoveryClient),
+		dynamicClient:         dynamicClient,
+		crdInformer:           crdInformer,
+		storageHandler:        configStorage,
+		monitoredResourceGVs:  monitoredResourceGVs,
+		monitoredResourceGVKs: monitoredResourceGVKs,
+		cachedDiscovery:       memory.NewMemCacheClient(discoveryClient),
 	}
 	c.crdLister = apiextensionsv1lister.NewCustomResourceDefinitionLister(c.crdInformer.GetIndexer())
 
 	return factory.New().WithInformers(c.crdInformer).ResyncEvery(defaultResyncDuration).WithSync(c.sync).ToController("ConfigObserverController", recorder.WithComponentSuffix("config-observer-controller"))
 }
 
-// currentResourceKinds returns list of group version configKind for OpenShift configuration types.
+// currentResourceKinds returns list of group version kind for each resource we want to watch currently.
+// We may be watching for CRDs which do not initially exist, thus why this is "current" resource kinds.
 func (c *ConfigObserverController) currentResourceKinds() ([]schema.GroupVersionKind, error) {
 	observedCrds, err := c.crdLister.List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 	var (
-		currentConfigResources []schema.GroupVersionKind
-		currentKinds           = sets.NewString()
+		currentConfigResources = []schema.GroupVersionKind{
+			{Group: "", Version: "v1", Kind: "Node"},
+			{Group: "", Version: "v1", Kind: "Pod"},
+			{Group: "", Version: "v1", Kind: "Event"},
+		}
+		currentKinds = sets.NewString()
 	)
 	for _, crd := range observedCrds {
-		for _, gv := range c.monitoredResources {
+		for _, gv := range c.monitoredResourceGVs {
 			if !strings.HasSuffix(crd.GetName(), "."+gv.Group) {
 				continue
 			}
@@ -86,13 +96,19 @@ func (c *ConfigObserverController) currentResourceKinds() ([]schema.GroupVersion
 				currentConfigResources = append(currentConfigResources, gvk)
 			}
 		}
-
+	}
+	for _, gvk := range c.monitoredResourceGVKs {
+		if currentKinds.Has(gvk.Kind) {
+			continue
+		}
+		currentKinds.Insert(gvk.Kind)
+		currentConfigResources = append(currentConfigResources, gvk)
 	}
 	return currentConfigResources, nil
 }
 
 func (c *ConfigObserverController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	current, err := c.currentResourceKinds()
+	currentResourcesToMonitor, err := c.currentResourceKinds()
 	if err != nil {
 		return err
 	}
@@ -103,7 +119,7 @@ func (c *ConfigObserverController) sync(ctx context.Context, syncCtx factory.Syn
 		needObserverList []string
 		kindNeedObserver []schema.GroupVersionKind
 	)
-	for _, configKind := range current {
+	for _, configKind := range currentResourcesToMonitor {
 		currentList = append(currentList, configKind.String())
 		hasObserver := false
 		for _, o := range c.dynamicInformers {

--- a/pkg/monitor/resourcewatch/storage/monitor_store.go
+++ b/pkg/monitor/resourcewatch/storage/monitor_store.go
@@ -1,0 +1,288 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+var (
+	coreScheme = runtime.NewScheme()
+	coreCodecs = serializer.NewCodecFactory(coreScheme)
+)
+
+type monitorStorage struct {
+	monitor     *monitor.Monitor
+	artifactDir string
+	client      kubernetes.Interface
+	startTime   time.Time
+}
+
+// NewMonitorStorage creates a monitor store for resource watch
+func NewMonitorStorage(artifactDir string, client kubernetes.Interface) (ResourceWatchStore, error) {
+	storage := &monitorStorage{
+		monitor:     monitor.NewMonitorWithInterval(time.Hour),
+		artifactDir: artifactDir,
+		client:      client,
+		startTime:   time.Now(),
+	}
+
+	return storage, nil
+}
+
+func decodeObject(objUnstructured *unstructured.Unstructured, obj runtime.Object) error {
+	objectBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, objUnstructured)
+	if err != nil {
+		return fmt.Errorf("encoding unstructured error: %v", err)
+	}
+	err = runtime.DecodeInto(coreCodecs.UniversalDecoder(corev1.SchemeGroupVersion), objectBytes, obj)
+	if err != nil {
+		return fmt.Errorf("decoding object error: %v", err)
+	}
+	return nil
+}
+
+func (s *monitorStorage) handleEvents(objUnstructured *unstructured.Unstructured) {
+	eventObj := corev1.Event{}
+	err := decodeObject(objUnstructured, &eventObj)
+	if err != nil {
+		klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+	}
+	monitor.EventAddOrUpdateFunc(context.TODO(), s.monitor, s.client, s.startTime, &eventObj)
+}
+
+// OnAdd processes add event for all monitored resources
+func (s *monitorStorage) OnAdd(obj interface{}) {
+	objUnstructured, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		klog.Warningf("Object is not unstructured: %v", obj)
+	}
+	gvk := objUnstructured.GroupVersionKind()
+	switch {
+	case gvk.Group == "" && gvk.Kind == "Node":
+		{
+			nodeObj := corev1.Node{}
+			err := decodeObject(objUnstructured, &nodeObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			monitor.NodeAddFunc(nodeObj)
+		}
+	case gvk.Group == "" && gvk.Kind == "Pod":
+		{
+			podObj := corev1.Pod{}
+			err := decodeObject(objUnstructured, &podObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+			monitor.PodAddFunc(s.monitor, &podObj)
+		}
+	case gvk.Group == "" && gvk.Kind == "Event":
+		s.handleEvents(objUnstructured)
+	case gvk.Group == "config.openshift.io" && gvk.Kind == "ClusterOperator":
+		{
+			coObj := configv1.ClusterOperator{}
+			err := decodeObject(objUnstructured, &coObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			monitor.ClusterOperatorAddFunc(s.monitor, time.Time{}, &coObj)
+		}
+	case gvk.Group == "config.openshift.io" && gvk.Kind == "ClusterVersion":
+		{
+			cvObj := configv1.ClusterVersion{}
+			err := decodeObject(objUnstructured, &cvObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			monitor.ClusterOperatorAddFunc(s.monitor, time.Time{}, &cvObj)
+		}
+	default:
+		{
+			name := objUnstructured.GetName()
+			s.monitor.Record(monitorapi.Condition{
+				Level:   monitorapi.Info,
+				Locator: fmt.Sprintf("%s/%s", gvk.Kind, name),
+				Message: fmt.Sprintf("added"),
+			})
+		}
+	}
+}
+
+// OnUpdate processes update event for all monitored resources
+func (s *monitorStorage) OnUpdate(old, obj interface{}) {
+	objUnstructured, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		klog.Warningf("Object is not unstructured: %v", obj)
+	}
+	oldObjUnstructured, ok := old.(*unstructured.Unstructured)
+	if !ok {
+		klog.Warningf("Old object is not unstructured: %v", obj)
+	}
+	gvk := objUnstructured.GroupVersionKind()
+	switch {
+	case gvk.Group == "" && gvk.Kind == "Node":
+		{
+			nodeObj := corev1.Node{}
+			err := decodeObject(objUnstructured, &nodeObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			oldObj := corev1.Node{}
+			err = decodeObject(oldObjUnstructured, &oldObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", oldObjUnstructured.GetName(), err)
+			}
+			monitor.NodeUpdateFunc(s.monitor, &oldObj, &nodeObj)
+
+		}
+	case gvk.Group == "" && gvk.Kind == "Pod":
+		{
+			podObj := corev1.Pod{}
+			err := decodeObject(objUnstructured, &podObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			oldObj := corev1.Pod{}
+			err = decodeObject(oldObjUnstructured, &oldObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", oldObjUnstructured.GetName(), err)
+			}
+			monitor.PodUpdateFunc(s.monitor, &oldObj, &podObj)
+		}
+	case gvk.Group == "" && gvk.Kind == "Event":
+		s.handleEvents(objUnstructured)
+	case gvk.Group == "config.openshift.io" && gvk.Kind == "ClusterOperator":
+		{
+			coObj := configv1.ClusterOperator{}
+			err := decodeObject(objUnstructured, &coObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			oldObj := configv1.ClusterOperator{}
+			err = decodeObject(oldObjUnstructured, &oldObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", oldObjUnstructured.GetName(), err)
+			}
+			monitor.ClusterOperatorUpdateFunc(s.monitor, &oldObj, &coObj)
+		}
+	case gvk.Group == "config.openshift.io" && gvk.Kind == "ClusterVersion":
+		{
+			cvObj := configv1.ClusterVersion{}
+			err := decodeObject(objUnstructured, &cvObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			oldObj := configv1.ClusterOperator{}
+			err = decodeObject(oldObjUnstructured, &oldObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", oldObjUnstructured.GetName(), err)
+			}
+			monitor.ClusterVersionUpdateFunc(s.monitor, &oldObj, &cvObj)
+		}
+	default:
+		{
+			name := objUnstructured.GetName()
+			s.monitor.Record(monitorapi.Condition{
+				Level:   monitorapi.Info,
+				Locator: fmt.Sprintf("%s/%s", gvk.Kind, name),
+				Message: fmt.Sprintf("updated"),
+			})
+		}
+	}
+}
+
+// OnDelete processes delete event for all monitored resources
+func (s *monitorStorage) OnDelete(obj interface{}) {
+	objUnstructured, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		klog.Warningf("Object is not unstructured: %v", obj)
+	}
+	gvk := objUnstructured.GroupVersionKind()
+	switch {
+	case gvk.Group == "" && gvk.Kind == "Node":
+		{
+			nodeObj := corev1.Node{}
+			err := decodeObject(objUnstructured, &nodeObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+			monitor.NodeDeleteFunc(s.monitor, nodeObj)
+		}
+	case gvk.Group == "" && gvk.Kind == "Pod":
+		{
+			podObj := corev1.Pod{}
+			err := decodeObject(objUnstructured, &podObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+			monitor.PodDeleteFunc(s.monitor, &podObj)
+		}
+	case gvk.Group == "config.openshift.io" && gvk.Kind == "ClusterOperator":
+		{
+			coObj := configv1.ClusterOperator{}
+			err := decodeObject(objUnstructured, &coObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			monitor.ClusterOperatorDeleteFunc(s.monitor, &coObj)
+		}
+	case gvk.Group == "config.openshift.io" && gvk.Kind == "ClusterVersion":
+		{
+			cvObj := configv1.ClusterVersion{}
+			err := decodeObject(objUnstructured, &cvObj)
+			if err != nil {
+				klog.Warningf("Decoding %s failed with error: %v", objUnstructured.GetName(), err)
+			}
+
+			monitor.ClusterOperatorDeleteFunc(s.monitor, &cvObj)
+		}
+	default:
+		{
+			name := objUnstructured.GetName()
+			s.monitor.Record(monitorapi.Condition{
+				Level:   monitorapi.Info,
+				Locator: fmt.Sprintf("%s/%s", gvk.Kind, name),
+				Message: fmt.Sprintf("deleted"),
+			})
+		}
+	}
+}
+
+// End writes captured events to disc
+func (s *monitorStorage) End() {
+	recordedEvents := s.monitor.Intervals(time.Time{}, time.Time{})
+	recordedResources := s.monitor.CurrentResourceState()
+	timeSuffix := fmt.Sprintf("_%s", time.Now().UTC().Format("20060102-150405"))
+
+	eventDir := fmt.Sprintf("%s/monitor-events", s.artifactDir)
+	if err := os.MkdirAll(eventDir, os.ModePerm); err != nil {
+		klog.Warningf("Failed to create monitor-events directory, err: %v", err)
+		return
+	}
+	err := monitor.WriteEventsForJobRun(eventDir, recordedResources, recordedEvents, timeSuffix)
+	if err != nil {
+		klog.Warningf("Failed to write event data, err: %v", err)
+		return
+	}
+}

--- a/pkg/monitor/resourcewatch/storage/monitor_store_test.go
+++ b/pkg/monitor/resourcewatch/storage/monitor_store_test.go
@@ -1,0 +1,1200 @@
+package storage
+
+import (
+	"fmt"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_Add(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		objs       []runtime.Object
+		expected   monitorapi.Intervals
+	}{
+		{
+			name:       "add_nodes",
+			apiVersion: "v1",
+			objs: []runtime.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode-1",
+					},
+					Status: corev1.NodeStatus{},
+				},
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode-2",
+					},
+					Status: corev1.NodeStatus{},
+				},
+			},
+			expected: monitorapi.Intervals{},
+		},
+		{
+			name:       "add_pods",
+			apiVersion: "v1",
+			objs: []runtime.Object{
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testpod-1",
+					},
+					Status: corev1.PodStatus{},
+				},
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testpod-2",
+					},
+					Status: corev1.PodStatus{},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "ns/ pod/testpod-1 node/ uid/",
+						Message: "reason/Created ",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "ns/ pod/testpod-2 node/ uid/",
+						Message: "reason/Created ",
+					},
+				},
+			},
+		},
+		{
+			name:       "add_events",
+			apiVersion: "v1",
+			objs: []runtime.Object{
+				&corev1.Event{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Event",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testevent-1",
+					},
+					LastTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					Message:       "testevent-1",
+					Count:         1,
+					Reason:        "testevent-1",
+				},
+				&corev1.Event{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Event",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testevent-2",
+					},
+					LastTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					Message:       "testevent-2",
+					Count:         2,
+					Reason:        "testevent-2",
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "/",
+						Message: "reason/testevent-1 testevent-1",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "/",
+						Message: "reason/testevent-2 testevent-2 (2 times)",
+					},
+				},
+			},
+		},
+		{
+			name:       "add_cluster_operator",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.ClusterOperator{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterOperator",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusteroperator-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+				&configv1.ClusterOperator{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterOperator",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusteroperator-2",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "clusteroperator/testclusteroperator-1",
+						Message: "created",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "clusteroperator/testclusteroperator-2",
+						Message: "created",
+					},
+				},
+			},
+		},
+		{
+			name:       "add_cluster_version",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.ClusterVersion{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterVersion",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusterversion-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+				&configv1.ClusterVersion{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterVersion",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusterversion-2",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "clusterversion/testclusterversion-1",
+						Message: "created",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "clusterversion/testclusterversion-2",
+						Message: "created",
+					},
+				},
+			},
+		},
+		{
+			name:       "add_Authentication",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.Authentication{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Authentication",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testauthentication-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+				&configv1.Authentication{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Authentication",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testauthentication-2",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "Authentication/testauthentication-1",
+						Message: "added",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "Authentication/testauthentication-2",
+						Message: "added",
+					},
+				},
+			},
+		},
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("error getting working directory, err: %v", err)
+	}
+	artifactDir := fmt.Sprintf("%s/test_add", wd)
+	const mediaType = runtime.ContentTypeJSON
+	info, ok := runtime.SerializerInfoForMediaType(coreCodecs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		t.Errorf("unable to locate encoder -- %q is not a supported media type", mediaType)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.RemoveAll(artifactDir); err != nil {
+				t.Errorf("Failed to remove output directory, err: %v", err)
+			}
+			if err := os.MkdirAll(artifactDir, os.ModePerm); err != nil {
+				t.Errorf("Failed to create output directory, err: %v", err)
+			}
+			objList := []unstructured.Unstructured{}
+			var enc runtime.Encoder
+			if tt.apiVersion == "config.openshift.io/v1" {
+				enc = coreCodecs.EncoderForVersion(info.Serializer, configv1.GroupVersion)
+			} else {
+				enc = coreCodecs.EncoderForVersion(info.Serializer, corev1.SchemeGroupVersion)
+			}
+			for _, obj := range tt.objs {
+				objectBytes, err := runtime.Encode(enc, obj)
+				if err != nil {
+					t.Errorf("error: %v while encoding object: %v", err, obj)
+				}
+				var objUnstructured unstructured.Unstructured
+				err = runtime.DecodeInto(unstructured.UnstructuredJSONScheme, objectBytes, &objUnstructured)
+				if err != nil {
+					t.Errorf("error: %v while decoding into unstructured object", err)
+				}
+				objList = append(objList, objUnstructured)
+			}
+
+			store, err := NewMonitorStorage(artifactDir, &kubernetes.Clientset{})
+			if err != nil {
+				t.Errorf("error calling NewMonitorStorage, err: %v", err)
+			}
+			for _, obj := range objList {
+				store.OnAdd(&obj)
+			}
+			store.End()
+
+			// Now analyze the result
+			eventDir := fmt.Sprintf("%s/monitor-events", artifactDir)
+			err = filepath.Walk(eventDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if strings.Contains(path, "e2e-events") {
+					events, err := monitorserialization.EventsFromFile(path)
+					if err != nil {
+						return fmt.Errorf("error unmarshalling events: %v", err)
+					}
+					if len(events) != len(tt.expected) {
+						return fmt.Errorf("len of events %d is not equal len of expected: %v", len(events), len(tt.expected))
+					}
+					for i := range events {
+						if reflect.DeepEqual(events[i].Condition, tt.expected[i].Condition) == false {
+							return fmt.Errorf("event at index %d: %+v is not equal to expected: %v", i, events[i], tt.expected[i])
+						}
+					}
+
+					return nil
+				}
+				return nil
+			})
+			if err != nil {
+				t.Errorf("test result analysis error: %+v", err)
+			}
+		})
+	}
+	if err := os.RemoveAll(artifactDir); err != nil {
+		t.Errorf("Failed to remove output directory, err: %v", err)
+	}
+}
+
+func Test_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		objs       []runtime.Object
+		oldObjs    []runtime.Object
+		expected   monitorapi.Intervals
+	}{
+		{
+			name:       "update_nodes",
+			apiVersion: "v1",
+			objs: []runtime.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode-1",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionFalse,
+						}},
+					},
+				},
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode-2",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionTrue,
+						}},
+					},
+				},
+			},
+			oldObjs: []runtime.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode-1",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionTrue,
+						}},
+					},
+				},
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode-2",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionFalse,
+						}},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "node/testnode-1",
+						Message: "condition/Ready status/False reason/ roles/ changed",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "node/testnode-2",
+						Message: "condition/Ready status/True reason/ roles/ changed",
+					},
+				},
+			},
+		},
+		{
+			name:       "update_pods",
+			apiVersion: "v1",
+			objs: []runtime.Object{
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testpod-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+					},
+				},
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testpod-2",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+					},
+				},
+			},
+			oldObjs: []runtime.Object{
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testpod-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+					},
+				},
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testpod-2",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Error,
+						Locator: "ns/ pod/testpod-1 node/ uid/",
+						Message: "reason/Failed (): ",
+					},
+				},
+			},
+		},
+		{
+			name:       "update_events",
+			apiVersion: "v1",
+			objs: []runtime.Object{
+				&corev1.Event{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Event",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testevent-1",
+					},
+					LastTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					Message:       "testevent-1 updated",
+					Count:         1,
+					Reason:        "testevent-1",
+				},
+				&corev1.Event{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Event",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testevent-2",
+					},
+					LastTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					Message:       "testevent-2 updated",
+					Count:         2,
+					Reason:        "testevent-2",
+				},
+			},
+			oldObjs: []runtime.Object{
+				&corev1.Event{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Event",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testevent-1",
+					},
+					LastTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					Message:       "testevent-1",
+					Count:         1,
+					Reason:        "testevent-1",
+				},
+				&corev1.Event{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Event",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testevent-2",
+					},
+					LastTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					Message:       "testevent-2",
+					Count:         2,
+					Reason:        "testevent-2",
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "/",
+						Message: "reason/testevent-1 testevent-1 updated",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "/",
+						Message: "reason/testevent-2 testevent-2 updated (2 times)",
+					},
+				},
+			},
+		},
+		{
+			name:       "add_cluster_operator",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.ClusterOperator{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterOperator",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusteroperator-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:               "Available",
+								Status:             configv1.ConditionTrue,
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Minute)},
+								Message:            "availableMessage",
+							},
+							{
+								Type:               "Degraded",
+								Status:             configv1.ConditionStatus("degraded"),
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Minute)},
+								Message:            "degradedMessage",
+							},
+							{
+								Type:               "Progressing",
+								Status:             configv1.ConditionStatus("progressing"),
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Minute)},
+								Message:            "progressingMessage",
+							},
+						},
+					},
+				},
+			},
+			oldObjs: []runtime.Object{
+				&configv1.ClusterOperator{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterOperator",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusteroperator-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:               "Available",
+								Status:             configv1.ConditionFalse,
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Minute)},
+								Message:            "availableMessage",
+							},
+							{
+								Type:               "Degraded",
+								Status:             configv1.ConditionStatus("degraded"),
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Minute)},
+								Message:            "degradedMessage",
+							},
+							{
+								Type:               "Progressing",
+								Status:             configv1.ConditionStatus("progressing"),
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Minute)},
+								Message:            "progressingMessage",
+							},
+						},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "clusteroperator/testclusteroperator-1",
+						Message: "condition/Available status/True changed: availableMessage",
+					},
+				},
+			},
+		},
+		{
+			name:       "add_cluster_version",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.ClusterVersion{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterVersion",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusterversion-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								CompletionTime: &metav1.Time{Time: time.Now().Add(time.Minute)},
+								Version:        "4.13",
+								State:          configv1.CompletedUpdate,
+							},
+							{
+								Version: "4.12",
+							},
+						},
+					},
+				},
+			},
+			oldObjs: []runtime.Object{
+				&configv1.ClusterVersion{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterVersion",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusterversion-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{
+								Version: "4.12",
+							},
+						},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "clusterversion/testclusterversion-1",
+						Message: "cluster reached 4.13",
+					},
+				},
+			},
+		},
+		{
+			name:       "update_Authentication",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.Authentication{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Authentication",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testauthentication-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+				&configv1.Authentication{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Authentication",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testauthentication-2",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+			},
+			oldObjs: []runtime.Object{
+				&configv1.Authentication{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Authentication",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testauthentication-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+				&configv1.Authentication{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Authentication",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testauthentication-2",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "Authentication/testauthentication-1",
+						Message: "updated",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "Authentication/testauthentication-2",
+						Message: "updated",
+					},
+				},
+			},
+		},
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("error getting working directory, err: %v", err)
+	}
+	artifactDir := fmt.Sprintf("%s/test_update", wd)
+	const mediaType = runtime.ContentTypeJSON
+	info, ok := runtime.SerializerInfoForMediaType(coreCodecs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		t.Errorf("unable to locate encoder -- %q is not a supported media type", mediaType)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.objs) != len(tt.oldObjs) {
+				t.Errorf("should have the same number of items in objs and oldObjs")
+			}
+			if err := os.RemoveAll(artifactDir); err != nil {
+				t.Errorf("Failed to remove output directory, err: %v", err)
+			}
+			if err := os.MkdirAll(artifactDir, os.ModePerm); err != nil {
+				t.Errorf("Failed to create output directory, err: %v", err)
+			}
+			objList := []unstructured.Unstructured{}
+			oldList := []unstructured.Unstructured{}
+			var enc runtime.Encoder
+			if tt.apiVersion == "config.openshift.io/v1" {
+				enc = coreCodecs.EncoderForVersion(info.Serializer, configv1.GroupVersion)
+			} else {
+				enc = coreCodecs.EncoderForVersion(info.Serializer, corev1.SchemeGroupVersion)
+			}
+			for i := range tt.objs {
+				obj := tt.objs[i]
+				objectBytes, err := runtime.Encode(enc, obj)
+				if err != nil {
+					t.Errorf("error: %v while encoding object: %v", err, obj)
+				}
+				var objUnstructured unstructured.Unstructured
+				err = runtime.DecodeInto(unstructured.UnstructuredJSONScheme, objectBytes, &objUnstructured)
+				if err != nil {
+					t.Errorf("error: %v while decoding into unstructured object", err)
+				}
+				objList = append(objList, objUnstructured)
+				old := tt.oldObjs[i]
+				objectBytes, err = runtime.Encode(enc, old)
+				if err != nil {
+					t.Errorf("error: %v while encoding object: %v", err, old)
+				}
+				err = runtime.DecodeInto(unstructured.UnstructuredJSONScheme, objectBytes, &objUnstructured)
+				if err != nil {
+					t.Errorf("error: %v while decoding into unstructured object", err)
+				}
+				oldList = append(oldList, objUnstructured)
+			}
+
+			store, err := NewMonitorStorage(artifactDir, &kubernetes.Clientset{})
+			if err != nil {
+				t.Errorf("error calling NewMonitorStorage, err: %v", err)
+			}
+			for i := range objList {
+				obj := objList[i]
+				old := oldList[i]
+				store.OnUpdate(&old, &obj)
+			}
+			store.End()
+
+			// Now analyze the result
+			eventDir := fmt.Sprintf("%s/monitor-events", artifactDir)
+			err = filepath.Walk(eventDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if strings.Contains(path, "e2e-events") {
+					events, err := monitorserialization.EventsFromFile(path)
+					if err != nil {
+						return fmt.Errorf("error unmarshalling events: %v", err)
+					}
+					if len(events) != len(tt.expected) {
+						return fmt.Errorf("len of events %d is not equal len of expected: %v", len(events), len(tt.expected))
+					}
+					for i := range events {
+						if reflect.DeepEqual(events[i].Condition, tt.expected[i].Condition) == false {
+							return fmt.Errorf("event at index %d: %+v is not equal to expected: %v", i, events[i], tt.expected[i])
+						}
+					}
+
+					return nil
+				}
+				return nil
+			})
+			if err != nil {
+				t.Errorf("test result analysis error: %+v", err)
+			}
+		})
+	}
+	if err := os.RemoveAll(artifactDir); err != nil {
+		t.Errorf("Failed to remove output directory, err: %v", err)
+	}
+}
+
+func Test_Delete(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		objs       []runtime.Object
+		expected   monitorapi.Intervals
+	}{
+		{
+			name:       "delete_nodes",
+			apiVersion: "v1",
+			objs: []runtime.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode-1",
+					},
+					Status: corev1.NodeStatus{},
+				},
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Node",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode-2",
+					},
+					Status: corev1.NodeStatus{},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "node/testnode-1",
+						Message: "roles/ deleted",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "node/testnode-2",
+						Message: "roles/ deleted",
+					},
+				},
+			},
+		},
+		{
+			name:       "delete_pods",
+			apiVersion: "v1",
+			objs: []runtime.Object{
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testpod-1",
+					},
+					Status: corev1.PodStatus{},
+				},
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testpod-2",
+					},
+					Status: corev1.PodStatus{},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "ns/ pod/testpod-1 node/ uid/",
+						Message: "reason/Deleted ",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "ns/ pod/testpod-1 node/ uid/",
+						Message: "reason/DeletedBeforeScheduling ",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "ns/ pod/testpod-2 node/ uid/",
+						Message: "reason/Deleted ",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "ns/ pod/testpod-2 node/ uid/",
+						Message: "reason/DeletedBeforeScheduling ",
+					},
+				},
+			},
+		},
+		{
+			name:       "delete_cluster_operator",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.ClusterOperator{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterOperator",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusteroperator-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+				&configv1.ClusterOperator{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterOperator",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusteroperator-2",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "clusteroperator/testclusteroperator-1",
+						Message: "deleted",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "clusteroperator/testclusteroperator-2",
+						Message: "deleted",
+					},
+				},
+			},
+		},
+		{
+			name:       "delete_cluster_version",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.ClusterVersion{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterVersion",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusterversion-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+				&configv1.ClusterVersion{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterVersion",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testclusterversion-2",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "clusterversion/testclusterversion-1",
+						Message: "deleted",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Warning,
+						Locator: "clusterversion/testclusterversion-2",
+						Message: "deleted",
+					},
+				},
+			},
+		},
+		{
+			name:       "delete_Authentication",
+			apiVersion: "config.openshift.io/v1",
+			objs: []runtime.Object{
+				&configv1.Authentication{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Authentication",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testauthentication-1",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+				&configv1.Authentication{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Authentication",
+						APIVersion: "config.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "testauthentication-2",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Minute)},
+					},
+				},
+			},
+			expected: monitorapi.Intervals{
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "Authentication/testauthentication-1",
+						Message: "deleted",
+					},
+				},
+				monitorapi.EventInterval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Info,
+						Locator: "Authentication/testauthentication-2",
+						Message: "deleted",
+					},
+				},
+			},
+		},
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("error getting working directory, err: %v", err)
+	}
+	artifactDir := fmt.Sprintf("%s/test_delete", wd)
+	const mediaType = runtime.ContentTypeJSON
+	info, ok := runtime.SerializerInfoForMediaType(coreCodecs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		t.Errorf("unable to locate encoder -- %q is not a supported media type", mediaType)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.RemoveAll(artifactDir); err != nil {
+				t.Errorf("Failed to remove output directory, err: %v", err)
+			}
+			if err := os.MkdirAll(artifactDir, os.ModePerm); err != nil {
+				t.Errorf("Failed to create output directory, err: %v", err)
+			}
+			objList := []unstructured.Unstructured{}
+			var enc runtime.Encoder
+			if tt.apiVersion == "config.openshift.io/v1" {
+				enc = coreCodecs.EncoderForVersion(info.Serializer, configv1.GroupVersion)
+			} else {
+				enc = coreCodecs.EncoderForVersion(info.Serializer, corev1.SchemeGroupVersion)
+			}
+			for _, obj := range tt.objs {
+				objectBytes, err := runtime.Encode(enc, obj)
+				if err != nil {
+					t.Errorf("error: %v while encoding object: %v", err, obj)
+				}
+				var objUnstructured unstructured.Unstructured
+				err = runtime.DecodeInto(unstructured.UnstructuredJSONScheme, objectBytes, &objUnstructured)
+				if err != nil {
+					t.Errorf("error: %v while decoding into unstructured object", err)
+				}
+				objList = append(objList, objUnstructured)
+			}
+
+			store, err := NewMonitorStorage(artifactDir, &kubernetes.Clientset{})
+			if err != nil {
+				t.Errorf("error calling NewMonitorStorage, err: %v", err)
+			}
+			for _, obj := range objList {
+				store.OnDelete(&obj)
+			}
+			store.End()
+
+			// Now analyze the result
+			eventDir := fmt.Sprintf("%s/monitor-events", artifactDir)
+			err = filepath.Walk(eventDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if strings.Contains(path, "e2e-events") {
+					events, err := monitorserialization.EventsFromFile(path)
+					if err != nil {
+						return fmt.Errorf("error unmarshalling events: %v", err)
+					}
+					if len(events) != len(tt.expected) {
+						return fmt.Errorf("len of events %d is not equal len of expected: %v", len(events), len(tt.expected))
+					}
+					for i := range events {
+						if reflect.DeepEqual(events[i].Condition, tt.expected[i].Condition) == false {
+							return fmt.Errorf("event at index %d: %+v is not equal to expected: %v", i, events[i], tt.expected[i])
+						}
+					}
+
+					return nil
+				}
+				return nil
+			})
+			if err != nil {
+				t.Errorf("test result analysis error: %+v", err)
+			}
+		})
+	}
+	if err := os.RemoveAll(artifactDir); err != nil {
+		t.Errorf("Failed to remove output directory, err: %v", err)
+	}
+}

--- a/pkg/monitor/resourcewatch/storage/store.go
+++ b/pkg/monitor/resourcewatch/storage/store.go
@@ -1,0 +1,8 @@
+package storage
+
+import "k8s.io/client-go/tools/cache"
+
+type ResourceWatchStore interface {
+	cache.ResourceEventHandler
+	End()
+}


### PR DESCRIPTION
Main changes with this PR:
1. Reorg existing monitor files (for node, pod, cluster operator etc) so that codes can be called from within monitor package and outside monitor package (e.g. for resource watch)
2. Add one monitor store for resource watch. For resources supported by monitor (currently node, pod, cluster operator and cluster version), an effort has been made to maintain the same event formats. Events is not supported yet.
3. Monitor store can be selected instead of git repo. But in a real observer, both stores can be started with two different instances of openshift-tests binary. 

[TRT-469](https://issues.redhat.com/browse/TRT-469)