### PR TITLE
If there are no test-failure-summary files, suppress risk analysis

### DIFF
--- a/pkg/riskanalysis/cmd.go
+++ b/pkg/riskanalysis/cmd.go
@@ -40,6 +40,9 @@ func (opt *Options) Run() error {
 	if err != nil {
 		return err
 	}
+	if len(resultFiles) == 0 {
+		return fmt.Errorf("no files of the form %s/%s*.json found; unable to perform risk analysis", opt.JUnitDir, testFailureSummaryFilePrefix)
+	}
 	fmt.Fprintf(opt.Out, "Found files: %v\n", resultFiles)
 
 	prowJobRuns := []*ProwJobRun{}


### PR DESCRIPTION
[TRT-697](https://issues.redhat.com//browse/TRT-697)

The glob operation is still valid when there are 0 matching files.  But if we didn't find any files, we can't run risk analysis.