### PR TITLE
make command errors easier to read

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -879,7 +879,8 @@ func (c *CLI) outputs(stdOutBuff, stdErrBuff *bytes.Buffer) (string, string, err
 		return stdOut, stdErr, nil
 	case *exec.ExitError:
 		framework.Logf("Error running %v:\nStdOut>\n%s\nStdErr>\n%s\n", cmd, stdOut, stdErr)
-		return stdOut, stdErr, err
+		wrappedErr := fmt.Errorf("Error running %v:\nStdOut>\n%s\nStdErr>\n%s\n%w\n", cmd, stdOut, stdErr, err)
+		return stdOut, stdErr, wrappedErr
 	default:
 		FatalErr(fmt.Errorf("unable to execute %q: %v", c.execPath, err))
 		// unreachable code


### PR DESCRIPTION
errors like 
```
fail [github.com/openshift/origin/test/extended/deployments/deployments.go:1002]: Unexpected error:
    <*exec.ExitError | 0xc00154c560>: {
        ProcessState: {
            pid: 67978,
            status: 256,
            rusage: {
                Utime: {Sec: 0, Usec: 120054},
                Stime: {Sec: 0, Usec: 33352},
                Maxrss: 230984,
                Ixrss: 0,
                Idrss: 0,
                Isrss: 0,
                Minflt: 3216,
                Majflt: 0,
                Nswap: 0,
                Inblock: 0,
                Oublock: 0,
                Msgsnd: 0,
                Msgrcv: 0,
                Nsignals: 0,
                Nvcsw: 511,
                Nivcsw: 10,
            },
        },
        Stderr: nil,
    }
    exit status 1
```

are really hard to read,  this should change it to be something more like
```
Error running /usr/bin/oc --namespace=e2e-test-cli-deployment-7kgkc --kubeconfig=/tmp/configfile4230829623 set env dc/history-limit A=9:
StdOut>
Unable to connect to the server: dial tcp 34.170.77.45:6443: i/o timeout
StdErr>
Unable to connect to the server: dial tcp 34.170.77.45:6443: i/o timeout

```