### PR TITLE
AUTH-365: add PodSecurityViolation to watched alerts

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/all.go
+++ b/pkg/monitortestlibrary/allowedalerts/all.go
@@ -69,5 +69,7 @@ func AllAlertTests(jobType *platformidentification.JobType, etcdAllowance AlertT
 	ret = append(ret, newAlert("samples", "SamplesImagestreamImportFailing", jobType).pending().neverFail().toTests()...)
 	ret = append(ret, newAlert("samples", "SamplesImagestreamImportFailing", jobType).firing().toTests()...)
 
+	ret = append(ret, newAlert("apiserver-auth", "PodSecurityViolation", jobType).firing().toTests()...)
+
 	return ret
 }


### PR DESCRIPTION
We don't want this to be firing in vanilla OpenShift clusters.

/cc @deads2k @ibihim @s-urbaniak 