### PR TITLE
Add tests for oc scc-subject-review and scc-review commands

### DIFF
--- a/test/extended/cli/policy.go
+++ b/test/extended/cli/policy.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	"k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-cli] policy", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc               = exutil.NewCLIWithPodSecurityLevel("oc-policy", api.LevelRestricted)
+		simpleDeployment = exutil.FixturePath("testdata", "deployments", "deployment-simple.yaml")
+	)
+
+	g.It("scc-subject-review, scc-review [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
+		err := oc.Run("policy", "scc-subject-review").Execute()
+		o.Expect(err).To(o.HaveOccurred())
+		err = oc.Run("policy", "scc-review").Execute()
+		o.Expect(err).To(o.HaveOccurred())
+		err = oc.Run("policy", "scc-subject-review").Args("-u", "invalid", "--namespace", "noexist").Execute()
+		o.Expect(err).To(o.HaveOccurred())
+
+		out, err := oc.Run("policy", "scc-subject-review").Args("-z", "foo,bar", "-f", simpleDeployment).Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("only one Service Account is supported"))
+
+		out, err = oc.Run("policy", "scc-review").Args("-z", "default", "-f", simpleDeployment, "--namespace=noexist").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("cannot create resource \"podsecuritypolicyreviews\" in API group \"security.openshift.io\" in the namespace \"noexist\""))
+
+		out, err = oc.Run("policy", "scc-subject-review").Args("-f", simpleDeployment, "-o=jsonpath={.status.allowedBy.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.Equal("restricted-v2"))
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1533,6 +1533,8 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc status returns expected help messages [apigroup:project.openshift.io][apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:apps.openshift.io][apigroup:route.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] policy scc-subject-review, scc-review [apigroup:authorization.openshift.io][apigroup:user.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/authentication.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "",
 
 	"[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/builds.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "",


### PR DESCRIPTION
This PR adds new tests for `oc policy scc-subject-review` and `oc policy scc-review`
commands. Since these commands are heavily relying on `oc login` command([ref](https://github.com/openshift/origin/blob/c1be83275d48902c0fbec5e1f7a39657b3b35f17/test/extended/testdata/cmd/test/cmd/policy.sh#L196-L240)) and
in test suite, managing `oc login` needs an extra caution, this PR adds some basic tests
at least providing a coverage bigger than zero.