### PR TITLE
NE-1068: Add test using chaos plugin to detect local DNS endpoint preference.

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1953,6 +1953,8 @@ var Annotations = map[string]string{
 
 	"[sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": " [Disabled:Broken]",
 
+	"[sig-network-edge] DNS should answer queries using the local DNS endpoint": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should be able to connect to a service that is idled because a GET on the route will unidle it [apigroup:config.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel/minimal]",
 
 	"[sig-network-edge][Conformance][Area:Networking][Feature:Router] The HAProxy router should pass the gRPC interoperability tests [apigroup:config.openshift.io][apigroup:route.openshift.io][apigroup:operator.openshift.io]": " [Suite:openshift/conformance/parallel/minimal]",


### PR DESCRIPTION
[NE-1068](https://issues.redhat.com//browse/NE-1068): Add test using chaos plugin to detect local DNS endpoint preference.

New test that uses a chaos query to detect which DNS pod respond will attempt a chaos request multiple times and verify all requests are answered by the local DNS endpoint. Regardless of SDN type, this should always pass.

This is being added due to a regression in which the local DNS endpoint preference broke in 4.11/4.12 https://issues.redhat.com/browse/OCPBUGS-488.