### PR TITLE
Flake and improve alert tests

### DIFF
--- a/pkg/alerts/allowed_conformance.go
+++ b/pkg/alerts/allowed_conformance.go
@@ -1,0 +1,100 @@
+package alerts
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	helper "github.com/openshift/origin/test/extended/util/prometheus"
+	"github.com/prometheus/common/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// AllowedAlertsDuringConformance lists all alerts that are allowed to be pending or firing during
+// conformance testing.
+// WARNING: there is a parallel list for allowed alerts during upgrade in allowed_upgrade.go,
+// ensure that alerts we want to allow in both are added to both.
+func AllowedAlertsDuringConformance(configClient configclient.Interface) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending helper.MetricConditions) {
+
+	firingAlertsWithBugs := helper.MetricConditions{
+		{
+			Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+		},
+		{
+			Selector: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+		},
+		{
+			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
+		},
+		{
+			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeAPIErrorBudgetBurn"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1953798",
+			Matches: func(_ *model.Sample) bool {
+				return framework.ProviderIs("gce")
+			},
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"}, // not sure how to do a job_name prefix
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2054426",
+		},
+	}
+	allowedFiringAlerts := helper.MetricConditions{
+		{
+			Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
+		{
+			Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
+			Text:     "high CPU utilization during e2e runs is normal",
+		},
+		{
+			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
+			Text:     "high CPU utilization during e2e runs is normal",
+		},
+	}
+	pendingAlertsWithBugs := helper.MetricConditions{}
+	allowedPendingAlerts := helper.MetricConditions{
+		{
+			Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
+			Text:     "high CPU utilization during e2e runs is normal",
+		},
+		{
+			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
+			Text:     "high CPU utilization during e2e runs is normal",
+		},
+	}
+
+	if featureGates, err := configClient.ConfigV1().FeatureGates().Get(context.TODO(), "cluster", metav1.GetOptions{}); err == nil {
+		switch featureGates.Spec.FeatureSet {
+		case configv1.TechPreviewNoUpgrade:
+			allowedFiringAlerts = append(
+				allowedFiringAlerts,
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": "TechPreviewNoUpgrade"},
+					Text:     "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been enabled",
+				},
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": "ClusterNotUpgradeable"},
+					Text:     "Allow testing of ClusterNotUpgradeable clusters, this will only fire when a FeatureGate has been enabled",
+				})
+		}
+	}
+
+	return firingAlertsWithBugs, allowedFiringAlerts, pendingAlertsWithBugs, allowedPendingAlerts
+}

--- a/pkg/alerts/allowed_upgrade.go
+++ b/pkg/alerts/allowed_upgrade.go
@@ -1,0 +1,147 @@
+package alerts
+
+import (
+	"context"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	helper "github.com/openshift/origin/test/extended/util/prometheus"
+	"github.com/prometheus/common/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// AllowedAlertsDuringUpgrade lists all alerts that are allowed to be pending or firing during
+// upgrade.
+// WARNING: there is a parallel list for allowed alerts during conformance in allowed_conformance.go,
+// ensure that alerts we want to allow in both are added to both.
+func AllowedAlertsDuringUpgrade(configClient configclient.Interface) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending helper.MetricConditions) {
+
+	firingAlertsWithBugs := helper.MetricConditions{
+		{
+			Selector: map[string]string{"alertname": "AggregatedAPIDown", "namespace": "default", "name": "v1beta1.metrics.k8s.io"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1970624",
+			Matches: func(_ *model.Sample) bool {
+				return framework.ProviderIs("gce")
+			},
+		},
+		{
+			Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+		},
+		{
+			Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "openshift-apiserver"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+		},
+		{
+			Selector: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+		},
+		{
+			Selector: map[string]string{"alertname": "ClusterOperatorDown", "name": "machine-config"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955300",
+		},
+		{
+			// Should be removed one release after the attached bugzilla is fixed, or after that bug is fixed in a backport to the previous minor.
+			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1985073",
+			Matches: func(_ *model.Sample) bool {
+				return framework.ProviderIs("gce")
+			},
+		},
+		{
+			// Should be removed one release after the attached bugzilla is fixed.
+			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
+		},
+		{
+			// Should be removed one release after the attached bugzilla is fixed.
+			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeAPIErrorBudgetBurn"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1953798",
+			Matches: func(_ *model.Sample) bool {
+				return framework.ProviderIs("gce")
+			},
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeDaemonSetRolloutStuck"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1943667",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2054426",
+			Matches: func(sample *model.Sample) bool {
+				// Only match if the job_name label starts with ip-reconciler:
+				if strings.HasPrefix(string(sample.Metric[model.LabelName("job_name")]), "ip-reconciler-") {
+					return true
+				}
+				return false
+			},
+		},
+		{
+			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-kube-apiserver-operator"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-kube-apiserver-operator"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
+		},
+	}
+
+	allowedFiringAlerts := helper.MetricConditions{
+		{
+			Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
+			Text:     "Loki is nice to have, but we can allow it to be down",
+		},
+	}
+	pendingAlertsWithBugs := helper.MetricConditions{
+		{
+			Selector: map[string]string{"alertname": "ClusterMonitoringOperatorReconciliationErrors"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1932624",
+		},
+		{
+			Selector: map[string]string{"alertname": "KubeClientErrors"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1925698",
+		},
+		{
+			Selector: map[string]string{"alertname": "NetworkPodsCrashLooping"},
+			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2009078",
+		},
+	}
+	allowedPendingAlerts := helper.MetricConditions{
+		{
+			Selector: map[string]string{"alertname": "etcdMemberCommunicationSlow"},
+			Text:     "Excluded because it triggers during upgrade (detects ~5m of high latency immediately preceeding the end of the test), and we don't want to change the alert because it is correct",
+		},
+	}
+
+	if featureGates, err := configClient.ConfigV1().FeatureGates().Get(context.TODO(), "cluster", metav1.GetOptions{}); err == nil {
+		switch featureGates.Spec.FeatureSet {
+		case configv1.TechPreviewNoUpgrade:
+			allowedFiringAlerts = append(
+				allowedFiringAlerts,
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": "TechPreviewNoUpgrade"},
+					Text:     "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been enabled",
+				},
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": "ClusterNotUpgradeable"},
+					Text:     "Allow testing of ClusterNotUpgradeable clusters, this will only fire when a FeatureGate has been enabled",
+				})
+		}
+	}
+
+	return firingAlertsWithBugs, allowedFiringAlerts, pendingAlertsWithBugs, allowedPendingAlerts
+}

--- a/pkg/alerts/check.go
+++ b/pkg/alerts/check.go
@@ -71,13 +71,13 @@ count_over_time(ALERTS{alertstate="firing",severity!="info",alertname!~"Watchdog
 		violation := fmt.Sprintf("alert %s fired for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
 		if cause := allowedFiringAlerts.Matches(series); cause != nil {
 			// TODO: this seems to never be firing? no search.ci results show allowed
-			debug.Insert(fmt.Sprintf("%s result=allowed (%s)", violation, cause.Text))
+			debug.Insert(fmt.Sprintf("%s result=allow (%s)", violation, cause.Text))
 			continue
 		}
 		if cause := firingAlertsWithBugs.Matches(series); cause != nil {
-			knownViolations.Insert(fmt.Sprintf("%s result=allowed bug=%s", violation, cause.Text))
+			knownViolations.Insert(fmt.Sprintf("%s result=allow bug=%s", violation, cause.Text))
 		} else {
-			unexpectedViolations.Insert(fmt.Sprintf("%s result=failure", violation))
+			unexpectedViolations.Insert(fmt.Sprintf("%s result=reject", violation))
 		}
 	}
 
@@ -100,15 +100,15 @@ sort_desc(
 		violation := fmt.Sprintf("alert %s pending for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
 		if cause := allowedPendingAlerts.Matches(series); cause != nil {
 			// TODO: this seems to never be firing? no search.ci results show allowed
-			debug.Insert(fmt.Sprintf("%s result=allowed (%s)", violation, cause.Text))
+			debug.Insert(fmt.Sprintf("%s result=allow (%s)", violation, cause.Text))
 			continue
 		}
 		if cause := pendingAlertsWithBugs.Matches(series); cause != nil {
-			knownViolations.Insert(fmt.Sprintf("%s result=allowed bug=%s", violation, cause.Text))
+			knownViolations.Insert(fmt.Sprintf("%s result=allow bug=%s", violation, cause.Text))
 		} else {
 			// treat pending errors as a flake right now because we are still trying to determine the scope
 			// TODO: move this to unexpectedViolations later
-			unexpectedViolationsAsFlakes.Insert(fmt.Sprintf("%s result=allowed", violation))
+			unexpectedViolationsAsFlakes.Insert(fmt.Sprintf("%s result=allow", violation))
 		}
 	}
 

--- a/pkg/alerts/check.go
+++ b/pkg/alerts/check.go
@@ -1,0 +1,133 @@
+package alerts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	o "github.com/onsi/gomega"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/origin/pkg/synthetictests/allowedalerts"
+	testresult "github.com/openshift/origin/pkg/test/ginkgo/result"
+	"github.com/openshift/origin/test/extended/util/disruption"
+	helper "github.com/openshift/origin/test/extended/util/prometheus"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+type allowedAlertsFunc func(configclient.Interface) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending helper.MetricConditions)
+
+// CheckAlerts will query prometheus and ensure no-unexpected alerts were pending or firing.
+// Used both post-upgrade and post-conformance, with different allowances for each.
+func CheckAlerts(allowancesFunc allowedAlertsFunc, prometheusClient prometheusv1.API, configClient configclient.Interface, testDuration time.Duration, f *framework.Framework) {
+	firingAlertsWithBugs, allowedFiringAlerts, pendingAlertsWithBugs, allowedPendingAlerts :=
+		allowancesFunc(configClient)
+
+	// we exclude alerts that have their own separate tests.
+	for _, alertTest := range allowedalerts.AllAlertTests(context.TODO(), nil, 0) {
+		switch alertTest.AlertState() {
+		case allowedalerts.AlertPending:
+			// a pending test covers pending and everything above (firing)
+			allowedPendingAlerts = append(allowedPendingAlerts,
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": alertTest.AlertName()},
+					Text:     "has a separate e2e test",
+				},
+			)
+			allowedFiringAlerts = append(allowedFiringAlerts,
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": alertTest.AlertName()},
+					Text:     "has a separate e2e test",
+				},
+			)
+		case allowedalerts.AlertInfo:
+			// an info test covers all firing
+			allowedFiringAlerts = append(allowedFiringAlerts,
+				helper.MetricCondition{
+					Selector: map[string]string{"alertname": alertTest.AlertName()},
+					Text:     "has a separate e2e test",
+				},
+			)
+		}
+	}
+
+	knownViolations := sets.NewString()
+	unexpectedViolations := sets.NewString()
+	unexpectedViolationsAsFlakes := sets.NewString()
+	debug := sets.NewString()
+
+	// Invariant: No non-info level alerts should have fired
+	firingAlertQuery := fmt.Sprintf(`
+sort_desc(
+count_over_time(ALERTS{alertstate="firing",severity!="info",alertname!~"Watchdog|AlertmanagerReceiversNotConfigured"}[%[1]s:1s])
+) > 0
+`, testDuration)
+	result, err := helper.RunQuery(context.TODO(), prometheusClient, firingAlertQuery)
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to check firing alerts")
+	for _, series := range result.Data.Result {
+		labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
+		violation := fmt.Sprintf("alert %s fired for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
+		if cause := allowedFiringAlerts.Matches(series); cause != nil {
+			debug.Insert(fmt.Sprintf("%s (allowed: %s)", violation, cause.Text))
+			continue
+		}
+		if cause := firingAlertsWithBugs.Matches(series); cause != nil {
+			knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
+		} else {
+			unexpectedViolations.Insert(violation)
+		}
+	}
+
+	// Invariant: There should be no pending alerts
+	pendingAlertQuery := fmt.Sprintf(`
+sort_desc(
+  time() * ALERTS + 1
+  -
+  last_over_time((
+    time() * ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured",alertstate="pending",severity!="info"}
+    unless
+    ALERTS offset 1s
+  )[%[1]s:1s])
+)
+`, testDuration)
+	result, err = helper.RunQuery(context.TODO(), prometheusClient, pendingAlertQuery)
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to retrieve pending alerts")
+	for _, series := range result.Data.Result {
+		labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
+		violation := fmt.Sprintf("alert %s pending for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
+		if cause := allowedPendingAlerts.Matches(series); cause != nil {
+			debug.Insert(fmt.Sprintf("%s (allowed: %s)", violation, cause.Text))
+			continue
+		}
+		if cause := pendingAlertsWithBugs.Matches(series); cause != nil {
+			knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
+		} else {
+			// treat pending errors as a flake right now because we are still trying to determine the scope
+			// TODO: move this to unexpectedViolations later
+			unexpectedViolationsAsFlakes.Insert(violation)
+		}
+	}
+
+	if len(debug) > 0 {
+		framework.Logf("Alerts were detected which are allowed:\n\n%s", strings.Join(debug.List(), "\n"))
+	}
+	if len(unexpectedViolations) > 0 {
+		framework.Failf("Unexpected alerts fired or pending:\n\n%s", strings.Join(unexpectedViolations.List(), "\n"))
+	}
+	if flakes := sets.NewString().Union(knownViolations).Union(unexpectedViolations).Union(unexpectedViolationsAsFlakes); len(flakes) > 0 {
+		// TODO: The two tests that had this duplicated code had slightly different ways of reporting flakes
+		// that I do not fully understand the implications of. Fork the logic here.
+		if f != nil {
+			// when called from alert.go within an UpgradeTest with a framework available
+			// f.TestSummaries is the part I'm unsure about here.
+			disruption.FrameworkFlakef(f, "Unexpected alert behavior:\n\n%s", strings.Join(flakes.List(), "\n"))
+		} else {
+			// when called from prometheus.go with no framework available
+			testresult.Flakef("Unexpected alert behavior:\n\n%s", strings.Join(flakes.List(), "\n"))
+		}
+	}
+	framework.Logf("No alerts fired")
+
+}

--- a/pkg/alerts/check.go
+++ b/pkg/alerts/check.go
@@ -70,13 +70,14 @@ count_over_time(ALERTS{alertstate="firing",severity!="info",alertname!~"Watchdog
 		labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
 		violation := fmt.Sprintf("alert %s fired for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
 		if cause := allowedFiringAlerts.Matches(series); cause != nil {
-			debug.Insert(fmt.Sprintf("%s (allowed: %s)", violation, cause.Text))
+			// TODO: this seems to never be firing? no search.ci results show allowed
+			debug.Insert(fmt.Sprintf("%s result=allowed (%s)", violation, cause.Text))
 			continue
 		}
 		if cause := firingAlertsWithBugs.Matches(series); cause != nil {
-			knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
+			knownViolations.Insert(fmt.Sprintf("%s result=allowed bug=%s", violation, cause.Text))
 		} else {
-			unexpectedViolations.Insert(violation)
+			unexpectedViolations.Insert(fmt.Sprintf("%s result=failure", violation))
 		}
 	}
 
@@ -98,15 +99,16 @@ sort_desc(
 		labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
 		violation := fmt.Sprintf("alert %s pending for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
 		if cause := allowedPendingAlerts.Matches(series); cause != nil {
-			debug.Insert(fmt.Sprintf("%s (allowed: %s)", violation, cause.Text))
+			// TODO: this seems to never be firing? no search.ci results show allowed
+			debug.Insert(fmt.Sprintf("%s result=allowed (%s)", violation, cause.Text))
 			continue
 		}
 		if cause := pendingAlertsWithBugs.Matches(series); cause != nil {
-			knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
+			knownViolations.Insert(fmt.Sprintf("%s result=allowed bug=%s", violation, cause.Text))
 		} else {
 			// treat pending errors as a flake right now because we are still trying to determine the scope
 			// TODO: move this to unexpectedViolations later
-			unexpectedViolationsAsFlakes.Insert(violation)
+			unexpectedViolationsAsFlakes.Insert(fmt.Sprintf("%s result=allowed", violation))
 		}
 	}
 

--- a/pkg/alerts/check.go
+++ b/pkg/alerts/check.go
@@ -115,9 +115,6 @@ sort_desc(
 	if len(debug) > 0 {
 		framework.Logf("Alerts were detected which are allowed:\n\n%s", strings.Join(debug.List(), "\n"))
 	}
-	if len(unexpectedViolations) > 0 {
-		framework.Failf("Unexpected alerts fired or pending:\n\n%s", strings.Join(unexpectedViolations.List(), "\n"))
-	}
 	if flakes := sets.NewString().Union(knownViolations).Union(unexpectedViolations).Union(unexpectedViolationsAsFlakes); len(flakes) > 0 {
 		// TODO: The two tests that had this duplicated code had slightly different ways of reporting flakes
 		// that I do not fully understand the implications of. Fork the logic here.

--- a/test/e2e/upgrade/alert/alert.go
+++ b/test/e2e/upgrade/alert/alert.go
@@ -2,22 +2,13 @@ package alert
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
-	o "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
-	"github.com/openshift/origin/pkg/synthetictests/allowedalerts"
+	"github.com/openshift/origin/pkg/alerts"
 	exutil "github.com/openshift/origin/test/extended/util"
-	"github.com/openshift/origin/test/extended/util/disruption"
-	helper "github.com/openshift/origin/test/extended/util/prometheus"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/model"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 )
@@ -50,164 +41,8 @@ func (t *UpgradeTest) Setup(f *framework.Framework) {
 // An alert firing during an upgrade is a high severity bug - it either points to a real issue in
 // a dependency, or a failure of the component, and therefore must be fixed.
 func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
-	tolerateDuringSkew := exutil.TolerateVersionSkewInTests()
-	firingAlertsWithBugs := helper.MetricConditions{
-		{
-			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-kube-apiserver-operator"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
-		},
-		{
-			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-kube-apiserver-operator"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
-		},
-		{
-			Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "openshift-apiserver"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
-		},
-		{
-			Selector: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
-		},
-		{
-			Selector: map[string]string{"alertname": "ClusterOperatorDown", "name": "machine-config"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955300",
-		},
-		{
-			Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
-		},
-		{
-			Selector: map[string]string{"alertname": "KubeDaemonSetRolloutStuck"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1943667",
-		},
-		{
-			Selector: map[string]string{"alertname": "KubeAPIErrorBudgetBurn"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1953798",
-			Matches: func(_ *model.Sample) bool {
-				return framework.ProviderIs("gce")
-			},
-		},
-		{
-			Selector: map[string]string{"alertname": "AggregatedAPIDown", "namespace": "default", "name": "v1beta1.metrics.k8s.io"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1970624",
-			Matches: func(_ *model.Sample) bool {
-				return framework.ProviderIs("gce")
-			},
-		},
-		{
-			// Should be removed one release after the attached bugzilla is fixed.
-			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
-		},
-		{
-			// Should be removed one release after the attached bugzilla is fixed.
-			Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
-		},
-		{
-			// Should be removed one release after the attached bugzilla is fixed, or after that bug is fixed in a backport to the previous minor.
-			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1985073",
-			Matches: func(_ *model.Sample) bool {
-				return framework.ProviderIs("gce")
-			},
-		},
-		{
-			Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2054426",
-			Matches: func(sample *model.Sample) bool {
-				// Only match if the job_name label starts with ip-reconciler:
-				if strings.HasPrefix(string(sample.Metric[model.LabelName("job_name")]), "ip-reconciler-") {
-					return true
-				}
-				return false
-			},
-		},
-	}
-	allowedFiringAlerts := helper.MetricConditions{
-		{
-			Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
-		},
-		{
-			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
-		},
-		{
-			Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
-		},
-	}
-
-	pendingAlertsWithBugs := helper.MetricConditions{
-		{
-			Selector: map[string]string{"alertname": "ClusterMonitoringOperatorReconciliationErrors"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1932624",
-		},
-		{
-			Selector: map[string]string{"alertname": "KubeClientErrors"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1925698",
-		},
-		{
-			Selector: map[string]string{"alertname": "NetworkPodsCrashLooping"},
-			Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2009078",
-		},
-	}
-	allowedPendingAlerts := helper.MetricConditions{
-		{
-			Selector: map[string]string{"alertname": "etcdMemberCommunicationSlow"},
-			Text:     "Excluded because it triggers during upgrade (detects ~5m of high latency immediately preceeding the end of the test), and we don't want to change the alert because it is correct",
-		},
-	}
-
-	if featureGates, err := t.configClient.ConfigV1().FeatureGates().Get(context.TODO(), "cluster", metav1.GetOptions{}); err == nil {
-		switch featureGates.Spec.FeatureSet {
-		case configv1.TechPreviewNoUpgrade:
-			allowedFiringAlerts = append(allowedFiringAlerts,
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": "TechPreviewNoUpgrade", "namespace": "openshift-kube-apiserver-operator"},
-					Text:     "When running as TechPreviewNoUpgrade, we allow TechPreviewNoUpgrade alert to be firing.",
-				},
-			)
-		}
-	}
-
-	// we exclude alerts that have their own separate tests.
-	for _, alertTest := range allowedalerts.AllAlertTests(context.TODO(), nil, 0) {
-		switch alertTest.AlertState() {
-		case allowedalerts.AlertPending:
-			// a pending test covers pending and everything above (firing)
-			allowedPendingAlerts = append(allowedPendingAlerts,
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": alertTest.AlertName()},
-					Text:     "has a separate e2e test",
-				},
-			)
-			allowedFiringAlerts = append(allowedFiringAlerts,
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": alertTest.AlertName()},
-					Text:     "has a separate e2e test",
-				},
-			)
-		case allowedalerts.AlertInfo:
-			// an info test covers all firing
-			allowedFiringAlerts = append(allowedFiringAlerts,
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": alertTest.AlertName()},
-					Text:     "has a separate e2e test",
-				},
-			)
-		}
-	}
-
-	knownViolations := sets.NewString()
-	unexpectedViolations := sets.NewString()
-	unexpectedViolationsAsFlakes := sets.NewString()
-	debug := sets.NewString()
-
 	g.By("Checking for alerts")
-
-	start := time.Now()
+	startTime := time.Now()
 
 	// Block until upgrade is done
 	g.By("Waiting for upgrade to finish before checking for alerts")
@@ -217,72 +52,9 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 	g.By("Waiting before checking for alerts")
 	time.Sleep(1 * time.Minute)
 
-	testDuration := time.Now().Sub(start).Round(time.Second)
+	testDuration := time.Now().Sub(startTime).Round(time.Second)
 
-	// Invariant: No non-info level alerts should have fired during the upgrade
-	firingAlertQuery := fmt.Sprintf(`
-sort_desc(
-count_over_time(ALERTS{alertstate="firing",severity!="info",alertname!~"Watchdog|AlertmanagerReceiversNotConfigured"}[%[1]s:1s])
-) > 0
-`, testDuration)
-	result, err := helper.RunQuery(context.TODO(), t.prometheusClient, firingAlertQuery)
-	o.Expect(err).NotTo(o.HaveOccurred(), "unable to check firing alerts during upgrade")
-	for _, series := range result.Data.Result {
-		labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
-		violation := fmt.Sprintf("alert %s fired for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
-		if cause := allowedFiringAlerts.Matches(series); cause != nil {
-			debug.Insert(fmt.Sprintf("%s (allowed: %s)", violation, cause.Text))
-			continue
-		}
-		if cause := firingAlertsWithBugs.Matches(series); cause != nil {
-			knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
-		} else {
-			unexpectedViolations.Insert(violation)
-		}
-	}
-
-	// Invariant: There should be no pending alerts 1m after the upgrade completes
-	pendingAlertQuery := fmt.Sprintf(`
-sort_desc(
-  time() * ALERTS + 1
-  -
-  last_over_time((
-    time() * ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured",alertstate="pending",severity!="info"}
-    unless
-    ALERTS offset 1s
-  )[%[1]s:1s])
-)
-`, testDuration)
-	result, err = helper.RunQuery(context.TODO(), t.prometheusClient, pendingAlertQuery)
-	o.Expect(err).NotTo(o.HaveOccurred(), "unable to retrieve pending alerts after upgrade")
-	for _, series := range result.Data.Result {
-		labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
-		violation := fmt.Sprintf("alert %s pending for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
-		if cause := allowedPendingAlerts.Matches(series); cause != nil {
-			debug.Insert(fmt.Sprintf("%s (allowed: %s)", violation, cause.Text))
-			continue
-		}
-		if cause := pendingAlertsWithBugs.Matches(series); cause != nil {
-			knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
-		} else {
-			// treat pending errors as a flake right now because we are still trying to determine the scope
-			// TODO: move this to unexpectedViolations later
-			unexpectedViolationsAsFlakes.Insert(violation)
-		}
-	}
-
-	if len(debug) > 0 {
-		framework.Logf("Alerts were detected during upgrade which are allowed:\n\n%s", strings.Join(debug.List(), "\n"))
-	}
-	if len(unexpectedViolations) > 0 {
-		if !tolerateDuringSkew {
-			framework.Failf("Unexpected alerts fired or pending during the upgrade:\n\n%s", strings.Join(unexpectedViolations.List(), "\n"))
-		}
-	}
-	if flakes := sets.NewString().Union(knownViolations).Union(unexpectedViolations).Union(unexpectedViolationsAsFlakes); len(flakes) > 0 {
-		disruption.FrameworkFlakef(f, "Unexpected alert behavior during upgrade:\n\n%s", strings.Join(flakes.List(), "\n"))
-	}
-	framework.Logf("No alerts fired during upgrade")
+	alerts.CheckAlerts(alerts.AllowedAlertsDuringUpgrade, t.prometheusClient, t.configClient, testDuration, f)
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -15,15 +15,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
 var _ = Describe("[sig-arch] Managed cluster", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 	It("should ensure pods use downstream images from our release image with proper ImagePullPolicy [apigroup:config.openshift.io]", func() {
-		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
-			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions")
-		}
 		imagePullSecret, err := oc.KubeFramework().ClientSet.CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
 		if err != nil {
 			e2e.Failf("unable to get pull secret for cluster: %v", err)

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -3,7 +3,6 @@ package operators
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -121,9 +120,6 @@ var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	g.It("have operators on the cluster version [apigroup:config.openshift.io]", func() {
-		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
-			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions")
-		}
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c := configclient.NewForConfigOrDie(cfg)

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,11 +12,10 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	"github.com/openshift/origin/pkg/alerts"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
-
 	v1 "k8s.io/api/core/v1"
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -203,186 +201,9 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 	)
 
 	g.It("shouldn't report any unexpected alerts in firing or pending state [apigroup:config.openshift.io]", func() {
-		// Watchdog and AlertmanagerReceiversNotConfigured are expected.
-		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
-			e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
-		}
-
-		firingAlertsWithBugs := helper.MetricConditions{
-			{
-				Selector: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
-			},
-			{
-				Selector: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1939580",
-			},
-			{
-				Selector: map[string]string{"alertname": "KubeAPIErrorBudgetBurn"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1953798",
-				Matches: func(_ *model.Sample) bool {
-					return framework.ProviderIs("gce")
-				},
-			},
-			{
-				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "prometheus-k8s"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1949262",
-			},
-			{
-				Selector: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "namespace": "openshift-monitoring", "workload": "alertmanager-main"},
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=1955489",
-			},
-			{
-				Selector: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-multus"}, // not sure how to do a job_name prefix
-				Text:     "https://bugzilla.redhat.com/show_bug.cgi?id=2054426",
-			},
-		}
-		allowedFiringAlerts := helper.MetricConditions{
-			{
-				Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
-				Text:     "Loki is nice to have, but we can allow it to be down",
-			},
-			{
-				Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-e2e-loki"},
-				Text:     "Loki is nice to have, but we can allow it to be down",
-			},
-			{
-				Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
-				Text:     "Loki is nice to have, but we can allow it to be down",
-			},
-			{
-				Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
-				Text:     "high CPU utilization during e2e runs is normal",
-			},
-			{
-				Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
-				Text:     "high CPU utilization during e2e runs is normal",
-			},
-		}
-
-		if isTechPreviewCluster(oc) {
-			allowedFiringAlerts = append(
-				allowedFiringAlerts,
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": "TechPreviewNoUpgrade"},
-					Text:     "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been installed",
-				},
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": "ClusterNotUpgradeable"},
-					Text:     "Allow testing of ClusterNotUpgradeable clusters, this will only fire when a FeatureGate has been installed",
-				})
-		}
-
-		pendingAlertsWithBugs := helper.MetricConditions{}
-		allowedPendingAlerts := helper.MetricConditions{
-			{
-				Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
-				Text:     "high CPU utilization during e2e runs is normal",
-			},
-			{
-				Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
-				Text:     "high CPU utilization during e2e runs is normal",
-			},
-		}
-
-		// we exclude alerts that have their own separate tests.
-		for _, alertTest := range allowedalerts.AllAlertTests(context.TODO(), nil, 0) {
-			switch alertTest.AlertState() {
-			case allowedalerts.AlertPending:
-				// a pending test covers pending and everything above (firing)
-				allowedPendingAlerts = append(allowedPendingAlerts,
-					helper.MetricCondition{
-						Selector: map[string]string{"alertname": alertTest.AlertName()},
-						Text:     "has a separate e2e test",
-					},
-				)
-				allowedFiringAlerts = append(allowedFiringAlerts,
-					helper.MetricCondition{
-						Selector: map[string]string{"alertname": alertTest.AlertName()},
-						Text:     "has a separate e2e test",
-					},
-				)
-			case allowedalerts.AlertInfo:
-				// an info test covers all firing
-				allowedFiringAlerts = append(allowedFiringAlerts,
-					helper.MetricCondition{
-						Selector: map[string]string{"alertname": alertTest.AlertName()},
-						Text:     "has a separate e2e test",
-					},
-				)
-			}
-		}
-
-		knownViolations := sets.NewString()
-		unexpectedViolations := sets.NewString()
-		unexpectedViolationsAsFlakes := sets.NewString()
-		debug := sets.NewString()
-
 		// we only consider samples since the beginning of the test
-		testDuration := exutil.DurationSinceStartInSeconds().String()
-
-		// Invariant: No non-info level alerts should have fired during the test run
-		firingAlertQuery := fmt.Sprintf(`
-sort_desc(
-count_over_time(ALERTS{alertstate="firing",severity!="info",alertname!~"Watchdog|AlertmanagerReceiversNotConfigured"}[%[1]s:1s])
-) > 0
-`, testDuration)
-		result, err := helper.RunQuery(context.TODO(), oc.NewPrometheusClient(context.TODO()), firingAlertQuery)
-		o.Expect(err).NotTo(o.HaveOccurred(), "unable to check firing alerts during test")
-		for _, series := range result.Data.Result {
-			labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
-			violation := fmt.Sprintf("alert %s fired for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
-			if cause := allowedFiringAlerts.Matches(series); cause != nil {
-				debug.Insert(fmt.Sprintf("%s (allowed: %s)", violation, cause.Text))
-				continue
-			}
-			if cause := firingAlertsWithBugs.Matches(series); cause != nil {
-				knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
-			} else {
-				unexpectedViolations.Insert(violation)
-			}
-		}
-
-		// Invariant: There should be no pending alerts after the test run
-		pendingAlertQuery := fmt.Sprintf(`
-sort_desc(
-  time() * ALERTS + 1
-  -
-  last_over_time((
-    time() * ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured",alertstate="pending",severity!="info"}
-    unless
-    ALERTS offset 1s
-  )[%[1]s:1s])
-)
-`, testDuration)
-		result, err = helper.RunQuery(context.TODO(), oc.NewPrometheusClient(context.TODO()), pendingAlertQuery)
-		o.Expect(err).NotTo(o.HaveOccurred(), "unable to retrieve pending alerts after upgrade")
-		for _, series := range result.Data.Result {
-			labels := helper.StripLabels(series.Metric, "alertname", "alertstate", "prometheus")
-			violation := fmt.Sprintf("alert %s pending for %s seconds with labels: %s", series.Metric["alertname"], series.Value, helper.LabelsAsSelector(labels))
-			if cause := allowedPendingAlerts.Matches(series); cause != nil {
-				debug.Insert(fmt.Sprintf("%s (allowed: %s)", violation, cause.Text))
-				continue
-			}
-			if cause := pendingAlertsWithBugs.Matches(series); cause != nil {
-				knownViolations.Insert(fmt.Sprintf("%s (open bug: %s)", violation, cause.Text))
-			} else {
-				// treat pending errors as a flake right now because we are still trying to determine the scope
-				// TODO: move this to unexpectedViolations later
-				unexpectedViolationsAsFlakes.Insert(violation)
-			}
-		}
-
-		if len(debug) > 0 {
-			framework.Logf("Alerts were detected during test run which are allowed:\n\n%s", strings.Join(debug.List(), "\n"))
-		}
-		if len(unexpectedViolations) > 0 {
-			framework.Failf("Unexpected alerts fired or pending after the test run:\n\n%s", strings.Join(unexpectedViolations.List(), "\n"))
-		}
-		if flakes := sets.NewString().Union(knownViolations).Union(unexpectedViolations).Union(unexpectedViolationsAsFlakes); len(flakes) > 0 {
-			testresult.Flakef("Unexpected alert behavior during test:\n\n%s", strings.Join(flakes.List(), "\n"))
-		}
-		framework.Logf("No alerts fired during test run")
+		testDuration := exutil.DurationSinceStartInSeconds()
+		alerts.CheckAlerts(alerts.AllowedAlertsDuringConformance, oc.NewPrometheusClient(context.TODO()), oc.AdminConfigClient(), testDuration, nil)
 	})
 
 	g.It("shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster", func() {
@@ -669,10 +490,6 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 		})
 
 		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io]", func() {
-			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
-				e2eskipper.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
-			}
-
 			// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
 			allowedAlertNames := []string{
 				"Watchdog",

--- a/test/extended/util/conditions.go
+++ b/test/extended/util/conditions.go
@@ -65,24 +65,6 @@ func DurationSinceStartInSeconds() time.Duration {
 	}
 }
 
-// TolerateVersionSkewInTests returns true if the test invoker has indicated
-// that version skew is known present via the TEST_UNSUPPORTED_ALLOW_VERSION_SKEW
-// environment variable. Tests that may fail if the component is skewed may then
-// be skipped or alter their behavior. The version skew is assumed to be one minor
-// release - for instance, if a test would fail because the previous version of
-// the kubelet does not yet support a value, when this function returns true it
-// would be acceptable for the test to invoke Skipf().
-//
-// Used by the node version skew environment (Kube @ version N, nodes @ version N-1)
-// to ensure OpenShift works when control plane and worker nodes are not updated,
-// as can occur during test suites.
-func TolerateVersionSkewInTests() bool {
-	if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
-		return true
-	}
-	return false
-}
-
 // unixTimeFromEnv reads a unix timestamp in seconds since the epoch and
 // returns a Time object. If no env var is set or if it does not parse, a
 // zero time is returned.


### PR DESCRIPTION
TRT has decided with input from @deads2k that we're ok with moving the generic alert backstop tests to always flake, as the signal is not as high value. The post-upgrade alert test fails 30% of the time globally, and the post-conformance variant is also not stellar, and both disproportionately affect certain NURPs.

In sippy as of https://github.com/openshift/sippy/pull/685 we will begin tracking the reasons this test is flaking in the db by storing metadata about what alerts fired, so we'll have good insight into what may be causing issues, provided somebody remembers to look.

PR also re-introduces the refactor to merge the two backstop alert tests into a common code path, which they once were forked from. We thought this caused a regression, turned out it was something else, so this change should be good provided we start getting good payloads again after https://github.com/openshift/origin/pull/27553.

Also improves output of the alert tests for better parsing in sippy. Clearly identifies if we accept or reject the failure, and if there  is an associated bug.