### PR TITLE
TRT-662: include test count totals for analysis

### DIFF
--- a/pkg/riskanalysis/cmd.go
+++ b/pkg/riskanalysis/cmd.go
@@ -70,6 +70,7 @@ func (opt *Options) Run() error {
 				testFailureSummaryFilePrefix, finalProwJobRun.ProwJob.Name, pjr.ProwJob.Name)
 		}
 		finalProwJobRun.Tests = append(finalProwJobRun.Tests, pjr.Tests...)
+		finalProwJobRun.TestCount += pjr.TestCount
 	}
 
 	inputBytes, err := json.Marshal(finalProwJobRun)

--- a/pkg/riskanalysis/types.go
+++ b/pkg/riskanalysis/types.go
@@ -6,9 +6,10 @@ package riskanalysis
 // We're getting dangerously close to being able to live push results after a job run.
 
 type ProwJobRun struct {
-	ID      int
-	ProwJob ProwJob
-	Tests   []ProwJobRunTest
+	ID        int
+	ProwJob   ProwJob
+	Tests     []ProwJobRunTest
+	TestCount int
 }
 
 type ProwJob struct {

--- a/pkg/riskanalysis/write_test_failure_summary.go
+++ b/pkg/riskanalysis/write_test_failure_summary.go
@@ -38,9 +38,10 @@ func WriteJobRunTestFailureSummary(artifactDir, timeSuffix string, finalSuiteRes
 	jobRunID, _ := strconv.Atoi(os.Getenv("BUILD_ID"))
 
 	jr := ProwJobRun{
-		ID:      jobRunID,
-		ProwJob: ProwJob{Name: os.Getenv("JOB_NAME")},
-		Tests:   []ProwJobRunTest{},
+		ID:        jobRunID,
+		ProwJob:   ProwJob{Name: os.Getenv("JOB_NAME")},
+		Tests:     []ProwJobRunTest{},
+		TestCount: len(tests),
 	}
 
 	for k, v := range tests {


### PR DESCRIPTION
Include the total test count so we can compare against previous runs and detect missing tests in cases like failed installs / upgrades, etc.

On the Sippy side adding:

```
type ProwJob struct {
	gorm.Model

	Kind        ProwKind
	Name        string         `gorm:"unique"`
	Release     string         `gorm:"varchar(10)"`
	Variants    pq.StringArray `gorm:"index;type:text[]"`
	TestGridURL string
	Bugs        []Bug        `gorm:"many2many:bug_jobs;"`
	JobRuns     []ProwJobRun `gorm:"constraint:OnDelete:CASCADE;"`
	TestCount   int			 `gorm:"-"`
}
```

So we can pass the value via struct but not store in db.  Can make that a request parameter if desired.