### PR TITLE
Allow baremetal tests to run on GCP platform

### DIFF
--- a/test/extended/baremetal/common.go
+++ b/test/extended/baremetal/common.go
@@ -47,6 +47,8 @@ func skipIfUnsupportedPlatformOrConfig(oc *exutil.CLI, dc dynamic.Interface) {
 		fallthrough
 	case configv1.AWSPlatformType:
 		fallthrough
+	case configv1.GCPPlatformType:
+		fallthrough
 	case configv1.NonePlatformType:
 		provisioningNetwork := getProvisioningNetwork(dc)
 		if provisioningNetwork != "Disabled" {

--- a/test/extended/baremetal/hosts.go
+++ b/test/extended/baremetal/hosts.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal/OpenStack/vSphere/None/AWS platforms [apigroup:config.openshift.io]", func() {
+var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal/OpenStack/vSphere/None/AWS/GCP platforms [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1881,7 +1881,7 @@ var Annotations = map[string]string{
 
 	"[sig-installer][Feature:baremetal] Baremetal platform should [apigroup:config.openshift.io] not allow updating BootMacAddress": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-installer][Feature:baremetal] Baremetal/OpenStack/vSphere/None/AWS platforms [apigroup:config.openshift.io] have a metal3 deployment": " [Suite:openshift/conformance/parallel]",
+	"[sig-installer][Feature:baremetal] Baremetal/OpenStack/vSphere/None/AWS/GCP platforms [apigroup:config.openshift.io] have a metal3 deployment": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-installer][Feature:baremetal][Serial] Baremetal platform should [apigroup:config.openshift.io] skip inspection when disabled by annotation": " [Suite:openshift/conformance/serial]",
 


### PR DESCRIPTION
Metal3 pods can now be deployed on GCP platform.
Baremetal hosts can be booted only via virtual media. We only check for the presence of the metal3 pod to verify the baremetal deployment is available in GCP too.