### PR TITLE
[release-4.12] Add bond cni test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,6 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 // indirect
-	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
@@ -279,6 +278,8 @@ require (
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+require github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 
 replace (
 	github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.0.0-20221104153651-0e2187c0d222


### PR DESCRIPTION
4.12 backport of https://github.com/openshift/origin/pull/27405
Adding a test case for the bond-cni.
The test checks if a pod with a bond is created successfully, and then checks connectivity between two pods with bond interfaces.