### PR TITLE
disruption: alwaysAllowOneSecond should always allow one second

### DIFF
--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -8,13 +8,14 @@ import (
 	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/openshift/origin/pkg/monitor"
-	"github.com/openshift/origin/pkg/monitor/backenddisruption"
-	"github.com/openshift/origin/pkg/synthetictests/allowedbackenddisruption"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
+
+	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/synthetictests/allowedbackenddisruption"
 )
 
 type BackendSampler interface {
@@ -75,12 +76,9 @@ func alwaysAllowOneSecond(delegateFn AllowedDisruptionFunc) AllowedDisruptionFun
 		if delegateError != nil {
 			return delegateDuration, delegateReason, delegateError
 		}
-		if delegateDuration == nil {
-			return delegateDuration, delegateReason, delegateError
-		}
 
 		oneSecond := 1 * time.Second
-		if *delegateDuration < oneSecond {
+		if delegateDuration == nil || *delegateDuration < oneSecond {
 			return &oneSecond, "always allow at least 1s", nil
 		}
 


### PR DESCRIPTION
I have an example of an NPE on this code[1] -- alwaysAllowOneSecond should always return one second but there is a case where it can return nil, which causes a null pointer error later on.

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.13-e2e-metal-ipi-upgrade-ovn-ipv6/1597863031415508992