### PR TITLE
Export DeployOAuthServer function for being used by oc login tests

### DIFF
--- a/test/extended/images/oc_tag.go
+++ b/test/extended/images/oc_tag.go
@@ -153,10 +153,8 @@ RUN touch /test-image
 
 		err = oc.Run("policy").Args("add-role-to-user", "testrole", "-z", "testsa", "--role-namespace="+oc.Namespace()).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// TODO (soltysh): after k8s 1.24 lands we should be able to replace this with:
-		// token, err := oc.Run("create").Args("token", "testsa").Output()
-		token, _, err := oc.Run("serviceaccounts").Args("new-token", "testsa").Outputs()
+		
+		token, err := oc.Run("create").Args("token", "testsa").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		err = oc.Run("login").Args("--token=" + token).Execute()

--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 
 	g.BeforeEach(func() {
 		var err error
-		newRequestTokenOptions, oauthServerCleanup, err = deployOAuthServer(oc)
+		newRequestTokenOptions, oauthServerCleanup, err = DeployOAuthServer(oc)
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 

--- a/test/extended/oauth/helpers.go
+++ b/test/extended/oauth/helpers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/oauthserver"
 )
 
-func deployOAuthServer(oc *util.CLI) (oauthserver.NewRequestTokenOptionsFunc, func(), error) {
+func DeployOAuthServer(oc *util.CLI) (oauthserver.NewRequestTokenOptionsFunc, func(), error) {
 	// secret containing htpasswd "file": `htpasswd -cbB htpasswd.tmp testuser password`
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "htpasswd"},

--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-auth][Feature:HTPasswdAuth] HTPasswd IDP", func() {
 	var oc = exutil.NewCLIWithPodSecurityLevel("htpasswd-idp", admissionapi.LevelBaseline)
 
 	g.It("should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io]", func() {
-		newTokenReqOpts, cleanup, err := deployOAuthServer(oc)
+		newTokenReqOpts, cleanup, err := DeployOAuthServer(oc)
 		defer cleanup()
 		o.Expect(err).ToNot(o.HaveOccurred())
 		tokenReqOpts := newTokenReqOpts("testuser", "password")

--- a/test/extended/oauth/server_headers.go
+++ b/test/extended/oauth/server_headers.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers][apigroup:route.ope
 
 		// deploy oauth server
 		var newRequestTokenOptions oauthserver.NewRequestTokenOptionsFunc
-		newRequestTokenOptions, oauthServerCleanup, err = deployOAuthServer(oc)
+		newRequestTokenOptions, oauthServerCleanup, err = DeployOAuthServer(oc)
 		o.Expect(err).ToNot(o.HaveOccurred(), "while attempting to deploy the oauth server")
 		oauthServerAddr = newRequestTokenOptions("", "").Issuer
 	})


### PR DESCRIPTION
Most of the `oc` commands related to the login functionality can not be tested in origin because it requires a temporary oauth server. `deployOAuthFunction` seems like a very good solution to overcome that issue and this PR exports this function for being used by oc login tests.