### PR TITLE
Add tests for template cross namespace processing

### DIFF
--- a/test/extended/cli/template.go
+++ b/test/extended/cli/template.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	"github.com/openshift/apiserver-library-go/pkg/authorization/scope"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-cli] templates ", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc              = exutil.NewCLI("oc-templates")
+		appTemplatePath = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "application-template-dockerbuild.json")
+	)
+
+	g.It("different namespaces [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:template.openshift.io][apigroup:authorization.openshift.io][Serial][Skipped:Disconnected]", func() {
+		bob := oc.CreateUser("bob-")
+
+		err := oc.Run("create").Args("-f", appTemplatePath).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.Run("policy").Args("add-role-to-user", "admin", bob.Name).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tokenStr, sha256TokenStr := exutil.GenerateOAuthTokenPair()
+		token := &oauthv1.OAuthAccessToken{
+			ObjectMeta: metav1.ObjectMeta{Name: sha256TokenStr},
+			ClientName: "openshift-challenging-client",
+			ExpiresIn:  86400,
+			Scopes: []string{
+				scope.UserFull,
+			},
+			RedirectURI: "https://127.0.0.1:12000/oauth/token/implicit",
+			UserName:    bob.Name,
+			UserUID:     string(bob.UID),
+		}
+		_, err = oc.AdminOAuthClient().OauthV1().OAuthAccessTokens().Create(context.Background(), token, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthaccesstokens"), token)
+
+		err = oc.Run("login").Args("--token", tokenStr).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		testProject2 := oc.Namespace() + "-project2"
+		out, err := oc.Run("new-project").Args(testProject2).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring(fmt.Sprintf("Now using project \"%s\" on server ", testProject2)))
+		defer func() {
+			err = oc.WithoutNamespace().Run("delete", "project").Args(testProject2).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}()
+
+		err = wait.PollImmediate(500*time.Millisecond, time.Minute, func() (bool, error) {
+			return oc.WithoutNamespace().Run("get").Args("templates").Execute() == nil, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.WithoutNamespace().Run("create").Args("-f", appTemplatePath).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.WithoutNamespace().Run("process").Args("template/ruby-helloworld-sample").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.WithoutNamespace().Run("process").Args("templates/ruby-helloworld-sample").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.WithoutNamespace().Run("process").Args(oc.Namespace() + "//ruby-helloworld-sample").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.WithoutNamespace().Run("process").Args(oc.Namespace() + "/template/ruby-helloworld-sample").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		outputYamlFile, err := oc.WithoutNamespace().Run("get").Args("template", "ruby-helloworld-sample", "-o", "yaml").OutputToFile("template.yaml")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.WithoutNamespace().Run("process").Args("-f", outputYamlFile).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})

--- a/test/extended/cli/template.go
+++ b/test/extended/cli/template.go
@@ -21,10 +21,12 @@ var _ = g.Describe("[sig-cli] templates", func() {
 	)
 
 	g.It("different namespaces [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:template.openshift.io][apigroup:authorization.openshift.io][Skipped:Disconnected]", func() {
+		bob := oc.CreateUser("bob-")
+
 		err := oc.Run("create").Args("-f", appTemplatePath).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		bob := oc.CreateUser("bob-")
+		err = oc.Run("policy").Args("add-role-to-user", "admin", bob.Name).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
 		oc.ChangeUser(bob.Name)
 
 		testProject2 := oc.Namespace() + "-project2"

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -31424,27 +31424,6 @@ os::cmd::expect_success 'oc delete pod/template-type-precision'
 echo "template data precision: ok"
 os::test::junit::declare_suite_end
 
-os::test::junit::declare_suite_start "cmd/templates/different-namespaces"
-#os::cmd::expect_success 'oc create -f ${TEST_DATA}/application-template-dockerbuild.json -n openshift'
-#os::cmd::expect_success 'oc policy add-role-to-user admin test-user'
-#new="$(mktemp -d)/tempconfig"
-#os::cmd::expect_success "oc config view --raw > ${new}"
-#old="${KUBECONFIG}"
-#export KUBECONFIG=${new}
-#os::cmd::expect_success 'oc login -u test-user -p password'
-#os::cmd::expect_success 'oc new-project test-template-project'
-## make sure the permissions on the new project are set up
-#os::cmd::try_until_success 'oc get templates'
-#os::cmd::expect_success 'oc create -f ${TEST_DATA}/application-template-dockerbuild.json'
-#os::cmd::expect_success 'oc process template/ruby-helloworld-sample'
-#os::cmd::expect_success 'oc process templates/ruby-helloworld-sample'
-#os::cmd::expect_success 'oc process openshift//ruby-helloworld-sample'
-#os::cmd::expect_success 'oc process openshift/template/ruby-helloworld-sample'
-#os::cmd::expect_success 'oc get template ruby-helloworld-sample -n openshift -o yaml | oc process -f -'
-#export KUBECONFIG=${old}
-echo "processing templates in different namespace: ok"
-os::test::junit::declare_suite_end
-
 os::test::junit::declare_suite_start "cmd/templates/process"
 # This test validates oc process
 # fail to process two templates by name

--- a/test/extended/testdata/cmd/test/cmd/templates.sh
+++ b/test/extended/testdata/cmd/test/cmd/templates.sh
@@ -127,27 +127,6 @@ os::cmd::expect_success 'oc delete pod/template-type-precision'
 echo "template data precision: ok"
 os::test::junit::declare_suite_end
 
-os::test::junit::declare_suite_start "cmd/templates/different-namespaces"
-#os::cmd::expect_success 'oc create -f ${TEST_DATA}/application-template-dockerbuild.json -n openshift'
-#os::cmd::expect_success 'oc policy add-role-to-user admin test-user'
-#new="$(mktemp -d)/tempconfig"
-#os::cmd::expect_success "oc config view --raw > ${new}"
-#old="${KUBECONFIG}"
-#export KUBECONFIG=${new}
-#os::cmd::expect_success 'oc login -u test-user -p password'
-#os::cmd::expect_success 'oc new-project test-template-project'
-## make sure the permissions on the new project are set up
-#os::cmd::try_until_success 'oc get templates'
-#os::cmd::expect_success 'oc create -f ${TEST_DATA}/application-template-dockerbuild.json'
-#os::cmd::expect_success 'oc process template/ruby-helloworld-sample'
-#os::cmd::expect_success 'oc process templates/ruby-helloworld-sample'
-#os::cmd::expect_success 'oc process openshift//ruby-helloworld-sample'
-#os::cmd::expect_success 'oc process openshift/template/ruby-helloworld-sample'
-#os::cmd::expect_success 'oc get template ruby-helloworld-sample -n openshift -o yaml | oc process -f -'
-#export KUBECONFIG=${old}
-echo "processing templates in different namespace: ok"
-os::test::junit::declare_suite_end
-
 os::test::junit::declare_suite_start "cmd/templates/process"
 # This test validates oc process
 # fail to process two templates by name

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1535,7 +1535,7 @@ var Annotations = map[string]string{
 
 	"[sig-cli] policy scc-subject-review, scc-review [apigroup:authorization.openshift.io][apigroup:user.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-cli] templates  different namespaces [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:template.openshift.io][apigroup:authorization.openshift.io][Serial][Skipped:Disconnected]": " [Suite:openshift/conformance/serial]",
+	"[sig-cli] templates different namespaces [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:template.openshift.io][apigroup:authorization.openshift.io][Skipped:Disconnected]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/authentication.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1535,6 +1535,8 @@ var Annotations = map[string]string{
 
 	"[sig-cli] policy scc-subject-review, scc-review [apigroup:authorization.openshift.io][apigroup:user.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] templates  different namespaces [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:template.openshift.io][apigroup:authorization.openshift.io][Serial][Skipped:Disconnected]": " [Suite:openshift/conformance/serial]",
+
 	"[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/authentication.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "",
 
 	"[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/builds.sh [apigroup:image.openshift.io][apigroup:config.openshift.io]": "",


### PR DESCRIPTION
This PR adds new serial suite test in order to verify template processing via `oc process` between different namespaces are working correctly. This test will not work in Disconnected environments because it requires accessing registry images. This test is in serial suite instead of parallel, because it creates temporary user and logins with that by making changes on kubeconfig.


Some steps of test will fail until https://github.com/openshift/oc/pull/1318 is merged.