### PR TITLE
Fix missing disruption uploads.

### DIFF
--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -134,13 +134,6 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	allowedDisruption, disruptionDetails, err := t.getAllowedDisruption(f)
-	framework.ExpectNoError(err)
-	if allowedDisruption == nil {
-		framework.Logf(fmt.Sprintf("Skipping: %s: No historical data", t.testName))
-		return
-	}
-
 	newBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: f.ClientSet.EventsV1()})
 	eventRecorder := newBroadcaster.NewRecorder(scheme.Scheme, "openshift.io/"+t.backend.GetDisruptionBackendName())
 	newBroadcaster.StartRecordingToSink(stopCh)
@@ -178,6 +171,13 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 	}
 	if disruptionErr != nil {
 		framework.Logf(fmt.Sprintf("unable to finish: %s", t.backend.GetLocator()))
+	}
+
+	allowedDisruption, disruptionDetails, err := t.getAllowedDisruption(f)
+	framework.ExpectNoError(err)
+	if allowedDisruption == nil {
+		framework.Logf(fmt.Sprintf("Skipping: %s: No historical data", t.testName))
+		return
 	}
 
 	end := time.Now()


### PR DESCRIPTION
Discovered that we are getting no data for image registry since Dec 7th
due to PR #27574 which shut off the entire monitor if we have less than
the required 100 runs to appear in the file of allowances to enforce. I
guess at this time, we did not have enough runs with image registry for
4.13. (which is unusual)

Skip the test, but let the monitor run.

[TRT-760](https://issues.redhat.com//browse/TRT-760)
