### PR TITLE
EgressIP: Run HTTP requests to netexec pods instead of using tcpdump

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -57,7 +57,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 
 		boundedReadySchedulableNodes     []corev1.Node
 		boundedReadySchedulableNodeNames []string
-		egressIPNodesNames        []string
+		egressIPNodesNames               []string
 		nonEgressIPNodeName              string
 
 		egressIPNamespace      string
@@ -219,7 +219,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// Requires a minimum of 3 worker nodes in total:
 			// 1 nonEgressIPNodeName + at least 2 as sources of EgressIP traffic.
 			o.Expect(len(egressIPNodesNames)).Should(o.BeNumerically(">", 1))
-			egressIPNodeStr := []string{egressIPNodesNames[0]}
+			egressIPNodeStr := egressIPNodesNames[0]
 			deploymentNodeStr := [][]string{
 				{egressIPNodesNames[0]},
 				{egressIPNodesNames[1]},
@@ -281,7 +281,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodeStr, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodeStr)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -375,7 +376,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesNames, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -462,7 +464,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// EgressIP on different nodes. And we also test that pods can be moved between nodes.
 			g.By(fmt.Sprintf("Finding potential Egress IPs for node %s", leftNode[0]))
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, leftNode, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				leftNode...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -521,7 +524,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesNames, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -569,7 +573,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesNames, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -640,7 +645,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// For this test, get a single EgressIP per node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesNames, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -147,26 +146,6 @@ type byName []corev1.Node
 func (n byName) Len() int           { return len(n) }
 func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
-
-// GetNodesOrdered returns a sorted slice (by node.Name) of nodes or error.
-func getWorkerNodesOrdered(clientset kubernetes.Interface) ([]corev1.Node, error) {
-	if clientset == nil {
-		return nil, fmt.Errorf("Nil pointer clientset provided")
-	}
-
-	nodes, err := clientset.CoreV1().Nodes().List(
-		context.TODO(),
-		metav1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/worker=",
-		})
-	if err != nil {
-		return nil, err
-	}
-	items := nodes.Items
-	sort.Sort(byName(items))
-
-	return items, nil
-}
 
 // findPacketSnifferInterface finds the interface that shall be used for packet capturing on all nodes in the list.
 // Return an error if there is no consensus about the interface that shall be used among nodes.

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -877,7 +877,8 @@ type capacity struct {
 // depend on the current cloud type, on the currenctly used cloudprivateipconfigs, and on an internal reservation
 // manager. Find <egressIPsPerNode> number of IPs per node.
 // TODO: Create the internal reservation manager, if needed.
-func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetworkClientset cloudnetwork.Interface, nodeNames []string, cloudType configv1.PlatformType, egressIPsPerNode int) (map[string][]string, error) {
+func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetworkClientset cloudnetwork.Interface,
+	cloudType configv1.PlatformType, egressIPsPerNode int, nodeNames ...string) (map[string][]string, error) {
 	// Get the node API objects corresponding to the node names.
 	var nodeList []*v1.Node
 	for _, nodeName := range nodeNames {


### PR DESCRIPTION
 Significantly simplify EgressIP tests. In order to do so, we must create a standalone CloudPrivateIPConfig with an extra IP and then attach the IP address temporarily to the node's br-ex (or in the case of SDN main interface). This will serve as our "external" host that we can run EgressIP queries against. We then run agnhost netexec inside that "external" host in a host
network pod. Finally, we run requests against the agnhost netexec pod (endpoint /clientip).  agnhost netexec will then return the IP address of the client that's dialing in.

How to test:
~~~
./openshift-tests run openshift/conformance/serial --run "\[sig-network\]\[Feature:EgressIP\]"
~~~

Tested against:
AWS, SDN
AWS, OVN

Problem / not working:
GCP is using Alias IP ranges:
https://github.com/openshift/cloud-network-config-controller/blob/master/pkg/cloudprovider/gcp.go#L77

However: https://cloud.google.com/vpc/docs/alias-ip#firewalls
Alias IP ranges are not included when you [specify sources](https://cloud.google.com/vpc/docs/firewalls#sources_for_the_rule) for an ingress firewall rule using source tags or source service accounts."
Hence the firewall rules that in theory unblock traffic between the nodes do not work 

![image](https://user-images.githubusercontent.com/3291433/205359321-30c9d43c-9bc1-4102-8b04-228bd270839a.png)
