### PR TITLE
USHIFT-647: ushift: fix loop variable capture in sig-cli

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -552,8 +552,10 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 	})
 
 	for group, bts := range builtinTypes {
-		g.It(fmt.Sprintf("should contain spec+status for %s [apigroup:%s]", group, group), func() {
-			for _, bt := range bts {
+		groupName := group
+		types := bts
+		g.It(fmt.Sprintf("should contain spec+status for %s [apigroup:%s]", groupName, groupName), func() {
+			for _, bt := range types {
 				e2e.Logf("Checking %s...", bt)
 				o.Expect(verifySpecStatusExplain(oc, nil, bt)).NotTo(o.HaveOccurred())
 			}
@@ -577,8 +579,10 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 	})
 
 	for group, sts := range specialTypes {
-		g.It(fmt.Sprintf("should contain proper fields description for %s [apigroup:%s]", group, group), func() {
-			for _, st := range sts {
+		groupName := group
+		types := sts
+		g.It(fmt.Sprintf("should contain proper fields description for %s [apigroup:%s]", groupName, groupName), func() {
+			for _, st := range types {
 				e2e.Logf("Checking %s, Field=%s...", st.gv, st.field)
 				resource := strings.Split(st.field, ".")
 				gvr := st.gv.WithResource(resource[0])


### PR DESCRIPTION
Fix loop variable capture in closure for `g.It`, as it currently fails randomly because `group`, `bts` and `sts` variables are getting overwritten values for all `g.It` functions in the loop.

As an example, this run mismatches api resources with the api groups they belong to: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-microshift-main-periodic-ocp-4.12-conformance-parallel/1593357119778721792