### PR TITLE
Separate out "startupProbe failed" messages from pathological events test

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -22,10 +22,11 @@ import (
 )
 
 const (
-	duplicateEventThreshold           = 20
-	duplicateSingleNodeEventThreshold = 30
-	ovnReadinessRegExpStr             = `ns/(?P<NS>openshift-ovn-kubernetes) pod/(?P<POD>ovnkube-node-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>Unhealthy) (?P<MSG>Readiness probe failed:.*$)`
-	consoleReadinessRegExpStr         = `ns/(?P<NS>openshift-console) pod/(?P<POD>console-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>ProbeError) (?P<MSG>Readiness probe error:.* connect: connection refused$)`
+	duplicateEventThreshold                 = 20
+	duplicateSingleNodeEventThreshold       = 30
+	ovnReadinessRegExpStr                   = `ns/(?P<NS>openshift-ovn-kubernetes) pod/(?P<POD>ovnkube-node-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>Unhealthy) (?P<MSG>Readiness probe failed:.*$)`
+	consoleReadinessRegExpStr               = `ns/(?P<NS>openshift-console) pod/(?P<POD>console-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>ProbeError) (?P<MSG>Readiness probe error:.* connect: connection refused$)`
+	marketplaceStartupProbeFailureRegExpStr = `ns/(?P<NS>openshift-marketplace) pod/(?P<POD>(community-operators|redhat-operators)-[a-z0-9-]+).*Startup probe failed`
 )
 
 func combinedRegexp(arr ...*regexp.Regexp) *regexp.Regexp {
@@ -132,6 +133,9 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 
 	// Separated out in testNodeHasSufficientPID
 	regexp.MustCompile(nodeHasSufficientPIDRegExpStr),
+
+	// Separated out in testMarketplaceStartupProbeFailure
+	regexp.MustCompile(marketplaceStartupProbeFailureRegExpStr),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{
@@ -165,6 +169,9 @@ var allowedUpgradeRepeatedEventPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/RequiredInstallerResourcesMissing configmaps: etcd-endpoints-[0-9]+`),
 	// There is a separate test to catch this specific case
 	regexp.MustCompile(requiredResourcesMissingRegEx),
+
+	// Separated out in testMarketplaceStartupProbeFailure
+	regexp.MustCompile(marketplaceStartupProbeFailureRegExpStr),
 }
 
 var knownEventsBugs = []knownProblem{

--- a/pkg/synthetictests/duplicated_events_special.go
+++ b/pkg/synthetictests/duplicated_events_special.go
@@ -170,17 +170,17 @@ func testConfigOperatorReadinessProbe(events monitorapi.Intervals) []*junitapi.J
 
 func testNodeHasNoDiskPressure(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] Test the NodeHasNoDiskPressure condition does not occur too often"
-	return makeNodeHasTest(testName, events, nodeHasNoDiskPressureRegExpStr, duplicateEventThreshold)
+	return eventExprMatchThresholdTest(testName, events, nodeHasNoDiskPressureRegExpStr, duplicateEventThreshold)
 }
 
 func testNodeHasSufficientMemory(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] Test the NodeHasSufficeintMemory condition does not occur too often"
-	return makeNodeHasTest(testName, events, nodeHasSufficientMemoryRegExpStr, duplicateEventThreshold)
+	return eventExprMatchThresholdTest(testName, events, nodeHasSufficientMemoryRegExpStr, duplicateEventThreshold)
 }
 
 func testNodeHasSufficientPID(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] Test the NodeHasSufficientPID condition does not occur too often"
-	return makeNodeHasTest(testName, events, nodeHasSufficientPIDRegExpStr, duplicateEventThreshold)
+	return eventExprMatchThresholdTest(testName, events, nodeHasSufficientPIDRegExpStr, duplicateEventThreshold)
 }
 
 func makeProbeTest(testName string, events monitorapi.Intervals, operatorName string, regExStr string, eventFlakeThreshold int) []*junitapi.JUnitTestCase {
@@ -190,7 +190,7 @@ func makeProbeTest(testName string, events monitorapi.Intervals, operatorName st
 	}, eventFlakeThreshold)
 }
 
-func makeNodeHasTest(testName string, events monitorapi.Intervals, regExStr string, eventFlakeThreshold int) []*junitapi.JUnitTestCase {
+func eventExprMatchThresholdTest(testName string, events monitorapi.Intervals, regExStr string, eventFlakeThreshold int) []*junitapi.JUnitTestCase {
 	messageRegExp := regexp.MustCompile(regExStr)
 	return eventMatchThresholdTest(testName, events, func(event monitorapi.EventInterval) bool { return messageRegExp.MatchString(event.Message) }, eventFlakeThreshold)
 }

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -61,6 +61,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testNodeHasSufficientPID(events)...)
 
 	tests = append(tests, testHttpConnectionLost(events)...)
+	tests = append(tests, testMarketplaceStartupProbeFailure(events)...)
 	return tests
 }
 
@@ -118,6 +119,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testNodeHasSufficientPID(events)...)
 
 	tests = append(tests, testHttpConnectionLost(events)...)
+	tests = append(tests, testMarketplaceStartupProbeFailure(events)...)
 	return tests
 }
 

--- a/pkg/synthetictests/marketplace.go
+++ b/pkg/synthetictests/marketplace.go
@@ -1,0 +1,12 @@
+package synthetictests
+
+import (
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+func testMarketplaceStartupProbeFailure(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-arch] openshift-marketplace pods should not get excessive startupProbe failures"
+	return eventExprMatchThresholdTest(testName, events, marketplaceStartupProbeFailureRegExpStr, duplicateEventThreshold)
+}


### PR DESCRIPTION
[TRT-702](https://issues.redhat.com//browse/TRT-702)
OCPBUGS-1152

Separate out "startupProbe failed" messages from pathological events test for community-operators and redhat-operators pods in openshift-marketplace namespace.