### PR TITLE
ETCD-336: add e2e replace unhealthy master machine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 	github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2
 	github.com/apparentlymart/go-cidr v1.1.0
+	github.com/aws/aws-sdk-go v1.38.49
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/fsouza/go-dockerclient v1.7.1
@@ -89,7 +90,6 @@ require (
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/auth0/go-jwt-middleware v0.0.0-20201030150249-d783b5c46b39 // indirect
-	github.com/aws/aws-sdk-go v1.38.49 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -217,7 +217,7 @@ func recoverClusterToInitialStateIfNeeded(ctx context.Context, t TestingT, machi
 // this method won't fail immediately on errors, this is useful during scaling down operation until the feature can ensure this operation to be graceful
 func EnsureVotingMembersCount(ctx context.Context, t TestingT, etcdClientFactory EtcdClientCreator, kubeClient kubernetes.Interface, expectedMembersCount int) error {
 	waitPollInterval := 15 * time.Second
-	waitPollTimeout := 10 * time.Minute
+	waitPollTimeout := 25 * time.Minute
 	t.Logf("Waiting up to %s for the cluster to reach the expected member count of %v", waitPollTimeout.String(), expectedMembersCount)
 
 	return wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -386,8 +386,6 @@ func SkipIfUnsupportedPlatform(ctx context.Context, oc *exutil.CLI) {
 	skipIfSingleNode(oc)
 	skipIfBareMetal(oc)
 	skipIfVsphere(oc)
-	skipIfGCP(oc)
-	skipIfOpenStack(oc)
 }
 
 func skipUnlessFunctionalMachineAPI(ctx context.Context, machineClient machinev1beta1client.MachineInterface) {
@@ -449,24 +447,6 @@ func skipIfVsphere(oc *exutil.CLI) {
 
 	if infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType {
 		e2eskipper.Skipf("this test is currently broken on the vsphere platform and needs to be fixed (BZ2094919)")
-	}
-}
-
-func skipIfGCP(oc *exutil.CLI) {
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	if infra.Status.PlatformStatus.Type == configv1.GCPPlatformType {
-		e2eskipper.Skipf("this test is currently broken on the GCP platform and needs to be fixed")
-	}
-}
-
-func skipIfOpenStack(oc *exutil.CLI) {
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	if infra.Status.PlatformStatus.Type == configv1.OpenStackPlatformType {
-		e2eskipper.Skipf("this test is currently broken on the OpenStack platform and needs to be fixed")
 	}
 }
 

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -3,14 +3,14 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"math/rand"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/davecgh/go-spew/spew"
 	o "github.com/onsi/gomega"
 
@@ -18,7 +18,6 @@ import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	machinev1beta1client "github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1beta1"
-
 	bmhelper "github.com/openshift/origin/test/extended/baremetal"
 	exutil "github.com/openshift/origin/test/extended/util"
 
@@ -155,7 +154,7 @@ func EnsureMasterMachinesAndCount(ctx context.Context, t TestingT, machineClient
 	return wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {
 		machineList, err := machineClient.List(ctx, metav1.ListOptions{LabelSelector: masterMachineLabelSelector})
 		if err != nil {
-			t.Logf("@MUSTAFA: can not list master machines: %w", err)
+			t.Logf("can not list master machines: %w", err)
 			return isTransientAPIError(t, err)
 		}
 

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -8,6 +8,7 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	testlibraryapi "github.com/openshift/library-go/test/library/apiserver"
 	scalingtestinglibrary "github.com/openshift/origin/test/extended/etcd/helpers"
@@ -162,6 +163,17 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 		memberName, err := scalingtestinglibrary.MachineNameToEtcdMemberName(ctx, kubeClient, machineClient, victimMachineName)
 		o.Expect(err).ToNot(o.HaveOccurred())
 
+		// wait till the victim's machine phase becomes `Failed`
+		o.Eventually(func() (*machinev1beta1.Machine, error) {
+			machine, err := machineClient.Get(ctx, victimMachineName, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+
+			return machine, nil
+		}).Should(o.HaveField("Status.Phase", o.BeEquivalentTo("Failed")))
+
+		// once victim machine is `Failed`, delete from api-server
 		err = machineClient.Delete(ctx, victimMachineName, metav1.DeleteOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
 		framework.Logf("successfully deleted master machine %q from the API", victimMachineName)

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -112,4 +112,78 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 		err = errors.Wrap(err, "scale-down: timed out waiting for only 3 Running master machines")
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
+
+	// The following test covers replacing a failed master machine from 3 master nodes cluster.
+	// It starts by setting one of the master machine to be failed/unhealthy.
+	// The failed machine is expected to be replaced automatically.
+	// The test ends validating the size of the cluster, and asserting the member was removed from the etcd cluster by contacting MemberList API.
+	g.It("is able to replace failed master machine from 3 master nodes cluster [Timeout:60m][apigroup:machine.openshift.io]", func() {
+		// set up
+		// TODO: shall we refactor this into `BeforeEach()`
+		ctx := context.TODO()
+		etcdClientFactory := scalingtestinglibrary.NewEtcdClientFactory(oc.KubeClient())
+		machineClientSet, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).ToNot(o.HaveOccurred())
+		machineClient := machineClientSet.MachineV1beta1().Machines("openshift-machine-api")
+		kubeClient := oc.KubeClient()
+
+		// make sure it can be run on the current platform
+		// TODO: shall we refactor this into `JustBeforeEach()`
+		scalingtestinglibrary.SkipIfUnsupportedPlatform(ctx, oc)
+
+		// assert the cluster state before we run the test
+		// TODO: shall we refactor this into `JustBeforeEach()`
+		err = scalingtestinglibrary.EnsureInitialClusterState(ctx, g.GinkgoT(), etcdClientFactory, machineClient, kubeClient)
+		err = errors.Wrap(err, "pre-test: timed out waiting for initial cluster state to have 3 running machines and 3 voting members")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 0: ensure clean state after the test
+		// TODO: shall we refactor this into `AfterEach()`
+		defer func() {
+			// since the deletion triggers a new rollout
+			// we need to make sure that the API is stable after the test
+			// so that other e2e test won't hit an API that undergoes a termination (write request might fail)
+			g.GinkgoT().Log("cleaning routine: ensuring initial cluster state and waiting for api servers to stabilize on the same revision")
+			err = scalingtestinglibrary.EnsureInitialClusterState(ctx, g.GinkgoT(), etcdClientFactory, machineClient, kubeClient)
+			err = errors.Wrap(err, "cleaning routine: timed out while ensuring cluster state back to 3 running machines and 3 voting members")
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			err = testlibraryapi.WaitForAPIServerToStabilizeOnTheSameRevision(g.GinkgoT(), oc.KubeClient().CoreV1().Pods("openshift-kube-apiserver"))
+			err = errors.Wrap(err, "cleaning routine: timed out waiting for APIServer pods to stabilize on the same revision")
+			o.Expect(err).ToNot(o.HaveOccurred())
+		}()
+
+		// step 1: edit one of the master machine's status to be failed/unhealthy
+		machineName, err := scalingtestinglibrary.FailRandomlyChosenMasterMachine(ctx, g.GinkgoT(), machineClient)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 2: delete the failed machine and wait until etcd member is removed from the etcd cluster
+		memberName, err := scalingtestinglibrary.MachineNameToEtcdMemberName(ctx, oc.KubeClient(), machineClient, machineName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		err = machineClient.Delete(ctx, machineName, metav1.DeleteOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+		framework.Logf("successfully deleted the machine %q from the API", machineName)
+
+		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 2)
+		err = errors.Wrap(err, "scale-down: timed out waiting for 2 voting members in the etcd cluster and etcd-endpoints configmap")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		err = scalingtestinglibrary.EnsureMemberRemoved(g.GinkgoT(), etcdClientFactory, memberName)
+		err = errors.Wrapf(err, "scale-down: timed out waiting for member (%v) to be removed", memberName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step3:  wait until a new member shows up and check if it is healthy
+		//         and until all kube-api servers have reached the same revision
+		//         this additional step is the best-effort of ensuring they
+		//         have observed the new member before disruption
+		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 3)
+		err = errors.Wrap(err, "scale-up: timed out waiting for 3 voting members in the etcd cluster and etcd-endpoints configmap")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		g.GinkgoT().Log("waiting for api servers to stabilize on the same revision")
+		err = testlibraryapi.WaitForAPIServerToStabilizeOnTheSameRevision(g.GinkgoT(), oc.KubeClient().CoreV1().Pods("openshift-kube-apiserver"))
+		err = errors.Wrap(err, "scale-up: timed out waiting for APIServer pods to stabilize on the same revision")
+		o.Expect(err).ToNot(o.HaveOccurred())
+	})
 })

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -8,7 +8,6 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	testlibraryapi "github.com/openshift/library-go/test/library/apiserver"
 	scalingtestinglibrary "github.com/openshift/origin/test/extended/etcd/helpers"
@@ -162,16 +161,6 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 		// step 2: delete the victim machine and wait until etcd member is removed from the etcd cluster
 		memberName, err := scalingtestinglibrary.MachineNameToEtcdMemberName(ctx, kubeClient, machineClient, victimMachineName)
 		o.Expect(err).ToNot(o.HaveOccurred())
-
-		// wait till the victim's machine phase becomes `Failed`
-		o.Eventually(func() (*machinev1beta1.Machine, error) {
-			machine, err := machineClient.Get(ctx, victimMachineName, metav1.GetOptions{})
-			if err != nil {
-				return nil, err
-			}
-
-			return machine, nil
-		}).Should(o.HaveField("Status.Phase", o.BeEquivalentTo("Failed")))
 
 		// once victim machine is `Failed`, delete from api-server
 		err = machineClient.Delete(ctx, victimMachineName, metav1.DeleteOptions{})

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -81,7 +81,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 		//         this additional step is the best-effort of ensuring they
 		//         have observed the new member before disruption
 		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 4)
-		err = errors.Wrap(err, "scale-up: timed out waiting for 4 voting members in the etcd cluster and etcd-endpoints configmap")
+		err = errors.Wrap(err, "scale-up: timed out waiting for 4 voting members in the etcd cluster")
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		memberName, err := scalingtestinglibrary.MachineNameToEtcdMemberName(ctx, oc.KubeClient(), machineClient, machineName)
@@ -101,7 +101,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 		framework.Logf("successfully deleted the machine %q from the API", machineName)
 
 		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 3)
-		err = errors.Wrap(err, "scale-down: timed out waiting for 3 voting members in the etcd cluster and etcd-endpoints configmap")
+		err = errors.Wrap(err, "scale-down: timed out waiting for 3 voting members in the etcd cluster")
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		err = scalingtestinglibrary.EnsureMemberRemoved(g.GinkgoT(), etcdClientFactory, memberName)
@@ -155,7 +155,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 
 		// assert that scaling down does NOT occur before deleting the victim machine explicitly from api-server
 		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 3)
-		err = errors.Wrap(err, "scale-down: timed out waiting for 3 voting members in the etcd cluster and etcd-endpoints configmap")
+		err = errors.Wrap(err, "scale-down: timed out waiting for 3 voting members in the etcd cluster")
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		// step 2: delete the victim machine and wait until etcd member is removed from the etcd cluster
@@ -173,7 +173,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 
 		// assert that scaling down did occur only after deleting the victim machine explicitly from api-server
 		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 2)
-		err = errors.Wrap(err, "scale-down: timed out waiting for 2 voting members in the etcd cluster and etcd-endpoints configmap")
+		err = errors.Wrap(err, "scale-down: timed out waiting for 2 voting members in the etcd cluster")
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		// step3:  wait until a new member shows up and check if it is healthy
@@ -187,7 +187,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 
 		// assert that scaling up did occur automatically in response to scaling-down
 		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 3)
-		err = errors.Wrap(err, "scale-up: timed out waiting for 3 voting members in the etcd cluster and etcd-endpoints configmap")
+		err = errors.Wrap(err, "scale-up: timed out waiting for 3 voting members in the etcd cluster")
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 })

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -153,6 +153,9 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 		victimMachineName, err := scalingtestinglibrary.FailStopRandomMasterMachine(ctx, g.GinkgoT(), kubeClient, machineClient)
 		o.Expect(err).ToNot(o.HaveOccurred())
 
+		// recreate etcd client to existing master node
+		etcdClientFactory = scalingtestinglibrary.NewEtcdClientFactory(oc.KubeClient())
+
 		// assert that scaling down does NOT occur before deleting the victim machine explicitly from api-server
 		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 3)
 		err = errors.Wrap(err, "scale-down: timed out waiting for 3 voting members in the etcd cluster")

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -115,7 +115,7 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 
 	// The following test covers replacing a failed master machine from 3 master nodes cluster.
 	// It starts by setting one of the master machine to be failed/unhealthy.
-	// The failed machine is expected to be replaced automatically.
+	// After the failed machine is being deleted, it is expected to be replaced automatically
 	// The test ends validating the size of the cluster, and asserting the member was removed from the etcd cluster by contacting MemberList API.
 	g.It("is able to replace failed master machine from 3 master nodes cluster [Timeout:60m][apigroup:machine.openshift.io]", func() {
 		// set up
@@ -154,11 +154,11 @@ var _ = g.Describe("[sig-etcd][Serial] etcd [apigroup:config.openshift.io]", fun
 		}()
 
 		// step 1: edit one of the master machine's status to be failed/unhealthy
-		machineName, err := scalingtestinglibrary.FailRandomlyChosenMasterMachine(ctx, g.GinkgoT(), machineClient)
+		machineName, err := scalingtestinglibrary.FailRandomlyChosenMasterMachine(ctx, g.GinkgoT(), kubeClient, machineClient)
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		// step 2: delete the failed machine and wait until etcd member is removed from the etcd cluster
-		memberName, err := scalingtestinglibrary.MachineNameToEtcdMemberName(ctx, oc.KubeClient(), machineClient, machineName)
+		memberName, err := scalingtestinglibrary.MachineNameToEtcdMemberName(ctx, kubeClient, machineClient, machineName)
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		err = machineClient.Delete(ctx, machineName, metav1.DeleteOptions{})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53091,11 +53091,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53091,13 +53091,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2019,6 +2019,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io]": "[Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io] [Serial]",
 
+	"[Top Level] [sig-etcd][Serial] etcd [apigroup:config.openshift.io] is able to replace failed master machine from 3 master nodes cluster [Timeout:60m][apigroup:machine.openshift.io]": "is able to replace failed master machine from 3 master nodes cluster [Timeout:60m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]",
+
 	"[Top Level] [sig-etcd][Serial] etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]",
 
 	"[Top Level] [sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": "should redirect on blob pull [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",

--- a/tools/junitreport/pkg/parser/gotest/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser_test.go
@@ -161,33 +161,33 @@ func TestExtractSuiteName(t *testing.T) {
 		fail         bool
 	}{
 		{
-			name: "basic",
-			testLine: "ok  	package/name 0.160s",
+			name:         "basic",
+			testLine:     "ok  	package/name 0.160s",
 			expectedName: "package/name",
 		},
 		{
-			name: "go 1.5.1",
-			testLine: "ok  	package/name	0.160s",
+			name:         "go 1.5.1",
+			testLine:     "ok  	package/name	0.160s",
 			expectedName: "package/name",
 		},
 		{
-			name: "numeric",
-			testLine: "ok  	1234 0.160s",
+			name:         "numeric",
+			testLine:     "ok  	1234 0.160s",
 			expectedName: "1234",
 		},
 		{
-			name: "url",
-			testLine: "ok  	github.com/maintainer/repository/package/file 0.160s",
+			name:         "url",
+			testLine:     "ok  	github.com/maintainer/repository/package/file 0.160s",
 			expectedName: "github.com/maintainer/repository/package/file",
 		},
 		{
-			name: "with coverage",
-			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			name:         "with coverage",
+			testLine:     `ok  	package/name 0.400s  coverage: 10.0% of statements`,
 			expectedName: "package/name",
 		},
 		{
-			name: "failed print",
-			testLine: `some other textok  	package/name 0.400s  coverage: 10.0% of statements`,
+			name:         "failed print",
+			testLine:     `some other textok  	package/name 0.400s  coverage: 10.0% of statements`,
 			expectedName: "package/name",
 			fail:         true,
 		},
@@ -219,8 +219,8 @@ func TestSuiteProperties(t *testing.T) {
 			expectedProperties: map[string]string{coveragePropertyName: "10.0"},
 		},
 		{
-			name: "with package declaration",
-			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			name:               "with package declaration",
+			testLine:           `ok  	package/name 0.400s  coverage: 10.0% of statements`,
 			expectedProperties: map[string]string{coveragePropertyName: "10.0"},
 		},
 		{

--- a/tools/junitreport/pkg/parser/gotest/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser_test.go
@@ -161,33 +161,33 @@ func TestExtractSuiteName(t *testing.T) {
 		fail         bool
 	}{
 		{
-			name:         "basic",
-			testLine:     "ok  	package/name 0.160s",
+			name: "basic",
+			testLine: "ok  	package/name 0.160s",
 			expectedName: "package/name",
 		},
 		{
-			name:         "go 1.5.1",
-			testLine:     "ok  	package/name	0.160s",
+			name: "go 1.5.1",
+			testLine: "ok  	package/name	0.160s",
 			expectedName: "package/name",
 		},
 		{
-			name:         "numeric",
-			testLine:     "ok  	1234 0.160s",
+			name: "numeric",
+			testLine: "ok  	1234 0.160s",
 			expectedName: "1234",
 		},
 		{
-			name:         "url",
-			testLine:     "ok  	github.com/maintainer/repository/package/file 0.160s",
+			name: "url",
+			testLine: "ok  	github.com/maintainer/repository/package/file 0.160s",
 			expectedName: "github.com/maintainer/repository/package/file",
 		},
 		{
-			name:         "with coverage",
-			testLine:     `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			name: "with coverage",
+			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
 			expectedName: "package/name",
 		},
 		{
-			name:         "failed print",
-			testLine:     `some other textok  	package/name 0.400s  coverage: 10.0% of statements`,
+			name: "failed print",
+			testLine: `some other textok  	package/name 0.400s  coverage: 10.0% of statements`,
 			expectedName: "package/name",
 			fail:         true,
 		},
@@ -219,8 +219,8 @@ func TestSuiteProperties(t *testing.T) {
 			expectedProperties: map[string]string{coveragePropertyName: "10.0"},
 		},
 		{
-			name:               "with package declaration",
-			testLine:           `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			name: "with package declaration",
+			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
 			expectedProperties: map[string]string{coveragePropertyName: "10.0"},
 		},
 		{


### PR DESCRIPTION
This PR adds a e2e workflow for the automated replacement of unhealthy master machine

cc @hasbro17 @tjungblu @JoelSpeed 

- [ ] use `BeforeEach`, `AfterEach` to remove setup duplication
- [ ] add logs and clear error msgs
- [ ] rename vars and funcs 
- [ ] refactor provider client to be agnostic 
- [ ] wait after killing instance, till machine being `failed`, before deletion from api-server