### PR TITLE
upgrade/adminack: guarantee one admin ack check post-upgrade

### DIFF
--- a/test/e2e/upgrade/adminack/adminack.go
+++ b/test/e2e/upgrade/adminack/adminack.go
@@ -51,6 +51,13 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 
 	adminAckTest := &clusterversionoperator.AdminAckTest{Oc: t.oc, Config: t.config, Poll: 10 * time.Minute}
 	adminAckTest.Test(ctx)
+
+	// Perform one guaranteed check after the upgrade is complete. The polled check above can be
+	// cancelled on done signal (which means, so we never know whether the poll was lucky to run at least once
+	// since the version was bumped.
+	postUpdateCtx, postUpdateCtxCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer postUpdateCtxCancel()
+	(&clusterversionoperator.AdminAckTest{Oc: t.oc, Config: t.config}).Test(postUpdateCtx)
 }
 
 // Teardown cleans up any remaining objects.

--- a/test/e2e/upgrade/adminack/adminack.go
+++ b/test/e2e/upgrade/adminack/adminack.go
@@ -51,13 +51,6 @@ func (t *UpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade
 
 	adminAckTest := &clusterversionoperator.AdminAckTest{Oc: t.oc, Config: t.config, Poll: 10 * time.Minute}
 	adminAckTest.Test(ctx)
-
-	// Perform one guaranteed check after the upgrade is complete. The polled check above can be
-	// cancelled on done signal (which means, so we never know whether the poll was lucky to run at least once
-	// since the version was bumped.
-	postUpdateCtx, postUpdateCtxCancel := context.WithTimeout(context.Background(), 15*time.Minute)
-	defer postUpdateCtxCancel()
-	(&clusterversionoperator.AdminAckTest{Oc: t.oc, Config: t.config}).Test(postUpdateCtx)
 }
 
 // Teardown cleans up any remaining objects.

--- a/test/extended/util/openshift/clusterversionoperator/adminack.go
+++ b/test/extended/util/openshift/clusterversionoperator/adminack.go
@@ -40,7 +40,9 @@ var adminAckGateRegexp = regexp.MustCompile(adminAckGateFmt)
 // and verifies that the Upgradeable condition no longer complains about the ack.
 func (t *AdminAckTest) Test(ctx context.Context) {
 	if t.Poll == 0 {
-		t.test(ctx, nil)
+		if err := t.test(ctx, nil); err != nil {
+			framework.Fail(err.Error())
+		}
 		return
 	}
 
@@ -97,6 +99,7 @@ func (t *AdminAckTest) test(ctx context.Context, exercisedGates map[string]struc
 			framework.Failf("Configmap openshift-config-managed/admin-gates gate %s does not contain description.", k)
 		}
 		if !gateApplicableToCurrentVersion(ackVersion, currentVersion) {
+			framework.Logf("Gate %s not applicable to current version %s", ackVersion, currentVersion)
 			continue
 		}
 		if ackCm.Data[k] == "true" {

--- a/test/extended/util/openshift/clusterversionoperator/adminack.go
+++ b/test/extended/util/openshift/clusterversionoperator/adminack.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -40,17 +41,18 @@ var adminAckGateRegexp = regexp.MustCompile(adminAckGateFmt)
 // and verifies that the Upgradeable condition no longer complains about the ack.
 func (t *AdminAckTest) Test(ctx context.Context) {
 	if t.Poll == 0 {
-		if err := t.test(ctx, nil); err != nil {
+		if err := t.test(ctx, nil, nil); err != nil {
 			framework.Fail(err.Error())
 		}
 		return
 	}
 
-	exercisedGates := map[string]struct{}{}
+	exercisedGates := sets.NewString()
+	exercisedVersions := sets.NewString()
 	success := false
 	var lastError error
 	if err := wait.PollImmediateUntilWithContext(ctx, t.Poll, func(ctx context.Context) (bool, error) {
-		if err := t.test(ctx, exercisedGates); err != nil {
+		if err := t.test(ctx, exercisedGates, exercisedVersions); err != nil {
 			framework.Logf("Retriable failure to evaluate admin acks: %v", err)
 			lastError = err
 		} else {
@@ -66,11 +68,21 @@ func (t *AdminAckTest) Test(ctx context.Context) {
 	if !success {
 		framework.Failf("Never able to evaluate admin acks.  Most recent failure: %v", lastError)
 	}
+
+	// Perform one guaranteed check after the upgrade is complete. The polled check above is cancelled
+	// on done signal (so we never know whether the poll was lucky to run at least once since
+	// the version was bumped).
+	postUpdateCtx, postUpdateCtxCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer postUpdateCtxCancel()
+	if current := getCurrentVersion(postUpdateCtx, t.Config); current != "" && !exercisedVersions.Has(current) {
+		// We never saw the current version while polling, so lets check it now
+		if err := t.test(postUpdateCtx, exercisedGates, exercisedVersions); err != nil {
+			framework.Fail(err.Error())
+		}
+	}
 }
 
-func (t *AdminAckTest) test(ctx context.Context, exercisedGates map[string]struct{}) error {
-	exists := struct{}{}
-
+func (t *AdminAckTest) test(ctx context.Context, exercisedGates, exercisedVersions sets.String) error {
 	gateCm, err := getAdminGatesConfigMap(ctx, t.Oc)
 	if err != nil {
 		return err
@@ -85,11 +97,12 @@ func (t *AdminAckTest) test(ctx context.Context, exercisedGates map[string]struc
 		return err
 	}
 	currentVersion := getCurrentVersion(ctx, t.Config)
+	if exercisedVersions != nil {
+		exercisedVersions.Insert(currentVersion)
+	}
 	for k, v := range gateCm.Data {
-		if exercisedGates != nil {
-			if _, ok := exercisedGates[k]; ok {
-				continue
-			}
+		if exercisedGates != nil && exercisedGates.Has(k) {
+			continue
 		}
 		ackVersion := adminAckGateRegexp.FindString(k)
 		if ackVersion == "" {
@@ -127,7 +140,7 @@ func (t *AdminAckTest) test(ctx context.Context, exercisedGates map[string]struc
 			framework.Fail(err.Error())
 		}
 		if exercisedGates != nil {
-			exercisedGates[k] = exists
+			exercisedGates.Insert(k)
 		}
 	}
 	framework.Logf("Admin Ack verified")


### PR DESCRIPTION
While looking into OCPBUGS-5505 I discovered that some 4.10->4.11
upgrade job runs perform an Admin Ack check, while some do not. 4.11 has
a `ack-4.11-kube-1.25-api-removals-in-4.12` gate, so these upgrade jobs
sometimes test that `Upgradeable` goes `false` after the ugprade, and
sometimes they do not. This is only determined by the polling race
condition: the check is executed once per 10 minutes, and we cancel the
polling after upgrade is completed. This means that in some cases we are
lucky and manage to run one check before the cancel, and sometimes we
are not and only check while still on the base version.

Example job that checked admin acks post-upgrade:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-cluster-version-operator-880-ci-4.11-upgrade-from-stable-4.10-e2e-azure-upgrade/1611444032104304640
```console
$ curl --silent https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/openshift-cluster-version-operator-880-ci-4.11-upgrade-from-stable-4.10-e2e-azure-upgrade/1611444032104304640/artifacts/e2e-azure-upgrade/openshift-e2e-test/artifacts/e2e.log | grep 'Waiting for Upgradeable to be AdminAckRequired'
Jan  6 21:16:40.153: INFO: Waiting for Upgradeable to be AdminAckRequired ...
```

Example job that did not check admin acks post-upgrade:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-cluster-version-operator-880-ci-4.11-upgrade-from-stable-4.10-e2e-azure-upgrade/1611444033509396480
```console
$ curl --silent https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/openshift-cluster-version-operator-880-ci-4.11-upgrade-from-stable-4.10-e2e-azure-upgrade/1611444033509396480/artifacts/e2e-azure-upgrade/openshift-e2e-test/artifacts/e2e.log | grep 'Waiting for Upgradeable to be AdminAckRequired'
```


Add a guaranteed single check execution after the upgrade, so that admin
ack is always checked at least once with the upgrade target version.
Doing checks after `done` is signalled has prior art in the [alert test](https://github.com/openshift/origin/blob/c081a2a8095237cee1fca893d750e7eb10975924/test/e2e/upgrade/alert/alert.go#L47-L49).
