### PR TITLE
[OCPCLOUD-1818] Enable vSphere platform check in external cloud provider test

### DIFF
--- a/test/extended/cloud_controller_manager/ccm.go
+++ b/test/extended/cloud_controller_manager/ccm.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-cloud-provider][Feature:OpenShiftCloudControllerManager
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		if infra.Status.PlatformStatus.Type != configv1.OpenStackPlatformType {
+		if !isPlatformExternal(infra.Status.PlatformStatus.Type) {
 			g.Skip("Platform does not use external cloud provider")
 		}
 
@@ -65,3 +65,15 @@ var _ = g.Describe("[sig-cloud-provider][Feature:OpenShiftCloudControllerManager
 		o.Expect(workerkubelet).To(o.ContainSubstring("cloud-provider=external"))
 	})
 })
+
+// isPlatformExternal returns true when the platform has an in-tree provider,
+// but the platform is expected to use the external provider.
+func isPlatformExternal(platformType configv1.PlatformType) bool {
+	switch platformType {
+	case configv1.OpenStackPlatformType,
+		configv1.VSpherePlatformType:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
This PR updates the test for checking whether an external cloud provider is deployed or not to run on both the OpenStack (existing) and vSphere (new) platforms.

This will now check that an external cloud provider runs on the vSphere platform.

Will not pass until this [library-go](https://github.com/openshift/library-go/pull/1451) and it's associated PRs merge