### PR TITLE
OCPBUGS-3633: Fix flake reporting for certain tests.

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -384,7 +384,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 	}
 
 	// calculate the effective test set we ran, excluding any incompletes
-	tests, _ = splitTests(tests, func(t *testCase) bool { return t.success || t.failed || t.skipped })
+	tests, _ = splitTests(tests, func(t *testCase) bool { return t.success || t.flake || t.failed || t.skipped })
 
 	end := time.Now()
 	duration := end.Sub(start).Round(time.Second / 10)

--- a/pkg/test/ginkgo/junit.go
+++ b/pkg/test/ginkgo/junit.go
@@ -54,19 +54,25 @@ func generateJUnitTestSuiteResults(
 					Output: lastLinesUntil(string(test.testOutputBytes), 100, "fail ["),
 				},
 			})
+		case test.flake:
+			s.NumTests++
+			s.NumFailed++
+			s.TestCases = append(s.TestCases, &junitapi.JUnitTestCase{
+				Name:      test.name,
+				SystemOut: string(test.testOutputBytes),
+				Duration:  test.duration.Seconds(),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: lastLinesUntil(string(test.testOutputBytes), 100, "flake:"),
+				},
+			})
+
+			// also add the successful junit result:
+			s.NumTests++
+			s.TestCases = append(s.TestCases, &junitapi.JUnitTestCase{
+				Name:     test.name,
+				Duration: test.duration.Seconds(),
+			})
 		case test.success:
-			if test.flake {
-				s.NumTests++
-				s.NumFailed++
-				s.TestCases = append(s.TestCases, &junitapi.JUnitTestCase{
-					Name:      test.name,
-					SystemOut: string(test.testOutputBytes),
-					Duration:  test.duration.Seconds(),
-					FailureOutput: &junitapi.FailureOutput{
-						Output: lastLinesUntil(string(test.testOutputBytes), 100, "flake:"),
-					},
-				})
-			}
 			s.NumTests++
 			s.TestCases = append(s.TestCases, &junitapi.JUnitTestCase{
 				Name:     test.name,


### PR DESCRIPTION
In PR #27516 we suspect reporting of flakes broke due to a missed
assumption that test.flake accompanied test.success. Our new goal is to
more clearly have just one status set, so we're going to lean into the
new approach and properly break out the flake state into it's own case.
