### PR TITLE
Remove redundant messages that might contain non-xml charactor

### DIFF
--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -253,7 +253,7 @@ func finalizeTest(start time.Time, tc *junit.TestCase, ts *junit.TestSuite, f *f
 	default:
 		tc.Errors = []*junit.Error{
 			{
-				Message: fmt.Sprintf("%v", r),
+				Message: "Ginkgo panic encountered. See CDATA for details.",
 				Type:    "Panic",
 				Value:   fmt.Sprintf("%v\n\n%s", r, debug.Stack()),
 			},


### PR DESCRIPTION
Ginkgo error contains non-xml charactors. This results in error unmarshalling the junit file during aggreation. In addition, the error message is already available in the following CDATA section.

[TRT-693](https://issues.redhat.com/browse/TRT-693)

Following is an example of the errored output. You can see that the relevant info is already in the CDATA section below:
```
<testcase name="[sig-instrumentation] Prometheus metrics should be available after an upgrade" classname="disruption_tests" time="31.183965591">

<error message="�[1m�[38;5;9mYour Test Panicked�[0m&#xA;�[38;5;243mgithub.com/openshift/origin/test/extended/prometheus/upgrade.go:40�[0m&#xA;  When you, or your assertion library, calls Ginkgo&#39;s Fail(),&#xA;  Ginkgo panics to prevent subsequent assertions from running.&#xA;&#xA;  Normally Ginkgo rescues this panic so you shouldn&#39;t see it.&#xA;&#xA;  However, if you make an assertion in a goroutine, Ginkgo can&#39;t capture the&#xA;  panic.&#xA;  To circumvent this, you should call&#xA;&#xA;  &#x9;defer GinkgoRecover()&#xA;&#xA;  at the top of the goroutine that caused this panic.&#xA;&#xA;  Alternatively, you may have made an assertion outside of a Ginkgo&#xA;  leaf node (e.g. in a container node or some out-of-band function) - please&#xA;  move your assertion to&#xA;  an appropriate Ginkgo node (e.g. a BeforeSuite, BeforeEach, It, etc...).&#xA;&#xA;  �[1mLearn more at:�[0m&#xA;  �[38;5;14m�[4mhttp://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure�[0m&#xA;" type="Panic">

<![CDATA[^[[1m^[[38;5;9mYour Test Panicked^[[0m
^[[38;5;243mgithub.com/openshift/origin/test/extended/prometheus/upgrade.go:40^[[0m
  When you, or your assertion library, calls Ginkgo's Fail(),
  Ginkgo panics to prevent subsequent assertions from running.

  Normally Ginkgo rescues this panic so you shouldn't see it.

  However, if you make an assertion in a goroutine, Ginkgo can't capture the
  panic.
  To circumvent this, you should call

        defer GinkgoRecover()

  at the top of the goroutine that caused this panic.

  Alternatively, you may have made an assertion outside of a Ginkgo
  leaf node (e.g. in a container node or some out-of-band function) - please
  move your assertion to
  an appropriate Ginkgo node (e.g. a BeforeSuite, BeforeEach, It, etc...).

  ^[[1mLearn more at:^[[0m
  ^[[38;5;14m^[[4mhttp://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure^[[0m


goroutine 258 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:24 +0x65
github.com/openshift/origin/test/extended/util/disruption.finalizeTest({0xc004a099b0?, 0x5249d65?, 0xcac97a0?}, 0xc0020b5e00, 0xc000bb20f0, 0xc002027e40)
        github.com/openshift/origin/test/extended/util/disruption/disruption.go:258 +0xc0e
panic({0x80ffe40, 0xc0006d1d50})
        runtime/panic.go:884 +0x212
github.com/onsi/ginkgo/v2.Fail({0xc00249c7e0, 0x119}, {0xc0067fbb00?, 0xc00249c7e0?, 0x87ae30d?})
        github.com/onsi/ginkgo/v2@v2.1.5-0.20220909190140-b488ab12695a/core_dsl.go:335 +0x225
github.com/onsi/gomega/internal.(*Assertion).match(0xc0069a4ec0, {0x93b0f08, 0xcafd8f0}, 0x0, {0x0, 0x0, 0x0})
        github.com/onsi/gomega@v1.20.1/internal/assertion.go:105 +0x1f0
github.com/onsi/gomega/internal.(*Assertion).NotTo(0xc0069a4ec0, {0x93b0f08, 0xcafd8f0}, {0x0, 0x0, 0x0})
        github.com/onsi/gomega@v1.20.1/internal/assertion.go:73 +0xb2
github.com/openshift/origin/test/extended/prometheus.(*MetricsAvailableAfterUpgradeTest).Setup(0xc001a03380, 0xc002027e40)
        github.com/openshift/origin/test/extended/prometheus/upgrade.go:40 +0x14d
github.com/openshift/origin/test/extended/util/disruption.(*chaosMonkeyAdapter).Test(0xc0021c9ef0, 0xc0018e0df8)
        github.com/openshift/origin/test/extended/util/disruption/disruption.go:194 +0x27f
k8s.io/kubernetes/test/e2e/chaosmonkey.(*Chaosmonkey).Do.func1()
        k8s.io/kubernetes@v1.25.0/test/e2e/chaosmonkey/chaosmonkey.go:94 +0x6a
created by k8s.io/kubernetes/test/e2e/chaosmonkey.(*Chaosmonkey).Do
        k8s.io/kubernetes@v1.25.0/test/e2e/chaosmonkey/chaosmonkey.go:91 +0x8b
]]>

</error>

</testcase>
```