### PR TITLE
tests: add synthetic test that checks if test namespaces were cleaned up

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -119,5 +119,6 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 func SystemEventInvariants(events monitorapi.Intervals, duration time.Duration, kubeClientConfig *rest.Config, testSuite string, _ *monitorapi.ResourcesMap) (tests []*junitapi.JUnitTestCase) {
 	tests = append(tests, testSystemDTimeout(events)...)
 	tests = append(tests, testPodIPReuse(events)...)
+	tests = append(tests, testNamespaceCleanup(events, kubeClientConfig)...)
 	return tests
 }

--- a/pkg/synthetictests/namespaces.go
+++ b/pkg/synthetictests/namespaces.go
@@ -1,0 +1,92 @@
+package synthetictests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+func errorToJUnitTestCase(testName string, err error) []*junitapi.JUnitTestCase {
+	return []*junitapi.JUnitTestCase{
+		{
+			Name: testName,
+			FailureOutput: &junitapi.FailureOutput{
+				Output: fmt.Sprintf("unexpected error: %v", err),
+			},
+			SystemOut: fmt.Sprintf("unexpected error: %v", err),
+		},
+	}
+}
+
+func testNamespaceCleanup(events monitorapi.Intervals, kubeClientConfig *rest.Config) []*junitapi.JUnitTestCase {
+	const testName = "[sig-apimachinery] unexpected namespaces detected after test suite finished"
+	client, err := kubeclient.NewForConfig(kubeClientConfig)
+	if err != nil {
+		return errorToJUnitTestCase(testName, err)
+	}
+
+	namespaces, err := client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return errorToJUnitTestCase(testName, err)
+	}
+
+	unexpextedNamespaces := []string{}
+	for i := range namespaces.Items {
+		name := namespaces.Items[i].Name
+		switch {
+		// exclude all openshift namespaces
+		case strings.HasPrefix(name, "openshift-"):
+			continue
+		case strings.HasPrefix(name, "kube-"):
+			continue
+		// exclude default k8s namespaces
+		case sets.NewString("default", "kubernetes", "openshift").Has(name):
+			continue
+		// if namespaces was marked for delete, but it is stuck deleting, flag it
+		case namespaces.Items[i].DeletionTimestamp != nil && time.Now().Sub(namespaces.Items[i].DeletionTimestamp.Time) > 5*time.Minute:
+			unexpextedNamespaces = append(unexpextedNamespaces, fmt.Sprintf("%s | created:%s | deleted: %s",
+				name,
+				namespaces.Items[i].CreationTimestamp,
+				namespaces.Items[i].DeletionTimestamp,
+			))
+		// exclude namespaces that are being deleted
+		case namespaces.Items[i].DeletionTimestamp != nil:
+			continue
+		default:
+			// every other namespace is considered as unexpected
+			unexpextedNamespaces = append(unexpextedNamespaces, fmt.Sprintf("%s | created:%s",
+				name,
+				namespaces.Items[i].CreationTimestamp,
+			))
+		}
+	}
+
+	if len(unexpextedNamespaces) == 0 {
+		return []*junitapi.JUnitTestCase{
+			{Name: testName},
+		}
+	}
+
+	// appending this will make the test "flaky" instead of failure
+	success := &junitapi.JUnitTestCase{Name: testName}
+
+	return []*junitapi.JUnitTestCase{
+		{
+			Name: testName,
+			FailureOutput: &junitapi.FailureOutput{
+				Output: fmt.Sprintf("\nfollowing namespaces created by tests were not cleaned up:\n%s\n", strings.Join(unexpextedNamespaces, "\n")),
+			},
+			SystemOut: fmt.Sprintf("\nfollowing namespaces created by tests were not cleaned up:\n\n%s\n", strings.Join(unexpextedNamespaces, "\n")),
+		},
+		success,
+	}
+}

--- a/test/extended/authorization/authorization.go
+++ b/test/extended/authorization/authorization.go
@@ -964,10 +964,11 @@ func (test subjectAccessReviewTest) run(t g.GinkgoTInterface) {
 
 func createProject(oc *exutil.CLI, nsPrefix string) string {
 	newNamespace := fmt.Sprintf("e2e-test-%s-%s", nsPrefix, utilrand.String(5))
-	_, err := oc.ProjectClient().ProjectV1().ProjectRequests().Create(context.Background(), &projectv1.ProjectRequest{
+	newProject, err := oc.ProjectClient().ProjectV1().ProjectRequests().Create(context.Background(), &projectv1.ProjectRequest{
 		ObjectMeta: metav1.ObjectMeta{Name: newNamespace},
 	}, metav1.CreateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
+	oc.AddProjectToDelete(newProject.Name)
 	return newNamespace
 }
 

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -183,10 +183,16 @@ RUN mkdir -p /var/lib && echo "a" > /var/lib/file
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		newNamespace := fmt.Sprintf("%s-another", oc.Namespace())
-		_, err = oc.ProjectClient().ProjectV1().ProjectRequests().Create(context.Background(), &projectv1.ProjectRequest{
+		newProject, err := oc.ProjectClient().ProjectV1().ProjectRequests().Create(context.Background(), &projectv1.ProjectRequest{
 			ObjectMeta: metav1.ObjectMeta{Name: newNamespace},
 		}, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.KubeFramework().AddNamespacesToDelete(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: newProject.Name,
+			},
+		})
+
 		ns = append(ns, newNamespace)
 
 		g.By("waiting for the build to finish")

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -187,11 +187,7 @@ RUN mkdir -p /var/lib && echo "a" > /var/lib/file
 			ObjectMeta: metav1.ObjectMeta{Name: newNamespace},
 		}, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		oc.KubeFramework().AddNamespacesToDelete(&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: newProject.Name,
-			},
-		})
+		oc.AddProjectToDelete(newProject.Name)
 
 		ns = append(ns, newNamespace)
 

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -874,6 +874,14 @@ func (c *CLI) AddResourceToDelete(resource schema.GroupVersionResource, metadata
 	c.resourcesToDelete = append(c.resourcesToDelete, resourceRef{Resource: resource, Namespace: metadata.GetNamespace(), Name: metadata.GetName()})
 }
 
+func (c *CLI) AddProjectToDelete(projectName string) {
+	c.KubeFramework().AddNamespacesToDelete(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: projectName,
+		},
+	})
+}
+
 func (c *CLI) CreateUser(prefix string) *userv1.User {
 	user, err := c.AdminUserClient().UserV1().Users().Create(context.Background(), &userv1.User{
 		ObjectMeta: metav1.ObjectMeta{GenerateName: prefix + c.Namespace()},


### PR DESCRIPTION
In https://github.com/openshift/kubernetes/pull/1383 we discovered at least one namespace leaking after the e2e tests were done. That cause the test to timeout, and debugging the timeout requires re-running the test, watching the cluster where the e2e test runs, and list namespaces AFTER the test finish.
This synthetic test aims to automate that. 
Maybe this is the wrong spot; maybe we need some "post-run" hook we can place tests like this? Maybe we need something that waits until the e2e test finishes... I am open for suggestions :-)