### PR TITLE
Remove ambiguity when checking for api resources existence

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -473,7 +473,7 @@ func getCrdTypes(oc *exutil.CLI) []schema.GroupVersionResource {
 	crdTypes = append(crdTypes, machineTypes...)
 	crdTypes = append(crdTypes, additionalOperatorTypes...)
 
-	exist, err := exutil.DoesApiResourceExist(oc.AdminConfig(), "clusterversions")
+	exist, err := exutil.DoesApiResourceExist(oc.AdminConfig(), "clusterversions", "config.openshift.io")
 	o.Expect(err).NotTo(o.HaveOccurred())
 	if exist {
 		clusterVersion, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -122,7 +122,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 		// A supported version of OpenShift must hold the CloudPrivateIPConfig CRD.
 		// Otherwise, skip this test.
 		g.By("Verifying that this is a supported version of OpenShift")
-		isSupportedOcpVersion, err := exutil.DoesApiResourceExist(oc.AdminConfig(), "cloudprivateipconfigs")
+		isSupportedOcpVersion, err := exutil.DoesApiResourceExist(oc.AdminConfig(), "cloudprivateipconfigs", "cloud.network.openshift.io")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if !isSupportedOcpVersion {
 			skipper.Skipf("This OCP version is not supported for this test (api-resource cloudprivateipconfigs not found)")

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -258,7 +258,7 @@ func (c CLI) WithToken(token string) *CLI {
 // All resources will be then created within this project.
 // Returns the name of the new project.
 func (c *CLI) SetupProject() string {
-	exist, err := DoesApiResourceExist(c.AdminConfig(), "projects")
+	exist, err := DoesApiResourceExist(c.AdminConfig(), "projects", "project.openshift.io")
 	o.Expect(err).ToNot(o.HaveOccurred())
 	if exist {
 		return c.setupProject()
@@ -888,7 +888,7 @@ func (c *CLI) CreateUser(prefix string) *userv1.User {
 
 func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
 
-	userAPIExists, err := DoesApiResourceExist(c.AdminConfig(), "users")
+	userAPIExists, err := DoesApiResourceExist(c.AdminConfig(), "users", "user.openshift.io")
 	if err != nil {
 		FatalErr(err)
 	}

--- a/test/extended/util/disruption/frontends/known_backends.go
+++ b/test/extended/util/disruption/frontends/known_backends.go
@@ -37,7 +37,7 @@ func StartAllIngressMonitoring(ctx context.Context, m monitor.Recorder, clusterC
 		}
 	}
 
-	configAvailable, err := exutil.DoesApiResourceExist(clusterConfig, "clusterversions")
+	configAvailable, err := exutil.DoesApiResourceExist(clusterConfig, "clusterversions", "config.openshift.io")
 	if err != nil {
 		return err
 	}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1942,7 +1942,7 @@ func GetRouterPodTemplate(oc *CLI) (*corev1.PodTemplateSpec, string, error) {
 }
 
 func FindRouterImage(oc *CLI) (string, error) {
-	exists, err := DoesApiResourceExist(oc.AdminConfig(), "clusteroperators")
+	exists, err := DoesApiResourceExist(oc.AdminConfig(), "clusteroperators", "config.openshift.io")
 	if err != nil {
 		return "", err
 	}
@@ -2056,7 +2056,7 @@ func SkipIfExternalControlplaneTopology(oc *CLI, reason string) {
 
 // DoesApiResourceExist searches the list of ApiResources and returns "true" if a given
 // apiResourceName Exists. Valid search strings are for example "cloudprivateipconfigs" or "machines".
-func DoesApiResourceExist(config *rest.Config, apiResourceName string) (bool, error) {
+func DoesApiResourceExist(config *rest.Config, apiResourceName, groupVersionName string) (bool, error) {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		return false, err
@@ -2066,6 +2066,9 @@ func DoesApiResourceExist(config *rest.Config, apiResourceName string) (bool, er
 		return false, err
 	}
 	for _, apiResourceList := range allResourceList {
+		if groupName(groupVersionName) != groupName(apiResourceList.GroupVersion) {
+			continue
+		}
 		for _, apiResource := range apiResourceList.APIResources {
 			if apiResource.Name == apiResourceName {
 				return true, nil
@@ -2074,4 +2077,8 @@ func DoesApiResourceExist(config *rest.Config, apiResourceName string) (bool, er
 	}
 
 	return false, nil
+}
+
+func groupName(groupVersionName string) string {
+	return strings.Split(groupVersionName, "/")[0]
 }


### PR DESCRIPTION
When using DoesApiResourceExist function from framework we might get false positives if there are two resources with the same name but difference API group. This change checks the API group (not version) with the resource name too in order to remove ambiguity.