### PR TITLE
Separate out more tests from 'events should not repeat pathologically' test

### DIFF
--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -29,3 +29,18 @@ func testPodNodeNameIsImmutable(events monitorapi.Intervals) []*junitapi.JUnitTe
 		},
 	}}
 }
+
+func testOauthApiserverProbeErrorLiveness(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[bz-apiserver-auth] openshift-oauth-apiserver should not get probe error on liveiness probe due to timeout"
+	return makeProbeTest(testName, events, probeErrorLivenessMessageRegExpStr, "openshift-oauth-apiserver", probeErrorLivenessEventThreshold)
+}
+
+func testOauthApiserverProbeErrorReadiness(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[bz-apiserver-auth] openshift-oauth-apiserver should not get probe error on readiiness probe due to timeout"
+	return makeProbeTest(testName, events, probeErrorReadinessMessageRegExpStr, "openshift-oauth-apiserver", probeErrorReadinessEventThreshold)
+}
+
+func testOauthApiserverProbeErrorConnectionRefused(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[bz-apiserver-auth] openshift-oauth-apiserver should not get probe error on readiiness probe due to connection refused"
+	return makeProbeTest(testName, events, probeErrorConnectionRefusedRegExpStr, "openshift-oauth-apiserver", probeErrorConnectionRefusedEventThreshold)
+}

--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -122,11 +122,25 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 	// If you see this error, it means enough was working to get this event which implies enough retries happened to allow initial openshift
 	// installation to succeed. Hence, we can ignore it.
 	regexp.MustCompile(`reason/FailedCreate .* error creating EC2 instance: InsufficientInstanceCapacity: We currently do not have sufficient .* capacity in the Availability Zone you requested`),
+
+	// Separated out in testNodeHasNoDiskPressure
+	regexp.MustCompile(nodeHasNoDiskPressureRegExpStr),
+
+	// Separated out in testNodeHasSufficientMemory
+	regexp.MustCompile(nodeHasSufficientMemoryRegExpStr),
+
+	// Separated out in testNodeHasSufficientPID
+	regexp.MustCompile(nodeHasSufficientPIDRegExpStr),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{
 	isConsoleReadinessDuringInstallation,
 	isConfigOperatorReadinessFailed,
+	isConfigOperatorProbeErrorReadinessFailed,
+	isConfigOperatorProbeErrorLivenessFailed,
+	isOauthApiserverProbeErrorReadinessFailed,
+	isOauthApiserverProbeErrorLivenessFailed,
+	isOauthApiserverProbeErrorConnectionRefusedFailed,
 }
 
 // allowedUpgradeRepeatedEventPatterns are patterns of events that we should only allow during upgrades, not during normal execution.
@@ -543,21 +557,68 @@ func isConsoleReadinessDuringInstallation(monitorEvent monitorapi.EventInterval,
 // isConfigOperatorReadinessFailed returns true if the event matches a readinessFailed error that timed out
 // in the openshift-config-operator.
 // like this:
-// ...ReadinessFailed Get \"https://10.130.0.16:8443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"
+// ...ReadinessFailed Get \"https://10.130.0.16:8443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
 func isConfigOperatorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
-	regExp := regexp.MustCompile(probeTimeoutMessageRegExpStr)
-	return isConfigOperatorReadinessProbeFailedMessage(monitorEvent, regExp), nil
+	regExp := regexp.MustCompile(readinessFailedMessageRegExpStr)
+	return isOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
 }
 
-func isConfigOperatorReadinessProbeFailedMessage(monitorEvent monitorapi.EventInterval, regExp *regexp.Regexp) bool {
+// isConfigOperatorProbeErrorReadinessFailed returns true if the event matches a ProbeError Readiness Probe message
+// in the openshift-config-operator.
+// like this:
+// reason/ProbeError Readiness probe error: Get "https://10.130.0.15:8443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+func isConfigOperatorProbeErrorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(probeErrorReadinessMessageRegExpStr)
+	return isOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
+}
+
+// isConfigOperatorProbeErrorLivenessFailed returns true if the event matches a ProbeError Liveness Probe message
+// in the openshift-config-operator.
+// like this:
+// ...reason/ProbeError Liveness probe error: Get "https://10.128.0.21:8443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+func isConfigOperatorProbeErrorLivenessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(probeErrorLivenessMessageRegExpStr)
+	return isOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
+}
+
+// isOauthApiserverProbeErrorReadinessFailed returns true if the event matches a ProbeError Readiness Probe message
+// in the openshift-oauth-operator.
+// like this:
+// ...ns/openshift-oauth-apiserver pod/apiserver-65fd7ffc59-bt5sf node/q72hs3bx-ac890-4pxpm-master-2 - reason/ProbeError Readiness probe error: Get "https://10.129.0.8:8443/readyz": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
+func isOauthApiserverProbeErrorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(probeErrorReadinessMessageRegExpStr)
+	return isOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
+}
+
+// isOauthApiserverProbeErrorLivenessFailed returns true if the event matches a ProbeError Liveness Probe message
+// in the openshift-oauth-operator.
+// like this:
+// ...reason/ProbeError Liveness probe error: Get "https://10.130.0.68:8443/healthz": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
+func isOauthApiserverProbeErrorLivenessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(probeErrorLivenessMessageRegExpStr)
+	return isOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
+}
+
+// isOauthApiserverProbeErrorConnectionRefusedFailed returns true if the event matches a ProbeError Readiness Probe connection refused message
+// in the openshift-oauth-operator.
+// like this:
+// ...ns/openshift-oauth-apiserver pod/apiserver-647fc6c7bf-s8b4h node/ip-10-0-150-209.us-west-1.compute.internal - reason/ProbeError Readiness probe error: Get "https://10.128.0.38:8443/readyz": dial tcp 10.128.0.38:8443: connect: connection refused
+func isOauthApiserverProbeErrorConnectionRefusedFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(probeErrorConnectionRefusedRegExpStr)
+	return isOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
+}
+
+// isOperatorMatchRegexMessage returns true if this monitorEvent is for the operator identified by the operatorName
+// and its message matches the given regex.
+func isOperatorMatchRegexMessage(monitorEvent monitorapi.EventInterval, operatorName string, regExp *regexp.Regexp) bool {
 	locatorParts := monitorapi.LocatorParts(monitorEvent.Locator)
 	if ns, ok := locatorParts["ns"]; ok {
-		if ns != "openshift-config-operator" {
+		if ns != operatorName {
 			return false
 		}
 	}
 	if pod, ok := locatorParts["pod"]; ok {
-		if !strings.HasPrefix(pod, "openshift-config-operator") {
+		if !strings.HasPrefix(pod, operatorName) {
 			return false
 		}
 	}

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -47,8 +47,16 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testAPIQuotaEvents(events)...)
 	tests = append(tests, testErrorUpdatingEndpointSlices(events)...)
 	tests = append(tests, testConfigOperatorReadinessProbe(events)...)
-	tests = append(tests, testHttpConnectionLost(events)...)
+	tests = append(tests, testConfigOperatorProbeErrorReadinessProbe(events)...)
+	tests = append(tests, testConfigOperatorProbeErrorLivenessProbe(events)...)
+	tests = append(tests, testOauthApiserverProbeErrorReadiness(events)...)
+	tests = append(tests, testOauthApiserverProbeErrorLiveness(events)...)
+	tests = append(tests, testOauthApiserverProbeErrorConnectionRefused(events)...)
+	tests = append(tests, testNodeHasNoDiskPressure(events)...)
+	tests = append(tests, testNodeHasSufficientMemory(events)...)
+	tests = append(tests, testNodeHasSufficientPID(events)...)
 
+	tests = append(tests, testHttpConnectionLost(events)...)
 	return tests
 }
 
@@ -92,9 +100,16 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testNoExcessiveSecretGrowthDuringUpgrade()...)
 	tests = append(tests, testNoExcessiveConfigMapGrowthDuringUpgrade()...)
 	tests = append(tests, testConfigOperatorReadinessProbe(events)...)
+	tests = append(tests, testConfigOperatorProbeErrorReadinessProbe(events)...)
+	tests = append(tests, testConfigOperatorProbeErrorLivenessProbe(events)...)
+	tests = append(tests, testOauthApiserverProbeErrorReadiness(events)...)
+	tests = append(tests, testOauthApiserverProbeErrorLiveness(events)...)
+	tests = append(tests, testOauthApiserverProbeErrorConnectionRefused(events)...)
+	tests = append(tests, testNodeHasNoDiskPressure(events)...)
+	tests = append(tests, testNodeHasSufficientMemory(events)...)
+	tests = append(tests, testNodeHasSufficientPID(events)...)
 
 	tests = append(tests, testHttpConnectionLost(events)...)
-
 	return tests
 }
 

--- a/pkg/synthetictests/node.go
+++ b/pkg/synthetictests/node.go
@@ -1,0 +1,57 @@
+package synthetictests
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+const (
+	nodeHasNoDiskPressureEventThreshold   = 5
+	nodeHasSufficientMemoryEventThreshold = 5
+	nodeHasSufficientPIDEventThreshold    = 5
+	nodeHasNoDiskPressureRegExpStr        = "reason/NodeHasNoDiskPressure.*status is now: NodeHasNoDiskPressure"
+	nodeHasSufficientMemoryRegExpStr      = "reason/NodeHasSufficientMemory.*status is now: NodeHasSufficientMemory"
+	nodeHasSufficientPIDRegExpStr         = "reason/NodeHasSufficientPID.*status is now: NodeHasSufficientPID"
+)
+
+func makeNodeHasTest(testName string, events monitorapi.Intervals, regExStr string, eventFlakeThreshold int) []*junitapi.JUnitTestCase {
+	messageRegExp := regexp.MustCompile(regExStr)
+	var failureOutput string
+	var count int
+	for _, event := range events {
+		if messageRegExp.MatchString(event.Message) {
+			// Place the failure time in the message to avoid having to extract the time from the events json file
+			// (in artifacts) when viewing the test failure output.
+			failureOutput += fmt.Sprintf("%s %s\n", event.From.Format("15:04:05"), event.Message)
+			count++
+		}
+	}
+
+	test := &junitapi.JUnitTestCase{Name: testName}
+	if count > eventFlakeThreshold {
+		// Flake for now.
+		test.FailureOutput = &junitapi.FailureOutput{
+			Output: failureOutput,
+		}
+		success := &junitapi.JUnitTestCase{Name: testName}
+		return []*junitapi.JUnitTestCase{test, success}
+	}
+	return []*junitapi.JUnitTestCase{test}
+}
+func testNodeHasNoDiskPressure(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-node] Test the NodeHasNoDiskPressure condition does not occur too often"
+	return makeNodeHasTest(testName, events, nodeHasNoDiskPressureRegExpStr, nodeHasNoDiskPressureEventThreshold)
+}
+
+func testNodeHasSufficientMemory(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-node] Test the NodeHasSufficeintMemory condition does not occur too often"
+	return makeNodeHasTest(testName, events, nodeHasSufficientMemoryRegExpStr, nodeHasSufficientMemoryEventThreshold)
+}
+
+func testNodeHasSufficientPID(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-node] Test the NodeHasSufficientPID condition does not occur too often"
+	return makeNodeHasTest(testName, events, nodeHasSufficientPIDRegExpStr, nodeHasSufficientPIDEventThreshold)
+}


### PR DESCRIPTION
Re: [TRT-596](https://issues.redhat.com//browse/TRT-596)

For the `[sig-arch] events should not repeat pathologically` test,

* create 6 new flaking tests to separate out ProbeError tests for openshift-config-operator and openshift-oauth-apiserver
* create 3 new flaking tests to separate out the NodeHasNoDiskPressure, NodeHasSufficientMemory, and NodeHasSufficientPID events