### PR TITLE
TRT-703: Fix upgrade junit results not present in risk analysis

### DIFF
--- a/pkg/alerts/check.go
+++ b/pkg/alerts/check.go
@@ -116,11 +116,9 @@ sort_desc(
 		framework.Logf("Alerts were detected which are allowed:\n\n%s", strings.Join(debug.List(), "\n"))
 	}
 	if flakes := sets.NewString().Union(knownViolations).Union(unexpectedViolations).Union(unexpectedViolationsAsFlakes); len(flakes) > 0 {
-		// TODO: The two tests that had this duplicated code had slightly different ways of reporting flakes
-		// that I do not fully understand the implications of. Fork the logic here.
+		// The two duplicated code paths merged together here had slightly different ways of reporting flakes:
 		if f != nil {
 			// when called from alert.go within an UpgradeTest with a framework available
-			// f.TestSummaries is the part I'm unsure about here.
 			disruption.FrameworkFlakef(f, "Unexpected alert behavior:\n\n%s", strings.Join(flakes.List(), "\n"))
 		} else {
 			// when called from prometheus.go with no framework available

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -149,14 +149,14 @@ func runChaosmonkey(
 			fname := filepath.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%s_%s.xml", packageName, timeSuffix))
 			f, err := os.Create(fname)
 			if err != nil {
-				// TODO: no logging?
+				fmt.Fprintf(os.Stderr, "error: Failed to write file %v: %v\n", fname, err)
 				return
 			}
 			defer f.Close()
 			xml.NewEncoder(f).Encode(testSuite)
 
 			if err := riskanalysis.WriteJobRunTestFailureSummary(framework.TestContext.ReportDir, timeSuffix, testSuite); err != nil {
-				// TODO: no logging?
+				fmt.Fprintf(os.Stderr, "error: Failed to write file %v: %v\n", fname, err)
 				return
 			}
 		}

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -1,5 +1,8 @@
 package disruption
 
+// TODO: this testing framework is used by many upgrade tests beyond disruption, the package is somewhat misleading
+// and it should probably be relocated.
+
 import (
 	"encoding/json"
 	"encoding/xml"
@@ -14,6 +17,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/origin/pkg/riskanalysis"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -25,7 +30,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/upgrades"
-	"k8s.io/kubernetes/test/utils/junit"
 )
 
 const (
@@ -84,23 +88,22 @@ type TestData struct {
 // test is being executed. Description is used to populate the JUnit suite name, and testname is
 // used to define the overall test that will be run.
 func Run(f *framework.Framework, description, testname string, adapter TestData, invariants []upgrades.Test, fn func()) {
-	testSuite := &junit.TestSuite{Name: description, Package: testname}
-	test := &junit.TestCase{Name: testname, Classname: testname}
-	testSuite.TestCases = append(testSuite.TestCases, test)
+	testSuite := &junitapi.JUnitTestSuite{Name: description}
 	cm := chaosmonkey.New(func() {
 		start := time.Now()
-		defer finalizeTest(start, test, testSuite, f)
+		defer finalizeTest(start, testname, testname, testSuite, f)
 		defer g.GinkgoRecover()
 		fn()
 	})
-	runChaosmonkey(cm, adapter, invariants, testSuite)
+	runChaosmonkey(cm, adapter, invariants, testSuite, testname)
 }
 
 func runChaosmonkey(
 	cm *chaosmonkey.Chaosmonkey,
 	testData TestData,
 	tests []upgrades.Test,
-	testSuite *junit.TestSuite,
+	testSuite *junitapi.JUnitTestSuite,
+	packageName string,
 ) {
 	testFrameworks := createTestFrameworks(tests)
 	for _, t := range tests {
@@ -108,11 +111,6 @@ func runChaosmonkey(
 		if dn, ok := t.(testWithDisplayName); ok {
 			displayName = dn.DisplayName()
 		}
-		testCase := &junit.TestCase{
-			Name:      displayName,
-			Classname: "disruption_tests",
-		}
-		testSuite.TestCases = append(testSuite.TestCases, testCase)
 
 		f, ok := testFrameworks[t.Name()]
 		if !ok {
@@ -122,7 +120,8 @@ func runChaosmonkey(
 			TestData:        testData,
 			framework:       f,
 			test:            t,
-			testReport:      testCase,
+			testName:        displayName,
+			className:       "disruption_tests",
 			testSuiteReport: testSuite,
 		}
 		cm.Register(cma.Test)
@@ -130,37 +129,36 @@ func runChaosmonkey(
 
 	start := time.Now()
 	defer func() {
-		testSuite.Update()
-		testSuite.Time = time.Since(start).Seconds()
 
-		// if the test fails and all failures are described as "Flake", create a second
-		// test case that is listed as success so the test is properly marked as flaky
-		for _, testCase := range testSuite.TestCases {
-			allFlakes := len(testCase.Failures) > 0 && len(testCase.Errors) == 0 && len(testCase.Skipped) == 0
-			for _, failure := range testCase.Failures {
-				if failure.Type == "Flake" {
-					failure.Type = "Failure"
-				} else {
-					allFlakes = false
-				}
+		// Calculate NumFailed and NumSkipped
+		for _, tc := range testSuite.TestCases {
+			testSuite.NumTests++
+			if tc.FailureOutput != nil {
+				testSuite.NumFailed++
 			}
-			if allFlakes {
-				testSuite.TestCases = append(testSuite.TestCases, &junit.TestCase{
-					Name:      testCase.Name,
-					Classname: testCase.Classname,
-					Time:      testCase.Time,
-				})
+			if tc.SkipMessage != nil {
+				testSuite.NumSkipped++
 			}
 		}
 
+		testSuite.Duration = time.Since(start).Seconds()
+
 		if framework.TestContext.ReportDir != "" {
-			fname := filepath.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%s_%d.xml", testSuite.Package, time.Now().Unix()))
+			timeSuffix := fmt.Sprintf("_%s", time.Now().UTC().Format("20060102-150405"))
+
+			fname := filepath.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%s_%s.xml", packageName, timeSuffix))
 			f, err := os.Create(fname)
 			if err != nil {
+				// TODO: no logging?
 				return
 			}
 			defer f.Close()
 			xml.NewEncoder(f).Encode(testSuite)
+
+			if err := riskanalysis.WriteJobRunTestFailureSummary(framework.TestContext.ReportDir, timeSuffix, testSuite); err != nil {
+				// TODO: no logging?
+				return
+			}
 		}
 	}()
 	cm.Do()
@@ -170,8 +168,9 @@ type chaosMonkeyAdapter struct {
 	TestData
 
 	test            upgrades.Test
-	testReport      *junit.TestCase
-	testSuiteReport *junit.TestSuite
+	testName        string
+	className       string
+	testSuiteReport *junitapi.JUnitTestSuite
 	framework       *framework.Framework
 }
 
@@ -183,11 +182,16 @@ func (cma *chaosMonkeyAdapter) Test(sem *chaosmonkey.Semaphore) {
 			sem.Ready()
 		})
 	}
-	defer finalizeTest(start, cma.testReport, cma.testSuiteReport, cma.framework)
+	defer finalizeTest(start, cma.testName, cma.className, cma.testSuiteReport, cma.framework)
 	defer ready()
 	if skippable, ok := cma.test.(upgrades.Skippable); ok && skippable.Skip(cma.UpgradeContext) {
 		g.By("skipping test " + cma.test.Name())
-		cma.testReport.Skipped = "skipping test " + cma.test.Name()
+		testResult := &junitapi.JUnitTestCase{
+			Name:      cma.testName,
+			Classname: cma.className,
+		}
+		testResult.SkipMessage = &junitapi.SkipMessage{Message: "skipping test " + cma.test.Name()}
+		cma.testSuiteReport.TestCases = append(cma.testSuiteReport.TestCases, testResult)
 		return
 	}
 	cma.framework.BeforeEach()
@@ -197,41 +201,54 @@ func (cma *chaosMonkeyAdapter) Test(sem *chaosmonkey.Semaphore) {
 	cma.test.Test(cma.framework, sem.StopCh, cma.UpgradeType)
 }
 
-func finalizeTest(start time.Time, tc *junit.TestCase, ts *junit.TestSuite, f *framework.Framework) {
+func finalizeTest(start time.Time, testName, className string, ts *junitapi.JUnitTestSuite, f *framework.Framework) {
 	now := time.Now().UTC()
-	tc.Time = now.Sub(start).Seconds()
+	testDuration := now.Sub(start).Seconds()
+
+	// r is the primary means we are informed of test results here. We expect ginko to panic on any failure so
+	// if r is nil, we passed. If not, we start checking if this was a flake or fail below.
 	r := recover()
 
 	// if the framework contains additional test results, add them to the parent suite or write them to disk
 	for _, summary := range f.TestSummaries {
+
 		if test, ok := summary.(additionalTest); ok {
-			testCase := &junit.TestCase{
-				Name: test.Name,
-				Time: test.Duration.Seconds(),
+			tc := &junitapi.JUnitTestCase{
+				Name:      test.Name,
+				Classname: className,
+				Duration:  test.Duration.Seconds(),
 			}
 			if len(test.Failure) > 0 {
-				testCase.Failures = append(testCase.Failures, &junit.Failure{
-					Message: test.Failure,
-					Value:   test.Failure,
-				})
+				tc.FailureOutput = &junitapi.FailureOutput{Message: test.Failure}
 			}
-			ts.TestCases = append(ts.TestCases, testCase)
+			ts.TestCases = append(ts.TestCases, tc)
 			continue
 		}
 
-		filePath := filepath.Join(framework.TestContext.ReportDir, fmt.Sprintf("%s_%s_%s.json", summary.SummaryKind(), filesystemSafeName(tc.Name), now.Format(time.RFC3339)))
+		// TODO: this is writing out Flake_[testname]_[timestamp].json files with content that is just: {"type":"Flake"}
+		// Find out if these are used by anything, but it looks like we should find a way to silence TestSummaries
+		// of type flakeSummary.
+		filePath := filepath.Join(framework.TestContext.ReportDir, fmt.Sprintf("%s_%s_%s.json", summary.SummaryKind(), filesystemSafeName(testName), now.Format(time.RFC3339)))
 		if err := ioutil.WriteFile(filePath, []byte(summary.PrintJSON()), 0644); err != nil {
 			fmt.Fprintf(os.Stderr, "error: Failed to write file %v with test data: %v\n", filePath, err)
 		}
 	}
 
 	if r == nil {
+		// Test can be considered successful, but may have flaked, see below:
+		ts.TestCases = append(ts.TestCases, &junitapi.JUnitTestCase{
+			Name:      testName,
+			Classname: className,
+			Duration:  testDuration,
+		})
 		if f != nil {
-			if message, ok := hasFrameworkFlake(f); ok {
-				tc.Failures = append(tc.Failures, &junit.Failure{
-					Type:    "Flake",
-					Message: message,
-					Value:   message,
+			if message, hasFlake := hasFrameworkFlake(f); hasFlake {
+				// Add another test case with the failure, this is a flake as we already added the success testcase above:
+				ts.TestCases = append(ts.TestCases, &junitapi.JUnitTestCase{
+					Name:          testName,
+					Classname:     className,
+					Duration:      testDuration,
+					FailureOutput: &junitapi.FailureOutput{Output: message},
 				})
 			}
 		}
@@ -239,29 +256,24 @@ func finalizeTest(start time.Time, tc *junit.TestCase, ts *junit.TestSuite, f *f
 	}
 	framework.Logf("recover: %v", r)
 
+	testResult := &junitapi.JUnitTestCase{
+		Name:      testName,
+		Classname: className,
+		Duration:  testDuration,
+	}
 	switch r := r.(type) {
 	case ginkgowrapper.FailurePanic:
-		tc.Failures = []*junit.Failure{
-			{
-				Message: r.Message,
-				Type:    "Failure",
-				Value:   fmt.Sprintf("%s\n\n%s", r.Message, r.FullStackTrace),
-			},
-		}
+		testResult.FailureOutput = &junitapi.FailureOutput{Message: fmt.Sprintf("%s\n\n%s", r.Message, r.FullStackTrace)}
 	case e2eskipper.SkipPanic:
-		tc.Skipped = fmt.Sprintf("%s:%d %q", r.Filename, r.Line, r.Message)
+		testResult.SkipMessage = &junitapi.SkipMessage{Message: fmt.Sprintf("%s:%d %q", r.Filename, r.Line, r.Message)}
 	default:
-		tc.Errors = []*junit.Error{
-			{
-				Message: "Ginkgo panic encountered. See CDATA for details.",
-				Type:    "Panic",
-				Value:   fmt.Sprintf("%v\n\n%s", r, debug.Stack()),
-			},
-		}
+		testResult.FailureOutput = &junitapi.FailureOutput{Message: fmt.Sprintf("%v\n\n%s", r, debug.Stack())}
 	}
+	ts.TestCases = append(ts.TestCases, testResult)
+
 	// if we have a panic but it hasn't been recorded by ginkgo, panic now
 	if !g.CurrentSpecReport().Failed() {
-		framework.Logf("%q: panic: %v", tc.Name, r)
+		framework.Logf("%q: panic: %v", testName, r)
 		func() {
 			defer g.GinkgoRecover()
 			panic(r)


### PR DESCRIPTION
While investigating why some tests were failing in spyglass, but not present in risk analysis, I discovered this second location where we output junit files (most notably the upgrade junit files) using test suites, which was not updated to also output the test failure summary we use for risk analysis.

Digging further I saw that this path of code was using a totally different representation of testsuite/testcase than everything else in origin (k8s TestSuite vs our ginko JUnitTestSuite). It would have been easier just to write another function to pull the test failures out of this, but I opted to get them both using the same objects as there were other subtle differences in the XML that made me nervous.

To validate I've compared junit_upgrade output from the aws-ovn-upgrade job with an older example: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27568/pull-ci-openshift-origin-master-e2e-aws-ovn-upgrade/1595382748753694720/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/junit_upgrade_1669214650.xml
Then ensured we have the same test counts, and the XML looks correct and consistent in all the ways we would expect.

[TRT-703](https://issues.redhat.com//browse/TRT-703)