### PR TITLE
tests: network: Prefer internal IPs first

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/network/utils.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/network/utils.go
@@ -115,6 +115,11 @@ func EndpointsUseHostNetwork(config *NetworkingTestConfig) {
 	config.EndpointsHostNetwork = true
 }
 
+// PreferExternalAddresses prefer node External Addresses for the tests
+func PreferExternalAddresses(config *NetworkingTestConfig) {
+	config.PreferExternalAddresses = true
+}
+
 // NewNetworkingTestConfig creates and sets up a new test config helper.
 func NewNetworkingTestConfig(f *framework.Framework, setters ...Option) *NetworkingTestConfig {
 	// default options
@@ -203,6 +208,8 @@ type NetworkingTestConfig struct {
 	// The kubernetes namespace within which all resources for this
 	// config are created
 	Namespace string
+	// Whether to prefer node External Addresses for the tests
+	PreferExternalAddresses bool
 }
 
 // NetexecDialResponse represents the response returned by the `netexec` subcommand of `agnhost`
@@ -815,13 +822,17 @@ func (config *NetworkingTestConfig) setup(selector map[string]string) {
 		family = v1.IPv6Protocol
 		secondaryFamily = v1.IPv4Protocol
 	}
-	// Get Node IPs from the cluster, ExternalIPs take precedence
-	config.NodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, family)
+	if config.PreferExternalAddresses {
+		// Get Node IPs from the cluster, ExternalIPs take precedence
+		config.NodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, family)
+	}
 	if config.NodeIP == "" {
 		config.NodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeInternalIP, family)
 	}
 	if config.DualStackEnabled {
-		config.SecondaryNodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, secondaryFamily)
+		if config.PreferExternalAddresses {
+			config.SecondaryNodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeExternalIP, secondaryFamily)
+		}
 		if config.SecondaryNodeIP == "" {
 			config.SecondaryNodeIP = e2enode.FirstAddressByTypeAndFamily(nodeList, v1.NodeInternalIP, secondaryFamily)
 		}


### PR DESCRIPTION
Many clusters block direct requests from internal resources to the nodes external IPs as best practice. All accesses from internal resources that want to access resources running on nodes go through load balancers, nodes being on private or public subnets. Let's prefer internal IPs first, so the tests can work even when there are security group rules present blocking requests to the external IPs.

We should not require ExternalIP for Conformance, but should keep testing ExternalIPs in sig network.

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>

This is a carry-over of https://github.com/kubernetes/kubernetes/pull/113799 so that we can enable creating clusters with public-only subnets in CI for AWS and GCP. This should save us in CI spending until we rebase on top of Kubernetes 1.27.