### PR TITLE
EgressIP: Run HTTP requests to netexec container on external VM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,14 @@ module github.com/openshift/origin
 go 1.18
 
 require (
+	github.com/Azure/azure-sdk-for-go v55.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.11.27
+	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
+	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2
 	github.com/apparentlymart/go-cidr v1.1.0
+	github.com/aws/aws-sdk-go v1.38.49
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/fsouza/go-dockerclient v1.7.1
@@ -42,6 +47,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
+	google.golang.org/api v0.60.0
 	google.golang.org/grpc v1.47.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -68,14 +74,12 @@ require (
 
 require (
 	cloud.google.com/go v0.97.0 // indirect
-	github.com/Azure/azure-sdk-for-go v55.0.0+incompatible // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
-	github.com/Azure/go-autorest/autorest v0.11.27 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.20 // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.4.5 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/mocks v0.4.2 // indirect
-	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
@@ -90,7 +94,6 @@ require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed // indirect
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
-	github.com/aws/aws-sdk-go v1.38.49 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -107,6 +110,7 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
+	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/docker v20.10.17+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
@@ -251,7 +255,6 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	golang.org/x/tools v0.1.12 // indirect
-	google.golang.org/api v0.60.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,11 +53,16 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest/autorest v0.11.24/go.mod h1:G6kyRlFnTuSbEYkQGawPfsCswgme4iYf6rfSKUDzbCc=
 github.com/Azure/go-autorest/autorest v0.11.27 h1:F3R3q42aWytozkV8ihzcgMO4OA4cuqr3bNlsEuF6//A=
 github.com/Azure/go-autorest/autorest v0.11.27/go.mod h1:7l8ybrIdUmGqZMTD0sRtAr8NvbHjfofbf8RSP2q7w7U=
 github.com/Azure/go-autorest/autorest/adal v0.9.18/go.mod h1:XVVeme+LZwABT8K5Lc3hA4nAe8LDBVle26gTrguhhPQ=
 github.com/Azure/go-autorest/autorest/adal v0.9.20 h1:gJ3E98kMpFB1MFqQCvA1yFab8vthOeD4VlFRQULxahg=
 github.com/Azure/go-autorest/autorest/adal v0.9.20/go.mod h1:XVVeme+LZwABT8K5Lc3hA4nAe8LDBVle26gTrguhhPQ=
+github.com/Azure/go-autorest/autorest/azure/auth v0.5.11 h1:P6bYXFoao05z5uhOQzbC3Qd8JqF3jUoocoTeIxkp2cA=
+github.com/Azure/go-autorest/autorest/azure/auth v0.5.11/go.mod h1:84w/uV8E37feW2NCJ08uT9VBfjfUHpgLVnG2InYD6cg=
+github.com/Azure/go-autorest/autorest/azure/cli v0.4.5 h1:0W/yGmFdTIT77fvdlGZ0LMISoLHFJ7Tx4U0yeB+uFs4=
+github.com/Azure/go-autorest/autorest/azure/cli v0.4.5/go.mod h1:ADQAXrkgm7acgWVUNamOgh8YNrv4p27l3Wc55oVfpzg=
 github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
@@ -240,6 +245,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
+github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/docker/distribution v0.0.0-20180920194744-16128bbac47f/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -57,7 +57,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 
 		boundedReadySchedulableNodes     []corev1.Node
 		boundedReadySchedulableNodeNames []string
-		egressIPNodesNames        []string
+		egressIPNodesNames               []string
 		nonEgressIPNodeName              string
 
 		egressIPNamespace      string
@@ -219,7 +219,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// Requires a minimum of 3 worker nodes in total:
 			// 1 nonEgressIPNodeName + at least 2 as sources of EgressIP traffic.
 			o.Expect(len(egressIPNodesNames)).Should(o.BeNumerically(">", 1))
-			egressIPNodeStr := []string{egressIPNodesNames[0]}
+			egressIPNodeStr := egressIPNodesNames[0]
 			deploymentNodeStr := [][]string{
 				{egressIPNodesNames[0]},
 				{egressIPNodesNames[1]},
@@ -281,7 +281,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodeStr, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodeStr)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -375,7 +376,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesNames, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -462,7 +464,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// EgressIP on different nodes. And we also test that pods can be moved between nodes.
 			g.By(fmt.Sprintf("Finding potential Egress IPs for node %s", leftNode[0]))
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, leftNode, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				leftNode...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -521,7 +524,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesNames, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -569,7 +573,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesNames, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -640,7 +645,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// For this test, get a single EgressIP per node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesNames, cloudType, egressIPsPerNode)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
+				egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -6,16 +6,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
+	"strconv"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -28,25 +29,58 @@ import (
 )
 
 const (
-	// for all tests
 	namespacePrefix = "egressip"
 	egressIPYaml    = "egressip.yaml"
 	probePodName    = "prober-pod"
 
-	// for tests against host networked pods
-	egressIPTargetHostPortMin = 32667
-	egressIPTargetHostPortMax = 32767
+	// Port 6443 should be open on most cloud platforms by default. That way, we do not necessarily have
+	// to update security groups (e.g. Azure). For AWS, we choose port 30000 for the same reasons (it's open for
+	// the worker node security group).
+	externalTargetPort    = 6443
+	externalTargetPortAWS = 30000
 
 	// Max time that we wait for changes to EgressIP objects
 	// to propagate to the CloudPrivateIPConfig objects.
 	// This can take a significant amount of time on Azure.
 	// BZ https://bugzilla.redhat.com/show_bug.cgi?id=2073045
-	egressUpdateTimeout = 180
+	egressUpdateTimeout = 300
+
+	agnhostImage            = "k8s.gcr.io/e2e-test-images/agnhost:2.43"
+	targetHostStartupScript = `#!/bin/bash
+yum install podman -y
+firewall-cmd --add-port={{listenPort}}/tcp
+podman run --network=host -d --rm {{agnhost}} netexec --http-port {{listenPort}} --udp-port {{listenPort}}
+`
+
+	// targetHostRequestPublicIP should always be set to false. It is only useful for debugging of the target host
+	// while developing EgressIP tests.
+	// If this is set to true, assign a DNAT / floating IP so that one can SSH into the host and open port 22 to
+	// 0.0.0.0/0. Additionally, print the private and public SSH key to the command line.
+	targetHostRequestPublicIP = false
 )
 
+// EgressIP tests work as follows:
+//   External host:
+//     Spawn an additional RHEL 8 VM on the cloud platform for tests, install podman on that VM and start an agnhost
+//     container.
+//   EgressIP pod:
+//     Inside the egressIPNamespace, we set up an agnhost netexec pod. Traffic outgoing of this pod will or will not be
+//     matched by EgressIPs, this depends on the test. The pod will be instructed to dial to the external host during
+//     the tests. In order to instruct the pod to dial to the external host, we must call into the agnhost netexec
+//     dial endpoint. Hence, we expose the EgressIP pod via a SVC and route, the setup looks +/- as follows:
+//       inside egressIPNamespace:
+//         Route:egressIPNamespace/route-to-agnhost
+//           --> SVC:egressIPNamespace/svc-to-agnhost
+//               --> Deployment:egressIPNamespace/agnhost
+//   prober pod:
+//     A prober pod is created inside externalNamespace. It dials into the route, targets the /dial HTTP endpoint
+//     which in turn triggers traffic generation from the EgressIP pod to the external host. Here is an example
+//     requests that the prober pod sends:
+//     kubeconfig exec prober-podwwfts -- \
+//       curl --max-time 15 -s http://e2e-test-egressip-4cjkc-0.apps.cluster.com/dial?protocol=http&host=10.0.128.5&port=32667&request=/clientip
 var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel(namespacePrefix, admissionapi.LevelPrivileged)
-	portAllocator := NewPortAllocator(egressIPTargetHostPortMin, egressIPTargetHostPortMax)
+	// portAllocator := NewPortAllocator(targetPodPortMin, targetPodPortMax)
 
 	var (
 		networkPlugin string
@@ -55,25 +89,22 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 		cloudNetworkClientset cloudnetwork.Interface
 		tmpDirEgressIP        string
 
-		boundedReadySchedulableNodes     []corev1.Node
-		boundedReadySchedulableNodeNames []string
-		egressIPNodesNames               []string
-		nonEgressIPNodeName              string
+		// boundedReadySchedulableNodes are schedulable and available nodes (= worker nodes in most cases).
+		boundedReadySchedulableNodes []corev1.Node
+		egressIPNodesNames           []string
+		// nonEgressIPNode              corev1.Node
 
-		egressIPNamespace      string
-		externalNamespace      string
-		packetSnifferDaemonSet *v1.DaemonSet
-		packetSnifferInterface string
+		// egressIPNamespace is the namespace that the the EgressIP is configured for.
+		egressIPNamespace string
+		// proberPodNamespace is the namespace that the prober pod is in.
+		proberPodNamespace string
 
 		ingressDomain string
-
-		cloudType configv1.PlatformType
-		hasIPv4   bool
-		hasIPv6   bool
-
-		targetProtocol string
-		targetHost     string
-		targetPort     int
+		cloudType     configv1.PlatformType
+		cc            cloudClient
+		targetVMIP    string
+		targetVMPort  int
+		targetVM      *vm
 	)
 
 	g.BeforeEach(func() {
@@ -98,7 +129,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Determining the cloud infrastructure type")
-		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(
+			context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		cloudType = infra.Spec.PlatformSpec.Type
 
@@ -108,7 +140,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			configv1.AWSPlatformType,
 			configv1.GCPPlatformType,
 			configv1.AzurePlatformType,
-			configv1.OpenStackPlatformType,
+			// configv1.OpenStackPlatformType, // TBD in a follow-up commit.
 		}
 		for _, supportedPlatform := range supportedPlatforms {
 			if cloudType == supportedPlatform {
@@ -120,66 +152,70 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			skipper.Skipf("This cloud platform (%s) is not supported for this test", cloudType)
 		}
 
-		// A supported version of OpenShift must hold the CloudPrivateIPConfig CRD.
-		// Otherwise, skip this test.
+		// A supported version of OpenShift must hold the CloudPrivateIPConfig CRD. Otherwise, skip this test.
 		g.By("Verifying that this is a supported version of OpenShift")
-		isSupportedOcpVersion, err := exutil.DoesApiResourceExist(oc.AdminConfig(), "cloudprivateipconfigs", "cloud.network.openshift.io")
+		isSupportedOcpVersion, err := exutil.DoesApiResourceExist(oc.AdminConfig(), "cloudprivateipconfigs",
+			"cloud.network.openshift.io")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if !isSupportedOcpVersion {
-			skipper.Skipf("This OCP version is not supported for this test (api-resource cloudprivateipconfigs not found)")
+			skipper.Skipf("API resource CloudPrivateIPConfigs not found")
 		}
 
 		g.By("Getting bounded ready schedulable (worker) nodes")
 		nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		fmt.Println(nodes)
 		boundedReadySchedulableNodes = nodes.Items
-		for _, s := range boundedReadySchedulableNodes {
-			boundedReadySchedulableNodeNames = append(boundedReadySchedulableNodeNames, s.Name)
-		}
 		if len(boundedReadySchedulableNodes) < 3 {
-			skipper.Skipf("This test requires a minimum of 3 worker nodes. However, this environment has %d worker nodes.", len(boundedReadySchedulableNodes))
+			skipper.Skipf("This test requires a minimum of 3 worker nodes. This environment has %d worker nodes.",
+				len(boundedReadySchedulableNodes),
+			)
 		}
-
-		g.By("Determining the cloud address families")
-		hasIPv4, hasIPv6, err = GetIPAddressFamily(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By("Determining the target protocol, host and port")
-		targetProtocol, targetHost, targetPort, err = getTargetProtocolHostPort(oc, hasIPv4, hasIPv6, cloudType, networkPlugin)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		framework.Logf("Testing against: CloudType: %s, NetworkPlugin: %s, Protocol %s, TargetHost: %s, TargetPort: %d",
-			cloudType,
-			networkPlugin,
-			targetProtocol,
-			targetHost,
-			targetPort)
 
 		g.By("Creating a project for the prober pod")
-		// Create a target project and assign source and target namespace
-		// to variables for later use.
+		// Create a target project and assign source and target namespace to variables for later use.
 		egressIPNamespace = f.Namespace.Name
-		externalNamespace = oc.SetupProject()
+		proberPodNamespace = oc.SetupProject()
 
 		g.By("Selecting the EgressIP nodes and a non-EgressIP node")
-		nonEgressIPNodeName = boundedReadySchedulableNodeNames[0]
-		egressIPNodesNames = boundedReadySchedulableNodeNames[1:]
+		// nonEgressIPNode = boundedReadySchedulableNodes[0]
+		egressIPNodes := boundedReadySchedulableNodes[1:]
+		egressIPNodesNames = make([]string, len(egressIPNodes))
+		for i, s := range egressIPNodes {
+			egressIPNodesNames[i] = s.Name
+		}
 
 		g.By("Setting the ingressdomain")
 		ingressDomain, err = getIngressDomain(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		if networkPluginName() == OVNKubernetesPluginName {
+		if networkPlugin == OVNKubernetesPluginName {
 			g.By("Setting the EgressIP nodes as EgressIP assignable")
 			for _, node := range egressIPNodesNames {
 				_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", node, "k8s.ovn.org/egress-assignable=")
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 		}
+
+		g.By(fmt.Sprintf("Setting up the cloud client for platform %s", cloudType))
+		cc, err = newCloudClient(oc, cloudType)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Setting up an external target")
+		targetVMPort = externalTargetPort
+		if cloudType == configv1.AWSPlatformType {
+			framework.Logf("Platform is AWS, choosing target port %d", externalTargetPortAWS)
+			targetVMPort = externalTargetPortAWS
+		}
+		targetVM, err = setupExternalTarget(oc, cc, f.Namespace.Name, targetVMPort)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		targetVMIP = targetVM.privateIP.String()
+		framework.Logf("VM private IP: %s, VM public IP: %s, VM port: %d", targetVMIP, targetVM.publicIP, targetVMPort)
 	})
 
-	// Do not check for errors in g.AfterEach as the other cleanup steps will fail, otherwise.
 	g.AfterEach(func() {
+		// We ignore any errors here on purpose as:
+		// a) we want to continue with execution of the other steps
+		// b) these errors are not important enough to stop testing / report a failure.
 		if networkPluginName() == OVNKubernetesPluginName {
 			g.By("Deleting the EgressIP object if it exists for OVN Kubernetes")
 			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
@@ -201,187 +237,35 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 
 		g.By("Removing the temp directory")
 		os.RemoveAll(tmpDirEgressIP)
+
+		g.By("Tearing down external target")
+		tearDownExternalTarget(oc, cc, targetVM)
+
+		g.By("Closing the CloudClient")
+		err := cc.Close()
+		if err != nil {
+			framework.Logf("Error closing CloudClient, err: %q", err)
+		}
 	})
 
-	g.Context("[internal-targets]", func() {
-		g.JustBeforeEach(func() {
-			// Host networked is needed for host networked pods.
-			g.By("Adding SCC hostnetwork to the external namespace")
-			_, err := runOcWithRetry(oc.AsAdmin(), "adm", "policy", "add-scc-to-user", "hostnetwork", fmt.Sprintf("system:serviceaccount:%s:default", externalNamespace))
-			o.Expect(err).NotTo(o.HaveOccurred())
-		})
-
-		g.It("EgressIP pods should query hostNetwork pods with the local node's SNAT", func() {
-			var targetIP string
-			var targetPort int
-
-			g.By("Selecting a single EgressIP node, and one node per source deployment")
-			// Requires a minimum of 3 worker nodes in total:
-			// 1 nonEgressIPNodeName + at least 2 as sources of EgressIP traffic.
-			o.Expect(len(egressIPNodesNames)).Should(o.BeNumerically(">", 1))
-			egressIPNodeStr := egressIPNodesNames[0]
-			deploymentNodeStr := [][]string{
-				{egressIPNodesNames[0]},
-				{egressIPNodesNames[1]},
-			}
-
-			g.By("Creating the target DaemonSet with a single hostnetworked pod on the target node")
-			daemonSetName := "hostnetworked"
-			// Try the entire port range to create the DaemonSet.
-			for i := 0; i < egressIPTargetHostPortMax-egressIPTargetHostPortMin; i++ {
-				containerPort, err := portAllocator.AllocateNextPort()
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				// use the port that we got from the port allocator for this
-				// new DS / pod. Store the created daemonset for later.
-				_, err = createHostNetworkedDaemonSetAndProbe(
-					clientset,
-					externalNamespace,
-					nonEgressIPNodeName,
-					daemonSetName,
-					containerPort,
-					10, // every 10 seconds
-					6,  // for 6 retries
-				)
-
-				// If this is a port conflict, then keep the port allocation and
-				// simply continue (but delete the current DS first).
-				// The current port is hence marked as unavailable for
-				// further tries.
-				if err != nil && strings.Contains(err.Error(), "Port conflict when creating pod") {
-					err := deleteDaemonSet(clientset, externalNamespace, daemonSetName)
-					o.Expect(err).NotTo(o.HaveOccurred())
-					continue
-				}
-				// Any other error shoud not have occurred.
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				// Break if no error was found.
-				targetPort = containerPort
-				break
-			}
-
-			g.By("Getting the targetIP for the test from the DaemonSet pod")
-			podIPs, err := getDaemonSetPodIPs(clientset, externalNamespace, daemonSetName)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(podIPs)).Should(o.BeNumerically(">", 0))
-			targetIP = podIPs[0]
-
-			var routeNames []string
-			for k, v := range deploymentNodeStr {
-				g.By(fmt.Sprintf("Creating EgressIP test source deployment %d with number of pods equals number of EgressIP nodes", k))
-				_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, fmt.Sprint(k), ingressDomain, len(v), v)
-				routeNames = append(routeNames, routeName)
-				o.Expect(err).NotTo(o.HaveOccurred())
-			}
-
-			// For this test, get a single EgressIP per node.
-			// Note: On some clouds like GCP, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
-			// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
-			// will pick the actual node.
-			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
-			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
-				egressIPNodeStr)
-			framework.Logf("%v", nodeEgressIPMap)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Choosing the EgressIPs to be assigned, one per node")
-			egressIPSet := make(map[string]string)
-			for nodeName, eip := range nodeEgressIPMap {
-				_, ok := egressIPSet[eip[0]]
-				if !ok {
-					egressIPSet[eip[0]] = nodeName
-				}
-			}
-
-			g.By("Creating the EgressIP object for OVN Kubernetes")
-			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
-			egressIPObjectName := egressIPNamespace
-			ovnKubernetesCreateEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
-
-			g.By("Applying the EgressIP object for OVN Kubernetes")
-			_, err = runOcWithRetry(oc.AsAdmin(), "create", "-f", tmpDirEgressIP+"/"+egressIPYaml)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			// This approach here is different from the other tests because:
-			// a) No additional SNAT or similar can be injected by the cloud as we go directly from node and we know that we have
-			// an endpoint on the cloud, always, thus we can directly query agnhost's /clientip.
-			// b) The requests in tcpdump did not expose the request string for some reason (probably needed better filters)
-			// c) It's simpler to just query for the /clientip instead of relying on the packet capture for these tests.
-			for _, routeName := range routeNames {
-				g.By(fmt.Sprintf("Launching a new prober pod and probing for EgressIPs at %s", routeName))
-				numberOfRequestsToSend := 10
-				clientIPSet, err := probeForClientIPs(oc, externalNamespace, probePodName, routeName, targetIP, targetPort, numberOfRequestsToSend)
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				// Note: my interpretation is that it's a bug if we see an egressIP here:
-				// We should never see egressIPs when querying internal targets:
-				// https://bugzilla.redhat.com/show_bug.cgi?id=2070929
-				// However, this was still a subject of discussion. When we enable these tests after
-				// we fix 2070929, decide if we want to see EgressIPs here or not and possibly remove
-				// this verification.
-				g.By("Making sure that EgressIPs were not part of the response")
-				framework.Logf("egressIPSet is: %v", egressIPSet)
-				framework.Logf("clientIPSet is: %v", clientIPSet)
-				o.Expect(len(clientIPSet)).Should(o.BeNumerically(">", 0))
-				o.Expect(
-					// return false if any key of x is in y or vice-versa.
-					func(x map[string]string, y map[string]struct{}) bool {
-						for k := range x {
-							if _, ok := y[k]; ok {
-								return false
-							}
-						}
-						for k := range y {
-							if _, ok := x[k]; ok {
-								return false
-							}
-						}
-						return true
-					}(egressIPSet, clientIPSet)).To(o.BeTrue())
-			}
-		})
-	}) // end testing to internal targets
-
 	g.Context("[external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io]", func() {
-		g.JustBeforeEach(func() {
-			// SCC privileged is needed to run tcpdump on the packet sniffer containers, and at the minimum host networked is needed for
-			// host networked pods.
-			g.By("Adding SCC privileged to the external namespace")
-			_, err := runOcWithRetry(oc.AsAdmin(), "adm", "policy", "add-scc-to-user", "privileged", fmt.Sprintf("system:serviceaccount:%s:default", externalNamespace))
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Determining the interface that will be used for packet sniffing")
-			packetSnifferInterface, err = findPacketSnifferInterface(oc, networkPlugin, egressIPNodesNames)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			framework.Logf("Using interface %s for packet captures", packetSnifferInterface)
-
-			g.By("Spawning the packet sniffer pods on the EgressIP assignable hosts")
-			packetSnifferDaemonSet, err = createPacketSnifferDaemonSet(oc, externalNamespace, egressIPNodesNames, targetProtocol, targetPort, packetSnifferInterface)
-			o.Expect(err).NotTo(o.HaveOccurred())
-		})
-
 		// OVNKubernetes
 		// OpenShiftSDN
 		// Skipped on Azure due to https://bugzilla.redhat.com/show_bug.cgi?id=2073045
 		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]", func() {
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
-			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesNames), egressIPNodesNames)
+			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain,
+				len(egressIPNodesNames), egressIPNodesNames)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// For this test, get a single EgressIP per node.
-			// Note: On some clouds like GCP, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
-			// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
-			// will pick the actual node.
-			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
+			g.By("Choosing the EgressIPs to be assigned, one per node")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
-				egressIPNodesNames...)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType,
+				[]string{targetVMIP}, egressIPsPerNode, egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Choosing the EgressIPs to be assigned, one per node")
 			egressIPSet := make(map[string]string)
 			for nodeName, eip := range nodeEgressIPMap {
 				_, ok := egressIPSet[eip[0]]
@@ -390,10 +274,9 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 				}
 			}
 
+			g.By("Setting number of requests to send")
 			numberOfRequestsToSend := 10
-			if targetHost == "self" {
-				targetHost = routeName
-			}
+
 			// Run this twice to make sure that repeated EgressIP creation and deletion works.
 			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
 			egressIPObjectName := egressIPNamespace
@@ -409,8 +292,10 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 					openshiftSDNAssignEgressIPsManually(oc, cloudNetworkClientset, egressIPNamespace, egressIPSet, egressUpdateTimeout)
 				}
 
-				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
-				spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests "+
+					"with EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+				spawnProberSendEgressIPTrafficCheckOutput(oc, proberPodNamespace, probePodName, routeName, targetVMIP,
+					targetVMPort, numberOfRequestsToSend, numberOfRequestsToSend, egressIPSet)
 
 				if networkPlugin == OVNKubernetesPluginName {
 					g.By("Deleting the EgressIP object for OVN Kubernetes")
@@ -431,8 +316,10 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 				g.By(fmt.Sprintf("Waiting for maximum %d seconds for the CloudPrivateIPConfig objects to vanish", egressUpdateTimeout))
 				waitForCloudPrivateIPConfigsDeletion(oc, cloudNetworkClientset, egressIPSet, egressUpdateTimeout)
 
-				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", 0, egressIPSet))
-				spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, 0, packetSnifferDaemonSet, egressIPSet)
+				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests "+
+					"with EgressIPs %v were seen", 0, egressIPSet))
+				spawnProberSendEgressIPTrafficCheckOutput(oc, proberPodNamespace, probePodName, routeName, targetVMIP,
+					targetVMPort, numberOfRequestsToSend, 0, egressIPSet)
 			}
 
 			if networkPlugin == OVNKubernetesPluginName {
@@ -445,7 +332,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 		// OpenShiftSDN
 		g.It("pods should keep the assigned EgressIPs when being rescheduled to another node", func() {
 			g.By("Selecting a single EgressIP node, and a single start node for the pod")
-			// requires a total of 3 worker nodes
+			// requires a total of 3 worker nodes (already verified in BeforeEach, additional verification here)
 			o.Expect(len(egressIPNodesNames)).Should(o.BeNumerically(">", 1))
 			leftNode := egressIPNodesNames[0:1]
 			rightNode := egressIPNodesNames[1:2]
@@ -454,29 +341,27 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			deploymentName, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(rightNode), rightNode)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			// Getting an EgressIP for a specific node only works on AWS. However, the important
-			// thing here is that we get only a single EgressIP which will be assigned to one
-			// of the 2 nodes only. On AWS, the EgressIP and the pod will end up on different nodes,
-			// the pod will then always be moved to the node that the EgressIP is on. On other cloud
-			// platforms, what happens depends on the involved controllers. Either, the pod and
-			// EgressIPs start out on the same node, or on different nodes. The end result though
-			// is that we always test both scenarios: pod and EgressIP on the same node, pod and
+			// Getting an EgressIP for a specific node and assigning it to that exact node doesn't work. However,
+			// the important thing here is that we get only a single EgressIP which will be assigned to one of the
+			// 2 nodes only. Either, the pod and EgressIPs start out on the same node, or on different nodes. The end
+			// result though is that we always test both scenarios: pod and EgressIP on the same node, pod and
 			// EgressIP on different nodes. And we also test that pods can be moved between nodes.
-			g.By(fmt.Sprintf("Finding potential Egress IPs for node %s", leftNode[0]))
+			g.By(fmt.Sprintf("Finding potential EgressIPs for node %s", leftNode[0]))
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
-				leftNode...)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType,
+				[]string{targetVMIP}, egressIPsPerNode, leftNode...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("Choosing the single EgressIP to be assigned")
 			egressIPSet := make(map[string]string)
 			for nodeName, eip := range nodeEgressIPMap {
-				_, ok := egressIPSet[eip[0]]
-				if !ok {
+				if _, ok := egressIPSet[eip[0]]; !ok {
 					egressIPSet[eip[0]] = nodeName
+					break
 				}
 			}
+			o.Expect(len(egressIPSet)).Should(o.BeNumerically(">", 0))
 
 			// This step is different depending on the network plugin.
 			if networkPlugin == OVNKubernetesPluginName {
@@ -492,40 +377,47 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 				openshiftSDNAssignEgressIPsManually(oc, cloudNetworkClientset, egressIPNamespace, egressIPSet, egressUpdateTimeout)
 			}
 
+			g.By("Setting number of requests to send")
 			numberOfRequestsToSend := 10
-			if targetHost == "self" {
-				targetHost = routeName
-			}
-			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
-			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+
+			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests "+
+				"with EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckOutput(oc, proberPodNamespace, probePodName, routeName, targetVMIP,
+				targetVMPort, numberOfRequestsToSend, numberOfRequestsToSend, egressIPSet)
 
 			g.By("Updating the source deployment's Affinity and moving it to the other source node")
 			err = updateDeploymentAffinity(oc, egressIPNamespace, deploymentName, leftNode)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
-			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests "+
+				"with EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckOutput(oc, proberPodNamespace, probePodName, routeName, targetVMIP,
+				targetVMPort, numberOfRequestsToSend, numberOfRequestsToSend, egressIPSet)
 		})
 
 		// OVNKubernetes
 		// Skipped on OpenShiftSDN as the plugin does not support pod selectors.
 		g.It("only pods matched by the pod selector should have the EgressIPs [Skipped:Network/OpenShiftSDN]", func() {
+			// requires a total of 3 worker nodes (already verified in BeforeEach, additional verification here)
+			o.Expect(len(egressIPNodesNames)).Should(o.BeNumerically(">", 1))
+			leftNode := egressIPNodesNames[0:1]
+			rightNode := egressIPNodesNames[1:2]
+
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
-			deployment0Name, route0Name, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "0", ingressDomain, len(egressIPNodesNames), egressIPNodesNames)
+			deployment0Name, route0Name, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "0",
+				ingressDomain, len(leftNode), leftNode)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("Creating the second EgressIP test source deployment with number of pods equals number of EgressIP nodes")
-			_, route1Name, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "1", ingressDomain, len(egressIPNodesNames), egressIPNodesNames)
+			_, route1Name, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "1", ingressDomain,
+				len(rightNode), rightNode)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// For this test, get a single EgressIP per node.
-			// Note: On some clouds like GCP, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
-			// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
-			// will pick the actual node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
-				egressIPNodesNames...)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType,
+				[]string{targetVMIP}, egressIPsPerNode, egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -538,43 +430,45 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 				}
 			}
 
-			g.By("Creating the EgressIP object for OVN Kubernetes")
+			podSelector := fmt.Sprintf("app: %s", deployment0Name)
+			g.By(fmt.Sprintf("Creating the EgressIP object for OVN Kubernetes with pod selector %q", podSelector))
 			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
 			egressIPObjectName := egressIPNamespace
-			ovnKubernetesCreateEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, fmt.Sprintf("app: %s", deployment0Name), egressIPSet)
+			ovnKubernetesCreateEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, podSelector,
+				egressIPSet)
 
 			g.By("Applying the EgressIP object for OVN Kubernetes")
 			applyEgressIPObject(oc, cloudNetworkClientset, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
 
+			g.By("Setting number of requests to send")
 			numberOfRequestsToSend := 10
-			if targetHost == "self" {
-				targetHost = route0Name
-			}
-			g.By(fmt.Sprintf("Testing first EgressIP test source deployment and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
-			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, route0Name, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
 
-			if targetHost == "self" {
-				targetHost = route1Name
-			}
-			g.By(fmt.Sprintf("Testing second EgressIP test source deployment and making sure that %d requests with search string and EgressIPs %v were seen", 0, egressIPSet))
-			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, route1Name, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, 0, packetSnifferDaemonSet, egressIPSet)
+			g.By(fmt.Sprintf("Testing first EgressIP test source deployment. "+
+				"Sending requests from prober and making sure that %d requests "+
+				"with EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckOutput(oc, proberPodNamespace, probePodName, route0Name, targetVMIP,
+				targetVMPort, numberOfRequestsToSend, numberOfRequestsToSend, egressIPSet)
+
+			g.By(fmt.Sprintf("Testing second EgressIP test source deployment. "+
+				"Sending requests from prober and making sure that %d requests "+
+				"with EgressIPs %v were seen", 0, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckOutput(oc, proberPodNamespace, probePodName, route1Name, targetVMIP,
+				targetVMPort, numberOfRequestsToSend, 0, egressIPSet)
 		})
 
 		// OVNKubernetes
 		// Skipped on OpenShiftSDN as this plugin has no EgressIPs object
 		g.It("pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN]", func() {
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
-			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesNames), egressIPNodesNames)
+			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain,
+				len(egressIPNodesNames), egressIPNodesNames)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// For this test, get a single EgressIP per node.
-			// Note: On some clouds like GCP, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
-			// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
-			// will pick the actual node.
-			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
+			g.By("Getting a map of source nodes and potential EgressIPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
-				egressIPNodesNames...)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType,
+				[]string{targetVMIP}, egressIPsPerNode, egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -586,20 +480,17 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 				if i > 1 {
 					break
 				}
-				i++
-
-				_, ok := egressIPSetTemp[eip[0]]
-				if !ok {
+				if _, ok := egressIPSetTemp[eip[0]]; !ok {
 					egressIPSetTemp[eip[0]] = nodeName
+					i++
 				}
 			}
 			o.Expect(len(egressIPSetTemp)).Should(o.BeNumerically("==", 2))
 
-			// Run this for each of the EgressIPs (and because we are applying, this will update the EgressIP object)
+			g.By("Setting number of requests to send")
 			numberOfRequestsToSend := 10
-			if targetHost == "self" {
-				targetHost = routeName
-			}
+
+			// Run this for each of the EgressIPs (and because we are applying, this will update the EgressIP object)
 			for eip, nodeName := range egressIPSetTemp {
 				egressIPSet := map[string]string{eip: nodeName}
 
@@ -611,8 +502,10 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 				g.By("Applying the EgressIP object for OVN Kubernetes")
 				applyEgressIPObject(oc, cloudNetworkClientset, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
 
-				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
-				spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests "+
+					"with EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+				spawnProberSendEgressIPTrafficCheckOutput(oc, proberPodNamespace, probePodName, routeName, targetVMIP,
+					targetVMPort, numberOfRequestsToSend, numberOfRequestsToSend, egressIPSet)
 			}
 		})
 
@@ -645,8 +538,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 			// For this test, get a single EgressIP per node.
 			g.By("Getting a map of source nodes and potential Egress IPs for these nodes")
 			egressIPsPerNode := 1
-			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType, egressIPsPerNode,
-				egressIPNodesNames...)
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, cloudType,
+				[]string{targetVMIP}, egressIPsPerNode, egressIPNodesNames...)
 			framework.Logf("%v", nodeEgressIPMap)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -665,12 +558,12 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 
+			g.By("Setting number of requests to send")
 			numberOfRequestsToSend := 10
-			if targetHost == "self" {
-				targetHost = routeName
-			}
-			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
-			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
+			g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests "+
+				"with EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
+			spawnProberSendEgressIPTrafficCheckOutput(oc, proberPodNamespace, probePodName, routeName, targetVMIP,
+				targetVMPort, numberOfRequestsToSend, numberOfRequestsToSend, egressIPSet)
 		})
 	}) // end testing to external targets
 })
@@ -682,22 +575,24 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:config.openshift.io
 // use and that can serve as readymade drop-in replacements for larger chunks of code.
 //
 
-// spawnProberSendEgressIPTrafficCheckLogs is a wrapper function to reduce code duplication when probing for EgressIPs.
-// Unfortunately, it can take a bit of time for EgressIPs to become active, so spawnProberSendEgressIPTrafficCheckLogs adds a 15 second retry
-// mechanism which eventually must observe an EgressIP in the logs before running the actual test.
-// It launches a new prober pod and sends <iterations> of requests with a unique search string. It then makes sure that <expectedHits> number
-// of hits were seen.
-func spawnProberSendEgressIPTrafficCheckLogs(
-	oc *exutil.CLI, externalNamespace, probePodName, routeName, targetProtocol, targetHost string, targetPort, iterations, expectedHits int, packetSnifferDaemonSet *v1.DaemonSet, egressIPSet map[string]string) {
+// spawnProberSendEgressIPTrafficCheckOutput is a wrapper function to reduce code duplication when probing for EgressIPs.
+// It launches a new prober pod and sends <iterations> of requests. It then makes sure that <expectedHits> number
+// of hits were seen. It then destroys the prober pod.
+func spawnProberSendEgressIPTrafficCheckOutput(oc *exutil.CLI, externalNamespace, probePodName, routeName,
+	targetHost string, targetPort, iterations, expectedHits int, egressIPSet map[string]string) {
 
 	framework.Logf("Launching a new prober pod")
 	proberPod := createProberPod(oc, externalNamespace, probePodName)
 
-	// Unfortunately, even after we created the EgressIP object and the CloudPrivateIPConfig, it can take some time before everything is applied correctly.
-	// Retry this test every 30 seconds for up to 2 minutes to give the cluster time to converge - eventually, this test should pass.
+	// Unfortunately, even after we created the EgressIP object and the CloudPrivateIPConfig, it can take some time
+	// before everything is applied correctly. Retry this test every 30 seconds for up to 2 minutes to give the cluster
+	// time to converge - eventually, this test should pass.
 	o.Eventually(func() bool {
-		framework.Logf("Verifying that the expected number of EgressIP outbound requests can be seen in the packet sniffer logs")
-		result, err := sendEgressIPProbesAndCheckPacketSnifferLogs(oc, proberPod, routeName, targetProtocol, targetHost, targetPort, iterations, expectedHits, packetSnifferDaemonSet, egressIPSet, 10)
+		framework.Logf("Verifying that the expected number of outbound requests match EgressIPs")
+		result, err := sendEgressIPProbesAndCheckOutput(oc, proberPod, routeName, targetHost, targetPort, iterations, expectedHits, egressIPSet)
+		if err != nil {
+			framework.Logf("Received error from sendEgressIPProbesAndCheckOutput, err: %q", err)
+		}
 		return err == nil && result
 	}, 120*time.Second, 30*time.Second).Should(o.BeTrue())
 
@@ -706,8 +601,7 @@ func spawnProberSendEgressIPTrafficCheckLogs(
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 
-// ovnKubernetesCreateEgressIPObject creates the file containing the EgressIP YAML definition which can
-// then be applied.
+// ovnKubernetesCreateEgressIPObject creates the file containing the EgressIP YAML definition which can then be applied.
 func ovnKubernetesCreateEgressIPObject(oc *exutil.CLI, egressIPYamlPath, egressIPObjectName, egressIPNamespace, podSelector string, egressIPSet map[string]string) string {
 	framework.Logf("Marshalling the desired EgressIPs into a string")
 	var egressIPs []string
@@ -754,7 +648,7 @@ func applyEgressIPObject(oc *exutil.CLI, cloudNetworkClientset cloudnetwork.Inte
 	var isAssigned bool
 	o.Eventually(func() bool {
 		for eip := range egressIPSet {
-			exists, isAssigned, err = cloudPrivateIpConfigExists(oc, cloudNetworkClientset, eip)
+			exists, isAssigned, err = cloudPrivateIPConfigExists(oc, cloudNetworkClientset, eip)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			if !exists {
 				framework.Logf("CloudPrivateIPConfig for %s not found.", eip)
@@ -793,7 +687,7 @@ func waitForCloudPrivateIPConfigsDeletion(oc *exutil.CLI, cloudNetworkClientset 
 
 	o.Eventually(func() bool {
 		for eip := range egressIPSet {
-			exists, _, err = cloudPrivateIpConfigExists(oc, cloudNetworkClientset, eip)
+			exists, _, err = cloudPrivateIPConfigExists(oc, cloudNetworkClientset, eip)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			if exists {
 				framework.Logf("CloudPrivateIPConfig for %s found.", eip)
@@ -822,7 +716,7 @@ func openshiftSDNAssignEgressIPsManually(oc *exutil.CLI, cloudNetworkClientset c
 	var isAssigned bool
 	o.Eventually(func() bool {
 		for eip := range egressIPSet {
-			exists, isAssigned, err = cloudPrivateIpConfigExists(oc, cloudNetworkClientset, eip)
+			exists, isAssigned, err = cloudPrivateIPConfigExists(oc, cloudNetworkClientset, eip)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			if !exists {
 				framework.Logf("CloudPrivateIPConfig for %s not found.", eip)
@@ -836,4 +730,71 @@ func openshiftSDNAssignEgressIPsManually(oc *exutil.CLI, cloudNetworkClientset c
 		framework.Logf("CloudPrivateIPConfigs for %v found.", egressIPSet)
 		return true
 	}, time.Duration(timeout)*time.Second, 5*time.Second).Should(o.BeTrue())
+}
+
+// setupExternalTarget sets up the external target. In order to do so, it creates an additional Virtual Machine
+// outside of the current OpenShift cluster using OpenShift's cloud credentials.
+// If targetHostRequestPublicIP is true then we request a public DNAT, open SSH globally and print the public and
+// private key to the console to make debugging easier.
+func setupExternalTarget(oc *exutil.CLI, cc cloudClient, name string, listenPort int) (*vm, error) {
+	g.By("Generating listenPorts for the target VM")
+	listenPorts := map[string]protocolPort{applicationPort: {port: listenPort, protocol: tcp}}
+	if targetHostRequestPublicIP {
+		listenPorts[sshPort] = protocolPort{port: 22, protocol: tcp}
+	}
+
+	g.By("Building startup script parameters for the VM")
+	parameters := map[string]string{
+		"agnhost":    agnhostImage,
+		"listenPort": strconv.Itoa(listenPort),
+	}
+
+	g.By("Generating the SSH key for the target VM")
+	sshPublicKey, sshPrivateKey, err := generateSSHKeyPair()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	// Only print the SSH key contents if we request a public IP address for debugging.
+	if targetHostRequestPublicIP {
+		framework.Logf("Private key:\n%s", sshPrivateKey)
+		framework.Logf("Public key:\n%s", sshPublicKey)
+	}
+
+	g.By(fmt.Sprintf("Creating target VM %s", name))
+	v := &vm{
+		name:                    name,
+		ports:                   listenPorts,
+		sshPrivateKey:           sshPrivateKey,
+		sshPublicKey:            sshPublicKey,
+		startupScript:           targetHostStartupScript,
+		startupScriptParameters: parameters,
+	}
+	err = cc.createVM(v, targetHostRequestPublicIP)
+	return v, err
+}
+
+// tearDownExternalTarget cleans up all resources that were created for the external target.
+func tearDownExternalTarget(oc *exutil.CLI, cc cloudClient, vm *vm) {
+	if vm == nil {
+		framework.Logf("No VM created, nothing to do")
+		return
+	}
+	err := retry.OnError(
+		wait.Backoff{
+			Steps:    5,
+			Duration: time.Minute,
+			Factor:   1.0,
+			Jitter:   0.1,
+		},
+		func(err error) bool {
+			return false
+		},
+		func() error {
+			err := cc.deleteVM(vm)
+			if err != nil {
+				framework.Logf("could not delete VM %s, err: %q", vm.name, err)
+			}
+			return err
+		})
+	if err != nil {
+		framework.Logf("Teardown of target failed with error: %q", err)
+	}
 }

--- a/test/extended/networking/egressip_cloud_clients.go
+++ b/test/extended/networking/egressip_cloud_clients.go
@@ -1,0 +1,132 @@
+package networking
+
+import (
+	"context"
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"golang.org/x/crypto/ssh"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	userAgent       = "e2e-cloud-network-config-controller"
+	applicationPort = "ApplicationPort"
+	sshPort         = "SSH"
+	tcp             = "tcp"
+	udp             = "udp"
+	secretNamespace = "openshift-cloud-network-config-controller"
+	secretName      = "cloud-credentials"
+)
+
+type cloudClient interface {
+	initCloudSecret() error
+	createVM(vm *vm, requestPublicIP bool) error
+	deleteVM(*vm) error
+	io.Closer
+}
+
+func newCloudClient(oc *exutil.CLI, platform configv1.PlatformType) (cloudClient, error) {
+	switch platform {
+	case configv1.GCPPlatformType:
+		return newGCPCloudClient(oc)
+	case configv1.AzurePlatformType:
+		return newAzureCloudClient(oc)
+	case configv1.AWSPlatformType:
+		return newAWSCloudClient(oc)
+	}
+	return nil, fmt.Errorf("Invalid platform. Cannot create CloudClient for %q", platform)
+}
+
+type vm struct {
+	name                    string
+	id                      string
+	privateIP               net.IP
+	publicIP                net.IP
+	ports                   map[string]protocolPort
+	sshPrivateKey           string
+	sshPublicKey            string
+	startupScript           string
+	startupScriptParameters map[string]string
+	securityGroupID         string // Specifically for AWS.
+	keyPairID               string // Specifially for AWS.
+	publicIPID              string // Specifically for AWS.
+}
+
+type protocolPort struct {
+	protocol string
+	port     int
+}
+
+// readCloudSecret reads the cloud credentials from the provided secret.
+func readCloudSecret(oc *exutil.CLI, secretNamespace, secretName string) (map[string][]byte, error) {
+	client := oc.AsAdmin().KubeFramework().ClientSet
+	secret, err := client.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error reading secret %s/%s, err: %q", secretNamespace, secretName, err)
+	}
+	return secret.Data, nil
+
+}
+
+// getWorkerProviderID returns the providerID of one of the worker nodes. This ID can then be used to extract further
+// details about that node, such as the network that it resides on.
+func getWorkerProviderID(oc *exutil.CLI) (string, error) {
+	listOptions := metav1.ListOptions{
+		LabelSelector: "node-role.kubernetes.io/worker=",
+		Limit:         1,
+	}
+	nodes, err := oc.KubeClient().CoreV1().Nodes().List(context.TODO(), listOptions)
+	if err != nil {
+		return "", err
+	}
+	if len(nodes.Items) != 1 {
+		return "", fmt.Errorf("expected to retrieve a single worker node, retrieved %d instead", len(nodes.Items))
+	}
+	node := nodes.Items[0]
+	return node.Spec.ProviderID, nil
+}
+
+// generateSSHKeyPair generates an SSH keypair. It returns the private/public keys as strings or error.
+// Directly taken from https://stackoverflow.com/questions/21151714/go-generate-an-ssh-public-key
+func generateSSHKeyPair() (string, string, error) {
+	privateKey, err := rsa.GenerateKey(crand.Reader, 1024)
+	if err != nil {
+		return "", "", err
+	}
+
+	// generate and write private key as PEM
+	var privKeyBuf strings.Builder
+
+	privateKeyPEM := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
+	if err := pem.Encode(&privKeyBuf, privateKeyPEM); err != nil {
+		return "", "", err
+	}
+
+	// generate and write public key
+	pub, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	var pubKeyBuf strings.Builder
+	pubKeyBuf.Write(ssh.MarshalAuthorizedKey(pub))
+
+	return pubKeyBuf.String(), privKeyBuf.String(), nil
+}
+
+// printp takes a text and a map of key/value pairs. {{key}} will be replaced with value.
+func printp(text string, parameters map[string]string) string {
+	for key, value := range parameters {
+		text = strings.Replace(text, fmt.Sprintf("{{%s}}", key), value, -1)
+	}
+	return text
+}

--- a/test/extended/networking/egressip_cloud_clients_aws.go
+++ b/test/extended/networking/egressip_cloud_clients_aws.go
@@ -1,0 +1,661 @@
+package networking
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/google/uuid"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	awsImageName                       = "RHEL-8"
+	awsCustomSecGroupSourceRange       = "10.0.0.0/8"
+	awsDefaultApplicationPort          = 30000
+	awsInstanceStartupDone             = "aws-instance-startup-done-marker"
+	awsVMUser                          = "ec2-user"
+	openshiftCloudCredentialOperatorNS = "openshift-cloud-credential-operator"
+	awsCredentialsRequestTemplate      = `apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  annotations:
+  name: %[2]s
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - ec2:CreateSecurityGroup
+      - ec2:DeleteSecurityGroup
+      - ec2:AuthorizeSecurityGroupIngress
+      - ec2:ImportKeyPair
+      - ec2:DeleteKeyPair
+      - ec2:CreateTags
+      - ec2:DescribeAvailabilityZones
+      - ec2:DescribeDhcpOptions
+      - ec2:DescribeImages
+      - ec2:DescribeInstances
+      - ec2:DescribeInstanceTypes
+      - ec2:DescribeInternetGateways
+      - ec2:DescribeSecurityGroups
+      - ec2:DescribeRegions
+      - ec2:DescribeSubnets
+      - ec2:DescribeVpcs
+      - ec2:RunInstances
+      - ec2:TerminateInstances
+      - ec2:AllocateAddress
+      - ec2:AssociateAddress
+      - ec2:ReleaseAddress
+      - ec2:GetConsoleOutput
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: %[2]s
+    namespace: %[1]s`
+)
+
+var (
+	// awsOperationTimeout is the maximum duration for select operations that take a long time such as initCloudSecret
+	// and createVM.
+	awsOperationTimeout = time.Minute * 10
+)
+
+// awsCloudClient implements interface cloudClient for AWS.
+type awsCloudClient struct {
+	oc              *exutil.CLI
+	ctx             context.Context
+	client          *ec2.EC2
+	region          string
+	instance        *ec2.Instance
+	secretNamespace string
+	secretName      string
+}
+
+// newAWSCloudClient initializes and returns a new awsCloudClient. It will also create a new namespace and secret
+// to hold AWS cloud credentials. The name of both the namespace and the secret will be "e2e-egressip-" + random UUID.
+// In case of an error, this will always return an object of type awsCloudClient and never nil. This is to avoid nil
+// pointer references during teardown.
+func newAWSCloudClient(oc *exutil.CLI) (*awsCloudClient, error) {
+	identifier := fmt.Sprintf("e2e-egressip-%s", uuid.New())
+	client := &awsCloudClient{
+		oc:              oc,
+		ctx:             context.Background(),
+		secretNamespace: identifier,
+		secretName:      identifier,
+	}
+
+	// Initialize the ec2.EC2 client client.client.
+	err := client.initCloudSecret()
+	if err != nil {
+		return client, err
+	}
+
+	// Set client.instance to the EC2 Instance for the first worker node that we can find. It does not matter which
+	// worker node we get, as we are interested in generic info such as the network/subnet or the security groups.
+	// Retry on Error as we might get "AuthFailure" - AWS sometimes takes a while to accept the new credentials even
+	// though all resources on the OCP side were created correctly.
+	err = retry.OnError(
+		wait.Backoff{
+			Steps:    10,
+			Duration: time.Second,
+			Factor:   2.0,
+			Jitter:   0.1,
+		},
+		// Retry on "AuthFailure" and "UnauthorizedOperation" only.
+		func(err error) bool {
+			ae, ok := err.(awserr.Error)
+			if !ok {
+				return false
+			}
+			if ae.Code() == "AuthFailure" {
+				framework.Logf("Received auth failure, backing off and trying again")
+				return true
+			}
+			if ae.Code() == "UnauthorizedOperation" {
+				framework.Logf("Received UnauthorizedOperation failure, backing off and trying again")
+				return true
+			}
+			return false
+		},
+		func() error {
+			instance, err := client.getInstance()
+			if err != nil {
+				return err
+			}
+			client.instance = instance
+			return nil
+		})
+	return client, err
+}
+
+// initCloudSecret creates a CredentialsRequest in a.secretNamespace, then reads the AWS cloud secret that was created
+// and initialiazes a.client with it. initCloudSecret must finish before awsOperationTimeout is up.
+func (a *awsCloudClient) initCloudSecret() error {
+	ctx, cancel := context.WithTimeout(a.ctx, awsOperationTimeout)
+	defer cancel()
+
+	framework.Logf("Creating CredentialsRequest with the permissions that are needed")
+	err := a.createCredentialsRequest()
+	if err != nil {
+		return err
+	}
+	framework.Logf("Reading cloud secret %s/%s", a.secretNamespace, a.secretName)
+	data, err := readCloudSecret(a.oc, a.secretNamespace, a.secretName)
+	if err != nil {
+		return err
+	}
+	for _, key := range []string{"aws_access_key_id", "aws_secret_access_key"} {
+		if _, ok := data[key]; !ok {
+			return fmt.Errorf("could not find required key %s in cloud secret", key)
+		}
+	}
+
+	framework.Logf("Getting region")
+	region, err := a.getRegion()
+	if err != nil {
+		return err
+	}
+	a.region = region
+
+	framework.Logf("Initializing cloud credentials")
+	c, err := awsInitCredentials(ctx, string(data["aws_access_key_id"]), string(data["aws_secret_access_key"]),
+		a.region)
+	if err != nil {
+		return err
+	}
+	a.client = c
+	return nil
+}
+
+// getRegion reads the AWS region from the Infrastructure CR named "cluster".
+func (a *awsCloudClient) getRegion() (string, error) {
+	infra, err := a.oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster",
+		metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return infra.Status.PlatformStatus.AWS.Region, nil
+}
+
+// getInstance returns the EC2 Instance for the first worker node that it can find. It does not matter which
+// worker node we get, as we are interested in generic info such as the network/subnet or the security groups.
+func (a *awsCloudClient) getInstance() (*ec2.Instance, error) {
+	providerID, err := getWorkerProviderID(a.oc.AsAdmin())
+	if err != nil {
+		return nil, err
+	}
+	splitProviderID := strings.Split(strings.TrimPrefix(providerID, "aws://"), "/")
+	if len(splitProviderID) > 3 {
+		return nil, fmt.Errorf("could not parse providerID %s", providerID)
+	}
+	instanceID := splitProviderID[len(splitProviderID)-1]
+	if instanceID == "" {
+		return nil, fmt.Errorf("could not parse providerID %s", providerID)
+	}
+
+	input := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{aws.String(instanceID)},
+	}
+	result, err := a.client.DescribeInstances(input)
+	if err != nil {
+		// Do never rewrite this error with fmt.Errorf or it will break the retry in newAWSCloudClient.
+		return nil, err
+	}
+	instances := []*ec2.Instance{}
+	for _, reservation := range result.Reservations {
+		instances = append(instances, reservation.Instances...)
+	}
+	if len(instances) != 1 {
+		return nil, fmt.Errorf("found conflicting instance replicas for %s, instances: %v", instanceID, instances)
+	}
+	return instances[0], nil
+}
+
+// createVM implements the cloudClient interface method of the same name. It is responsible for creating a SecurityGroup,
+// Public IP, Instance and for running the startup script. createVM must finish before awsOperationTimeout is up.
+func (a *awsCloudClient) createVM(vm *vm, requestPublicIP bool) error {
+	ctx, cancel := context.WithTimeout(a.ctx, awsOperationTimeout)
+	defer cancel()
+
+	// Create a securityGroup if needed - port 30000 is always open for worker nodes. Therefore, in such a case, skip
+	// securityGroup creation if only 30000 shall be opened.
+	var err error
+	var securityGroupIDs []*string
+	for _, g := range a.instance.SecurityGroups {
+		if g.GroupId != nil {
+			securityGroupIDs = append(securityGroupIDs, g.GroupId)
+		}
+	}
+	if len(vm.ports) > 0 {
+		p, ok := vm.ports[applicationPort]
+		if len(vm.ports) > 1 || !ok || p.protocol != tcp || p.port != awsDefaultApplicationPort {
+			framework.Logf("Spawning security group for VM %s", vm.name)
+			g, err := a.createSecurityGroup(vm, requestPublicIP)
+			if err != nil {
+				return err
+			}
+			securityGroupIDs = []*string{&g}
+			vm.securityGroupID = g
+		}
+	}
+
+	framework.Logf("Spawning instance for VM %s", vm.name)
+	instance, err := a.createInstance(ctx, vm, securityGroupIDs)
+	if err != nil {
+		return err
+	}
+	framework.Logf("Getting the instance ID")
+	if instance.InstanceId == nil || *instance.InstanceId == "" {
+		return fmt.Errorf("could not get VM %s instanceID", vm.name)
+	}
+	vm.id = *instance.InstanceId
+
+	framework.Logf("Getting the instance's private IP addresses")
+	interfaces := instance.NetworkInterfaces
+	var privateIP *string
+	var interfaceID *string
+	for _, intf := range interfaces {
+		interfaceID = intf.NetworkInterfaceId
+		privateIP = intf.PrivateIpAddress
+		break
+	}
+	if privateIP != nil {
+		vm.privateIP = net.ParseIP(*privateIP)
+	}
+	if vm.privateIP == nil {
+		return fmt.Errorf("could not get VM %s privateIP", vm.name)
+	}
+
+	if requestPublicIP {
+		framework.Logf("Creating an ElasticIP (publicIP)")
+		allocateInput := &ec2.AllocateAddressInput{
+			Domain: a.instance.VpcId,
+			TagSpecifications: []*ec2.TagSpecification{
+				{
+					ResourceType: aws.String("elastic-ip"),
+					Tags: []*ec2.Tag{
+						{
+							Key:   pointer.String("Name"),
+							Value: &vm.name,
+						},
+					},
+				},
+			},
+		}
+		allocateOutput, err := a.client.AllocateAddress(allocateInput)
+		if err != nil {
+			return fmt.Errorf("could not create ElasticIP, err: %q", err)
+		}
+		vm.publicIPID = *allocateOutput.AllocationId
+
+		framework.Logf("Associating ElasticIP to instance")
+		associateAddressInput := &ec2.AssociateAddressInput{
+			InstanceId:         instance.InstanceId,
+			NetworkInterfaceId: interfaceID,
+			PrivateIpAddress:   privateIP,
+			AllocationId:       allocateOutput.AllocationId,
+		}
+		_, err = a.client.AssociateAddress(associateAddressInput)
+		if err != nil {
+			return fmt.Errorf("could not associate ElasticIP address, err: %q", err)
+		}
+		vm.publicIP = net.ParseIP(*allocateOutput.PublicIp)
+	}
+
+	return nil
+}
+
+// deleteVM implements the cloudClient interface method of the same name. It is responsible for tearing down all
+// resources that were created during the createVM stage.
+func (a *awsCloudClient) deleteVM(vm *vm) error {
+	framework.Logf("Deleting VM %s with ID %s", vm.name, vm.id)
+	if vm.id == "" {
+		return fmt.Errorf("could not delete VM %q, invalid instanceId %q", vm.name, vm.id)
+	}
+	_, err := a.client.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: []*string{&vm.id}})
+	if err == nil {
+		framework.Logf("Waiting until VM %s instance %s is terminated", vm.name, vm.id)
+		descInstancesInput := &ec2.DescribeInstancesInput{InstanceIds: []*string{&vm.id}}
+		err = a.client.WaitUntilInstanceTerminated(descInstancesInput)
+		if err != nil {
+			return fmt.Errorf("error while waiting until instance terminated, err: %q", err)
+		}
+	} else if parseAWSDeleteError(err) != nil {
+		return err
+	}
+
+	if vm.publicIP != nil {
+		framework.Logf("Releasing the ElasticIP for VM %s", vm.name)
+		releaseAddressInput := &ec2.ReleaseAddressInput{
+			AllocationId: &vm.publicIPID,
+		}
+		_, err := a.client.ReleaseAddress(releaseAddressInput)
+		if parseAWSDeleteError(err) != nil {
+			return fmt.Errorf("could not release ElasticIP, err: %q", err)
+		}
+	}
+
+	if vm.securityGroupID != "" {
+		framework.Logf("Deleting security group for VM %s", vm.name)
+		deleteSecGroupInput := &ec2.DeleteSecurityGroupInput{
+			GroupId: &vm.securityGroupID,
+		}
+		_, err = a.client.DeleteSecurityGroup(deleteSecGroupInput)
+		if parseAWSDeleteError(err) != nil {
+			return fmt.Errorf("could not delete security group, err: %q", err)
+		}
+	}
+
+	framework.Logf("Deleting KeyPair VM %s with ID %s", vm.name, vm.keyPairID)
+	deleteKeyPairInput := &ec2.DeleteKeyPairInput{
+		KeyPairId: &vm.keyPairID,
+	}
+	_, err = a.client.DeleteKeyPair(deleteKeyPairInput)
+	if parseAWSDeleteError(err) != nil {
+		return fmt.Errorf("could not delete keypair, err: %q", err)
+	}
+	return nil
+}
+
+// Close implements the cloudClient interface and io.Closer interface method of the same name. In AWS,
+// this cleans up the CloudCredentialsRequest and corresponding namespace that were created during initialization.
+func (a *awsCloudClient) Close() error {
+	framework.Logf("Closing awsCloudClient for %s/%s", a.secretNamespace, a.secretName)
+	err := a.deleteCredentialsRequest()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createCredentialsRequest creates a CredentialsRequest on AWS. The CredentialsRequest will create a cloud secret
+// that we can then use to talk to AWS with the necessary permissions. Contrary to the other big cloud platforms,
+// existing secrets are fairly limited in scope for AWS. Given that we need some very specific permissions to list
+// images, create security groups, and so on, we must create our own CredentialsRequest. If you want to see what we
+// are requesting, see constant awsCredentialsRequestTemplate.
+func (a *awsCloudClient) createCredentialsRequest() error {
+	framework.Logf("Creating namespace %s", a.secretNamespace)
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: a.secretNamespace,
+		},
+	}
+	_, err := a.oc.AsAdmin().KubeClient().CoreV1().Namespaces().Create(a.ctx, ns, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Creating temporary file to store CredentialsRequest")
+	credentialsRequest := fmt.Sprintf(awsCredentialsRequestTemplate, a.secretNamespace, a.secretName)
+	f, err := os.CreateTemp("", a.secretName)
+	if err != nil {
+		return fmt.Errorf("could not create tempfile, err: %q", err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	if _, err := f.Write([]byte(credentialsRequest)); err != nil {
+		return fmt.Errorf("could not write to file %s, err: %q", f.Name(), err)
+	}
+
+	framework.Logf("Applying CredentialsRequest at path %s", f.Name())
+	out, err := a.oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", f.Name()).Output()
+	if err != nil {
+		return fmt.Errorf("could not apply CredentialsRequest, out: %q, err: %q", out, err)
+	}
+
+	framework.Logf("Waiting for credentials Secret %s/%s to be created", a.secretNamespace, a.secretName)
+	return retry.OnError(
+		wait.Backoff{
+			Steps:    5,
+			Duration: time.Second,
+			Factor:   2.0,
+			Jitter:   0.1,
+		},
+		func(err error) bool {
+			if errors.IsNotFound(err) {
+				framework.Logf("Secret %s/%s not yet created, retrying", a.secretNamespace, a.secretName)
+				return true
+			}
+			return false
+		},
+		func() error {
+			_, err := a.oc.AsAdmin().KubeClient().CoreV1().Secrets(a.secretNamespace).Get(a.ctx, a.secretName,
+				metav1.GetOptions{})
+			return err
+		})
+}
+
+// deleteCredentialsRequest deletes the CredentialsRequest and namespace which were created during initialization.
+func (a *awsCloudClient) deleteCredentialsRequest() error {
+	framework.Logf("Deleting Credentials Request %q", a.secretName)
+	out, err := a.oc.AsAdmin().WithoutNamespace().Run("delete").
+		Args("CredentialsRequest", "-n", openshiftCloudCredentialOperatorNS, a.secretName).Output()
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("could not delete CredentialsRequest, out: %q, err: %q", out, err)
+	}
+
+	framework.Logf("Deleting namespace %s", a.secretNamespace)
+	err = a.oc.AsAdmin().KubeClient().CoreV1().Namespaces().Delete(a.ctx, a.secretNamespace, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("could not delete namespace %s, err: %q", a.secretNamespace, err)
+	}
+	return nil
+}
+
+// createInstance creates the AWS instance for the target host. The instance will run a startup script. After the
+// script terminates, we echo string awsInstanceStartupDone to /dev/ttyS0. We constantly monitor the console log for
+// the presence of this string. As soon as the string was found, we know that the startup script ran to completion.
+func (a *awsCloudClient) createInstance(ctx context.Context, vm *vm, securityGroupIDs []*string) (*ec2.Instance, error) {
+	framework.Logf("Importing SSH keypair")
+	importKeyPairInput := &ec2.ImportKeyPairInput{
+		KeyName:           aws.String(vm.name),
+		PublicKeyMaterial: []byte(vm.sshPublicKey),
+	}
+	importKeyPairOutput, err := a.client.ImportKeyPair(importKeyPairInput)
+	if err != nil {
+		return nil, fmt.Errorf("could not create keypair for VM %s, err: %q", vm.name, err)
+	}
+	vm.keyPairID = *importKeyPairOutput.KeyPairId
+
+	framework.Logf("Getting %s image ID", awsImageName)
+	imageID, err := a.getImageID()
+	if err != nil {
+		return nil, err
+	}
+	framework.Logf("Found image ID %s", imageID)
+
+	framework.Logf("Creating instance for VM %s", vm.name)
+	startupScript := fmt.Sprintf("%s\necho \"%s\" > /dev/ttyS0\n",
+		printp(vm.startupScript, vm.startupScriptParameters),
+		awsInstanceStartupDone,
+	)
+	input := &ec2.RunInstancesInput{
+		ImageId:          &imageID,
+		InstanceType:     a.instance.InstanceType,
+		MinCount:         aws.Int64(1),
+		MaxCount:         aws.Int64(1),
+		SubnetId:         a.instance.SubnetId,
+		SecurityGroupIds: securityGroupIDs,
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("instance"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   pointer.String("Name"),
+						Value: &vm.name,
+					},
+				},
+			},
+		},
+		UserData: aws.String(base64.StdEncoding.EncodeToString([]byte(startupScript))),
+		KeyName:  &vm.name,
+	}
+	framework.Logf("AWS RunInstances input: %v", *input)
+	reservation, err := a.client.RunInstances(input)
+	if err != nil {
+		return nil, err
+	}
+	instance := reservation.Instances[0]
+
+	framework.Logf("Waiting until VM %s instance %s is running", vm.name, *instance.InstanceId)
+	descInstancesInput := &ec2.DescribeInstancesInput{InstanceIds: []*string{instance.InstanceId}}
+	err = a.client.WaitUntilInstanceRunning(descInstancesInput)
+	if err != nil {
+		return instance, fmt.Errorf("error while waiting until instance running, err: %q", err)
+	}
+
+	framework.Logf("Waiting until user-data script is done running")
+	counter := 0
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+outer:
+	for {
+		select {
+		case <-ctx.Done():
+			return instance, fmt.Errorf("startup script never finished or never posted status to console for VM %s",
+				vm.name)
+		case <-ticker.C:
+			counter++
+			framework.Logf("Reading serial port output of VM %s", vm.name)
+			gi := &ec2.GetConsoleOutputInput{InstanceId: instance.InstanceId, Latest: aws.Bool(true)}
+			output, err := a.client.GetConsoleOutput(gi)
+			if err != nil {
+				return instance, err
+			}
+			consoleOut, err := base64.StdEncoding.DecodeString(aws.StringValue(output.Output))
+			if err != nil {
+				framework.Logf("Could not decode VM %s console logs, err:\n%q", vm.name, err)
+				continue
+			}
+			if strings.Contains(string(consoleOut), awsInstanceStartupDone) {
+				framework.Logf("Found string %s in VM %s logs", awsInstanceStartupDone, vm.name)
+				break outer
+			}
+			framework.Logf("Could not find string %s in VM %s console logs", awsInstanceStartupDone, vm.name)
+			if counter%10 == 0 {
+				framework.Logf("Console logs are:\n%s", string(consoleOut))
+			}
+		}
+	}
+	return instance, nil
+}
+
+// getImageID gets the latest image (by creation date) that matches string awsImageName.
+func (a *awsCloudClient) getImageID() (string, error) {
+	imageName := fmt.Sprintf("%s*", awsImageName)
+	describeImagesInput := &ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			{Name: aws.String("name"), Values: []*string{&imageName}},
+			{Name: aws.String("owner-alias"), Values: []*string{aws.String("amazon")}},
+		}}
+	describeImagesOutput, err := a.client.DescribeImages(describeImagesInput)
+	if err != nil {
+		return "", fmt.Errorf("could not find %s image, err: %q", awsImageName, err)
+	}
+	images := describeImagesOutput.Images
+	if len(images) == 0 {
+		return "", fmt.Errorf("could not find any valid cloud images for %s", awsImageName)
+	}
+	sort.Slice(images, func(i, j int) bool {
+		return *images[i].CreationDate > *images[j].CreationDate
+	})
+
+	return *images[0].ImageId, nil
+}
+
+// createSecurityGroup creates an AWS security group for the VM.
+func (a *awsCloudClient) createSecurityGroup(vm *vm, requestPublicIP bool) (string, error) {
+	framework.Logf("Creating security group for VM %s", vm.name)
+	secGroupInput := &ec2.CreateSecurityGroupInput{
+		Description: &vm.name,
+		GroupName:   &vm.name,
+		VpcId:       a.instance.VpcId,
+	}
+	secGroupOutput, err := a.client.CreateSecurityGroup(secGroupInput)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "InvalidVpcID.NotFound":
+				return "", fmt.Errorf("unable to find VPC with ID %q", *secGroupInput.VpcId)
+			case "InvalidGroup.Duplicate":
+				return "", fmt.Errorf("security group %q already exists", *secGroupInput.GroupName)
+			}
+		}
+		return "", fmt.Errorf("could not create security group %s, err: %q", vm.name, err)
+	}
+
+	framework.Logf("Creating security group ingress for security group %s for vm %s", *secGroupOutput.GroupId, vm.name)
+	var perms []*ec2.IpPermission
+	for portName, pp := range vm.ports {
+		sourceRange := awsCustomSecGroupSourceRange
+		// In the case of SSH, we open this globally to allow debugging.
+		if portName == sshPort && requestPublicIP {
+			sourceRange = "0.0.0.0/0"
+		}
+		perms = append(perms, &ec2.IpPermission{
+			FromPort:   aws.Int64(int64(pp.port)),
+			IpProtocol: aws.String(strings.ToLower(pp.protocol)),
+			IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(sourceRange)}},
+			ToPort:     aws.Int64(int64(pp.port)),
+		})
+	}
+	_, err = a.client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:       secGroupOutput.GroupId,
+		IpPermissions: perms,
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not authorize security group ingress for security group %s (VM %s), err: %q",
+			*secGroupOutput.GroupId, vm.name, err)
+	}
+	return *secGroupOutput.GroupId, nil
+}
+
+// awsInitCredentials initializes a session to AWS with the provided keys and region.
+func awsInitCredentials(ctx context.Context, accessKeyID, secretAccessKey, region string) (*ec2.EC2, error) {
+	creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+	sessionOpts := session.Options{
+		Config: aws.Config{
+			Region:                        &region,
+			CredentialsChainVerboseErrors: pointer.Bool(true),
+			Credentials:                   creds,
+		},
+	}
+	mySession, err := session.NewSessionWithOptions(sessionOpts)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize AWS session: %w", err)
+	}
+	return ec2.New(mySession), nil
+}
+
+// parseAWSDeleteError returns nil if the provided err is of type not found. Otherwise, it returns err as is.
+func parseAWSDeleteError(err error) error {
+	if ae, ok := err.(awserr.Error); ok {
+		if ae.Code() == "NotFound" {
+			return nil
+		}
+	}
+	return err
+}

--- a/test/extended/networking/egressip_cloud_clients_azure.go
+++ b/test/extended/networking/egressip_cloud_clients_azure.go
@@ -1,0 +1,599 @@
+package networking
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/to"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	azureVMPublisher       = "RedHat"
+	azureVMOffer           = "RHEL"
+	azureVMSku             = "8-LVM"
+	azureVMVersion         = "latest"
+	azureVMSize            = "Standard_A2_v2"
+	azureVMUser            = "cloud-user"
+	azureVMAdminPassword   = "Ara$#hdei4"
+	azureVMDisablePassword = false
+	azureVMPublicKeyPath   = "/home/cloud-user/.ssh/authorized_keys"
+)
+
+var (
+	defaultAzureOperationTimeout = 10 * time.Second
+)
+
+type azureCloudClient struct {
+	oc                             *exutil.CLI
+	vmClient                       compute.VirtualMachinesClient
+	virtualNetworkClient           network.VirtualNetworksClient
+	networkClient                  network.InterfacesClient
+	ipClient                       network.PublicIPAddressesClient
+	securityGroupsClient           network.SecurityGroupsClient
+	interfacesClient               network.InterfacesClient
+	virtualMachineExtensionsClient compute.VirtualMachineExtensionsClient
+	env                            azure.Environment
+	resourceGroup                  string
+	ctx                            context.Context
+	location                       *string
+	subnet                         *network.Subnet
+}
+
+func newAzureCloudClient(oc *exutil.CLI) (*azureCloudClient, error) {
+	client := &azureCloudClient{oc: oc, ctx: context.TODO()}
+	err := client.initCloudSecret()
+	if err != nil {
+		return nil, err
+	}
+	// Extract location.
+	instance, err := client.getInstance()
+	if err != nil {
+		return nil, err
+	}
+	client.location = instance.Location
+
+	// Extract subnet.
+	principalInterface, err := client.getPrincipalInterface(instance)
+	if err != nil {
+		return nil, err
+	}
+	for _, ipConfiguration := range *principalInterface.IPConfigurations {
+		client.subnet = ipConfiguration.Subnet
+		break
+	}
+
+	return client, nil
+}
+
+func (a *azureCloudClient) initCloudSecret() error {
+	data, err := readCloudSecret(a.oc, secretNamespace, secretName)
+	if err != nil {
+		return err
+	}
+
+	fields := []string{"azure_client_id", "azure_client_secret", "azure_tenant_id", "azure_subscription_id",
+		"azure_resourcegroup"}
+	for _, f := range fields {
+		if _, ok := data[f]; !ok {
+			return fmt.Errorf("could not read %q from cloud secret", f)
+		}
+	}
+	clientID := string(data["azure_client_id"])
+	clientSecret := string(data["azure_client_secret"])
+	tenantID := string(data["azure_tenant_id"])
+	subscriptionID := string(data["azure_subscription_id"])
+	a.resourceGroup = string(data["azure_resourcegroup"])
+
+	// Pick the Azure "Environment", which is just a named set of API endpoints.
+	name := "AzurePublicCloud"
+	a.env, err = azure.EnvironmentFromName(name)
+	if err != nil {
+		return fmt.Errorf("failed to initialize Azure environment: %w", err)
+	}
+
+	authorizer, err := a.getAuthorizer(a.env, clientID, clientSecret, tenantID)
+	if err != nil {
+		return err
+	}
+
+	a.vmClient = compute.NewVirtualMachinesClientWithBaseURI(a.env.ResourceManagerEndpoint, subscriptionID)
+	a.vmClient.Authorizer = authorizer
+	err = a.vmClient.AddToUserAgent(userAgent)
+	if err != nil {
+		return err
+	}
+
+	a.networkClient = network.NewInterfacesClientWithBaseURI(a.env.ResourceManagerEndpoint, subscriptionID)
+	a.networkClient.Authorizer = authorizer
+	err = a.networkClient.AddToUserAgent(userAgent)
+	if err != nil {
+		return err
+	}
+
+	a.virtualNetworkClient = network.NewVirtualNetworksClientWithBaseURI(a.env.ResourceManagerEndpoint, subscriptionID)
+	a.virtualNetworkClient.Authorizer = authorizer
+	err = a.virtualNetworkClient.AddToUserAgent(userAgent)
+	if err != nil {
+		return err
+	}
+
+	a.ipClient = network.NewPublicIPAddressesClient(subscriptionID)
+	a.ipClient.Authorizer = authorizer
+	err = a.ipClient.AddToUserAgent(userAgent)
+	if err != nil {
+		return err
+	}
+
+	a.securityGroupsClient = network.NewSecurityGroupsClient(subscriptionID)
+	a.securityGroupsClient.Authorizer = authorizer
+	err = a.securityGroupsClient.AddToUserAgent(userAgent)
+	if err != nil {
+		return err
+	}
+
+	a.virtualMachineExtensionsClient = compute.NewVirtualMachineExtensionsClient(subscriptionID)
+	a.virtualMachineExtensionsClient.Authorizer = authorizer
+	err = a.virtualMachineExtensionsClient.AddToUserAgent(userAgent)
+	if err != nil {
+		return err
+	}
+
+	a.interfacesClient = network.NewInterfacesClient(subscriptionID)
+	a.interfacesClient.Authorizer = authorizer
+	err = a.interfacesClient.AddToUserAgent(userAgent)
+	return err
+}
+
+func azureSecurityGroupName(vmName string) string {
+	return fmt.Sprintf("%s-security-group", vmName)
+}
+
+func azurePublicIPName(vmName string) string {
+	return fmt.Sprintf("%s-public-ip", vmName)
+}
+
+func azureInterfaceName(vmName string) string {
+	return fmt.Sprintf("%s-interface", vmName)
+}
+
+func azureExtensionName(vmName string) string {
+	return fmt.Sprintf("%s-extension", vmName)
+}
+
+// createVM creates a VirtualMachine in Azure and sets the VM's privateIP and publicIP field after creation.
+// In Azure, we can create a custom security group for the port. However, that takes a bit longer and is more error
+// prone. For port 6443, we do not need any of this because the default security group already allows 6443 to the
+// subnet.
+func (a *azureCloudClient) createVM(vm *vm, requestPublicIP bool) error {
+	// Create a securityGroup if needed.
+	var err error
+	var securityGroup *network.SecurityGroup
+	if len(vm.ports) > 0 {
+		p, ok := vm.ports[applicationPort]
+		if len(vm.ports) > 2 || (ok && !(p.protocol == tcp && p.port == 6443)) {
+			securityGroupName := azureSecurityGroupName(vm.name)
+			framework.Logf("Creating security group %s for VM %s", securityGroupName, vm.name)
+			securityGroup, err = a.createSecurityGroup(securityGroupName, vm.ports)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	// Create a public IP address for IP address assignment if requested.
+	var createdPublicIP *network.PublicIPAddress
+	if requestPublicIP {
+		publicIPName := azurePublicIPName(vm.name)
+		framework.Logf("Creating public IP %s for VM %s", publicIPName, vm.name)
+		createdPublicIP, err = a.createPublicIP(publicIPName)
+		if err != nil {
+			return err
+		}
+	}
+	// Create a network interface from the provided principal interface.
+	interfaceName := azureInterfaceName(vm.name)
+	framework.Logf("Creating interface %s for VM %s", interfaceName, vm.name)
+	createdInterface, err := a.createNetworkInterface(createdPublicIP, securityGroup, interfaceName)
+	if err != nil {
+		return err
+	}
+	// Create a Virtual Machine.
+	framework.Logf("Creating VirtualMachine %s", vm.name)
+	err = a.createVirtualMachine(vm.name, vm.sshPublicKey, createdInterface)
+	if err != nil {
+		return err
+	}
+	// Create VirtualMachineExtension of type CustomScript to install podman and to run agnhost on VM.
+	virtualMachineExtensionName := azureExtensionName(vm.name)
+	framework.Logf("Creating VirtualMachine CustomScript extension %s for VM %s", virtualMachineExtensionName, vm.name)
+	script := printp(vm.startupScript, vm.startupScriptParameters)
+	err = a.createVirtualMachineExtension(vm.name, virtualMachineExtensionName, script)
+	if err != nil {
+		return err
+	}
+	// Read private IP information.
+	var retrievedPrivateIP *string
+	retrievedNetworkInterface, err := a.interfacesClient.Get(a.ctx, a.resourceGroup, interfaceName, "")
+	if err != nil {
+		return err
+	}
+	for _, ipConfiguration := range *retrievedNetworkInterface.IPConfigurations {
+		retrievedPrivateIP = ipConfiguration.PrivateIPAddress
+		break
+	}
+	if retrievedPrivateIP == nil {
+		return fmt.Errorf("invalid private IP address")
+	}
+	vm.privateIP = net.ParseIP(*retrievedPrivateIP)
+	// Read public IP information and wait for the public IP to be assigned if a public IP was requested.
+	if requestPublicIP {
+		framework.Logf("Retrieving updated public IP information for VM %s", vm.name)
+		if createdPublicIP.Name == nil {
+			return fmt.Errorf("create public IP name is nil")
+		}
+		retrievedPublicIPAddress, err := a.ipClient.Get(a.ctx, a.resourceGroup, *createdPublicIP.Name, "")
+		if err != nil {
+			return err
+		}
+		if retrievedPublicIPAddress.IPAddress == nil {
+			return fmt.Errorf("invalid public IP address")
+		}
+		// Set VM publicIP and privateIP.
+		vm.publicIP = net.ParseIP(*retrievedPublicIPAddress.IPAddress)
+	}
+	return nil
+}
+
+// deleteVM deletes the provided VM instance from Azure and tears down security groups, public IPs and ports.
+func (a *azureCloudClient) deleteVM(vm *vm) error {
+	// Delete a Virtual Machine.
+	framework.Logf("Deleting VirtualMachine %s", vm.name)
+	err := a.deleteVirtualMachine(vm.name)
+	if azureParseDeleteError(err) != nil {
+		return err
+	}
+	// Delete a network interface from the provided principal interface.
+	interfaceName := azureInterfaceName(vm.name)
+	framework.Logf("Deleting interface %s for VM %s", interfaceName, vm.name)
+	err = a.deleteNetworkInterface(interfaceName)
+	if azureParseDeleteError(err) != nil {
+		return err
+	}
+	// Delete a public IP address for IP address assignment.
+	publicIPName := azurePublicIPName(vm.name)
+	framework.Logf("Deleting public IP %s for VM %s", publicIPName, vm.name)
+	err = a.deletePublicIP(publicIPName)
+	if azureParseDeleteError(err) != nil {
+		return err
+	}
+	// Delete a custom security group.
+	securityGroupName := azureSecurityGroupName(vm.name)
+	framework.Logf("Deleting security group %s for VM %s", securityGroupName, vm.name)
+	err = a.deleteSecurityGroup(securityGroupName)
+	if azureParseDeleteError(err) != nil {
+		return err
+	}
+	return nil
+}
+
+// Close implements the cloudClient interface method of the same name and implementes the Closer interface. In Azure,
+// this is a noop.
+func (a *azureCloudClient) Close() error {
+	return nil
+}
+
+// azureParseDeleteError takes an Azure error message. If the error message is of type DetailedError and has a
+// StatusCode of 404, we return nil. The goal is to ignore NotFound errors. Otherwise, we return the same error that
+// we got as input.
+func azureParseDeleteError(err error) error {
+	if detErr, ok := err.(autorest.DetailedError); ok {
+		if detErr.StatusCode == 404 {
+			framework.Logf("Element not found, err: %q", err)
+			return nil
+		}
+	}
+	return err
+}
+
+// getInstance gets a single worker node instance. We want to create a new virtual machine at the same location and
+// subnet as the first worker node that we can find.
+func (a *azureCloudClient) getInstance() (*compute.VirtualMachine, error) {
+	providerID, err := getWorkerProviderID(a.oc.AsAdmin())
+	if err != nil {
+		return nil, err
+	}
+	providerData := strings.Split(providerID, "/")
+	if len(providerData) != 11 {
+		return nil, fmt.Errorf("unexpected provider ID %s", providerID)
+	}
+	ctx, cancel := context.WithTimeout(a.ctx, defaultAzureOperationTimeout)
+	defer cancel()
+	instance, err := a.vmClient.Get(ctx, a.resourceGroup, providerData[len(providerData)-1], "")
+	if err != nil {
+		return nil, err
+	}
+	return &instance, nil
+}
+
+// createVirtualMachineExtension creates a VirtualMachineExtension of type CustomScript. This lets us run a bash
+// script directly on the virtual machine to set up an agnhost container for /clientip tests (or other things).
+func (a *azureCloudClient) createVirtualMachineExtension(name, virtualMachineExtensionName, script string) error {
+	scriptEncoded := base64.StdEncoding.EncodeToString([]byte(script))
+	type protectedSettings struct {
+		Script string `json:"script"`
+	}
+	extensionParameters := compute.VirtualMachineExtension{
+		Response: autorest.Response{},
+		VirtualMachineExtensionProperties: &compute.VirtualMachineExtensionProperties{
+			Publisher:          to.StringPtr("Microsoft.Azure.Extensions"),
+			Type:               to.StringPtr("CustomScript"),
+			TypeHandlerVersion: to.StringPtr("2.1"),
+			// Settings:           protectedSettings{Script: scriptEncoded},
+			ProtectedSettings: protectedSettings{Script: scriptEncoded},
+			ProvisioningState: new(string),
+			InstanceView: &compute.VirtualMachineExtensionInstanceView{
+				Name:               new(string),
+				Type:               new(string),
+				TypeHandlerVersion: new(string),
+				Substatuses:        &[]compute.InstanceViewStatus{},
+				Statuses:           &[]compute.InstanceViewStatus{},
+			},
+		},
+		Location: a.location,
+	}
+	res, err := a.virtualMachineExtensionsClient.CreateOrUpdate(a.ctx, a.resourceGroup, name, virtualMachineExtensionName,
+		extensionParameters)
+	if err != nil {
+		return err
+	}
+	return res.WaitForCompletionRef(a.ctx, a.virtualMachineExtensionsClient.Client)
+}
+
+// createVirtualMachine creates the actual virtual machine.
+func (a *azureCloudClient) createVirtualMachine(name, sshPublicKey string, createdInterface *network.Interface) error {
+	parameters := compute.VirtualMachine{
+		Location: a.location,
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			StorageProfile: &compute.StorageProfile{
+				ImageReference: &compute.ImageReference{
+					Publisher: to.StringPtr(azureVMPublisher),
+					Offer:     to.StringPtr(azureVMOffer),
+					Sku:       to.StringPtr(azureVMSku),
+					Version:   to.StringPtr(azureVMVersion),
+				},
+			},
+			HardwareProfile: &compute.HardwareProfile{
+				// https://learn.microsoft.com/en-us/azure/virtual-machines/av2-series
+				VMSize: azureVMSize,
+			},
+			OsProfile: &compute.OSProfile{
+				ComputerName:  to.StringPtr(name),
+				AdminUsername: to.StringPtr(azureVMUser),
+				AdminPassword: to.StringPtr(azureVMAdminPassword),
+				LinuxConfiguration: &compute.LinuxConfiguration{
+					DisablePasswordAuthentication: to.BoolPtr(azureVMDisablePassword),
+					SSH: &compute.SSHConfiguration{
+						PublicKeys: &[]compute.SSHPublicKey{
+							{
+								Path:    to.StringPtr(azureVMPublicKeyPath),
+								KeyData: to.StringPtr(sshPublicKey),
+							},
+						},
+					},
+				},
+			},
+			NetworkProfile: &compute.NetworkProfile{
+				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
+					{
+						ID: createdInterface.ID,
+						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
+							Primary: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+		},
+	}
+	createOrUpdateFuture, err := a.vmClient.CreateOrUpdate(a.ctx, a.resourceGroup, name, parameters)
+	if err != nil {
+		return err
+	}
+	return createOrUpdateFuture.WaitForCompletionRef(a.ctx, a.ipClient.Client)
+}
+
+func (a *azureCloudClient) deleteVirtualMachine(name string) error {
+	res, err := a.vmClient.Delete(a.ctx, a.resourceGroup, name)
+	if err != nil {
+		return err
+	}
+	return res.WaitForCompletionRef(a.ctx, a.vmClient.Client)
+}
+
+func (a *azureCloudClient) createNetworkInterface(createdPublicIP *network.PublicIPAddress,
+	securityGroup *network.SecurityGroup, interfaceName string) (*network.Interface, error) {
+	var publicIPAddress *network.PublicIPAddress
+	if createdPublicIP != nil {
+		publicIPAddress = &network.PublicIPAddress{
+			ID: createdPublicIP.ID,
+		}
+	}
+	var newIPConfigurations []network.InterfaceIPConfiguration
+	// Set up IPConfigurations.
+	newIPConfigurations = append(newIPConfigurations, network.InterfaceIPConfiguration{
+		Response: autorest.Response{},
+		InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+			PrivateIPAllocationMethod: network.Dynamic,
+			Subnet:                    a.subnet,
+			PublicIPAddress:           publicIPAddress,
+		},
+		Name: &interfaceName,
+	})
+	// Set up interface parameters and link to securityGroup if one was provided.
+	interfaceParameters := network.Interface{
+		Response: autorest.Response{},
+		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+			IPConfigurations:     &newIPConfigurations,
+			NetworkSecurityGroup: securityGroup,
+		},
+		Location: a.location,
+	}
+	createOrUpdateInterface, err := a.interfacesClient.CreateOrUpdate(a.ctx, a.resourceGroup, interfaceName,
+		interfaceParameters)
+	if err != nil {
+		return nil, err
+	}
+	err = createOrUpdateInterface.WaitForCompletionRef(a.ctx, a.interfacesClient.Client)
+	if err != nil {
+		return nil, err
+	}
+	createdInterface, err := createOrUpdateInterface.Result(a.interfacesClient)
+	if err != nil {
+		return nil, err
+	}
+	return &createdInterface, nil
+}
+
+func (a *azureCloudClient) deleteNetworkInterface(interfaceName string) error {
+	res, err := a.interfacesClient.Delete(a.ctx, a.resourceGroup, interfaceName)
+	if err != nil {
+		return err
+	}
+	return res.WaitForCompletionRef(a.ctx, a.interfacesClient.Client)
+}
+
+func (a *azureCloudClient) createPublicIP(publicIPName string) (*network.PublicIPAddress, error) {
+	publicIPResult, err := a.ipClient.CreateOrUpdate(
+		a.ctx,
+		a.resourceGroup,
+		publicIPName,
+		network.PublicIPAddress{
+			Sku: &network.PublicIPAddressSku{
+				Name: network.PublicIPAddressSkuNameBasic,
+			},
+			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+				PublicIPAllocationMethod: network.Dynamic,
+			},
+			Location: a.location,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	err = publicIPResult.WaitForCompletionRef(a.ctx, a.ipClient.Client)
+	if err != nil {
+		return nil, err
+	}
+	createdPublicIP, err := publicIPResult.Result(a.ipClient)
+	if err != nil {
+		return nil, err
+	}
+	return &createdPublicIP, nil
+}
+
+func (a *azureCloudClient) deletePublicIP(publicIPName string) error {
+	res, err := a.ipClient.Delete(a.ctx, a.resourceGroup, publicIPName)
+	if err != nil {
+		return err
+	}
+	return res.WaitForCompletionRef(a.ctx, a.ipClient.Client)
+}
+
+func (a *azureCloudClient) createSecurityGroup(securityGroupName string, listenPorts map[string]protocolPort) (*network.SecurityGroup, error) {
+	var securityRules []network.SecurityRule
+	var priority int32 = 100
+	for name, pp := range listenPorts {
+		priority++
+		securityRules = append(securityRules, network.SecurityRule{
+			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+				Description:              to.StringPtr(name),
+				Protocol:                 network.SecurityRuleProtocol(strings.Title(strings.ToLower(pp.protocol))),
+				DestinationPortRange:     to.StringPtr(strconv.Itoa(pp.port)),
+				DestinationAddressPrefix: to.StringPtr("*"),
+				SourcePortRange:          to.StringPtr("*"),
+				SourceAddressPrefix:      to.StringPtr("*"),
+				Access:                   network.SecurityRuleAccessAllow,
+				Priority:                 to.Int32Ptr(priority),
+				Direction:                network.SecurityRuleDirectionInbound,
+			},
+			Name: to.StringPtr(name),
+		})
+	}
+	securityGroupResult, err := a.securityGroupsClient.CreateOrUpdate(
+		a.ctx,
+		a.resourceGroup,
+		securityGroupName,
+		network.SecurityGroup{
+			Location: a.location,
+			SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
+				SecurityRules: &securityRules,
+			},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	err = securityGroupResult.WaitForCompletionRef(a.ctx, a.securityGroupsClient.Client)
+	if err != nil {
+		return nil, err
+	}
+	securityGroup, err := securityGroupResult.Result(a.securityGroupsClient)
+	if err != nil {
+		return nil, err
+	}
+	return &securityGroup, nil
+}
+
+func (a *azureCloudClient) deleteSecurityGroup(name string) error {
+	res, err := a.securityGroupsClient.Delete(a.ctx, a.resourceGroup, name)
+	if err != nil {
+		return err
+	}
+	return res.WaitForCompletionRef(a.ctx, a.securityGroupsClient.Client)
+}
+
+func (a *azureCloudClient) getPrincipalInterface(instance *compute.VirtualMachine) (*network.Interface, error) {
+	var principalInterface network.Interface
+	for _, netif := range *instance.NetworkProfile.NetworkInterfaces {
+		if netif.NetworkInterfaceReferenceProperties != nil && netif.Primary != nil && *netif.Primary {
+			intf, err := a.networkClient.Get(a.ctx, a.resourceGroup, azureGetNameFromResourceID(*netif.ID), "")
+			if err != nil {
+				return nil, err
+			}
+			principalInterface = intf
+			break
+		}
+	}
+	return &principalInterface, nil
+}
+
+// azureGetNameFromResourceID gets the resource name from the resourceID string (returns the last index).
+func azureGetNameFromResourceID(id string) string {
+	return id[strings.LastIndex(id, "/"):]
+}
+
+func (a *azureCloudClient) getAuthorizer(env azure.Environment, clientID, clientSecret,
+	tenantID string) (autorest.Authorizer, error) {
+	c := &auth.ClientCredentialsConfig{
+		TenantID:     tenantID,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		AADEndpoint:  env.ActiveDirectoryEndpoint,
+	}
+	c.Resource = env.TokenAudience
+	authorizer, err := c.Authorizer()
+	if err != nil {
+		return nil, err
+	}
+	return authorizer, nil
+}

--- a/test/extended/networking/egressip_cloud_clients_gcp.go
+++ b/test/extended/networking/egressip_cloud_clients_gcp.go
@@ -1,0 +1,364 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	gcpSourceImage         = "/projects/centos-cloud/global/images/family/centos-stream-8"
+	gcpMachineType         = "/projects/%s/zones/%s/machineTypes/n1-standard-2"
+	gcpVMUser              = "cloud-user"
+	gcpInstanceStartupDone = "gcp-instance-startup-done-marker"
+)
+
+var (
+	gcpFirewallSourceRanges = []string{"10.0.0.0/8"}
+	gcpOperationTimeout     = time.Minute * 10
+)
+
+// gcpCloudClient implements interface cloudClient for GCP.
+type gcpCloudClient struct {
+	oc            *exutil.CLI
+	ctx           context.Context
+	googleService *compute.Service
+	project       string
+	zone          string
+	subnet        string
+	network       string
+}
+
+// newGCPCloudClient initializes and returns a new gcpCloudClient.
+func newGCPCloudClient(oc *exutil.CLI) (*gcpCloudClient, error) {
+	client := &gcpCloudClient{oc: oc, ctx: context.Background()}
+	err := client.initCloudSecret()
+	if err != nil {
+		return nil, err
+	}
+
+	var instance *compute.Instance
+	client.project, client.zone, instance, err = client.getInstance()
+	if err != nil {
+		return nil, err
+	}
+	for _, intf := range instance.NetworkInterfaces {
+		client.subnet = intf.Subnetwork
+		client.network = intf.Network
+	}
+
+	return client, nil
+}
+
+// gcpReadCloudSecret reads the JSON cloud secret for GCP from Secret cloud-credentials in namespace
+// openshift-cloud-network-config-controller and initializes g.googleService.
+func (g *gcpCloudClient) initCloudSecret() error {
+	ctx, cancel := context.WithTimeout(g.ctx, gcpOperationTimeout)
+	defer cancel()
+
+	secretField := "service_account.json"
+	data, err := readCloudSecret(g.oc, secretNamespace, secretName)
+	if err != nil {
+		return err
+	}
+	credentials, ok := data[secretField]
+	if !ok {
+		return fmt.Errorf("cloud secret does not have expected field %s", secretField)
+	}
+	c, err := gcpInitCredentials(ctx, string(credentials))
+	if err != nil {
+		return err
+	}
+	g.googleService = c
+	return nil
+}
+
+// createVM creates a GCP VirtualMachine according to the specs provided by the vm object. It first creates the
+// instance, followed by the firewall. Next, it populates the provided vm's publicIP and privateIP addresses.
+func (g *gcpCloudClient) createVM(vm *vm, requestPublicIP bool) error {
+	ctx, cancel := context.WithTimeout(g.ctx, gcpOperationTimeout)
+	defer cancel()
+
+	framework.Logf("Creating VM %s", vm.name)
+	loadedInstance, err := g.createInstance(ctx, vm, requestPublicIP)
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Creating firewall for VM %s", vm.name)
+	err = g.createFirewall(vm.name, vm.ports)
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Extracting public and private IP info from instance %s", vm.name)
+	var privateIP string
+	var publicIP string
+	for _, intf := range loadedInstance.NetworkInterfaces {
+		privateIP = intf.NetworkIP
+		for _, accessConfig := range intf.AccessConfigs {
+			publicIP = accessConfig.NatIP
+			break
+		}
+		break
+	}
+	vm.privateIP = net.ParseIP(privateIP)
+	vm.publicIP = net.ParseIP(publicIP)
+	if vm.privateIP == nil {
+		return fmt.Errorf("created instance does not have a valid private IP address")
+	}
+
+	return err
+}
+
+// deleteVM deletes the GCP Virtual Machine that matches the provided vm object. It first deletes the associated
+// Firewall followed by the Instance.
+func (g *gcpCloudClient) deleteVM(vm *vm) error {
+	ctx, cancel := context.WithTimeout(g.ctx, gcpOperationTimeout)
+	defer cancel()
+
+	framework.Logf("Deleting VM %s firewall", vm.name)
+	_, err := g.googleService.Firewalls.Delete(g.project, vm.name).Do()
+	if parseGCPDeleteError(err) != nil {
+		return err
+	}
+
+	framework.Logf("Deleting VM %s", vm.name)
+	op, err := g.googleService.Instances.Delete(g.project, g.zone, vm.name).Do()
+	if parseGCPDeleteError(err) != nil {
+		return err
+	}
+	if err == nil {
+		framework.Logf("Waiting for VM %s deletion to finish", vm.name)
+		err = g.waitForOperation(ctx, op)
+		if parseGCPDeleteError(err) != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Close implements the cloudClient interface method of the same name and implementes the Closer interface. In GCP,
+// this is a noop.
+func (g *gcpCloudClient) Close() error {
+	return nil
+}
+
+// createFirewall creates a GCP firewall rule that allows <ports> traffic from global gcpFirewallSourceRanges to
+// instances marked with <tag>.
+func (g *gcpCloudClient) createFirewall(tag string, ports map[string]protocolPort) error {
+	portsPerProtocol := make(map[string][]string)
+	for _, protocolPort := range ports {
+		portsPerProtocol[strings.ToLower(protocolPort.protocol)] = append(
+			portsPerProtocol[protocolPort.protocol],
+			strconv.Itoa(protocolPort.port))
+	}
+	var firewallAllowed []*compute.FirewallAllowed
+	for protocol, ports := range portsPerProtocol {
+		firewallAllowed = append(firewallAllowed, &compute.FirewallAllowed{
+			IPProtocol: protocol,
+			Ports:      ports,
+		})
+	}
+	firewall := &compute.Firewall{
+		Allowed:      firewallAllowed,
+		Name:         tag,
+		Network:      g.network,
+		SourceRanges: gcpFirewallSourceRanges,
+		TargetTags:   []string{tag},
+	}
+	_, err := g.googleService.Firewalls.Insert(g.project, firewall).Do()
+	return err
+}
+
+// createInstance takes a context with a timeout and a VM definition and spawns a GCP VirtualMachine. It then waits
+// for the operation to finish. It repeatedly reads the GCP console log until it finds string gcpInstanceStartupDone.
+// Finally, it retrieves the latest state of the VirtualMachine and returns it.
+func (g *gcpCloudClient) createInstance(ctx context.Context, vm *vm, requestPublicIP bool) (*compute.Instance, error) {
+	framework.Logf("Creating instance %s", vm.name)
+	startupScript := fmt.Sprintf("%s\necho \"%s\" > /dev/ttyS0\n",
+		printp(vm.startupScript, vm.startupScriptParameters),
+		gcpInstanceStartupDone,
+	)
+	machineType := fmt.Sprintf(gcpMachineType, g.project, g.zone)
+	var accessConfigs []*compute.AccessConfig
+	if requestPublicIP {
+		accessConfigs = []*compute.AccessConfig{
+			{
+				Name: "External NAT",
+				Type: "ONE_TO_ONE_NAT",
+			},
+		}
+	}
+	newInstance := &compute.Instance{
+		MachineType: machineType,
+		Name:        vm.name,
+		Tags: &compute.Tags{
+			Items: []string{
+				vm.name,
+			},
+		},
+		NetworkInterfaces: []*compute.NetworkInterface{
+			{
+				Network:       g.network,
+				Subnetwork:    g.subnet,
+				AccessConfigs: accessConfigs,
+			},
+		},
+		Disks: []*compute.AttachedDisk{
+			{
+				AutoDelete: true,
+				Boot:       true,
+				Type:       "PERSISTENT",
+				InitializeParams: &compute.AttachedDiskInitializeParams{
+					SourceImage: gcpSourceImage,
+				},
+			},
+		},
+		Metadata: &compute.Metadata{
+			Items: []*compute.MetadataItems{
+				{
+					Key:   "startup-script",
+					Value: &startupScript,
+				},
+				{
+					Key:   "ssh-keys",
+					Value: pointer.String(fmt.Sprintf("%s:%s", gcpVMUser, vm.sshPublicKey)),
+				},
+			},
+		},
+	}
+	op, err := g.googleService.Instances.Insert(g.project, g.zone, newInstance).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	framework.Logf("Waiting for VM %s creation to finish", vm.name)
+	err = g.waitForOperation(ctx, op)
+	if err != nil {
+		return nil, err
+	}
+
+	framework.Logf("Waiting until startup script finishes for VM %s", vm.name)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+outer:
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("startup script never finished or never posted status to console"+
+				"for VM %s", vm.name)
+		case <-ticker.C:
+			framework.Logf("Reading serial port output of VM %s", vm.name)
+			serialPortOutput, err := g.googleService.Instances.GetSerialPortOutput(g.project, g.zone, vm.name).Do()
+			if err != nil {
+				return nil, err
+			}
+			if strings.Contains(serialPortOutput.Contents, gcpInstanceStartupDone) {
+				framework.Logf("Found string %s in VM %s logs", gcpInstanceStartupDone, vm.name)
+				break outer
+			}
+			framework.Logf("Could not find string %s in VM %s logs", gcpInstanceStartupDone, vm.name)
+		}
+	}
+
+	framework.Logf("Retrieving latest copy of VM %s", vm.name)
+	return g.googleService.Instances.Get(g.project, g.zone, vm.name).Do()
+}
+
+// waitForOperation waits for the compute operation to finish.
+// Copied from https://github.com/googleapis/google-cloud-go/issues/178.
+func (g *gcpCloudClient) waitForOperation(ctx context.Context, op *compute.Operation) error {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for operation to complete")
+		case <-ticker.C:
+			result, err := g.googleService.ZoneOperations.Get(g.project, g.zone, op.Name).Do()
+			if err != nil {
+				return fmt.Errorf("ZoneOperations.Get: %s", err)
+			}
+
+			if result.Status == "DONE" {
+				if result.Error != nil {
+					var errors []string
+					for _, e := range result.Error.Errors {
+						errors = append(errors, e.Message)
+					}
+					return fmt.Errorf("operation %q failed with error(s): %s", op.Name, strings.Join(errors, ", "))
+				}
+				return nil
+			}
+		}
+	}
+}
+
+// gcpGetInstance retrieves the GCP instance referred by the Node object.
+// returns the project and zone name as well.
+//   This is what the node's providerID looks like on GCP
+//      spec:
+//    providerID: gce://openshift-gce-devel-ci/us-east1-b/ci-ln-pvr3lyb-f76d1-6w8mm-master-0
+//   i.e: projectID/zone/instanceName
+//
+// split out and return these components
+func (g *gcpCloudClient) getInstance() (project string, zone string, instance *compute.Instance, err error) {
+	providerID, err := getWorkerProviderID(g.oc.AsAdmin())
+	if err != nil {
+		return
+	}
+	u, err := url.Parse(providerID)
+	if err != nil {
+		err = fmt.Errorf("failed to parse node provider id %s: %w", providerID, err)
+		return
+	}
+	parts := strings.SplitN(u.Path, "/", 3)
+	if len(parts) != 3 {
+		err = fmt.Errorf("failed to parse provider id %s: expected two path components", providerID)
+		return
+	}
+	project = u.Host
+	zone = parts[1]
+	instanceStr := parts[2]
+
+	instance, err = g.googleService.Instances.Get(project, zone, instanceStr).Do()
+	if err != nil {
+		return "", "", nil, err
+	}
+	return
+}
+
+// gcpInitCredentials takes a raw secret (in JSON format) and returns an initialized google.Service.
+func gcpInitCredentials(ctx context.Context, rawSecretData string) (*compute.Service, error) {
+	opts := []option.ClientOption{
+		option.WithCredentialsJSON([]byte(rawSecretData)),
+		option.WithUserAgent(userAgent),
+	}
+
+	return compute.NewService(ctx, opts...)
+}
+
+// parseGCPDeleteError returns the provided error unless it's an error of type *googleapi.Error with a Code of 404.
+// In that case, it will return nil.
+func parseGCPDeleteError(err error) error {
+	if ge, ok := err.(*googleapi.Error); ok {
+		if ge.Code == 404 {
+			return nil
+		}
+	}
+	return err
+}

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -147,26 +146,6 @@ type byName []corev1.Node
 func (n byName) Len() int           { return len(n) }
 func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
-
-// GetNodesOrdered returns a sorted slice (by node.Name) of nodes or error.
-func getWorkerNodesOrdered(clientset kubernetes.Interface) ([]corev1.Node, error) {
-	if clientset == nil {
-		return nil, fmt.Errorf("Nil pointer clientset provided")
-	}
-
-	nodes, err := clientset.CoreV1().Nodes().List(
-		context.TODO(),
-		metav1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/worker=",
-		})
-	if err != nil {
-		return nil, err
-	}
-	items := nodes.Items
-	sort.Sort(byName(items))
-
-	return items, nil
-}
 
 // findPacketSnifferInterface finds the interface that shall be used for packet capturing on all nodes in the list.
 // Return an error if there is no consensus about the interface that shall be used among nodes.

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -877,7 +877,8 @@ type capacity struct {
 // depend on the current cloud type, on the currenctly used cloudprivateipconfigs, and on an internal reservation
 // manager. Find <egressIPsPerNode> number of IPs per node.
 // TODO: Create the internal reservation manager, if needed.
-func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetworkClientset cloudnetwork.Interface, nodeNames []string, cloudType configv1.PlatformType, egressIPsPerNode int) (map[string][]string, error) {
+func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetworkClientset cloudnetwork.Interface,
+	cloudType configv1.PlatformType, egressIPsPerNode int, nodeNames ...string) (map[string][]string, error) {
 	// Get the node API objects corresponding to the node names.
 	var nodeList []*v1.Node
 	for _, nodeName := range nodeNames {

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -9,20 +9,16 @@ import (
 	"io"
 	"math/rand"
 	"net"
-	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	configv1 "github.com/openshift/api/config/v1"
 	networkv1 "github.com/openshift/api/network/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	cloudnetwork "github.com/openshift/client-go/cloudnetwork/clientset/versioned"
 	networkclient "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
-	"github.com/openshift/origin/test/extended/util"
 	exutil "github.com/openshift/origin/test/extended/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -59,12 +55,13 @@ type EgressIP struct {
 	Status EgressIPStatus `json:"status,omitempty"`
 }
 
+// EgressIPStatus reports the EgressIP status.
 type EgressIPStatus struct {
 	// The list of assigned egress IPs and their corresponding node assignment.
 	Items []EgressIPStatusItem `json:"items"`
 }
 
-// The per node status, for those egress IPs who have been assigned.
+// EgressIPStatusItem reports the per node status, for those egress IPs who have been assigned.
 type EgressIPStatusItem struct {
 	// Assigned node name
 	Node string `json:"node"`
@@ -91,8 +88,6 @@ type EgressIPSpec struct {
 	PodSelector metav1.LabelSelector `json:"podSelector,omitempty"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +resource:path=egressip
 // EgressIPList is the list of EgressIPList.
 type EgressIPList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -147,44 +142,6 @@ func (n byName) Len() int           { return len(n) }
 func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
 
-// findPacketSnifferInterface finds the interface that shall be used for packet capturing on all nodes in the list.
-// Return an error if there is no consensus about the interface that shall be used among nodes.
-func findPacketSnifferInterface(oc *exutil.CLI, networkPlugin string, egressIPNodesOrderedNames []string) (string, error) {
-	var intf string
-	var packetSnifferNode, packetSnifferInterface string
-	var err error
-	for _, node := range egressIPNodesOrderedNames {
-		intf, err = findPacketSnifferInterfaceOnNode(oc, networkPlugin, node)
-		if err != nil {
-			return "", err
-		}
-		if packetSnifferInterface == "" {
-			packetSnifferInterface = intf
-			packetSnifferNode = node
-			continue
-		}
-		if packetSnifferInterface != intf {
-			return "", fmt.Errorf("Selected different interfaces for packet capture. Node %s reported '%s' but node %s reports '%s'",
-				packetSnifferNode,
-				packetSnifferInterface,
-				node,
-				intf)
-		}
-	}
-	return packetSnifferInterface, nil
-}
-
-// findPacketSnifferInterfaceOnNode finds the interface that shall be used for packet capturing on this node.
-func findPacketSnifferInterfaceOnNode(oc *exutil.CLI, networkPlugin, nodeName string) (string, error) {
-	if networkPlugin == openshiftSDNPluginName {
-		return findDefaultInterfaceForOpenShiftSDN(oc, nodeName)
-	}
-	if networkPlugin == OVNKubernetesPluginName {
-		return findBridgePhysicalInterface(oc, nodeName, "br-ex")
-	}
-	return "", fmt.Errorf("Invalid network plugin name: '%s'", networkPlugin)
-}
-
 // findDefaultInterfaceForOpenShiftSDN returns the default interface for a node with the OpenShiftSDN plugin.
 func findDefaultInterfaceForOpenShiftSDN(oc *exutil.CLI, nodeName string) (string, error) {
 	var podName string
@@ -234,69 +191,6 @@ func findDefaultInterfaceForOpenShiftSDN(oc *exutil.CLI, nodeName string) (strin
 	return defaultRoutes[0].Dev, nil
 }
 
-// findBridgePhysicalInterface returns the name of the physical interface that belogs to <bridgeName> on node <nodeName>.
-func findBridgePhysicalInterface(oc *exutil.CLI, nodeName, bridgeName string) (string, error) {
-	var podName string
-	var out string
-	var err error
-
-	out, err = runOcWithRetry(oc.AsAdmin(), "get",
-		"pods",
-		"-o", "name",
-		"-n", "openshift-ovn-kubernetes",
-		"--field-selector", fmt.Sprintf("spec.nodeName=%s", nodeName),
-		"-l", "app=ovnkube-node")
-	if err != nil {
-		return "", err
-	}
-	outReader := bufio.NewScanner(strings.NewReader(out))
-	re := regexp.MustCompile("^pod/(.*)")
-	for outReader.Scan() {
-		match := re.FindSubmatch([]byte(outReader.Text()))
-		if len(match) != 2 {
-			continue
-		}
-		podName = string(match[1])
-		break
-	}
-	if podName == "" {
-		return "", fmt.Errorf("Could not find a valid ovnkube-node pod on node '%s'", nodeName)
-	}
-	out, err = adminExecInPod(oc, "openshift-ovn-kubernetes", podName, "ovnkube-node", fmt.Sprintf("ovs-vsctl list-ports %s", bridgeName))
-	if err != nil {
-		return "", fmt.Errorf("failed to get list of ports on bridge %s:, error: %v",
-			bridgeName, err)
-	}
-	for _, port := range strings.Split(out, "\n") {
-		out, err = adminExecInPod(
-			oc, "openshift-ovn-kubernetes", podName, "ovnkube-node",
-			fmt.Sprintf("ovs-vsctl get Port %s Interfaces", port))
-		if err != nil {
-			return "", fmt.Errorf("failed to get port %s on bridge %s: error: %v",
-				bridgeName, port, err)
-
-		}
-		// remove brackets on list of interfaces
-		ifaces := strings.TrimPrefix(strings.TrimSuffix(out, "]"), "[")
-		for _, iface := range strings.Split(ifaces, ",") {
-			out, err = adminExecInPod(
-				oc, "openshift-ovn-kubernetes", podName, "ovnkube-node",
-				fmt.Sprintf("ovs-vsctl get Interface %s Type", strings.TrimSpace(iface)))
-			if err != nil {
-				return "", fmt.Errorf("failed to get Interface %q Type on bridge %q:, error: %v",
-					iface, bridgeName, err)
-
-			}
-			// If system Type we know this is the OVS port is the NIC
-			if out == "system" {
-				return port, nil
-			}
-		}
-	}
-	return "", fmt.Errorf("Could not find a physical interface connected to bridge %s on node %s (pod %s)",
-		bridgeName, nodeName, podName)
-}
-
 // adminExecInPod runs a command as admin in the provides pod inside the provided namespace.
 func adminExecInPod(oc *exutil.CLI, namespace, pod, container, script string) (string, error) {
 	var out string
@@ -306,309 +200,6 @@ func adminExecInPod(oc *exutil.CLI, namespace, pod, container, script string) (s
 		return true, err
 	})
 	return out, waitErr
-}
-
-// createPacketSnifferDaemonSet creates packet sniffer pods on the hosts specified in scheduleOnHosts.
-func createPacketSnifferDaemonSet(oc *exutil.CLI, namespace string, scheduleOnHosts []string, packetCaptureProtocol string, packetCapturePort int, packetCaptureInterface string) (*appsv1.DaemonSet, error) {
-	f := oc.KubeFramework()
-	clientset := f.ClientSet
-
-	tcpdumpImage, err := util.DetermineImageFromRelease(oc, "network-tools")
-	if err != nil {
-		return nil, err
-	}
-
-	daemonsetName := fmt.Sprintf("%s-packet-sniffer", namespace)
-	targetDaemonset, err := createHostNetworkedPacketSnifferDaemonSet(
-		clientset,
-		tcpdumpImage,
-		packetCaptureProtocol,
-		packetCapturePort,
-		namespace,
-		daemonsetName,
-		scheduleOnHosts,
-		packetCaptureInterface,
-	)
-	if err != nil {
-		return targetDaemonset, err
-	}
-
-	var ds *appsv1.DaemonSet
-	retries := 12
-	pollInterval := 5
-	for i := 0; i < retries; i++ {
-		// Get the DS
-		ds, err = clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), daemonsetName, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		// Check if NumberReady == DesiredNumberScheduled.
-		// In that case, simply return as all went well.
-		if ds.Status.NumberReady == ds.Status.DesiredNumberScheduled {
-			return ds, nil
-		}
-		// If no port conflict error was found, simply sleep for pollInterval and then
-		// check again.
-		time.Sleep(time.Duration(pollInterval) * time.Second)
-	}
-
-	// The DaemonSet is not ready, but this is not because of a port conflict.
-	// This shouldn't happen and other parts of the code will likely report this error
-	// as a CI failure.
-	return ds, fmt.Errorf("Daemonset still not ready after %d tries", retries)
-}
-
-const (
-	// The tcpCaptureScript runs tcpdump and extracts all GET request strings from the packets.
-	// The resulting lines will be something like:
-	// 10.128.2.15.36749  /f8f721fa-53c9-444f-bc96-69c7388fcb5a
-	tcpCaptureScript = `#!/bin/bash
-tcpdump -nne -i %s -l -s 0  'port %d and tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x47455420' | awk '{print $10 " " $(NF-1)}'
-`
-
-	// The udpCaptureScript runs tcpdump with option -xx and then decodes the hexadecimal information.
-	// We have to read the UDP payload and it is actually a bit difficult to get this with just tcpdump.
-	// It is also a bit tricky to know when a UDP payload actually ended (specifically for the last packet
-	// that's captured).
-	// tshark would definitely be the better tool here, but that would introduce another dependency. Hence,
-	// decode the hexadecimal information and look for payload that is marked with 'START(.*)EOF$' and extract
-	// the '(.*)' part. The resulting lines will be `sourceIP + "  " + z.group(1)`, hence something like:
-	// 10.128.2.15.36749 f8f721fa-53c9-444f-bc96-69c7388fcb5a
-	udpCaptureScript = `#!/bin/bash
-
-cat <<'EOF' > capture-python.py
-#!/usr/bin/python
-
-import sys
-import select
-import re
-
-# Source IP is at location 9 in the first line if a specific
-# interface is used or at location 8 if the any interface is
-# used
-sourceIPOffset = 9
-# UDP payload starts at around Byte 21
-# We don't care about the offset though, having everything
-# in one line is enough.
-udpPayloadOffset = 0
-
-# globals
-fullHex = []
-sourceIP = ""
-
-def decodePayload(hexArray):
-    payloadStr = ""
-    for x in hexArray[udpPayloadOffset:]:
-        try:
-            byte_array = bytearray.fromhex(x)
-            payloadStr += byte_array.decode()
-        except:
-            pass
-    return payloadStr
-
-def printLine():
-    global sourceIP
-    global fullHex
-    if sourceIP != "" and fullHex != []:
-        decodedPayload = decodePayload(fullHex)
-        z = re.search(r'START(.*)EOF$', decodedPayload)
-        if z:
-            print(sourceIP + "  " + z.group(1))
-            fullHex = []
-            sourceIP = ""
-
-for line in sys.stdin:
-    if not re.match(r'^$', line) and re.match(r'^\s', line):
-        hexLine = line.split()
-        if re.match(r'^0x', hexLine[0]):
-            for x in hexLine[1:]:
-                fullHex.append(x)
-        printLine()
-    elif not re.match(r'^$', line):
-        printLine()
-        sourceIP = line.split()[sourceIPOffset]
-
-printLine()
-EOF
-chmod +x capture-python.py
-
-tcpdump -nne -i %s -l -xx -s0 port %d and udp | ./capture-python.py
-`
-)
-
-// createHostNetworkedPacketSnifferDaemonSet creates a host networked pod in namespace <namespace> on
-// node <nodeName>. It will start a packet sniffer and it will log all GET request's source IP and the actual request string.
-func createHostNetworkedPacketSnifferDaemonSet(clientset kubernetes.Interface, networkPacketSnifferImage, packetCaptureProtocol string, packetCapturePort int,
-	namespace, daemonsetName string, scheduleOnHosts []string, packetCaptureInterface string) (*appsv1.DaemonSet, error) {
-	if packetCaptureProtocol != "http" && packetCaptureProtocol != "udp" {
-		return nil, fmt.Errorf("createHostNetworkedPacketSnifferDaemonSet supports only 'http' and 'udp' protocols, got: %s", packetCaptureProtocol)
-	}
-	// https://www.middlewareinventory.com/blog/tcpdump-capture-http-get-post-requests-apache-weblogic-websphere/#How_to_capture_All_incoming_HTTP_GET_traffic_or_requests
-	cmd := tcpCaptureScript
-	if packetCaptureProtocol == "udp" {
-		cmd = udpCaptureScript
-	}
-	podCommand := []string{
-		"/bin/bash",
-		"-c",
-		fmt.Sprintf(cmd, packetCaptureInterface, packetCapturePort),
-	}
-	podLabels := map[string]string{
-		"app": daemonsetName,
-	}
-	// create deployment
-	nodeAffinity := v1.Affinity{
-		NodeAffinity: &v1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-				NodeSelectorTerms: []v1.NodeSelectorTerm{
-					{
-						MatchExpressions: []v1.NodeSelectorRequirement{
-							{
-								Key:      "kubernetes.io/hostname",
-								Operator: v1.NodeSelectorOpIn,
-								Values:   scheduleOnHosts,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	readinessProbe := &v1.Probe{
-		ProbeHandler: v1.ProbeHandler{
-			Exec: &v1.ExecAction{
-				Command: []string{
-					"echo",
-					"ready",
-				},
-			},
-		},
-	}
-	runAsUser := int64(0)
-	securityContext := &v1.SecurityContext{
-		RunAsUser: &runAsUser,
-		Capabilities: &v1.Capabilities{
-			Add: []v1.Capability{
-				"SETFCAP",
-				"CAP_NET_RAW",
-				"CAP_NET_ADMIN",
-			},
-		},
-	}
-	dsDefinition := &appsv1.DaemonSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "DaemonSet",
-			APIVersion: "apps/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      daemonsetName,
-		},
-		Spec: appsv1.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: podLabels,
-				},
-				Spec: corev1.PodSpec{
-					Affinity:    &nodeAffinity,
-					HostNetwork: true,
-					Containers: []v1.Container{
-						{
-							Name:            "tcpdump",
-							Image:           networkPacketSnifferImage,
-							Command:         podCommand,
-							ReadinessProbe:  readinessProbe,
-							SecurityContext: securityContext,
-							TTY:             true, // needed for immediate log propagation
-							Stdin:           true, // needed for immediate log propagation
-						},
-					},
-				},
-			},
-		},
-	}
-	ds, err := clientset.AppsV1().DaemonSets(namespace).Create(context.TODO(), dsDefinition, metav1.CreateOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return ds, nil
-}
-
-// scanPacketSnifferDaemonSetPodLogs iterates over the pods logs and searches for searchString
-// and then counts the occurrences for each found IP address.
-func scanPacketSnifferDaemonSetPodLogs(oc *exutil.CLI, ds *appsv1.DaemonSet, targetProtocol, searchString string) (map[string]int, error) {
-	if oc == nil {
-		return nil, fmt.Errorf("Nil pointer to exutil.CLI oc was provided in ScanPacketSnifferDaemonSetPodLogs")
-	}
-	if ds == nil {
-		return nil, fmt.Errorf("Nil pointer to DaemonSet ds was provided in ScanPacketSnifferDaemonSetPodLogs")
-	}
-	if targetProtocol != "http" && targetProtocol != "udp" {
-		return nil, fmt.Errorf("ScanPacketSnifferDaemonSetPodLogs supports only 'http' and 'udp' protocols.")
-	}
-
-	f := oc.KubeFramework()
-	clientset := f.ClientSet
-
-	pods, err := clientset.CoreV1().Pods(ds.Namespace).List(
-		context.TODO(),
-		metav1.ListOptions{LabelSelector: labels.Set(ds.Spec.Selector.MatchLabels).String()})
-	if err != nil {
-		return nil, err
-	}
-
-	matchedIPs := make(map[string]int)
-	for _, pod := range pods.Items {
-		logOptions := corev1.PodLogOptions{}
-		req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &logOptions)
-		logs, err := req.Stream(context.TODO())
-		if err != nil {
-			return nil, fmt.Errorf("Error in opening log stream")
-		}
-		defer logs.Close()
-
-		buf := new(bytes.Buffer)
-		_, err = io.Copy(buf, logs)
-		if err != nil {
-			return nil, fmt.Errorf("Error in copying info from pod logs to buffer")
-		}
-		_ = buf.String()
-
-		var ip string
-		scanner := bufio.NewScanner(buf)
-		for scanner.Scan() {
-			logLine := scanner.Text()
-			if strings.Contains(logLine, searchString) {
-				// Currently, it is not necessary to discriminate by protocol.
-				// a log line should look like this for http:
-				// 10.0.144.5.33226 /bed729aa-4e83-482d-a433-db798e569147
-				// a log line should look like this for udp:
-				// 10.0.144.5.33226 bed729aa-4e83-482d-a433-db798e569147
-				// Should it ever be necessary, the targetProtocol to this method (which is currently
-				// not used) serves this purpose.
-				framework.Logf("Found hit in log line: %s", logLine)
-				logLineExploded := strings.Fields(logLine)
-				if len(logLineExploded) != 2 {
-					return nil, fmt.Errorf("Unexpected logline content: %s", logLine)
-				}
-				ipAddressPortExploded := strings.Split(logLineExploded[0], ".")
-				if len(ipAddressPortExploded) == 2 {
-					// ipv6
-					ip = ipAddressPortExploded[0]
-				} else if len(ipAddressPortExploded) == 5 {
-					// ipv4
-					ip = strings.Join(ipAddressPortExploded[:len(ipAddressPortExploded)-1], ".")
-				} else {
-					return nil, fmt.Errorf("Unexpected logline content, invalid IP/Port: %s", logLine)
-				}
-				matchedIPs[ip]++
-			}
-		}
-	}
-	return matchedIPs, nil
 }
 
 func getIngressDomain(oc *exutil.CLI) (string, error) {
@@ -854,6 +445,7 @@ func updateDeploymentAffinity(oc *exutil.CLI, namespace, deploymentName string, 
 	return nil
 }
 
+// NodeEgressIPConfiguration reports the node egress IP config.
 // from github.com/openshift/cloud-network-config-controller/pkg/cloudprovider/cloudprovider.go
 type NodeEgressIPConfiguration struct {
 	Interface string   `json:"interface"`
@@ -872,13 +464,15 @@ type capacity struct {
 	IP   int `json:"ip,omitempty"`
 }
 
-// findNodeEgressIPs will return a list of available EgressIPs in a map <nodeName>:<egressIP>.
+// findNodeEgressIPs will return a map available EgressIPs per node (map[<nodeName>]<egressIP>).
 // The returned EgressIPs are chosen from the nodes' cloud.network.openshift.io/egress-ipconfig annotation and they
-// depend on the current cloud type, on the currenctly used cloudprivateipconfigs, and on an internal reservation
-// manager. Find <egressIPsPerNode> number of IPs per node.
-// TODO: Create the internal reservation manager, if needed.
+// depend on the current cloud type, on the currently used CloudPrivateIPConfigs, and on an internal reservation
+// manager. A maximum of <egressIPsPerNode> number of IPs will be returned per node.
+// Note: On most clouds, there is no dedicated CIDR per node and instead all EgressIPs come from a common pool.
+// Thus, this is only an artificial assignment of EgressIP to node on these cloud platforms and the EgressIP feature
+// will pick the actual node.
 func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetworkClientset cloudnetwork.Interface,
-	cloudType configv1.PlatformType, egressIPsPerNode int, nodeNames ...string) (map[string][]string, error) {
+	cloudType configv1.PlatformType, excludedIPs []string, egressIPsPerNode int, nodeNames ...string) (map[string][]string, error) {
 	// Get the node API objects corresponding to the node names.
 	var nodeList []*v1.Node
 	for _, nodeName := range nodeNames {
@@ -892,7 +486,7 @@ func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetw
 	// Build the list of reserved IPs. To do so, look at the currently used cloudprivateipconfigs
 	// and egressips as well as nodes.
 	var reservedIPs []string
-	reservedIPs, err := buildReservedEgressIPList(oc, clientset, cloudNetworkClientset)
+	reservedIPs, err := buildReservedEgressIPList(oc, clientset, cloudNetworkClientset, excludedIPs)
 	if err != nil {
 		return nil, err
 	}
@@ -936,9 +530,8 @@ func findNodeEgressIPs(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetw
 // tests.
 // TODO: add an internal reservation system based on a singleton to avoid race conditions during
 // concurrent tests.
-func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface, cloudNetworkClientset cloudnetwork.Interface) ([]string, error) {
-	var reservedIPs []string
-
+func buildReservedEgressIPList(oc *exutil.CLI, clientset kubernetes.Interface,
+	cloudNetworkClientset cloudnetwork.Interface, reservedIPs []string) ([]string, error) {
 	// cloudprivateipconfigs
 	cloudPrivateIPConfigs, err := cloudNetworkClientset.CloudV1().CloudPrivateIPConfigs().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -1087,10 +680,10 @@ func createProberPod(oc *exutil.CLI, proberPodNamespace, proberPodName string) *
 // destroyProberPod destroys the given proberPod.
 func destroyProberPod(oc *exutil.CLI, proberPod *v1.Pod) error {
 	if oc == nil {
-		return fmt.Errorf("Nil pointer to exutil.CLI oc was provided in destroyProberPod.")
+		return fmt.Errorf("nil pointer to exutil.CLI oc was provided in destroyProberPod")
 	}
 	if proberPod == nil {
-		return fmt.Errorf("Nil pointer to proberPod was provided in destroyProberPod.")
+		return fmt.Errorf("nil pointer to proberPod was provided in destroyProberPod")
 	}
 	f := oc.KubeFramework()
 	clientset := f.ClientSet
@@ -1106,137 +699,101 @@ func destroyProberPod(oc *exutil.CLI, proberPod *v1.Pod) error {
 	)
 }
 
-// sendEgressIPProbesAndCheckPacketSnifferLogs sends requests with a unique search string from the prober pod. It then
-// makes sure that the expectedHits number of requests were seen in the packetSnifferDaemonSet's pod logs.
-// We are only interested in sending our searchString (a unique UUID per query).
-// We do not care about the response because:
-// a) We inspect the traffic that we are sending and we search for the unique searchString
-// b) We make sure that the request leaves from one of the EgressIPs
-// Therefore, we can send our request against any destination.
-// If we tests against any TCP/HTTP endpoint, we can additionally
-// c) Prove that we established a bidirectional stream.
+// sendEgressIPProbesAndCheckOutput sends requests from the prober pod to the target and queries /clientip. Each
+// query is sent in its own go function to speed up the total process.
+// As soon as all requests were sent, parse the output and for each clientIP address that the target reported, count
+// how often it occurred.
+// Sum up the hits of all EgressIPs and make sure that the expectedHits number of requests were seen.
 //
 // Parameters:
-//
-// oc: the CLI
-// proberPod: a pointer to the pod that sends the probes (this is not an EgressIP pod, instead, it dials into the route/service of the EgressIP pods)
-// routeName: Name of the routes that covers the EgressIP nodes
-// targetProtocol: one of http or udp, protocol that EgressIP outbound traffic will use
-// targetHost: a host that resides outside of the cluster, target for EgressIP traffic
-// targetPort: the target port of outbound EgressIP traffic
-// probeCount: the number of probes to send
-// expectedHits: the number of expected log hits (usually, either 0 or expectedHits == probeCount)
-// packetSnifferDaemonSet: the DaemonSet that runs the tcpdump processes (we must check the logs of each pod in this DaemonSet)
-// egressIPSet: Those are the EgressIPs that we are looking for. The sum of log hits for seach EgressIP must be == expectedHits
-// logScanMaxTries: Needed do deal with log propagation delay. Rescan logs every second for logScanMaxTries if expectedHits != probeCount
-func sendEgressIPProbesAndCheckPacketSnifferLogs(
-	oc *exutil.CLI, proberPod *corev1.Pod, routeName, targetProtocol, targetHost string, targetPort,
-	probeCount, expectedHits int, packetSnifferDaemonSet *appsv1.DaemonSet, egressIPSet map[string]string, logScanMaxTries int) (bool, error) {
+// oc:             The CLI client.
+// proberPod:      A pointer to the pod that sends the probes (this is not an EgressIP pod, instead, it dials
+//                 into the route/service of the EgressIP pods).
+// routeName:      Name of the routes to dial into the EgressIP pods' agnhost netexec.
+// targetHost:     A host that resides outside of the cluster, target for EgressIP traffic.
+// targetPort:     The target port of outbound EgressIP traffic.
+// probeCount:     The number of probes to send.
+// expectedHits:   The number of expected log hits (usually, either 0 or expectedHits == probeCount).
+// egressIPSet:    Those are the EgressIPs that we are looking for. Expect sum(EgressIP clientIPs) == expectedHits.
+func sendEgressIPProbesAndCheckOutput(oc *exutil.CLI, proberPod *corev1.Pod, routeName, targetHost string, targetPort,
+	probeCount, expectedHits int, egressIPSet map[string]string) (bool, error) {
 
-	// Send requests.
-	framework.Logf("Sending requests with a unique search string from prober pod %s/%s", proberPod.Namespace, proberPod.Name)
-	searchString, err := sendProbesToHostPort(oc, proberPod, routeName, targetProtocol, targetHost, targetPort, probeCount)
-	if err != nil {
-		return false, err
-	}
-
-	// Tcpdump runs with -l for line buffered and the container runs with a TTY.
-	// Even with all of this in place, it can still take a while for log entries to show up inside the container logs so add this retry mechanism.
-	for i := 0; i < logScanMaxTries; i++ {
-		// Collect log entries inside map "found".
-		framework.Logf("Making sure that %d requests with search string %s and EgressIPs %v were seen (try %d of %d)", expectedHits, searchString, egressIPSet, i+1, logScanMaxTries)
-		numberFound := 0
-		found, err := scanPacketSnifferDaemonSetPodLogs(oc, packetSnifferDaemonSet, targetProtocol, searchString)
-		if err != nil {
-			return false, err
-		}
-		framework.Logf("Found map is: %v", found)
-
-		// Count number of found entries for all EgressIPs.
-		for egressIP := range egressIPSet {
-			if n, ok := found[egressIP]; ok {
-				framework.Logf("Found EgressIP %s for string %s %d times", egressIP, searchString, n)
-				numberFound += n
-			}
-		}
-
-		// Return true if number found and expectHits count match.
-		if numberFound == expectedHits {
-			return true, nil
-		}
-
-		// If numberFound > expectedHits, then something is wrong that we can't fix by rescanning the logs.
-		if numberFound > expectedHits {
-			return false, nil
-		}
-
-		framework.Logf("Sleeping for 1 seconds to give container logs and tcpdump some more time to refresh")
-		time.Sleep(1 * time.Second)
-	}
-	return false, nil
-}
-
-// sendProbesToHostPort generates a random string and runs curl against
-// http://%s/dial?host=%s&port=%d&request=<random-string> for the specified number of iterations.
-// Returns the random string that was used as a request.
-func sendProbesToHostPort(oc *exutil.CLI, proberPod *v1.Pod, url, targetProtocol, targetHost string, targetPort, iterations int) (string, error) {
 	if oc == nil {
-		return "", fmt.Errorf("Nil pointer to exutil.CLI oc was provided in sendProbesToHostPort.")
+		return false, fmt.Errorf("nil pointer to exutil.CLI oc was provided in sendProbesToHostPort")
 	}
 	if proberPod == nil {
-		return "", fmt.Errorf("Nil pointer to proberPod was provided in sendProbesToHostPort.")
-	}
-	if targetProtocol != "http" && targetProtocol != "udp" {
-		return "", fmt.Errorf("sendProbesToHostPort supports only 'http' and 'udp' protocols.")
+		return false, fmt.Errorf("nil pointer to proberPod was provided in sendProbesToHostPort")
 	}
 
-	randomID := uuid.New()
-	randomIDStr := randomID.String()
-	if targetProtocol == "udp" {
-		randomIDStr = fmt.Sprintf("START%sEOF", randomIDStr)
-	}
-
-	// Connect to the url, instruct the netexec server running on the other side to dial targetProtocol/targetHost/targetPort and insert
-	// the randomIDStr in the request. Run these tests in their own go routines to speed this up (for UDP, agnhost unfortunately has a
-	// 7 second or so wait time before it returns and the delay here compounds a lot when running several iterations).
-	request := fmt.Sprintf("http://%s/dial?protocol=%s&host=%s&port=%d&request=%s", url, targetProtocol, targetHost, targetPort, randomIDStr)
+	// Connect to the url, instruct the netexec server running on the other side to dial HTTP targetHost:targetPort
+	// and to run the clientip request.
+	requestStr := "clientip"
+	targetProtocol := "http"
+	request := fmt.Sprintf("http://%s/dial?protocol=%s&host=%s&port=%d&request=%s", routeName, targetProtocol,
+		targetHost, targetPort, requestStr)
+	clientIPs := make(map[string]int)
 	var wg sync.WaitGroup
-	errChan := make(chan error, iterations)
-	for i := 0; i < iterations; i++ {
+	outputChan := make(chan string, probeCount)
+	for i := 0; i < probeCount; i++ {
 		// Make sure that we don´t reuse the i variable when passing it to the go func.
 		i := i
-		// Randomize the start time a little bit per go routine.
-		// Max of 250 ms * current iteration counter
-		n := rand.Intn(250) * i
-		framework.Logf("Sleeping for %d ms for iteration %d", n, i)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// Randomize the start time a little bit per go routine.
+			// Max of 250 ms * current iteration counter
+			n := rand.Intn(250) * i
+			framework.Logf("Sleeping for %d ms for iteration %d", n, i)
 			time.Sleep(time.Duration(n) * time.Millisecond)
-			output, err := runOcWithRetry(oc.AsAdmin(), "exec", proberPod.Name, "--", "curl", "--max-time", "15", "-s", request)
-			// Report errors.
+
+			output, err := runOcWithRetry(oc.AsAdmin(), "exec", proberPod.Name, "-n", proberPod.Namespace, "--",
+				"curl", "--max-time", "15", "-s", request)
 			if err != nil {
-				errChan <- fmt.Errorf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
+				framework.Logf("Query failed. Request: %s, Output: %s, Error: %v", request, output, err)
+				return
 			}
-			return
+			outputChan <- output
 		}()
 	}
 	wg.Wait()
+	close(outputChan)
 
-	// If the above yielded any errors, then append them to a list and report them.
-	if len(errChan) > 0 {
-		errList := "Encountered the following errors: "
-		for e := range errChan {
-			errList = fmt.Sprintf("%s {%s}", errList, e.Error())
+	for output := range outputChan {
+		framework.Logf("Output is: %s", output)
+		resp := struct {
+			Responses []string
+		}{}
+		err := json.Unmarshal([]byte(output), &resp)
+		if err != nil {
+			framework.Logf("Could not unmarshal output %s", output)
+			continue
 		}
-		return "", fmt.Errorf(errList)
+		if len(resp.Responses) != 1 {
+			framework.Logf("Could not parse output %s", output)
+			continue
+		}
+		ipPort := strings.Split(resp.Responses[0], ":")
+		if len(ipPort) != 2 {
+			framework.Logf("Could not parse output %s", output)
+			continue
+		}
+		ip := ipPort[0]
+		clientIPs[ip]++
 	}
 
-	return randomID.String(), nil
-}
+	numHits := 0
+	for eip := range egressIPSet {
+		numHits += clientIPs[eip]
+	}
+	framework.Logf("Reported clientIPs are: %v", clientIPs)
+	if numHits != expectedHits {
+		framework.Logf("Unexpected number of hits for EgressIPs %v, expected: %d, got: %d",
+			egressIPSet, expectedHits, numHits)
+		return false, nil
+	}
 
-// TODO: make port allocator a singleton, shared among all test processes for egressip
-// TODO: add an egressip allocator similar to the port allocator
+	return true, nil
+}
 
 // PortAllocator is a simple class to allocate ports serially.
 type PortAllocator struct {
@@ -1281,7 +838,7 @@ func (p *PortAllocator) AllocateNextPort() (int, error) {
 		p.nextPort++
 	}
 
-	return -1, fmt.Errorf("Cannot allocate new port after %d tries.", rangeSize)
+	return -1, fmt.Errorf("cannot allocate new port after %d tries", rangeSize)
 }
 
 // ReleasePort will release the allocatoin for port <port>.
@@ -1539,13 +1096,13 @@ func getDaemonSetPodIPs(clientset kubernetes.Interface, namespace, daemonsetName
 // At the end of the test, the prober pod is deleted again.
 func probeForClientIPs(oc *exutil.CLI, proberPodNamespace, proberPodName, url, targetIP string, targetPort, iterations int) (map[string]struct{}, error) {
 	if oc == nil {
-		return nil, fmt.Errorf("Nil pointer to exutil.CLI oc was provided in SendProbesToHostPort.")
+		return nil, fmt.Errorf("nil pointer to exutil.CLI oc was provided in SendProbesToHostPort")
 	}
 
 	f := oc.KubeFramework()
 	clientset := f.ClientSet
 
-	clientIpSet := make(map[string]struct{})
+	clientIPSet := make(map[string]struct{})
 
 	proberPod := frameworkpod.CreateExecPodOrFail(clientset, proberPodNamespace, probePodName, func(pod *corev1.Pod) {
 		// pod.ObjectMeta.Annotations = annotation
@@ -1574,12 +1131,12 @@ func probeForClientIPs(oc *exutil.CLI, proberPodNamespace, proberPodName, url, t
 		if len(dialResponse.Responses) != 1 {
 			continue
 		}
-		clientIpPort := strings.Split(dialResponse.Responses[0], ":")
-		if len(clientIpPort) != 2 {
+		clientIPPort := strings.Split(dialResponse.Responses[0], ":")
+		if len(clientIPPort) != 2 {
 			continue
 		}
-		clientIp := clientIpPort[0]
-		clientIpSet[clientIp] = struct{}{}
+		clientIP := clientIPPort[0]
+		clientIPSet[clientIP] = struct{}{}
 	}
 
 	// delete the exec pod again - in foreground, so that it blocks
@@ -1590,59 +1147,13 @@ func probeForClientIPs(oc *exutil.CLI, proberPodNamespace, proberPodName, url, t
 		return nil, err
 	}
 
-	return clientIpSet, nil
+	return clientIPSet, nil
 }
 
-// getTargetProtocolHostPort gets targetProtocol, targetHost, targetPort.
-// Special targetHost keyword "self" means that the tests should be against th cluster router.
-// networkPluginName is currently unused but passed in here in case it is needed in the future e.g. to modify the default settings
-// based on the pluginName, for example: if networkPluginName == OVNKubernetesPluginName {
-func getTargetProtocolHostPort(oc *exutil.CLI, hasIPv4, hasIPv6 bool, cloudType configv1.PlatformType, networkPluginName string) (string, string, int, error) {
-	var targetProtocol string
-	var targetPort int
-	var targetHost string
-	var err error
-
-	// default settings based on cloud type
-	if cloudType == configv1.AWSPlatformType {
-		// exploiting https://bugzilla.redhat.com/show_bug.cgi?id=2071960
-		targetProtocol = "http"
-		targetHost = "self"
-		targetPort = 80
-	} else {
-		targetProtocol = "udp"
-		targetPort = 80
-		// https://en.wikipedia.org/wiki/Reserved_IP_addresses
-		if hasIPv4 {
-			targetHost = "192.0.2.10"
-		} else {
-			targetHost = "2001:db8::10"
-		}
-	}
-
-	// manual overrides
-	if tp, found := os.LookupEnv("EGRESSIP_TARGET_PROTOCOL"); found {
-		if tp != "udp" && tp != "http" {
-			return "", "", 0, fmt.Errorf("EGRESSIP_TARGET_PROTOCOL must be set to either of 'udp' or 'http', invalid value: %s", tp)
-		}
-		targetProtocol = tp
-	}
-	if th, found := os.LookupEnv("EGRESSIP_TARGET_HOST"); found {
-		targetHost = th
-	}
-	if tp, found := os.LookupEnv("EGRESSIP_TARGET_PORT"); found {
-		targetPort, err = strconv.Atoi(tp)
-		if err != nil {
-			return "", "", 0, fmt.Errorf("EGRESSIP_TARGET_PORT is invalid: %v", err)
-		}
-	}
-	return targetProtocol, targetHost, targetPort, nil
-}
-
-// cloudPrivateIpConfigExists returns if a given ip was found as a cloudprivateipconfigs object
+// cloudPrivateIPConfigExists returns if a given ip was found as a cloudprivateipconfigs object
 // and if it was assigned to a node as a separate value.
 // Returns the following: exists bool, isAssigned bool, err error.
-func cloudPrivateIpConfigExists(oc *exutil.CLI, cloudNetworkClientset cloudnetwork.Interface, ip string) (bool, bool, error) {
+func cloudPrivateIPConfigExists(oc *exutil.CLI, cloudNetworkClientset cloudnetwork.Interface, ip string) (bool, bool, error) {
 	cpic, err := cloudNetworkClientset.CloudV1().CloudPrivateIPConfigs().Get(context.Background(), ip, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/auth/LICENSE
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/auth/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 Microsoft Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/auth/auth.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/auth/auth.go
@@ -1,0 +1,761 @@
+package auth
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"unicode/utf16"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/azure/cli"
+	"github.com/Azure/go-autorest/logger"
+	"github.com/dimchansky/utfbom"
+)
+
+// The possible keys in the Values map.
+const (
+	SubscriptionID          = "AZURE_SUBSCRIPTION_ID"
+	TenantID                = "AZURE_TENANT_ID"
+	AuxiliaryTenantIDs      = "AZURE_AUXILIARY_TENANT_IDS"
+	ClientID                = "AZURE_CLIENT_ID"
+	ClientSecret            = "AZURE_CLIENT_SECRET"
+	CertificatePath         = "AZURE_CERTIFICATE_PATH"
+	CertificatePassword     = "AZURE_CERTIFICATE_PASSWORD"
+	Username                = "AZURE_USERNAME"
+	Password                = "AZURE_PASSWORD"
+	EnvironmentName         = "AZURE_ENVIRONMENT"
+	Resource                = "AZURE_AD_RESOURCE"
+	ActiveDirectoryEndpoint = "ActiveDirectoryEndpoint"
+	ResourceManagerEndpoint = "ResourceManagerEndpoint"
+	GraphResourceID         = "GraphResourceID"
+	SQLManagementEndpoint   = "SQLManagementEndpoint"
+	GalleryEndpoint         = "GalleryEndpoint"
+	ManagementEndpoint      = "ManagementEndpoint"
+)
+
+// NewAuthorizerFromEnvironment creates an Authorizer configured from environment variables in the order:
+// 1. Client credentials
+// 2. Client certificate
+// 3. Username password
+// 4. MSI
+func NewAuthorizerFromEnvironment() (autorest.Authorizer, error) {
+	logger.Instance.Writeln(logger.LogInfo, "NewAuthorizerFromEnvironment() determining authentication mechanism")
+	settings, err := GetSettingsFromEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	return settings.GetAuthorizer()
+}
+
+// NewAuthorizerFromEnvironmentWithResource creates an Authorizer configured from environment variables in the order:
+// 1. Client credentials
+// 2. Client certificate
+// 3. Username password
+// 4. MSI
+func NewAuthorizerFromEnvironmentWithResource(resource string) (autorest.Authorizer, error) {
+	logger.Instance.Writeln(logger.LogInfo, "NewAuthorizerFromEnvironmentWithResource() determining authentication mechanism")
+	settings, err := GetSettingsFromEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	settings.Values[Resource] = resource
+	return settings.GetAuthorizer()
+}
+
+// EnvironmentSettings contains the available authentication settings.
+type EnvironmentSettings struct {
+	Values      map[string]string
+	Environment azure.Environment
+}
+
+// GetSettingsFromEnvironment returns the available authentication settings from the environment.
+func GetSettingsFromEnvironment() (s EnvironmentSettings, err error) {
+	s = EnvironmentSettings{
+		Values: map[string]string{},
+	}
+	s.setValue(SubscriptionID)
+	s.setValue(TenantID)
+	s.setValue(AuxiliaryTenantIDs)
+	s.setValue(ClientID)
+	s.setValue(ClientSecret)
+	s.setValue(CertificatePath)
+	s.setValue(CertificatePassword)
+	s.setValue(Username)
+	s.setValue(Password)
+	s.setValue(EnvironmentName)
+	s.setValue(Resource)
+	if v := s.Values[EnvironmentName]; v == "" {
+		s.Environment = azure.PublicCloud
+	} else {
+		s.Environment, err = azure.EnvironmentFromName(v)
+	}
+	if s.Values[Resource] == "" {
+		s.Values[Resource] = s.Environment.ResourceManagerEndpoint
+	}
+	return
+}
+
+// GetSubscriptionID returns the available subscription ID or an empty string.
+func (settings EnvironmentSettings) GetSubscriptionID() string {
+	return settings.Values[SubscriptionID]
+}
+
+// adds the specified environment variable value to the Values map if it exists
+func (settings EnvironmentSettings) setValue(key string) {
+	if v := os.Getenv(key); v != "" {
+		logger.Instance.Writef(logger.LogInfo, "GetSettingsFromEnvironment() found environment var %s\n", key)
+		settings.Values[key] = v
+	}
+}
+
+// helper to return client and tenant IDs
+func (settings EnvironmentSettings) getClientAndTenant() (string, string) {
+	clientID := settings.Values[ClientID]
+	tenantID := settings.Values[TenantID]
+	return clientID, tenantID
+}
+
+// GetClientCredentials creates a config object from the available client credentials.
+// An error is returned if no client credentials are available.
+func (settings EnvironmentSettings) GetClientCredentials() (ClientCredentialsConfig, error) {
+	secret := settings.Values[ClientSecret]
+	if secret == "" {
+		logger.Instance.Writeln(logger.LogInfo, "EnvironmentSettings.GetClientCredentials() missing client secret")
+		return ClientCredentialsConfig{}, errors.New("missing client secret")
+	}
+	clientID, tenantID := settings.getClientAndTenant()
+	config := NewClientCredentialsConfig(clientID, secret, tenantID)
+	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
+	config.Resource = settings.Values[Resource]
+	if auxTenants, ok := settings.Values[AuxiliaryTenantIDs]; ok {
+		config.AuxTenants = strings.Split(auxTenants, ";")
+		for i := range config.AuxTenants {
+			config.AuxTenants[i] = strings.TrimSpace(config.AuxTenants[i])
+		}
+	}
+	return config, nil
+}
+
+// GetClientCertificate creates a config object from the available certificate credentials.
+// An error is returned if no certificate credentials are available.
+func (settings EnvironmentSettings) GetClientCertificate() (ClientCertificateConfig, error) {
+	certPath := settings.Values[CertificatePath]
+	if certPath == "" {
+		logger.Instance.Writeln(logger.LogInfo, "EnvironmentSettings.GetClientCertificate() missing certificate path")
+		return ClientCertificateConfig{}, errors.New("missing certificate path")
+	}
+	certPwd := settings.Values[CertificatePassword]
+	clientID, tenantID := settings.getClientAndTenant()
+	config := NewClientCertificateConfig(certPath, certPwd, clientID, tenantID)
+	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
+	config.Resource = settings.Values[Resource]
+	return config, nil
+}
+
+// GetUsernamePassword creates a config object from the available username/password credentials.
+// An error is returned if no username/password credentials are available.
+func (settings EnvironmentSettings) GetUsernamePassword() (UsernamePasswordConfig, error) {
+	username := settings.Values[Username]
+	password := settings.Values[Password]
+	if username == "" || password == "" {
+		logger.Instance.Writeln(logger.LogInfo, "EnvironmentSettings.GetUsernamePassword() missing username and/or password")
+		return UsernamePasswordConfig{}, errors.New("missing username/password")
+	}
+	clientID, tenantID := settings.getClientAndTenant()
+	config := NewUsernamePasswordConfig(username, password, clientID, tenantID)
+	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
+	config.Resource = settings.Values[Resource]
+	return config, nil
+}
+
+// GetMSI creates a MSI config object from the available client ID.
+func (settings EnvironmentSettings) GetMSI() MSIConfig {
+	config := NewMSIConfig()
+	config.Resource = settings.Values[Resource]
+	config.ClientID = settings.Values[ClientID]
+	return config
+}
+
+// GetDeviceFlow creates a device-flow config object from the available client and tenant IDs.
+func (settings EnvironmentSettings) GetDeviceFlow() DeviceFlowConfig {
+	clientID, tenantID := settings.getClientAndTenant()
+	config := NewDeviceFlowConfig(clientID, tenantID)
+	config.AADEndpoint = settings.Environment.ActiveDirectoryEndpoint
+	config.Resource = settings.Values[Resource]
+	return config
+}
+
+// GetAuthorizer creates an Authorizer configured from environment variables in the order:
+// 1. Client credentials
+// 2. Client certificate
+// 3. Username password
+// 4. MSI
+func (settings EnvironmentSettings) GetAuthorizer() (autorest.Authorizer, error) {
+	//1.Client Credentials
+	if c, e := settings.GetClientCredentials(); e == nil {
+		logger.Instance.Writeln(logger.LogInfo, "EnvironmentSettings.GetAuthorizer() using client secret credentials")
+		return c.Authorizer()
+	}
+
+	//2. Client Certificate
+	if c, e := settings.GetClientCertificate(); e == nil {
+		logger.Instance.Writeln(logger.LogInfo, "EnvironmentSettings.GetAuthorizer() using client certificate credentials")
+		return c.Authorizer()
+	}
+
+	//3. Username Password
+	if c, e := settings.GetUsernamePassword(); e == nil {
+		logger.Instance.Writeln(logger.LogInfo, "EnvironmentSettings.GetAuthorizer() using user name/password credentials")
+		return c.Authorizer()
+	}
+
+	// 4. MSI
+	if !adal.MSIAvailable(context.Background(), nil) {
+		return nil, errors.New("MSI not available")
+	}
+	logger.Instance.Writeln(logger.LogInfo, "EnvironmentSettings.GetAuthorizer() using MSI authentication")
+	return settings.GetMSI().Authorizer()
+}
+
+// NewAuthorizerFromFile creates an Authorizer configured from a configuration file in the following order.
+// 1. Client credentials
+// 2. Client certificate
+// The path to the configuration file must be specified in the AZURE_AUTH_LOCATION environment variable.
+// resourceBaseURI - used to determine the resource type
+func NewAuthorizerFromFile(resourceBaseURI string) (autorest.Authorizer, error) {
+	settings, err := GetSettingsFromFile()
+	if err != nil {
+		return nil, err
+	}
+	if a, err := settings.ClientCredentialsAuthorizer(resourceBaseURI); err == nil {
+		return a, err
+	}
+	if a, err := settings.ClientCertificateAuthorizer(resourceBaseURI); err == nil {
+		return a, err
+	}
+	return nil, errors.New("auth file missing client and certificate credentials")
+}
+
+// NewAuthorizerFromFileWithResource creates an Authorizer configured from a configuration file in the following order.
+// 1. Client credentials
+// 2. Client certificate
+// The path to the configuration file must be specified in the AZURE_AUTH_LOCATION environment variable.
+func NewAuthorizerFromFileWithResource(resource string) (autorest.Authorizer, error) {
+	s, err := GetSettingsFromFile()
+	if err != nil {
+		return nil, err
+	}
+	if a, err := s.ClientCredentialsAuthorizerWithResource(resource); err == nil {
+		return a, err
+	}
+	if a, err := s.ClientCertificateAuthorizerWithResource(resource); err == nil {
+		return a, err
+	}
+	return nil, errors.New("auth file missing client and certificate credentials")
+}
+
+// NewAuthorizerFromCLI creates an Authorizer configured from Azure CLI 2.0 for local development scenarios.
+func NewAuthorizerFromCLI() (autorest.Authorizer, error) {
+	settings, err := GetSettingsFromEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+	if settings.Values[Resource] == "" {
+		settings.Values[Resource] = settings.Environment.ResourceManagerEndpoint
+	}
+
+	return NewAuthorizerFromCLIWithResource(settings.Values[Resource])
+}
+
+// NewAuthorizerFromCLIWithResource creates an Authorizer configured from Azure CLI 2.0 for local development scenarios.
+func NewAuthorizerFromCLIWithResource(resource string) (autorest.Authorizer, error) {
+	token, err := cli.GetTokenFromCLI(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	adalToken, err := token.ToADALToken()
+	if err != nil {
+		return nil, err
+	}
+
+	return autorest.NewBearerAuthorizer(&adalToken), nil
+}
+
+// GetSettingsFromFile returns the available authentication settings from an Azure CLI authentication file.
+func GetSettingsFromFile() (FileSettings, error) {
+	s := FileSettings{}
+	fileLocation := os.Getenv("AZURE_AUTH_LOCATION")
+	if fileLocation == "" {
+		return s, errors.New("environment variable AZURE_AUTH_LOCATION is not set")
+	}
+
+	contents, err := ioutil.ReadFile(fileLocation)
+	if err != nil {
+		return s, err
+	}
+
+	// Auth file might be encoded
+	decoded, err := decode(contents)
+	if err != nil {
+		return s, err
+	}
+
+	authFile := map[string]interface{}{}
+	err = json.Unmarshal(decoded, &authFile)
+	if err != nil {
+		return s, err
+	}
+
+	s.Values = map[string]string{}
+	s.setKeyValue(ClientID, authFile["clientId"])
+	s.setKeyValue(ClientSecret, authFile["clientSecret"])
+	s.setKeyValue(CertificatePath, authFile["clientCertificate"])
+	s.setKeyValue(CertificatePassword, authFile["clientCertificatePassword"])
+	s.setKeyValue(SubscriptionID, authFile["subscriptionId"])
+	s.setKeyValue(TenantID, authFile["tenantId"])
+	s.setKeyValue(ActiveDirectoryEndpoint, authFile["activeDirectoryEndpointUrl"])
+	s.setKeyValue(ResourceManagerEndpoint, authFile["resourceManagerEndpointUrl"])
+	s.setKeyValue(GraphResourceID, authFile["activeDirectoryGraphResourceId"])
+	s.setKeyValue(SQLManagementEndpoint, authFile["sqlManagementEndpointUrl"])
+	s.setKeyValue(GalleryEndpoint, authFile["galleryEndpointUrl"])
+	s.setKeyValue(ManagementEndpoint, authFile["managementEndpointUrl"])
+	return s, nil
+}
+
+// FileSettings contains the available authentication settings.
+type FileSettings struct {
+	Values map[string]string
+}
+
+// GetSubscriptionID returns the available subscription ID or an empty string.
+func (settings FileSettings) GetSubscriptionID() string {
+	return settings.Values[SubscriptionID]
+}
+
+// adds the specified value to the Values map if it isn't nil
+func (settings FileSettings) setKeyValue(key string, val interface{}) {
+	if val != nil {
+		settings.Values[key] = val.(string)
+	}
+}
+
+// returns the specified AAD endpoint or the public cloud endpoint if unspecified
+func (settings FileSettings) getAADEndpoint() string {
+	if v, ok := settings.Values[ActiveDirectoryEndpoint]; ok {
+		return v
+	}
+	return azure.PublicCloud.ActiveDirectoryEndpoint
+}
+
+// ServicePrincipalTokenFromClientCredentials creates a ServicePrincipalToken from the available client credentials.
+func (settings FileSettings) ServicePrincipalTokenFromClientCredentials(baseURI string) (*adal.ServicePrincipalToken, error) {
+	resource, err := settings.getResourceForToken(baseURI)
+	if err != nil {
+		return nil, err
+	}
+	return settings.ServicePrincipalTokenFromClientCredentialsWithResource(resource)
+}
+
+// ClientCredentialsAuthorizer creates an authorizer from the available client credentials.
+func (settings FileSettings) ClientCredentialsAuthorizer(baseURI string) (autorest.Authorizer, error) {
+	resource, err := settings.getResourceForToken(baseURI)
+	if err != nil {
+		return nil, err
+	}
+	return settings.ClientCredentialsAuthorizerWithResource(resource)
+}
+
+// ServicePrincipalTokenFromClientCredentialsWithResource creates a ServicePrincipalToken
+// from the available client credentials and the specified resource.
+func (settings FileSettings) ServicePrincipalTokenFromClientCredentialsWithResource(resource string) (*adal.ServicePrincipalToken, error) {
+	if _, ok := settings.Values[ClientSecret]; !ok {
+		return nil, errors.New("missing client secret")
+	}
+	config, err := adal.NewOAuthConfig(settings.getAADEndpoint(), settings.Values[TenantID])
+	if err != nil {
+		return nil, err
+	}
+	return adal.NewServicePrincipalToken(*config, settings.Values[ClientID], settings.Values[ClientSecret], resource)
+}
+
+func (settings FileSettings) clientCertificateConfigWithResource(resource string) (ClientCertificateConfig, error) {
+	if _, ok := settings.Values[CertificatePath]; !ok {
+		return ClientCertificateConfig{}, errors.New("missing certificate path")
+	}
+	cfg := NewClientCertificateConfig(settings.Values[CertificatePath], settings.Values[CertificatePassword], settings.Values[ClientID], settings.Values[TenantID])
+	cfg.AADEndpoint = settings.getAADEndpoint()
+	cfg.Resource = resource
+	return cfg, nil
+}
+
+// ClientCredentialsAuthorizerWithResource creates an authorizer from the available client credentials and the specified resource.
+func (settings FileSettings) ClientCredentialsAuthorizerWithResource(resource string) (autorest.Authorizer, error) {
+	spToken, err := settings.ServicePrincipalTokenFromClientCredentialsWithResource(resource)
+	if err != nil {
+		return nil, err
+	}
+	return autorest.NewBearerAuthorizer(spToken), nil
+}
+
+// ServicePrincipalTokenFromClientCertificate creates a ServicePrincipalToken from the available certificate credentials.
+func (settings FileSettings) ServicePrincipalTokenFromClientCertificate(baseURI string) (*adal.ServicePrincipalToken, error) {
+	resource, err := settings.getResourceForToken(baseURI)
+	if err != nil {
+		return nil, err
+	}
+	return settings.ServicePrincipalTokenFromClientCertificateWithResource(resource)
+}
+
+// ClientCertificateAuthorizer creates an authorizer from the available certificate credentials.
+func (settings FileSettings) ClientCertificateAuthorizer(baseURI string) (autorest.Authorizer, error) {
+	resource, err := settings.getResourceForToken(baseURI)
+	if err != nil {
+		return nil, err
+	}
+	return settings.ClientCertificateAuthorizerWithResource(resource)
+}
+
+// ServicePrincipalTokenFromClientCertificateWithResource creates a ServicePrincipalToken from the available certificate credentials.
+func (settings FileSettings) ServicePrincipalTokenFromClientCertificateWithResource(resource string) (*adal.ServicePrincipalToken, error) {
+	cfg, err := settings.clientCertificateConfigWithResource(resource)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.ServicePrincipalToken()
+}
+
+// ClientCertificateAuthorizerWithResource creates an authorizer from the available certificate credentials and the specified resource.
+func (settings FileSettings) ClientCertificateAuthorizerWithResource(resource string) (autorest.Authorizer, error) {
+	cfg, err := settings.clientCertificateConfigWithResource(resource)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Authorizer()
+}
+
+func decode(b []byte) ([]byte, error) {
+	reader, enc := utfbom.Skip(bytes.NewReader(b))
+
+	switch enc {
+	case utfbom.UTF16LittleEndian:
+		u16 := make([]uint16, (len(b)/2)-1)
+		err := binary.Read(reader, binary.LittleEndian, &u16)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(string(utf16.Decode(u16))), nil
+	case utfbom.UTF16BigEndian:
+		u16 := make([]uint16, (len(b)/2)-1)
+		err := binary.Read(reader, binary.BigEndian, &u16)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(string(utf16.Decode(u16))), nil
+	}
+	return ioutil.ReadAll(reader)
+}
+
+func (settings FileSettings) getResourceForToken(baseURI string) (string, error) {
+	// Compare default base URI from the SDK to the endpoints from the public cloud
+	// Base URI and token resource are the same string. This func finds the authentication
+	// file field that matches the SDK base URI. The SDK defines the public cloud
+	// endpoint as its default base URI
+	if !strings.HasSuffix(baseURI, "/") {
+		baseURI += "/"
+	}
+	switch baseURI {
+	case azure.PublicCloud.ServiceManagementEndpoint:
+		return settings.Values[ManagementEndpoint], nil
+	case azure.PublicCloud.ResourceManagerEndpoint:
+		return settings.Values[ResourceManagerEndpoint], nil
+	case azure.PublicCloud.ActiveDirectoryEndpoint:
+		return settings.Values[ActiveDirectoryEndpoint], nil
+	case azure.PublicCloud.GalleryEndpoint:
+		return settings.Values[GalleryEndpoint], nil
+	case azure.PublicCloud.GraphEndpoint:
+		return settings.Values[GraphResourceID], nil
+	}
+	return "", fmt.Errorf("auth: base URI not found in endpoints")
+}
+
+// NewClientCredentialsConfig creates an AuthorizerConfig object configured to obtain an Authorizer through Client Credentials.
+// Defaults to Public Cloud and Resource Manager Endpoint.
+func NewClientCredentialsConfig(clientID string, clientSecret string, tenantID string) ClientCredentialsConfig {
+	return ClientCredentialsConfig{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TenantID:     tenantID,
+		Resource:     azure.PublicCloud.ResourceManagerEndpoint,
+		AADEndpoint:  azure.PublicCloud.ActiveDirectoryEndpoint,
+	}
+}
+
+// NewClientCertificateConfig creates a ClientCertificateConfig object configured to obtain an Authorizer through client certificate.
+// Defaults to Public Cloud and Resource Manager Endpoint.
+func NewClientCertificateConfig(certificatePath string, certificatePassword string, clientID string, tenantID string) ClientCertificateConfig {
+	return ClientCertificateConfig{
+		CertificatePath:     certificatePath,
+		CertificatePassword: certificatePassword,
+		ClientID:            clientID,
+		TenantID:            tenantID,
+		Resource:            azure.PublicCloud.ResourceManagerEndpoint,
+		AADEndpoint:         azure.PublicCloud.ActiveDirectoryEndpoint,
+	}
+}
+
+// NewUsernamePasswordConfig creates an UsernamePasswordConfig object configured to obtain an Authorizer through username and password.
+// Defaults to Public Cloud and Resource Manager Endpoint.
+func NewUsernamePasswordConfig(username string, password string, clientID string, tenantID string) UsernamePasswordConfig {
+	return UsernamePasswordConfig{
+		Username:    username,
+		Password:    password,
+		ClientID:    clientID,
+		TenantID:    tenantID,
+		Resource:    azure.PublicCloud.ResourceManagerEndpoint,
+		AADEndpoint: azure.PublicCloud.ActiveDirectoryEndpoint,
+	}
+}
+
+// NewMSIConfig creates an MSIConfig object configured to obtain an Authorizer through MSI.
+func NewMSIConfig() MSIConfig {
+	return MSIConfig{
+		Resource: azure.PublicCloud.ResourceManagerEndpoint,
+	}
+}
+
+// NewDeviceFlowConfig creates a DeviceFlowConfig object configured to obtain an Authorizer through device flow.
+// Defaults to Public Cloud and Resource Manager Endpoint.
+func NewDeviceFlowConfig(clientID string, tenantID string) DeviceFlowConfig {
+	return DeviceFlowConfig{
+		ClientID:    clientID,
+		TenantID:    tenantID,
+		Resource:    azure.PublicCloud.ResourceManagerEndpoint,
+		AADEndpoint: azure.PublicCloud.ActiveDirectoryEndpoint,
+	}
+}
+
+//AuthorizerConfig provides an authorizer from the configuration provided.
+type AuthorizerConfig interface {
+	Authorizer() (autorest.Authorizer, error)
+}
+
+// ClientCredentialsConfig provides the options to get a bearer authorizer from client credentials.
+type ClientCredentialsConfig struct {
+	ClientID     string
+	ClientSecret string
+	TenantID     string
+	AuxTenants   []string
+	AADEndpoint  string
+	Resource     string
+}
+
+// ServicePrincipalToken creates a ServicePrincipalToken from client credentials.
+func (ccc ClientCredentialsConfig) ServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewOAuthConfig(ccc.AADEndpoint, ccc.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	return adal.NewServicePrincipalToken(*oauthConfig, ccc.ClientID, ccc.ClientSecret, ccc.Resource)
+}
+
+// MultiTenantServicePrincipalToken creates a MultiTenantServicePrincipalToken from client credentials.
+func (ccc ClientCredentialsConfig) MultiTenantServicePrincipalToken() (*adal.MultiTenantServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewMultiTenantOAuthConfig(ccc.AADEndpoint, ccc.TenantID, ccc.AuxTenants, adal.OAuthOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return adal.NewMultiTenantServicePrincipalToken(oauthConfig, ccc.ClientID, ccc.ClientSecret, ccc.Resource)
+}
+
+// Authorizer gets the authorizer from client credentials.
+func (ccc ClientCredentialsConfig) Authorizer() (autorest.Authorizer, error) {
+	if len(ccc.AuxTenants) == 0 {
+		spToken, err := ccc.ServicePrincipalToken()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get SPT from client credentials: %v", err)
+		}
+		return autorest.NewBearerAuthorizer(spToken), nil
+	}
+	mtSPT, err := ccc.MultiTenantServicePrincipalToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get multitenant SPT from client credentials: %v", err)
+	}
+	return autorest.NewMultiTenantServicePrincipalTokenAuthorizer(mtSPT), nil
+}
+
+// ClientCertificateConfig provides the options to get a bearer authorizer from a client certificate.
+type ClientCertificateConfig struct {
+	ClientID            string
+	CertificatePath     string
+	CertificatePassword string
+	TenantID            string
+	AuxTenants          []string
+	AADEndpoint         string
+	Resource            string
+}
+
+// ServicePrincipalToken creates a ServicePrincipalToken from client certificate.
+func (ccc ClientCertificateConfig) ServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewOAuthConfig(ccc.AADEndpoint, ccc.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	certData, err := ioutil.ReadFile(ccc.CertificatePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the certificate file (%s): %v", ccc.CertificatePath, err)
+	}
+	certificate, rsaPrivateKey, err := adal.DecodePfxCertificateData(certData, ccc.CertificatePassword)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode pkcs12 certificate while creating spt: %v", err)
+	}
+	return adal.NewServicePrincipalTokenFromCertificate(*oauthConfig, ccc.ClientID, certificate, rsaPrivateKey, ccc.Resource)
+}
+
+// MultiTenantServicePrincipalToken creates a MultiTenantServicePrincipalToken from client certificate.
+func (ccc ClientCertificateConfig) MultiTenantServicePrincipalToken() (*adal.MultiTenantServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewMultiTenantOAuthConfig(ccc.AADEndpoint, ccc.TenantID, ccc.AuxTenants, adal.OAuthOptions{})
+	if err != nil {
+		return nil, err
+	}
+	certData, err := ioutil.ReadFile(ccc.CertificatePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the certificate file (%s): %v", ccc.CertificatePath, err)
+	}
+	certificate, rsaPrivateKey, err := adal.DecodePfxCertificateData(certData, ccc.CertificatePassword)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode pkcs12 certificate while creating spt: %v", err)
+	}
+	return adal.NewMultiTenantServicePrincipalTokenFromCertificate(oauthConfig, ccc.ClientID, certificate, rsaPrivateKey, ccc.Resource)
+}
+
+// Authorizer gets an authorizer object from client certificate.
+func (ccc ClientCertificateConfig) Authorizer() (autorest.Authorizer, error) {
+	if len(ccc.AuxTenants) == 0 {
+		spToken, err := ccc.ServicePrincipalToken()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get oauth token from certificate auth: %v", err)
+		}
+		return autorest.NewBearerAuthorizer(spToken), nil
+	}
+	mtSPT, err := ccc.MultiTenantServicePrincipalToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get multitenant SPT from certificate auth: %v", err)
+	}
+	return autorest.NewMultiTenantServicePrincipalTokenAuthorizer(mtSPT), nil
+}
+
+// DeviceFlowConfig provides the options to get a bearer authorizer using device flow authentication.
+type DeviceFlowConfig struct {
+	ClientID    string
+	TenantID    string
+	AADEndpoint string
+	Resource    string
+}
+
+// Authorizer gets the authorizer from device flow.
+func (dfc DeviceFlowConfig) Authorizer() (autorest.Authorizer, error) {
+	spToken, err := dfc.ServicePrincipalToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get oauth token from device flow: %v", err)
+	}
+	return autorest.NewBearerAuthorizer(spToken), nil
+}
+
+// ServicePrincipalToken gets the service principal token from device flow.
+func (dfc DeviceFlowConfig) ServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewOAuthConfig(dfc.AADEndpoint, dfc.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	oauthClient := &autorest.Client{}
+	deviceCode, err := adal.InitiateDeviceAuth(oauthClient, *oauthConfig, dfc.ClientID, dfc.Resource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start device auth flow: %s", err)
+	}
+	log.Println(*deviceCode.Message)
+	token, err := adal.WaitForUserCompletion(oauthClient, deviceCode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to finish device auth flow: %s", err)
+	}
+	return adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, dfc.ClientID, dfc.Resource, *token)
+}
+
+// UsernamePasswordConfig provides the options to get a bearer authorizer from a username and a password.
+type UsernamePasswordConfig struct {
+	ClientID    string
+	Username    string
+	Password    string
+	TenantID    string
+	AADEndpoint string
+	Resource    string
+}
+
+// ServicePrincipalToken creates a ServicePrincipalToken from username and password.
+func (ups UsernamePasswordConfig) ServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewOAuthConfig(ups.AADEndpoint, ups.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	return adal.NewServicePrincipalTokenFromUsernamePassword(*oauthConfig, ups.ClientID, ups.Username, ups.Password, ups.Resource)
+}
+
+// Authorizer gets the authorizer from a username and a password.
+func (ups UsernamePasswordConfig) Authorizer() (autorest.Authorizer, error) {
+	spToken, err := ups.ServicePrincipalToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get oauth token from username and password auth: %v", err)
+	}
+	return autorest.NewBearerAuthorizer(spToken), nil
+}
+
+// MSIConfig provides the options to get a bearer authorizer through MSI.
+type MSIConfig struct {
+	Resource string
+	ClientID string
+}
+
+// ServicePrincipalToken creates a ServicePrincipalToken from MSI.
+func (mc MSIConfig) ServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
+	spToken, err := adal.NewServicePrincipalTokenFromManagedIdentity(mc.Resource, &adal.ManagedIdentityOptions{
+		ClientID: mc.ClientID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get oauth token from MSI: %v", err)
+	}
+	return spToken, nil
+}
+
+// Authorizer gets the authorizer from MSI.
+func (mc MSIConfig) Authorizer() (autorest.Authorizer, error) {
+	spToken, err := mc.ServicePrincipalToken()
+	if err != nil {
+		return nil, err
+	}
+
+	return autorest.NewBearerAuthorizer(spToken), nil
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/auth/go_mod_tidy_hack.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/auth/go_mod_tidy_hack.go
@@ -1,0 +1,25 @@
+//go:build modhack
+// +build modhack
+
+package auth
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// This file, and the github.com/Azure/go-autorest import, won't actually become part of
+// the resultant binary.
+
+// Necessary for safely adding multi-module repo.
+// See: https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository
+import _ "github.com/Azure/go-autorest"

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/cli/LICENSE
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/cli/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 Microsoft Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/cli/go_mod_tidy_hack.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/cli/go_mod_tidy_hack.go
@@ -1,0 +1,25 @@
+//go:build modhack
+// +build modhack
+
+package cli
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// This file, and the github.com/Azure/go-autorest import, won't actually become part of
+// the resultant binary.
+
+// Necessary for safely adding multi-module repo.
+// See: https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository
+import _ "github.com/Azure/go-autorest"

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/cli/profile.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/cli/profile.go
@@ -1,0 +1,83 @@
+package cli
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/dimchansky/utfbom"
+	"github.com/mitchellh/go-homedir"
+)
+
+// Profile represents a Profile from the Azure CLI
+type Profile struct {
+	InstallationID string         `json:"installationId"`
+	Subscriptions  []Subscription `json:"subscriptions"`
+}
+
+// Subscription represents a Subscription from the Azure CLI
+type Subscription struct {
+	EnvironmentName string `json:"environmentName"`
+	ID              string `json:"id"`
+	IsDefault       bool   `json:"isDefault"`
+	Name            string `json:"name"`
+	State           string `json:"state"`
+	TenantID        string `json:"tenantId"`
+	User            *User  `json:"user"`
+}
+
+// User represents a User from the Azure CLI
+type User struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+const azureProfileJSON = "azureProfile.json"
+
+func configDir() string {
+	return os.Getenv("AZURE_CONFIG_DIR")
+}
+
+// ProfilePath returns the path where the Azure Profile is stored from the Azure CLI
+func ProfilePath() (string, error) {
+	if cfgDir := configDir(); cfgDir != "" {
+		return filepath.Join(cfgDir, azureProfileJSON), nil
+	}
+	return homedir.Expand("~/.azure/" + azureProfileJSON)
+}
+
+// LoadProfile restores a Profile object from a file located at 'path'.
+func LoadProfile(path string) (result Profile, err error) {
+	var contents []byte
+	contents, err = ioutil.ReadFile(path)
+	if err != nil {
+		err = fmt.Errorf("failed to open file (%s) while loading token: %v", path, err)
+		return
+	}
+	reader := utfbom.SkipOnly(bytes.NewReader(contents))
+
+	dec := json.NewDecoder(reader)
+	if err = dec.Decode(&result); err != nil {
+		err = fmt.Errorf("failed to decode contents of file (%s) into a Profile representation: %v", path, err)
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/cli/token.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/cli/token.go
@@ -1,0 +1,227 @@
+package cli
+
+// Copyright 2017 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/mitchellh/go-homedir"
+)
+
+// Token represents an AccessToken from the Azure CLI
+type Token struct {
+	AccessToken      string `json:"accessToken"`
+	Authority        string `json:"_authority"`
+	ClientID         string `json:"_clientId"`
+	ExpiresOn        string `json:"expiresOn"`
+	IdentityProvider string `json:"identityProvider"`
+	IsMRRT           bool   `json:"isMRRT"`
+	RefreshToken     string `json:"refreshToken"`
+	Resource         string `json:"resource"`
+	TokenType        string `json:"tokenType"`
+	UserID           string `json:"userId"`
+}
+
+const accessTokensJSON = "accessTokens.json"
+
+// ToADALToken converts an Azure CLI `Token`` to an `adal.Token``
+func (t Token) ToADALToken() (converted adal.Token, err error) {
+	tokenExpirationDate, err := ParseExpirationDate(t.ExpiresOn)
+	if err != nil {
+		err = fmt.Errorf("Error parsing Token Expiration Date %q: %+v", t.ExpiresOn, err)
+		return
+	}
+
+	difference := tokenExpirationDate.Sub(date.UnixEpoch())
+
+	converted = adal.Token{
+		AccessToken:  t.AccessToken,
+		Type:         t.TokenType,
+		ExpiresIn:    "3600",
+		ExpiresOn:    json.Number(strconv.Itoa(int(difference.Seconds()))),
+		RefreshToken: t.RefreshToken,
+		Resource:     t.Resource,
+	}
+	return
+}
+
+// AccessTokensPath returns the path where access tokens are stored from the Azure CLI
+// TODO(#199): add unit test.
+func AccessTokensPath() (string, error) {
+	// Azure-CLI allows user to customize the path of access tokens through environment variable.
+	if accessTokenPath := os.Getenv("AZURE_ACCESS_TOKEN_FILE"); accessTokenPath != "" {
+		return accessTokenPath, nil
+	}
+
+	// Azure-CLI allows user to customize the path to Azure config directory through environment variable.
+	if cfgDir := configDir(); cfgDir != "" {
+		return filepath.Join(cfgDir, accessTokensJSON), nil
+	}
+
+	// Fallback logic to default path on non-cloud-shell environment.
+	// TODO(#200): remove the dependency on hard-coding path.
+	return homedir.Expand("~/.azure/" + accessTokensJSON)
+}
+
+// ParseExpirationDate parses either a Azure CLI or CloudShell date into a time object
+func ParseExpirationDate(input string) (*time.Time, error) {
+	// CloudShell (and potentially the Azure CLI in future)
+	expirationDate, cloudShellErr := time.Parse(time.RFC3339, input)
+	if cloudShellErr != nil {
+		// Azure CLI (Python) e.g. 2017-08-31 19:48:57.998857 (plus the local timezone)
+		const cliFormat = "2006-01-02 15:04:05.999999"
+		expirationDate, cliErr := time.ParseInLocation(cliFormat, input, time.Local)
+		if cliErr == nil {
+			return &expirationDate, nil
+		}
+
+		return nil, fmt.Errorf("Error parsing expiration date %q.\n\nCloudShell Error: \n%+v\n\nCLI Error:\n%+v", input, cloudShellErr, cliErr)
+	}
+
+	return &expirationDate, nil
+}
+
+// LoadTokens restores a set of Token objects from a file located at 'path'.
+func LoadTokens(path string) ([]Token, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file (%s) while loading token: %v", path, err)
+	}
+	defer file.Close()
+
+	var tokens []Token
+
+	dec := json.NewDecoder(file)
+	if err = dec.Decode(&tokens); err != nil {
+		return nil, fmt.Errorf("failed to decode contents of file (%s) into a `cli.Token` representation: %v", path, err)
+	}
+
+	return tokens, nil
+}
+
+// GetTokenFromCLI gets a token using Azure CLI 2.0 for local development scenarios.
+func GetTokenFromCLI(resource string) (*Token, error) {
+	return GetTokenFromCLIWithParams(GetAccessTokenParams{Resource: resource})
+}
+
+// GetAccessTokenParams is the parameter struct of GetTokenFromCLIWithParams
+type GetAccessTokenParams struct {
+	Resource     string
+	ResourceType string
+	Subscription string
+	Tenant       string
+}
+
+// GetTokenFromCLIWithParams gets a token using Azure CLI 2.0 for local development scenarios.
+func GetTokenFromCLIWithParams(params GetAccessTokenParams) (*Token, error) {
+	cliCmd := GetAzureCLICommand()
+
+	cliCmd.Args = append(cliCmd.Args, "account", "get-access-token", "-o", "json")
+	if params.Resource != "" {
+		if err := validateParameter(params.Resource); err != nil {
+			return nil, err
+		}
+		cliCmd.Args = append(cliCmd.Args, "--resource", params.Resource)
+	}
+	if params.ResourceType != "" {
+		if err := validateParameter(params.ResourceType); err != nil {
+			return nil, err
+		}
+		cliCmd.Args = append(cliCmd.Args, "--resource-type", params.ResourceType)
+	}
+	if params.Subscription != "" {
+		if err := validateParameter(params.Subscription); err != nil {
+			return nil, err
+		}
+		cliCmd.Args = append(cliCmd.Args, "--subscription", params.Subscription)
+	}
+	if params.Tenant != "" {
+		if err := validateParameter(params.Tenant); err != nil {
+			return nil, err
+		}
+		cliCmd.Args = append(cliCmd.Args, "--tenant", params.Tenant)
+	}
+
+	var stderr bytes.Buffer
+	cliCmd.Stderr = &stderr
+
+	output, err := cliCmd.Output()
+	if err != nil {
+		if stderr.Len() > 0 {
+			return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", stderr.String())
+		}
+
+		return nil, fmt.Errorf("Invoking Azure CLI failed with the following error: %s", err.Error())
+	}
+
+	tokenResponse := Token{}
+	err = json.Unmarshal(output, &tokenResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokenResponse, err
+}
+
+func validateParameter(param string) error {
+	// Validate parameters, since it gets sent as a command line argument to Azure CLI
+	const invalidResourceErrorTemplate = "Parameter %s is not in expected format. Only alphanumeric characters, [dot], [colon], [hyphen], and [forward slash] are allowed."
+	match, err := regexp.MatchString("^[0-9a-zA-Z-.:/]+$", param)
+	if err != nil {
+		return err
+	}
+	if !match {
+		return fmt.Errorf(invalidResourceErrorTemplate, param)
+	}
+	return nil
+}
+
+// GetAzureCLICommand can be used to run arbitrary Azure CLI command
+func GetAzureCLICommand() *exec.Cmd {
+	// This is the path that a developer can set to tell this class what the install path for Azure CLI is.
+	const azureCLIPath = "AzureCLIPath"
+
+	// The default install paths are used to find Azure CLI. This is for security, so that any path in the calling program's Path environment is not used to execute Azure CLI.
+	azureCLIDefaultPathWindows := fmt.Sprintf("%s\\Microsoft SDKs\\Azure\\CLI2\\wbin; %s\\Microsoft SDKs\\Azure\\CLI2\\wbin", os.Getenv("ProgramFiles(x86)"), os.Getenv("ProgramFiles"))
+
+	// Default path for non-Windows.
+	const azureCLIDefaultPath = "/bin:/sbin:/usr/bin:/usr/local/bin"
+
+	// Execute Azure CLI to get token
+	var cliCmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cliCmd = exec.Command(fmt.Sprintf("%s\\system32\\cmd.exe", os.Getenv("windir")))
+		cliCmd.Env = os.Environ()
+		cliCmd.Env = append(cliCmd.Env, fmt.Sprintf("PATH=%s;%s", os.Getenv(azureCLIPath), azureCLIDefaultPathWindows))
+		cliCmd.Args = append(cliCmd.Args, "/c", "az")
+	} else {
+		cliCmd = exec.Command("az")
+		cliCmd.Env = os.Environ()
+		cliCmd.Env = append(cliCmd.Env, fmt.Sprintf("PATH=%s:%s", os.Getenv(azureCLIPath), azureCLIDefaultPath))
+	}
+
+	return cliCmd
+}

--- a/vendor/github.com/dimchansky/utfbom/.gitignore
+++ b/vendor/github.com/dimchansky/utfbom/.gitignore
@@ -1,0 +1,37 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+*.o
+*.a
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.prof
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# Gogland
+.idea/

--- a/vendor/github.com/dimchansky/utfbom/.travis.yml
+++ b/vendor/github.com/dimchansky/utfbom/.travis.yml
@@ -1,0 +1,29 @@
+language: go
+sudo: false
+
+go:
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x  
+  - 1.13.x
+  - 1.14.x
+  - 1.15.x
+
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod
+
+env:
+  global:
+    - GO111MODULE=on
+
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+  - go get golang.org/x/tools/cmd/goimports
+  - go get golang.org/x/lint/golint
+script:
+  - gofiles=$(find ./ -name '*.go') && [ -z "$gofiles" ] || unformatted=$(goimports -l $gofiles) && [ -z "$unformatted" ] || (echo >&2 "Go files must be formatted with gofmt. Following files has problem:\n $unformatted" && false)
+  - golint ./... # This won't break the build, just show warnings
+  - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/vendor/github.com/dimchansky/utfbom/LICENSE
+++ b/vendor/github.com/dimchansky/utfbom/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) 2018-2020, Dmitrij Koniajev (dimchansky@gmail.com)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/dimchansky/utfbom/README.md
+++ b/vendor/github.com/dimchansky/utfbom/README.md
@@ -1,0 +1,66 @@
+# utfbom [![Godoc](https://godoc.org/github.com/dimchansky/utfbom?status.png)](https://godoc.org/github.com/dimchansky/utfbom) [![License](https://img.shields.io/:license-apache-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Build Status](https://travis-ci.org/dimchansky/utfbom.svg?branch=master)](https://travis-ci.org/dimchansky/utfbom) [![Go Report Card](https://goreportcard.com/badge/github.com/dimchansky/utfbom)](https://goreportcard.com/report/github.com/dimchansky/utfbom) [![Coverage Status](https://coveralls.io/repos/github/dimchansky/utfbom/badge.svg?branch=master)](https://coveralls.io/github/dimchansky/utfbom?branch=master)
+
+The package utfbom implements the detection of the BOM (Unicode Byte Order Mark) and removing as necessary. It can also return the encoding detected by the BOM.
+
+## Installation
+
+    go get -u github.com/dimchansky/utfbom
+    
+## Example
+
+```go
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/dimchansky/utfbom"
+)
+
+func main() {
+	trySkip([]byte("\xEF\xBB\xBFhello"))
+	trySkip([]byte("hello"))
+}
+
+func trySkip(byteData []byte) {
+	fmt.Println("Input:", byteData)
+
+	// just skip BOM
+	output, err := ioutil.ReadAll(utfbom.SkipOnly(bytes.NewReader(byteData)))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("ReadAll with BOM skipping", output)
+
+	// skip BOM and detect encoding
+	sr, enc := utfbom.Skip(bytes.NewReader(byteData))
+	fmt.Printf("Detected encoding: %s\n", enc)
+	output, err = ioutil.ReadAll(sr)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("ReadAll with BOM detection and skipping", output)
+	fmt.Println()
+}
+```
+
+Output:
+
+```
+$ go run main.go
+Input: [239 187 191 104 101 108 108 111]
+ReadAll with BOM skipping [104 101 108 108 111]
+Detected encoding: UTF8
+ReadAll with BOM detection and skipping [104 101 108 108 111]
+
+Input: [104 101 108 108 111]
+ReadAll with BOM skipping [104 101 108 108 111]
+Detected encoding: Unknown
+ReadAll with BOM detection and skipping [104 101 108 108 111]
+```
+
+

--- a/vendor/github.com/dimchansky/utfbom/utfbom.go
+++ b/vendor/github.com/dimchansky/utfbom/utfbom.go
@@ -1,0 +1,192 @@
+// Package utfbom implements the detection of the BOM (Unicode Byte Order Mark) and removing as necessary.
+// It wraps an io.Reader object, creating another object (Reader) that also implements the io.Reader
+// interface but provides automatic BOM checking and removing as necessary.
+package utfbom
+
+import (
+	"errors"
+	"io"
+)
+
+// Encoding is type alias for detected UTF encoding.
+type Encoding int
+
+// Constants to identify detected UTF encodings.
+const (
+	// Unknown encoding, returned when no BOM was detected
+	Unknown Encoding = iota
+
+	// UTF8, BOM bytes: EF BB BF
+	UTF8
+
+	// UTF-16, big-endian, BOM bytes: FE FF
+	UTF16BigEndian
+
+	// UTF-16, little-endian, BOM bytes: FF FE
+	UTF16LittleEndian
+
+	// UTF-32, big-endian, BOM bytes: 00 00 FE FF
+	UTF32BigEndian
+
+	// UTF-32, little-endian, BOM bytes: FF FE 00 00
+	UTF32LittleEndian
+)
+
+// String returns a user-friendly string representation of the encoding. Satisfies fmt.Stringer interface.
+func (e Encoding) String() string {
+	switch e {
+	case UTF8:
+		return "UTF8"
+	case UTF16BigEndian:
+		return "UTF16BigEndian"
+	case UTF16LittleEndian:
+		return "UTF16LittleEndian"
+	case UTF32BigEndian:
+		return "UTF32BigEndian"
+	case UTF32LittleEndian:
+		return "UTF32LittleEndian"
+	default:
+		return "Unknown"
+	}
+}
+
+const maxConsecutiveEmptyReads = 100
+
+// Skip creates Reader which automatically detects BOM (Unicode Byte Order Mark) and removes it as necessary.
+// It also returns the encoding detected by the BOM.
+// If the detected encoding is not needed, you can call the SkipOnly function.
+func Skip(rd io.Reader) (*Reader, Encoding) {
+	// Is it already a Reader?
+	b, ok := rd.(*Reader)
+	if ok {
+		return b, Unknown
+	}
+
+	enc, left, err := detectUtf(rd)
+	return &Reader{
+		rd:  rd,
+		buf: left,
+		err: err,
+	}, enc
+}
+
+// SkipOnly creates Reader which automatically detects BOM (Unicode Byte Order Mark) and removes it as necessary.
+func SkipOnly(rd io.Reader) *Reader {
+	r, _ := Skip(rd)
+	return r
+}
+
+// Reader implements automatic BOM (Unicode Byte Order Mark) checking and
+// removing as necessary for an io.Reader object.
+type Reader struct {
+	rd  io.Reader // reader provided by the client
+	buf []byte    // buffered data
+	err error     // last error
+}
+
+// Read is an implementation of io.Reader interface.
+// The bytes are taken from the underlying Reader, but it checks for BOMs, removing them as necessary.
+func (r *Reader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	if r.buf == nil {
+		if r.err != nil {
+			return 0, r.readErr()
+		}
+
+		return r.rd.Read(p)
+	}
+
+	// copy as much as we can
+	n = copy(p, r.buf)
+	r.buf = nilIfEmpty(r.buf[n:])
+	return n, nil
+}
+
+func (r *Reader) readErr() error {
+	err := r.err
+	r.err = nil
+	return err
+}
+
+var errNegativeRead = errors.New("utfbom: reader returned negative count from Read")
+
+func detectUtf(rd io.Reader) (enc Encoding, buf []byte, err error) {
+	buf, err = readBOM(rd)
+
+	if len(buf) >= 4 {
+		if isUTF32BigEndianBOM4(buf) {
+			return UTF32BigEndian, nilIfEmpty(buf[4:]), err
+		}
+		if isUTF32LittleEndianBOM4(buf) {
+			return UTF32LittleEndian, nilIfEmpty(buf[4:]), err
+		}
+	}
+
+	if len(buf) > 2 && isUTF8BOM3(buf) {
+		return UTF8, nilIfEmpty(buf[3:]), err
+	}
+
+	if (err != nil && err != io.EOF) || (len(buf) < 2) {
+		return Unknown, nilIfEmpty(buf), err
+	}
+
+	if isUTF16BigEndianBOM2(buf) {
+		return UTF16BigEndian, nilIfEmpty(buf[2:]), err
+	}
+	if isUTF16LittleEndianBOM2(buf) {
+		return UTF16LittleEndian, nilIfEmpty(buf[2:]), err
+	}
+
+	return Unknown, nilIfEmpty(buf), err
+}
+
+func readBOM(rd io.Reader) (buf []byte, err error) {
+	const maxBOMSize = 4
+	var bom [maxBOMSize]byte // used to read BOM
+
+	// read as many bytes as possible
+	for nEmpty, n := 0, 0; err == nil && len(buf) < maxBOMSize; buf = bom[:len(buf)+n] {
+		if n, err = rd.Read(bom[len(buf):]); n < 0 {
+			panic(errNegativeRead)
+		}
+		if n > 0 {
+			nEmpty = 0
+		} else {
+			nEmpty++
+			if nEmpty >= maxConsecutiveEmptyReads {
+				err = io.ErrNoProgress
+			}
+		}
+	}
+	return
+}
+
+func isUTF32BigEndianBOM4(buf []byte) bool {
+	return buf[0] == 0x00 && buf[1] == 0x00 && buf[2] == 0xFE && buf[3] == 0xFF
+}
+
+func isUTF32LittleEndianBOM4(buf []byte) bool {
+	return buf[0] == 0xFF && buf[1] == 0xFE && buf[2] == 0x00 && buf[3] == 0x00
+}
+
+func isUTF8BOM3(buf []byte) bool {
+	return buf[0] == 0xEF && buf[1] == 0xBB && buf[2] == 0xBF
+}
+
+func isUTF16BigEndianBOM2(buf []byte) bool {
+	return buf[0] == 0xFE && buf[1] == 0xFF
+}
+
+func isUTF16LittleEndianBOM2(buf []byte) bool {
+	return buf[0] == 0xFF && buf[1] == 0xFE
+}
+
+func nilIfEmpty(buf []byte) (res []byte) {
+	if len(buf) > 0 {
+		res = buf
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,6 +25,12 @@ github.com/Azure/go-autorest/autorest/azure
 # github.com/Azure/go-autorest/autorest/adal v0.9.20
 ## explicit; go 1.15
 github.com/Azure/go-autorest/autorest/adal
+# github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
+## explicit; go 1.15
+github.com/Azure/go-autorest/autorest/azure/auth
+# github.com/Azure/go-autorest/autorest/azure/cli v0.4.5
+## explicit; go 1.15
+github.com/Azure/go-autorest/autorest/azure/cli
 # github.com/Azure/go-autorest/autorest/date v0.3.0
 ## explicit; go 1.12
 github.com/Azure/go-autorest/autorest/date
@@ -226,6 +232,9 @@ github.com/cyphar/filepath-securejoin
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
+# github.com/dimchansky/utfbom v1.1.1
+## explicit
+github.com/dimchansky/utfbom
 # github.com/docker/distribution v2.8.1+incompatible
 ## explicit
 github.com/docker/distribution


### PR DESCRIPTION
Spawn a RHEL virtual machine on the MachineNetwork which serves as an
external target for EgressIP tests. Run the agnhost container inside the
VM with podman, then send requests from OCP to the VM.

While complex, this is the only reliable and realistic way to test the
EgressIP feature. The previous approach of sending UDP packets to a
non-existing target and analyzing the packets with tcpdump on the sender
machine turned out to be insufficient as this did not test allow-listing
of outgoing traffic on instance ports.