### PR TITLE
add Late test to check for unready nodes

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
+	_ "github.com/openshift/origin/test/extended/nodes"
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/olm"
 	_ "github.com/openshift/origin/test/extended/operators"

--- a/test/extended/nodes/node.go
+++ b/test/extended/nodes/node.go
@@ -1,0 +1,57 @@
+package nodes
+
+import (
+	"context"
+	"fmt"
+	g "github.com/onsi/ginkgo/v2"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"strings"
+)
+
+var _ = g.Describe("[sig-node][Late]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithoutNamespace("no-unready-nodes")
+	cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().
+		       Get(context.Background(), "version", metav1.GetOptions{})
+
+	if err != nil {
+		e2e.Failf("Unable to determine cluster install completionTime :" + cv.Name)
+	}
+
+	g.It("nodes should not go unready after cluster install is complete", func() {
+
+		var failures []string
+		events, err := oc.AdminKubeClient().CoreV1().Events("").List(context.TODO(), metav1.ListOptions{})
+
+		if err != nil {
+			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
+		}
+
+		nodesWentUnready := make(map[string][]string)
+
+		for _, event := range events.Items {
+			if strings.Contains(event.Reason, "NodeNotReady") &&
+				cv.Status.History[0].CompletionTime.Time.Before(event.CreationTimestamp.Time) {
+
+				failureMessage := fmt.Sprintf("Node went unready at %s with message \"%s\" after " +
+					"cluster install was complete at %s",
+					event.CreationTimestamp, event.Message, cv.Status.History[0].CompletionTime)
+				nodesWentUnready[event.Name] = append(nodesWentUnready[event.Name], failureMessage)
+			}
+		}
+
+		for unready := range nodesWentUnready {
+			if len(unready) > 0 {
+				failures = append(failures, fmt.Sprintf("Node went unready: %s", unready))
+			}
+		}
+
+		if len(failures) > 0 {
+			e2e.Failf(strings.Join(failures, "\n"))
+		}
+
+	})
+})


### PR DESCRIPTION
once the cluster is installed nodes should not go unready. this is a "Late" check which should run at the conclusion of the normal e2e tests.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>