### PR TITLE
Add Event intervals for Startup Probe failures

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -132,6 +132,13 @@
         return false
     }
 
+    function isKubeletStartupProbeFailure(eventInterval) {
+        if (eventInterval.locator.includes("container/") && (eventInterval.message.includes("reason/StartupProbeFailed"))) {
+            return true
+        }
+        return false
+    }
+
     function isE2EFailed(eventInterval) {
         if (eventInterval.locator.startsWith("e2e-test/") && eventInterval.message.includes("finished As \"Failed")) {
             return true
@@ -222,6 +229,9 @@
             if (m[2] == "ReadinessErrored") {
                 return [item.locator, ` (kubelet container readiness)`, "ContainerReadinessErrored"];
             }
+        }
+        if (m && isKubeletStartupProbeFailure(item)){
+            return [item.locator, ` (kubelet container startupProbe)`, "StartupProbeFailed"];
         }
 
         return [item.locator, "", "Unknown"];
@@ -431,14 +441,14 @@
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
                 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', // nodes
                 'Passed', 'Skipped', 'Flaked', 'Failed',  // tests
-                'PodCreated', 'PodScheduled', 'PodTerminating','ContainerWait', 'ContainerStart', 'ContainerNotReady', 'ContainerReady', 'ContainerReadinessFailed', 'ContainerReadinessErrored',  // pods
+                'PodCreated', 'PodScheduled', 'PodTerminating','ContainerWait', 'ContainerStart', 'ContainerNotReady', 'ContainerReady', 'ContainerReadinessFailed', 'ContainerReadinessErrored',  'StartupProbeFailed', // pods
                 'Degraded', 'Upgradeable', 'False', 'Unknown'])
             .range([
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators
                 '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes
                 '#3cb043', '#ceba76', '#ffa500', '#d0312d', // tests
-                '#96cbff', '#1e7bd9', '#ffa500', '#ca8dfd', '#9300ff', '#fada5e','#3cb043', '#d0312d', '#d0312d', // pods
+                '#96cbff', '#1e7bd9', '#ffa500', '#ca8dfd', '#9300ff', '#fada5e','#3cb043', '#d0312d', '#d0312d', '#c90076', // pods
                 '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
         myChart.
         data(timelineGroups).

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -113,13 +113,14 @@ const (
 	PodReasonDeleted               = "Deleted"
 	PodReasonScheduled             = "Scheduled"
 
-	ContainerReasonContainerExit    = "ContainerExit"
-	ContainerReasonContainerStart   = "ContainerStart"
-	ContainerReasonContainerWait    = "ContainerWait"
-	ContainerReasonReadinessFailed  = "ReadinessFailed"
-	ContainerReasonReadinessErrored = "ReadinessErrored"
-	ContainerReasonReady            = "Ready"
-	ContainerReasonNotReady         = "NotReady"
+	ContainerReasonContainerExit      = "ContainerExit"
+	ContainerReasonContainerStart     = "ContainerStart"
+	ContainerReasonContainerWait      = "ContainerWait"
+	ContainerReasonReadinessFailed    = "ReadinessFailed"
+	ContainerReasonReadinessErrored   = "ReadinessErrored"
+	ContainerReasonStartupProbeFailed = "StartupProbeFailed"
+	ContainerReasonReady              = "Ready"
+	ContainerReasonNotReady           = "NotReady"
 
 	PodReasonDeletedBeforeScheduling = "DeletedBeforeScheduling"
 	PodReasonDeletedAfterCompletion  = "DeletedAfterCompletion"
@@ -159,6 +160,7 @@ var (
 	KubeletReadinessCheckReasons = sets.NewString(
 		ContainerReasonReadinessFailed,
 		ContainerReasonReadinessErrored,
+		ContainerReasonStartupProbeFailed,
 	)
 )
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -49246,6 +49246,13 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return false
     }
 
+    function isKubeletStartupProbeFailure(eventInterval) {
+        if (eventInterval.locator.includes("container/") && (eventInterval.message.includes("reason/StartupProbeFailed"))) {
+            return true
+        }
+        return false
+    }
+
     function isE2EFailed(eventInterval) {
         if (eventInterval.locator.startsWith("e2e-test/") && eventInterval.message.includes("finished As \"Failed")) {
             return true
@@ -49336,6 +49343,9 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             if (m[2] == "ReadinessErrored") {
                 return [item.locator, ` + "`" + ` (kubelet container readiness)` + "`" + `, "ContainerReadinessErrored"];
             }
+        }
+        if (m && isKubeletStartupProbeFailure(item)){
+            return [item.locator, ` + "`" + ` (kubelet container startupProbe)` + "`" + `, "StartupProbeFailed"];
         }
 
         return [item.locator, "", "Unknown"];
@@ -49545,14 +49555,14 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
                 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', // nodes
                 'Passed', 'Skipped', 'Flaked', 'Failed',  // tests
-                'PodCreated', 'PodScheduled', 'PodTerminating','ContainerWait', 'ContainerStart', 'ContainerNotReady', 'ContainerReady', 'ContainerReadinessFailed', 'ContainerReadinessErrored',  // pods
+                'PodCreated', 'PodScheduled', 'PodTerminating','ContainerWait', 'ContainerStart', 'ContainerNotReady', 'ContainerReady', 'ContainerReadinessFailed', 'ContainerReadinessErrored',  'StartupProbeFailed', // pods
                 'Degraded', 'Upgradeable', 'False', 'Unknown'])
             .range([
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators
                 '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes
                 '#3cb043', '#ceba76', '#ffa500', '#d0312d', // tests
-                '#96cbff', '#1e7bd9', '#ffa500', '#ca8dfd', '#9300ff', '#fada5e','#3cb043', '#d0312d', '#d0312d', // pods
+                '#96cbff', '#1e7bd9', '#ffa500', '#ca8dfd', '#9300ff', '#fada5e','#3cb043', '#d0312d', '#d0312d', '#c90076', // pods
                 '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
         myChart.
         data(timelineGroups).


### PR DESCRIPTION
[TRT-724](https://issues.redhat.com//browse/TRT-724)

The kubelet logs contain the startup probe errors.  We extract them (similar to how the readiness probe events were extracted) so they will be represented in the event Intervals and the Interval charts.

Sample output:

* Startup probes occur just before a container goes to `Ready` state.  You can see them in this [chart](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27612/pull-ci-openshift-origin-master-e2e-aws-ovn-fips/1603377226177318912/artifacts/e2e-aws-ovn-fips/openshift-e2e-test/artifacts/junit/e2e-timelines_openshift-support-stuff_20221215-140123.html) for pods (e.g., `redhat-operators-5nk4h`) that are in the `openshift-marketplace` namespace.
* For the [node logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27612/pull-ci-openshift-origin-master-e2e-aws-ovn-fips/1603377226177318912/artifacts/e2e-aws-ovn-fips/gather-extra/artifacts/nodes/) of this [job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27612/pull-ci-openshift-origin-master-e2e-aws-ovn-fips/1603377226177318912), we see 4 Startup Probe events which show up in the chart.  Note that both log line cases (`output="` and `output=<`) are represented:
```
$ grep 5nk4h ip-10-0-149-44.us-west-2.compute.internal-journal.log|grep '"Probe failed" probeType="Startup"'
Dec 15 14:35:33.232637 ip-10-0-149-44 kubenswrapper[2416]: I1215 14:35:33.209265    2416 prober.go:114] "Probe failed" probeType="Startup" pod="openshift-marketplace/redhat-operators-5nk4h" podUID=b2e47f45-5d77-47c8-94c9-dfbdab5c1834 containerName="registry-server" probeResult=failure output="command timed out"
Dec 15 14:35:43.223691 ip-10-0-149-44 kubenswrapper[2416]: I1215 14:35:43.222242    2416 prober.go:114] "Probe failed" probeType="Startup" pod="openshift-marketplace/redhat-operators-5nk4h" podUID=b2e47f45-5d77-47c8-94c9-dfbdab5c1834 containerName="registry-server" probeResult=failure output="command timed out"
Dec 15 14:35:53.047639 ip-10-0-149-44 kubenswrapper[2416]: I1215 14:35:53.042936    2416 prober.go:114] "Probe failed" probeType="Startup" pod="openshift-marketplace/redhat-operators-5nk4h" podUID=b2e47f45-5d77-47c8-94c9-dfbdab5c1834 containerName="registry-server" probeResult=failure output=<
Dec 15 14:36:03.233780 ip-10-0-149-44 kubenswrapper[2416]: I1215 14:36:03.233339    2416 prober.go:114] "Probe failed" probeType="Startup" pod="openshift-marketplace/redhat-operators-5nk4h" podUID=b2e47f45-5d77-47c8-94c9-dfbdab5c1834 containerName="registry-server" probeResult=failure output="command timed out"
```
<img width="460" alt="Screen Shot 2022-12-15 at 10 31 23 AM" src="https://user-images.githubusercontent.com/93946516/207901637-c107cc14-2f6d-4e4c-980a-f641ab9f3ad6.png">

NOTE: the case where the log ends with `output=<` is for multi-line output. I purposely did not add the logic to capture the text in the multiline output.  If we feel like this info is valuable in the future, we may pursue this.