### PR TITLE
Fail on APIs removed in the next release

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -229,7 +229,7 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, oc *exutil.CLI, etcdClient3Fn fu
 
 	var tt *testing.T // will cause nil panics that make it easy enough to find where things went wrong
 
-	kubeConfig := restclient.CopyConfig(oc.AdminConfig())
+	kubeConfig := restclient.CopyConfig(oc.UserConfig())
 	kubeConfig.QPS = 99999
 	kubeConfig.Burst = 9999
 	kubeClient := kclientset.NewForConfigOrDie(kubeConfig)


### PR DESCRIPTION
This will hard fail until we fix the problems in:
~1. api & auth & etcd https://issues.redhat.com/browse/OCPBUGS-3841~
~2. cvo https://issues.redhat.com/browse/OCPBUGS-3810~
~3. monitoring https://issues.redhat.com/browse/OCPBUGS-3924~

/assign @deads2k 
/hold