### PR TITLE
USHIFT-658: ushift: skip networking bond interface tests

### DIFF
--- a/test/extended/networking/bonds.go
+++ b/test/extended/networking/bonds.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-network][Feature:bond]", func() {
 	oc := exutil.NewCLI("bond")
 	f := oc.KubeFramework()
 
-	g.It("should create a pod with bond interface", func() {
+	g.It("should create a pod with bond interface [apigroup:k8s.cni.cncf.io]", func() {
 		namespace := f.Namespace.Name
 		podName1, podName2 := "pod1", "pod2"
 		bondnad1, bondnad2 := "bondnad1", "bondnad2"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2607,7 +2607,7 @@ var Annotations = map[string]string{
 
 	"[sig-network][Feature:Whereabouts] should use whereabouts net-attach-def to limit IP ranges for newly created pods [apigroup:k8s.cni.cncf.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][Feature:bond] should create a pod with bond interface": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][Feature:bond] should create a pod with bond interface [apigroup:k8s.cni.cncf.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:tuning] pod should not start for sysctls not on whitelist [apigroup:k8s.cni.cncf.io] net.ipv4.conf.IFNAME.arp_filter": " [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
API group k8s.cni.cncf.io is not installed.

Pending JIRA ticket.