### PR TITLE
OCPBUGS-3282: Fix apigroup tag missing closing brace.

### DIFF
--- a/test/extended/scheduling/pods.go
+++ b/test/extended/scheduling/pods.go
@@ -134,7 +134,7 @@ var _ = g.Describe("[sig-scheduling][Early]", func() {
 		})
 	})
 
-	g.Describe("The openshift-console console pods [apigroup:console.openshift.io", func() {
+	g.Describe("The openshift-console console pods [apigroup:console.openshift.io]", func() {
 		g.It("should be scheduled on different nodes", func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-console", deployment: "console"}.run(oc)
 		})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -3293,7 +3293,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-scheduling][Early] The openshift-authentication pods [apigroup:oauth.openshift.io] should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-scheduling][Early] The openshift-console console pods [apigroup:console.openshift.io should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-scheduling][Early] The openshift-console console pods [apigroup:console.openshift.io] should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-scheduling][Early] The openshift-console downloads pods [apigroup:console.openshift.io] should be scheduled on different nodes": "should be scheduled on different nodes [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
This was causing the test to be skipped:

: [sig-scheduling][Early] The openshift-console console pods [apigroup:console.openshift.io should be scheduled on different nodes [Suite:openshift/conformance/parallel]
Reason: skipped because the following required API groups are missing: console.openshift.io should be scheduled on different nodes [Suite:openshift/conformance/parallel
