### PR TITLE
[wip] 1.24 - add timing

### DIFF
--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -79,7 +79,7 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 
 		listStepCtx := exutil.AddStep(testCtx, "listStep")
 		listStart := time.Now()
-		nodeList, err := oc.KubeClient().CoreV1().Nodes().List(testCtx, metav1.ListOptions{})
+		nodeList, err := oc.KubeClient().CoreV1().Nodes().List(listStepCtx, metav1.ListOptions{})
 		exutil.StepEnd(listStepCtx, listStart)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -64,13 +65,22 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed clu
 
 var _ = g.Describe("[sig-node] Managed cluster", func() {
 	defer g.GinkgoRecover()
+
+	ctx := context.Background()
+	ctx = exutil.WithDescription(ctx, "[sig-node] Managed cluster")
+
 	var (
-		oc = exutil.NewCLIWithoutNamespace("managed-cluster-node").AsAdmin()
+		oc = exutil.NewCLIWithoutNamespaceWithContext(exutil.AddStep(ctx, "initializing"), "managed-cluster-node").AsAdmin()
 	)
 
 	var staticNodeNames []string
 	g.It("record the number of nodes at the beginning of the tests [Early]", func() {
-		nodeList, err := oc.KubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		testCtx := exutil.WithTestName(ctx, "record the number of nodes at the beginning of the tests [Early]")
+
+		listStepCtx := exutil.AddStep(testCtx, "listStep")
+		listStart := time.Now()
+		nodeList, err := oc.KubeClient().CoreV1().Nodes().List(testCtx, metav1.ListOptions{})
+		exutil.StepEnd(listStepCtx, listStart)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		for _, node := range nodeList.Items {

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -730,7 +730,9 @@ func (c *CLI) AdminTemplateClient() templatev1client.Interface {
 
 // KubeClient provides a Kubernetes client for the current namespace
 func (c *CLI) KubeClient() kubernetes.Interface {
-	return kubernetes.NewForConfigOrDie(c.UserConfig())
+	config := c.UserConfig()
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf"
+	return kubernetes.NewForConfigOrDie(config)
 }
 
 func (c *CLI) DynamicClient() dynamic.Interface {

--- a/test/extended/util/trace.go
+++ b/test/extended/util/trace.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	describeKey  = "describe"
+	testNameKey  = "testName"
+	stepNamesKey = "stepNames"
+)
+
+func WithDescription(parent context.Context, description string) context.Context {
+	return context.WithValue(parent, describeKey, description)
+}
+
+func DescriptionFrom(ctx context.Context) (string, bool) {
+	description, ok := ctx.Value(describeKey).(string)
+	return description, ok
+}
+
+func WithTestName(parent context.Context, testName string) context.Context {
+	return context.WithValue(parent, testNameKey, testName)
+}
+
+func TestNameFrom(ctx context.Context) (string, bool) {
+	testName, ok := ctx.Value(testNameKey).(string)
+	return testName, ok
+}
+
+func AddStep(parent context.Context, stepName string) context.Context {
+	stepNamesToSet := []string{}
+	if currSteps, ok := StepsFrom(parent); ok {
+		stepNamesToSet = append(stepNamesToSet, currSteps...)
+	}
+	stepNamesToSet = append(stepNamesToSet, stepName)
+	return context.WithValue(parent, stepNamesKey, stepNamesToSet)
+}
+
+func StepsFrom(ctx context.Context) ([]string, bool) {
+	stepNames, ok := ctx.Value(stepNamesKey).([]string)
+	return stepNames, ok
+}
+
+func StepEnd(ctx context.Context, startTime time.Time) {
+	description, _ := DescriptionFrom(ctx)
+	testName, _ := TestNameFrom(ctx)
+	endTime := time.Now()
+	steps, _ := StepsFrom(ctx)
+
+	e2e.Logf("TEST TIMING: %q -- for step (%v) -- %v", description+" "+testName, strings.Join(steps, "."), endTime.Sub(startTime))
+}

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/trace.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/trace.go
@@ -1,0 +1,63 @@
+package v1
+
+import (
+	"context"
+	"strings"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+const (
+	describeKey  = "describe"
+	testNameKey  = "testName"
+	stepNamesKey = "stepNames"
+)
+
+func WithDescription(parent context.Context, description string) context.Context {
+	return context.WithValue(parent, describeKey, description)
+}
+
+func DescriptionFrom(ctx context.Context) (string, bool) {
+	description, ok := ctx.Value(describeKey).(string)
+	return description, ok
+}
+
+func WithTestName(parent context.Context, testName string) context.Context {
+	return context.WithValue(parent, testNameKey, testName)
+}
+
+func TestNameFrom(ctx context.Context) (string, bool) {
+	testName, ok := ctx.Value(testNameKey).(string)
+	return testName, ok
+}
+
+func AddStep(parent context.Context, stepName string) context.Context {
+	stepNamesToSet := []string{}
+	if currSteps, ok := StepsFrom(parent); ok {
+		stepNamesToSet = append(stepNamesToSet, currSteps...)
+	}
+	stepNamesToSet = append(stepNamesToSet, stepName)
+	return context.WithValue(parent, stepNamesKey, stepNamesToSet)
+}
+
+func StepsFrom(ctx context.Context) ([]string, bool) {
+	stepNames, ok := ctx.Value(stepNamesKey).([]string)
+	return stepNames, ok
+}
+
+func StepEnd(ctx context.Context, startTime time.Time) {
+	description, _ := DescriptionFrom(ctx)
+	testName, _ := TestNameFrom(ctx)
+	endTime := time.Now()
+	steps, _ := StepsFrom(ctx)
+
+	level:="INFO"
+	format := "TEST TIMING: %q -- for step (%v) -- %v"
+	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", description+" "+testName, strings.Join(steps, "."), endTime.Sub(startTime))
+}
+
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -969,7 +969,7 @@ func (r *Request) transformResponseWithContext(ctx context.Context, resp *http.R
 	bodyReadStart := time.Now()
 	var body []byte
 	if resp.Body != nil {
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := ReadAll(bodyReadCtx, resp.Body)
 		switch err.(type) {
 		case nil:
 			body = data

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -994,6 +994,7 @@ func (r *Request) transformResponseWithContext(ctx context.Context, resp *http.R
 			}
 		}
 	}
+	GinkgoLogf("read %v bytes", len(body))
 	StepEnd(bodyReadCtx, bodyReadStart)
 
 

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -994,7 +994,7 @@ func (r *Request) transformResponseWithContext(ctx context.Context, resp *http.R
 			}
 		}
 	}
-	GinkgoLogf("read %v bytes", len(body))
+	GinkgoLogf("read %v bytes from %T %#v", len(body), resp.Body, resp.Body)
 	StepEnd(bodyReadCtx, bodyReadStart)
 
 

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -929,7 +929,7 @@ func (r *Request) Do(ctx context.Context) Result {
 		transformContext := AddStep(ctx, "Transform")
 		start := time.Now()
 		defer StepEnd(transformContext, start)
-		result = r.transformResponse(resp, req)
+		result = r.transformResponseWithContext(transformContext, resp, req)
 	})
 	if err != nil {
 		return Result{err: err}
@@ -961,6 +961,12 @@ func (r *Request) DoRaw(ctx context.Context) ([]byte, error) {
 
 // transformResponse converts an API response into a structured API object
 func (r *Request) transformResponse(resp *http.Response, req *http.Request) Result {
+	return r.transformResponseWithContext(context.TODO(), resp, req)
+}
+
+func (r *Request) transformResponseWithContext(ctx context.Context, resp *http.Response, req *http.Request) Result {
+	bodyReadCtx := AddStep(ctx, "BodyRead")
+	bodyReadStart := time.Now()
 	var body []byte
 	if resp.Body != nil {
 		data, err := ioutil.ReadAll(resp.Body)
@@ -988,10 +994,14 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 			}
 		}
 	}
+	StepEnd(bodyReadCtx, bodyReadStart)
+
 
 	glogBody("Response Body", body)
 
 	// verify the content type is accurate
+	allDecoderCtx := AddStep(ctx, "DecoderIdentification")
+	allDecoderStart := time.Now()
 	var decoder runtime.Decoder
 	contentType := resp.Header.Get("Content-Type")
 	if len(contentType) == 0 {
@@ -1003,6 +1013,8 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 		if err != nil {
 			return Result{err: errors.NewInternalError(err)}
 		}
+		negotiateCtx := AddStep(allDecoderCtx, "Negotiate")
+		negotiateStart := time.Now()
 		decoder, err = r.c.content.Negotiator.Decoder(mediaType, params)
 		if err != nil {
 			// if we fail to negotiate a decoder, treat this as an unstructured error
@@ -1019,7 +1031,9 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 				warnings:    handleWarnings(resp.Header, r.warningHandler),
 			}
 		}
+		StepEnd(negotiateCtx, negotiateStart)
 	}
+	StepEnd(allDecoderCtx, allDecoderStart)
 
 	switch {
 	case resp.StatusCode == http.StatusSwitchingProtocols:

--- a/vendor/k8s.io/client-go/rest/trace.go
+++ b/vendor/k8s.io/client-go/rest/trace.go
@@ -1,0 +1,63 @@
+package rest
+
+import (
+	"context"
+	"strings"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+const (
+	describeKey  = "describe"
+	testNameKey  = "testName"
+	stepNamesKey = "stepNames"
+)
+
+func WithDescription(parent context.Context, description string) context.Context {
+	return context.WithValue(parent, describeKey, description)
+}
+
+func DescriptionFrom(ctx context.Context) (string, bool) {
+	description, ok := ctx.Value(describeKey).(string)
+	return description, ok
+}
+
+func WithTestName(parent context.Context, testName string) context.Context {
+	return context.WithValue(parent, testNameKey, testName)
+}
+
+func TestNameFrom(ctx context.Context) (string, bool) {
+	testName, ok := ctx.Value(testNameKey).(string)
+	return testName, ok
+}
+
+func AddStep(parent context.Context, stepName string) context.Context {
+	stepNamesToSet := []string{}
+	if currSteps, ok := StepsFrom(parent); ok {
+		stepNamesToSet = append(stepNamesToSet, currSteps...)
+	}
+	stepNamesToSet = append(stepNamesToSet, stepName)
+	return context.WithValue(parent, stepNamesKey, stepNamesToSet)
+}
+
+func StepsFrom(ctx context.Context) ([]string, bool) {
+	stepNames, ok := ctx.Value(stepNamesKey).([]string)
+	return stepNames, ok
+}
+
+func StepEnd(ctx context.Context, startTime time.Time) {
+	description, _ := DescriptionFrom(ctx)
+	testName, _ := TestNameFrom(ctx)
+	endTime := time.Now()
+	steps, _ := StepsFrom(ctx)
+
+	level:="INFO"
+	format := "TEST TIMING: %q -- for step (%v) -- %v"
+	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", description+" "+testName, strings.Join(steps, "."), endTime.Sub(startTime))
+}
+
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}

--- a/vendor/k8s.io/client-go/rest/trace.go
+++ b/vendor/k8s.io/client-go/rest/trace.go
@@ -61,3 +61,8 @@ func StepEnd(ctx context.Context, startTime time.Time) {
 func nowStamp() string {
 	return time.Now().Format(time.StampMilli)
 }
+
+func GinkgoLogf(format string, args ...interface{}){
+	level:="INFO"
+	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+}

--- a/vendor/k8s.io/client-go/rest/trace.go
+++ b/vendor/k8s.io/client-go/rest/trace.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"fmt"
 	"time"
+	"io"
 
 	"github.com/onsi/ginkgo"
 )
@@ -65,4 +66,26 @@ func nowStamp() string {
 func GinkgoLogf(format string, args ...interface{}){
 	level:="INFO"
 	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+}
+
+func ReadAll(ctx context.Context, r io.Reader) ([]byte, error) {
+	b := make([]byte, 0, 512)
+	count := 0
+	for {
+		count++
+		if len(b) == cap(b) {
+			// Add more capacity (let append pick how much).
+			b = append(b, 0)[:len(b)]
+		}
+		n, err := r.Read(b[len(b):cap(b)])
+		b = b[:len(b)+n]
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+
+			GinkgoLogf("reading took %v reads", count)
+			return b, err
+		}
+	}
 }


### PR DESCRIPTION
They're all about like this

> I1031 14:26:26.386329  120609 round_trippers.go:553] GET https://api.ci-ln-5q2b1lk-76ef8.origin-ci-int-aws.dev.rhcloud.com:6443/api/v1/nodes 200 OK in 17 milliseconds
Oct 31 14:26:26.403: INFO: TEST TIMING: "[sig-node] Managed cluster record the number of nodes at the beginning of the tests [Early]" -- for step (listStep) -- 34.870954ms

compiled with 1.19