### PR TITLE
USHIFT-646: ushift: Graceful return to disable telemetry

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -741,6 +741,9 @@ func telemetryIsEnabled(ctx context.Context, client clientset.Interface) (enable
 func hasPullSecret(ctx context.Context, client clientset.Interface, name string) (enabled error, err error) {
 	scrt, err := client.CoreV1().Secrets("openshift-config").Get(ctx, "pull-secret", metav1.GetOptions{})
 	if err != nil {
+		if kapierrs.IsNotFound(err) {
+			return fmt.Errorf("openshift-config/pull-secret not found"), nil
+		}
 		return nil, fmt.Errorf("could not retrieve pull-secret: %w", err)
 	}
 


### PR DESCRIPTION
MicroShift does not have a prometheus instance so we need to disable any tests that require it. In order to skip some of them we need a graceful return from telemetryIsEnabled function. This function calls hasPullSecret, which checks for specific pull secrets in the openshift-config/pull-secret configmap, non-existent in MicroShift. Function already returns a graceful error if there is no pull secret for a specific domain, so this commit mimicks the behavior to a situation where there is no configmap at all.