### PR TITLE
Store monitor events in artifact directory at the end of run monitor

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -129,6 +129,9 @@ func newRunMonitorCommand() *cobra.Command {
 			return monitorOpt.Run()
 		},
 	}
+	cmd.Flags().StringVar(&monitorOpt.ArtifactDir,
+		"artifact-dir", monitorOpt.ArtifactDir,
+		"The directory where monitor events will be stored.")
 	return cmd
 }
 


### PR DESCRIPTION
This is in preparation for using run monitor as CI observer. 

[TRT-469](https://issues.redhat.com/browse/TRT-469)