### PR TITLE
Add pathological events into spyglass charts

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -97,7 +97,24 @@
         return false
     }
 
+    function isInterestingOrPathological(eventInterval) {
+        if (eventInterval.message.includes("pathological/true") || (eventInterval.message.includes("interesting/true"))) {
+            return true
+        }
+        return false
+    }
+
     function isPod(eventInterval) {
+        // this check was added to keep the repeating events out fo the "pods" section
+        const nTimes = new RegExp("\\(\\d+ times\\)")
+        if (eventInterval.message.match(nTimes)) {
+            return false
+        }
+        // this check was added to avoid the events from the "interesting-events" section from being
+        // duplicated in the "pods" section.
+        if (isInterestingOrPathological(eventInterval)) {
+            return false
+        }
         if (eventInterval.locator.includes("pod/") && !eventInterval.locator.includes("alert/")) {
             return true
         }
@@ -190,6 +207,19 @@
         }
         return false
     }
+
+    function interestingEvents(item) {
+        if (item.message.includes("pathological/true")) {
+            if (item.message.includes("interesting/true")) {
+                return [item.locator, ` (pathological known)`, "PathologicalKnown"];
+            } else {
+                return [item.locator, ` (pathological new)`, "PathologicalNew"];
+            }
+        }
+        if (item.message.includes("interesting/true")) {
+		    return [item.locator, ` (interesting event)`, "InterestingEvent"];
+        }
+	}
 
     const reReason = new RegExp("(^| )reason/([^ ]+)")
     function podStateValue(item) {
@@ -411,6 +441,9 @@
         timelineGroups.push({group: "e2e-test-passed", data: []})
         createTimelineData("Passed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EPassed, regex)
 
+        timelineGroups.push({group: "interesting-events", data: []})
+        createTimelineData(interestingEvents, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isInterestingOrPathological, regex)
+
         var segmentFunc = function (segment) {
             // for (var i in data) {
             //     if (data[i].group == segment.group) {
@@ -437,6 +470,7 @@
         const myChart = TimelinesChart();
         var ordinalScale = d3.scaleOrdinal()
             .domain([
+                'InterestingEvent', 'PathologicalKnown', "PathologicalNew", // interesting and pathological events
                 'AlertInfo', 'AlertPending', 'AlertWarning', 'AlertCritical', // alerts
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
                 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', // nodes
@@ -444,6 +478,7 @@
                 'PodCreated', 'PodScheduled', 'PodTerminating','ContainerWait', 'ContainerStart', 'ContainerNotReady', 'ContainerReady', 'ContainerReadinessFailed', 'ContainerReadinessErrored',  'StartupProbeFailed', // pods
                 'Degraded', 'Upgradeable', 'False', 'Unknown'])
             .range([
+                '#6E6E6E', '#0000ff', '#d0312d', // pathological and interesting events
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators
                 '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes

--- a/pkg/duplicateevents/duplicated_event_patterns.go
+++ b/pkg/duplicateevents/duplicated_event_patterns.go
@@ -1,0 +1,469 @@
+package duplicateevents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	v1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	ImagePullRedhatRegEx             = `reason/[a-zA-Z]+ .*Back-off pulling image .*registry.redhat.io`
+	RequiredResourcesMissingRegEx    = `reason/RequiredInstallerResourcesMissing secrets: etcd-all-certs-[0-9]+`
+	BackoffRestartingFailedRegEx     = `reason/BackOff Back-off restarting failed container`
+	ErrorUpdatingEndpointSlicesRegex = `reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices`
+	NodeHasNoDiskPressureRegExpStr   = "reason/NodeHasNoDiskPressure.*status is now: NodeHasNoDiskPressure"
+	NodeHasSufficientMemoryRegExpStr = "reason/NodeHasSufficientMemory.*status is now: NodeHasSufficientMemory"
+	NodeHasSufficientPIDRegExpStr    = "reason/NodeHasSufficientPID.*status is now: NodeHasSufficientPID"
+
+	OvnReadinessRegExpStr                   = `ns/(?P<NS>openshift-ovn-kubernetes) pod/(?P<POD>ovnkube-node-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>Unhealthy) (?P<MSG>Readiness probe failed:.*$)`
+	ConsoleReadinessRegExpStr               = `ns/(?P<NS>openshift-console) pod/(?P<POD>console-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>ProbeError) (?P<MSG>Readiness probe error:.* connect: connection refused$)`
+	MarketplaceStartupProbeFailureRegExpStr = `ns/(?P<NS>openshift-marketplace) pod/(?P<POD>(community-operators|redhat-operators)-[a-z0-9-]+).*Startup probe failed`
+
+	ImagePullRedhatFlakeThreshold              = 5
+	RequiredResourceMissingFlakeThreshold      = 10
+	BackoffRestartingFlakeThreshold            = 10
+	ErrorUpdatingEndpointSlicesFailedThreshold = -1 // flake only
+	ErrorUpdatingEndpointSlicesFlakeThreshold  = 10
+
+	ReadinessFailedMessageRegExpStr           = "reason/ReadinessFailed.*Get.*healthz.*net/http.*request canceled while waiting for connection.*Client.Timeout exceeded"
+	ProbeErrorReadinessMessageRegExpStr       = "reason/ProbeError.*Readiness probe error.*Client.Timeout exceeded while awaiting headers"
+	ProbeErrorLivenessMessageRegExpStr        = "reason/(ProbeError|Unhealthy).*Liveness probe error.*Client.Timeout exceeded while awaiting headers"
+	ProbeErrorConnectionRefusedRegExpStr      = "reason/ProbeError.*Readiness probe error.*connection refused"
+	SingleNodeErrorConnectionRefusedRegExpStr = "reason/.*dial tcp.*connection refused"
+
+	DuplicateEventThreshold           = 20
+	DuplicateSingleNodeEventThreshold = 30
+	PathologicalMark                  = "pathological/true"
+	InterestingMark                   = "interesting/true"
+)
+
+var EventCountExtractor = regexp.MustCompile(`(?s)(.*) \((\d+) times\).*`)
+
+var AllowedRepeatedEventPatterns = []*regexp.Regexp{
+	// [sig-apps] StatefulSet Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod's predecessor fails [Suite:openshift/conformance/parallel] [Suite:k8s]
+	// PauseNewPods intentionally causes readiness probe to fail.
+	regexp.MustCompile(`ns/e2e-statefulset-[0-9]+ pod/ss-[0-9] node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: `),
+
+	// [sig-apps] StatefulSet Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
+	// breakPodHTTPProbe intentionally causes readiness probe to fail.
+	regexp.MustCompile(`ns/e2e-statefulset-[0-9]+ pod/ss2-[0-9] node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: HTTP probe failed with statuscode: 404`),
+
+	// [sig-node] Probing container ***
+	// these tests intentionally cause repeated probe failures to ensure good handling
+	regexp.MustCompile(`ns/e2e-container-probe-[0-9]+ .* probe failed: `),
+	regexp.MustCompile(`ns/e2e-container-probe-[0-9]+ .* probe warning: `),
+
+	// Kubectl Port forwarding ***
+	// The same pod name is used many times for all these tests with a tight readiness check to make the tests fast.
+	// This results in hundreds of events while the pod isn't ready.
+	regexp.MustCompile(`ns/e2e-port-forwarding-[0-9]+ pod/pfpod node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed:`),
+
+	// should not start app containers if init containers fail on a RestartAlways pod
+	// the init container intentionally fails to start
+	regexp.MustCompile(`ns/e2e-init-container-[0-9]+ pod/pod-init-[a-z0-9.-]+ node/[a-z0-9.-]+ - reason/BackOff Back-off restarting failed container`),
+
+	// TestAllowedSCCViaRBAC and TestPodUpdateSCCEnforcement
+	// The pod is shaped to intentionally not be scheduled.  Looks like an artifact of the old integration testing.
+	regexp.MustCompile(`ns/e2e-test-scc-[a-z0-9]+ pod/.* - reason/FailedScheduling.*`),
+
+	// Security Context ** should not run with an explicit root user ID
+	// Security Context ** should not run without a specified user ID
+	// This container should never run
+	regexp.MustCompile(`ns/e2e-security-context-test-[0-9]+ pod/.*-root-uid node/[a-z0-9.-]+ - reason/Failed Error: container's runAsUser breaks non-root policy.*"`),
+
+	// PersistentVolumes-local tests should not run the pod when there is a volume node
+	// affinity and node selector conflicts.
+	regexp.MustCompile(`ns/e2e-persistent-local-volumes-test-[0-9]+ pod/pod-[a-z0-9.-]+ reason/FailedScheduling`),
+
+	// various DeploymentConfig tests trigger this by canceling multiple rollouts
+	regexp.MustCompile(`reason/DeploymentAwaitingCancellation Deployment of version [0-9]+ awaiting cancellation of older running deployments`),
+
+	// this image is used specifically to be one that cannot be pulled in our tests
+	regexp.MustCompile(`.*reason/BackOff Back-off pulling image "webserver:404"`),
+
+	// If image pulls in e2e namespaces fail catastrophically we'd expect them to lead to test failures
+	// We are deliberately not ignoring image pull failures for core component namespaces
+	regexp.MustCompile(`ns/e2e-.* reason/BackOff Back-off pulling image`),
+
+	// promtail crashlooping as its being started by sideloading manifests.  per @vrutkovs
+	regexp.MustCompile("ns/openshift-e2e-loki pod/loki-promtail.*Readiness probe"),
+
+	// Related to known bug below, but we do not need to report on loki: https://bugzilla.redhat.com/show_bug.cgi?id=1986370
+	regexp.MustCompile("ns/openshift-e2e-loki pod/loki-promtail.*reason/NetworkNotReady"),
+
+	// kube-apiserver guard probe failing due to kube-apiserver operands getting rolled out
+	// multiple times during the bootstrapping phase of a cluster installation
+	regexp.MustCompile("ns/openshift-kube-apiserver pod/kube-apiserver-guard.*ProbeError Readiness probe error"),
+	// the same thing happens for kube-controller-manager and kube-scheduler
+	regexp.MustCompile("ns/openshift-kube-controller-manager pod/kube-controller-manager-guard.*ProbeError Readiness probe error"),
+	regexp.MustCompile("ns/openshift-kube-scheduler pod/kube-scheduler-guard.*ProbeError Readiness probe error"),
+
+	// this is the less specific even sent by the kubelet when a probe was executed successfully but returned false
+	// we ignore this event because openshift has a patch in patch_prober that sends a more specific event about
+	// readiness failures in openshift-* namespaces.  We will catch the more specific ProbeError events.
+	regexp.MustCompile("Unhealthy Readiness probe failed"),
+	// readiness probe errors during pod termination are expected, so we do not fail on them.
+	regexp.MustCompile("TerminatingPodProbeError"),
+
+	// we have a separate test for this
+	regexp.MustCompile(OvnReadinessRegExpStr),
+
+	// Separated out in testBackoffPullingRegistryRedhatImage
+	regexp.MustCompile(ImagePullRedhatRegEx),
+
+	// Separated out in testRequiredInstallerResourcesMissing
+	regexp.MustCompile(RequiredResourcesMissingRegEx),
+
+	// Separated out in testBackoffStartingFailedContainer
+	regexp.MustCompile(BackoffRestartingFailedRegEx),
+
+	// Separated out in testErrorUpdatingEndpointSlices
+	regexp.MustCompile(ErrorUpdatingEndpointSlicesRegex),
+
+	// If you see this error, it means enough was working to get this event which implies enough retries happened to allow initial openshift
+	// installation to succeed. Hence, we can ignore it.
+	regexp.MustCompile(`reason/FailedCreate .* error creating EC2 instance: InsufficientInstanceCapacity: We currently do not have sufficient .* capacity in the Availability Zone you requested`),
+
+	// Separated out in testNodeHasNoDiskPressure
+	regexp.MustCompile(NodeHasNoDiskPressureRegExpStr),
+
+	// Separated out in testNodeHasSufficientMemory
+	regexp.MustCompile(NodeHasSufficientMemoryRegExpStr),
+
+	// Separated out in testNodeHasSufficientPID
+	regexp.MustCompile(NodeHasSufficientPIDRegExpStr),
+
+	// Separated out in testMarketplaceStartupProbeFailure
+	regexp.MustCompile(MarketplaceStartupProbeFailureRegExpStr),
+}
+
+// AllowedUpgradeRepeatedEventPatterns are patterns of events that we should only allow during upgrades, not during normal execution.
+var AllowedUpgradeRepeatedEventPatterns = []*regexp.Regexp{
+	// Operators that use library-go can report about multiple versions during upgrades.
+	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/MultipleVersions multiple versions found, probably in transition: .*`),
+	regexp.MustCompile(`ns/openshift-kube-apiserver-operator deployment/kube-apiserver-operator - reason/MultipleVersions multiple versions found, probably in transition: .*`),
+	regexp.MustCompile(`ns/openshift-kube-controller-manager-operator deployment/kube-controller-manager-operator - reason/MultipleVersions multiple versions found, probably in transition: .*`),
+	regexp.MustCompile(`ns/openshift-kube-scheduler-operator deployment/openshift-kube-scheduler-operator - reason/MultipleVersions multiple versions found, probably in transition: .*`),
+
+	// etcd-quorum-guard can fail during upgrades.
+	regexp.MustCompile(`ns/openshift-etcd pod/etcd-quorum-guard-[a-z0-9-]+ node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: `),
+	// etcd can have unhealthy members during an upgrade
+	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/UnhealthyEtcdMember unhealthy members: .*`),
+	// etcd-operator began to version etcd-endpoints configmap in 4.10 as part of static-pod-resource. During upgrade existing revisions will not contain the resource.
+	// The condition reconciles with the next revision which the result of the upgrade. TODO(hexfusion) remove in 4.11
+	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/RequiredInstallerResourcesMissing configmaps: etcd-endpoints-[0-9]+`),
+	// There is a separate test to catch this specific case
+	regexp.MustCompile(RequiredResourcesMissingRegEx),
+
+	// Separated out in testMarketplaceStartupProbeFailure
+	regexp.MustCompile(MarketplaceStartupProbeFailureRegExpStr),
+}
+
+type KnownProblem struct {
+	Regexp *regexp.Regexp
+	BZ     string
+
+	// Platform limits the exception to a specific OpenShift platform.
+	Platform *v1.PlatformType
+
+	// Topology limits the exception to a specific topology (e.g. single replica)
+	Topology *v1.TopologyMode
+
+	// TestSuite limits the exception to a specific test suite (e.g. openshift/builds)
+	TestSuite *string
+}
+
+var KnownEventsBugs = []KnownProblem{
+	{
+		Regexp: regexp.MustCompile(`ns/openshift-multus pod/network-metrics-daemon-[a-z0-9]+ node/[a-z0-9.-]+ - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net\.d/\. Has your network provider started\?`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
+	},
+	{
+		Regexp: regexp.MustCompile(`ns/openshift-e2e-loki pod/loki-promtail-[a-z0-9]+ node/[a-z0-9.-]+ - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net\.d/\. Has your network provider started\?`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
+	},
+	{
+		Regexp: regexp.MustCompile(`ns/openshift-network-diagnostics pod/network-check-target-[a-z0-9]+ node/[a-z0-9.-]+ - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net\.d/\. Has your network provider started\?`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
+	},
+	{
+		Regexp: regexp.MustCompile(`ns/.* service/.* - reason/FailedToDeleteOVNLoadBalancer .*`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1990631",
+	},
+	{
+		Regexp: regexp.MustCompile(`ns/.*horizontalpodautoscaler.*failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API.*`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1993985",
+	},
+	{
+		Regexp: regexp.MustCompile(`ns/.*unable to ensure pod container exists: failed to create container.*slice already exists.*`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1993980",
+	},
+	{
+		Regexp: regexp.MustCompile(`ns/openshift-etcd pod/etcd-quorum-guard-[a-z0-9-]+ node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: `),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2000234",
+	},
+	{
+		Regexp: regexp.MustCompile(`ns/openshift-etcd pod/etcd-guard-.* node/.* - reason/ProbeError Readiness probe error: .* connect: connection refused`),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2075204",
+	},
+	{
+		Regexp: regexp.MustCompile("ns/openshift-etcd-operator namespace/openshift-etcd-operator -.*rpc error: code = Canceled desc = grpc: the client connection is closing.*"),
+		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
+	},
+	{
+		Regexp: regexp.MustCompile("reason/TopologyAwareHintsDisabled"),
+		BZ:     "https://issues.redhat.com/browse/OCPBUGS-5943",
+	},
+	{
+		Regexp:   regexp.MustCompile("ns/.*reason/.*APICheckFailed.*503.*"),
+		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
+		Topology: TopologyPointer(v1.SingleReplicaTopologyMode),
+	},
+	// builds tests trigger many changes in the config which creates new rollouts -> event for each pod
+	// working as intended (not a bug) and needs to be tolerated
+	{
+		Regexp:    regexp.MustCompile(`ns/openshift-route-controller-manager deployment/route-controller-manager - reason/ScalingReplicaSet \(combined from similar events\): Scaled (down|up) replica set route-controller-manager-[a-z0-9-]+ to [0-9]+`),
+		TestSuite: StringPointer("openshift/build"),
+	},
+	// builds tests trigger many changes in the config which creates new rollouts -> event for each pod
+	// working as intended (not a bug) and needs to be tolerated
+	{
+		Regexp:    regexp.MustCompile(`ns/openshift-controller-manager deployment/controller-manager - reason/ScalingReplicaSet \(combined from similar events\): Scaled (down|up) replica set controller-manager-[a-z0-9-]+ to [0-9]+`),
+		TestSuite: StringPointer("openshift/build"),
+	},
+	//{ TODO this should only be skipped for single-node
+	//	name:    "single=node-storage",
+	//  BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1990662
+	//	message: "ns/openshift-cluster-csi-drivers pod/aws-ebs-csi-driver-controller-66469455cd-2thfv node/ip-10-0-161-38.us-east-2.compute.internal - reason/BackOff Back-off restarting failed container",
+	//},
+}
+
+// IsRepeatedEventOKFunc takes a monitorEvent as input and returns true if the repeated event is OK.
+// This commonly happens for known bugs and for cases where events are repeated intentionally by tests.
+// Use this to handle cases where, "if X is true, then the repeated event is ok".
+type IsRepeatedEventOKFunc func(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, times int) (bool, error)
+
+var AllowedRepeatedEventFns = []IsRepeatedEventOKFunc{
+	isConsoleReadinessDuringInstallation,
+	isConfigOperatorReadinessFailed,
+	isConfigOperatorProbeErrorReadinessFailed,
+	isConfigOperatorProbeErrorLivenessFailed,
+	isOauthApiserverProbeErrorReadinessFailed,
+	isOauthApiserverProbeErrorLivenessFailed,
+	isOauthApiserverProbeErrorConnectionRefusedFailed,
+}
+
+var AllowedSingleNodeRepeatedEventFns = []IsRepeatedEventOKFunc{
+	isConnectionRefusedOnSingleNode,
+}
+
+func TopologyPointer(topology v1.TopologyMode) *v1.TopologyMode {
+	return &topology
+}
+
+func PlatformPointer(platform v1.PlatformType) *v1.PlatformType {
+	return &platform
+}
+
+func StringPointer(testSuite string) *string {
+	return &testSuite
+}
+
+// isConsoleReadinessDuringInstallation returns true if the event is for console readiness and it happens during the
+// initial installation of the cluster.
+// we're looking for something like
+// > ns/openshift-console pod/console-7c6f797fd9-5m94j node/ip-10-0-158-106.us-west-2.compute.internal - reason/ProbeError Readiness probe error: Get "https://10.129.0.49:8443/health": dial tcp 10.129.0.49:8443: connect: connection refused
+// with a firstTimestamp before the cluster completed the initial installation
+func isConsoleReadinessDuringInstallation(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, _ int) (bool, error) {
+	if !strings.Contains(monitorEvent.Locator, "ns/openshift-console") {
+		return false, nil
+	}
+	if !strings.Contains(monitorEvent.Locator, "pod/console-") {
+		return false, nil
+	}
+	if !strings.Contains(monitorEvent.Locator, "Readiness probe") {
+		return false, nil
+	}
+	if !strings.Contains(monitorEvent.Locator, "connect: connection refused") {
+		return false, nil
+	}
+
+	regExp := regexp.MustCompile(ConsoleReadinessRegExpStr)
+	// if the readiness probe failure for this pod happened AFTER the initial installation was complete,
+	// then this probe failure is unexpected and should fail.
+	return IsEventDuringInstallation(monitorEvent, kubeClientConfig, regExp)
+}
+
+// isConfigOperatorReadinessFailed returns true if the event matches a readinessFailed error that timed out
+// in the openshift-config-operator.
+// like this:
+// ...ReadinessFailed Get \"https://10.130.0.16:8443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+func isConfigOperatorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(ReadinessFailedMessageRegExpStr)
+	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
+}
+
+// isConfigOperatorProbeErrorReadinessFailed returns true if the event matches a ProbeError Readiness Probe message
+// in the openshift-config-operator.
+// like this:
+// reason/ProbeError Readiness probe error: Get "https://10.130.0.15:8443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+func isConfigOperatorProbeErrorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(ProbeErrorReadinessMessageRegExpStr)
+	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
+}
+
+// isConfigOperatorProbeErrorLivenessFailed returns true if the event matches a ProbeError Liveness Probe message
+// in the openshift-config-operator.
+// like this:
+// ...reason/ProbeError Liveness probe error: Get "https://10.128.0.21:8443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+func isConfigOperatorProbeErrorLivenessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(ProbeErrorLivenessMessageRegExpStr)
+	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
+}
+
+// isOauthApiserverProbeErrorReadinessFailed returns true if the event matches a ProbeError Readiness Probe message
+// in the openshift-oauth-operator.
+// like this:
+// ...ns/openshift-oauth-apiserver pod/apiserver-65fd7ffc59-bt5sf node/q72hs3bx-ac890-4pxpm-master-2 - reason/ProbeError Readiness probe error: Get "https://10.129.0.8:8443/readyz": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
+func isOauthApiserverProbeErrorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(ProbeErrorReadinessMessageRegExpStr)
+	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
+}
+
+// isOauthApiserverProbeErrorLivenessFailed returns true if the event matches a ProbeError Liveness Probe message
+// in the openshift-oauth-operator.
+// like this:
+// ...reason/ProbeError Liveness probe error: Get "https://10.130.0.68:8443/healthz": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
+func isOauthApiserverProbeErrorLivenessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(ProbeErrorLivenessMessageRegExpStr)
+	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
+}
+
+// isOauthApiserverProbeErrorConnectionRefusedFailed returns true if the event matches a ProbeError Readiness Probe connection refused message
+// in the openshift-oauth-operator.
+// like this:
+// ...ns/openshift-oauth-apiserver pod/apiserver-647fc6c7bf-s8b4h node/ip-10-0-150-209.us-west-1.compute.internal - reason/ProbeError Readiness probe error: Get "https://10.128.0.38:8443/readyz": dial tcp 10.128.0.38:8443: connect: connection refused
+func isOauthApiserverProbeErrorConnectionRefusedFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+	regExp := regexp.MustCompile(ProbeErrorConnectionRefusedRegExpStr)
+	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
+}
+
+// isConnectionRefusedOnSingleNode returns true if the event matched has a connection refused message for single node events and is with in threshold.
+func isConnectionRefusedOnSingleNode(monitorEvent monitorapi.EventInterval, _ *rest.Config, count int) (bool, error) {
+	regExp := regexp.MustCompile(SingleNodeErrorConnectionRefusedRegExpStr)
+	return regExp.MatchString(monitorEvent.String()) && count < DuplicateSingleNodeEventThreshold, nil
+}
+
+// IsOperatorMatchRegexMessage returns true if this monitorEvent is for the operator identified by the operatorName
+// and its message matches the given regex.
+func IsOperatorMatchRegexMessage(monitorEvent monitorapi.EventInterval, operatorName string, regExp *regexp.Regexp) bool {
+	locatorParts := monitorapi.LocatorParts(monitorEvent.Locator)
+	if ns, ok := locatorParts["ns"]; ok {
+		if ns != operatorName {
+			return false
+		}
+	}
+	if pod, ok := locatorParts["pod"]; ok {
+		if !strings.HasPrefix(pod, operatorName) {
+			return false
+		}
+	}
+	if !regExp.MatchString(monitorEvent.Message) {
+		return false
+	}
+	return true
+}
+
+// isEventDuringInstallation returns true if the monitorEvent represents a real event that happened after installation.
+// regExp defines the pattern of the monitorEvent message. Named match is used in the pattern using `(?P<>)`. The names are placed inside <>. See example below
+// `ns/(?P<NS>openshift-ovn-kubernetes) pod/(?P<POD>ovnkube-node-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>Unhealthy) (?P<MSG>Readiness probe failed:.*$`
+func IsEventDuringInstallation(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, regExp *regexp.Regexp) (bool, error) {
+	if kubeClientConfig == nil {
+		// default to OK
+		return true, nil
+	}
+	installCompletionTime := getInstallCompletionTime(kubeClientConfig)
+	if installCompletionTime == nil {
+		return true, nil
+	}
+
+	message := fmt.Sprintf("%s - %s", monitorEvent.Locator, monitorEvent.Message)
+	namespace, pod, _, reason, msg, err := getMatchedElementsFromMonitorEventMsg(regExp, message)
+	if err != nil {
+		return false, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(kubeClientConfig)
+	if err != nil {
+		return true, nil
+	}
+	kubeEvents, err := kubeClient.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return true, nil
+	}
+	for _, event := range kubeEvents.Items {
+		if event.Related == nil ||
+			event.Related.Name != pod ||
+			event.Reason != reason ||
+			!strings.Contains(event.Message, msg) {
+			continue
+		}
+
+		if event.FirstTimestamp.After(installCompletionTime.Time) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+func getInstallCompletionTime(kubeClientConfig *rest.Config) *metav1.Time {
+	configClient, err := configclient.NewForConfig(kubeClientConfig)
+	if err != nil {
+		return nil
+	}
+	clusterVersion, err := configClient.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	if len(clusterVersion.Status.History) == 0 {
+		return nil
+	}
+	return clusterVersion.Status.History[len(clusterVersion.Status.History)-1].CompletionTime
+}
+
+func getMatchedElementsFromMonitorEventMsg(regExp *regexp.Regexp, message string) (string, string, string, string, string, error) {
+	var namespace, pod, node, reason, msg string
+	if !regExp.MatchString(message) {
+		return namespace, pod, node, reason, msg, errors.New("regex match error")
+	}
+	subMatches := regExp.FindStringSubmatch(message)
+	subNames := regExp.SubexpNames()
+	for i, name := range subNames {
+		switch name {
+		case "NS":
+			namespace = subMatches[i]
+		case "POD":
+			pod = subMatches[i]
+		case "NODE":
+			node = subMatches[i]
+		case "REASON":
+			reason = subMatches[i]
+		case "MSG":
+			msg = subMatches[i]
+		}
+	}
+	if len(namespace) == 0 ||
+		len(pod) == 0 ||
+		len(node) == 0 ||
+		len(msg) == 0 {
+		return namespace, pod, node, reason, msg, fmt.Errorf("regex match expects non-empty elements, got namespace: %s, pod: %s, node: %s, msg: %s", namespace, pod, node, msg)
+	}
+	return namespace, pod, node, reason, msg, nil
+}

--- a/pkg/monitor/event_test.go
+++ b/pkg/monitor/event_test.go
@@ -1,0 +1,110 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func Test_recordAddOrUpdateEvent(t *testing.T) {
+
+	type KubeEventsItems struct {
+		Items []corev1.Event `json:"items"`
+	}
+
+	// Get the kubeconfig by creating a file using the output of the KAAS tool or cluster-bot.
+	// You can possible get panics due to timeout of KAAS kube configs.
+	// Get the json file for all events from artifacts/gather-extra.  Or by using using
+	// "oc -n aNamespace get event" after setting KUBECONFIG.
+	kubeconfig := "/tmp/k.txt"
+	jsonFile := "/tmp/kube_events.json"
+
+	file, err := os.Open(jsonFile)
+	if err != nil {
+		fmt.Println("Error opening jsonFile:", err)
+		return
+	}
+	defer file.Close()
+
+	var kubeEvents KubeEventsItems
+	if err := json.NewDecoder(file).Decode(&kubeEvents); err != nil {
+		fmt.Println("Error reading jsonFile:", err)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		fmt.Println("Unable to setup *rest.Config:", err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Println("Unable to setup kube client:", err)
+	}
+
+	smallKubeEvents := KubeEventsItems{
+		Items: []corev1.Event{
+			{
+				Count:   2,
+				Reason:  "NodeHasNoDiskPressure",
+				Message: "sample message",
+			},
+		},
+	}
+	type args struct {
+		ctx                    context.Context
+		m                      Recorder
+		client                 kubernetes.Interface
+		reMatchFirstQuote      *regexp.Regexp
+		significantlyBeforeNow time.Time
+		kubeEventList          KubeEventsItems
+	}
+
+	tests := []struct {
+		name string
+		args args
+		skip bool
+	}{
+		{
+			name: "Single Event test",
+			args: args{
+				ctx:                    context.TODO(),
+				m:                      NewMonitorWithInterval(time.Second),
+				client:                 nil,
+				reMatchFirstQuote:      regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`),
+				significantlyBeforeNow: time.Now().UTC().Add(-15 * time.Minute),
+				kubeEventList:          smallKubeEvents,
+			},
+		},
+		{
+			name: "Multiple Event (from file) test",
+			skip: true, // skip in case we don't have a file
+			args: args{
+				ctx:               context.TODO(),
+				m:                 NewMonitorWithInterval(time.Second),
+				client:            client,
+				reMatchFirstQuote: regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`),
+
+				// Use the timestamp of the first corev1.Event
+				significantlyBeforeNow: kubeEvents.Items[0].LastTimestamp.UTC().Add(-15 * time.Minute),
+				kubeEventList:          kubeEvents,
+			},
+		},
+	}
+	for _, tt := range tests {
+		if tt.skip {
+			continue
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			for _, event := range tt.args.kubeEventList.Items {
+				recordAddOrUpdateEvent(tt.args.ctx, tt.args.m, tt.args.client, tt.args.reMatchFirstQuote, tt.args.significantlyBeforeNow, &event)
+			}
+		})
+	}
+}

--- a/pkg/monitor/intervalcreation/rendering.go
+++ b/pkg/monitor/intervalcreation/rendering.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openshift/origin/pkg/duplicateevents"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 	"github.com/openshift/origin/test/extended/testdata"
@@ -80,6 +81,13 @@ func BelongsInEverything(eventInterval monitorapi.EventInterval) bool {
 	return true
 }
 
+func isInterestingOrPathological(eventInterval monitorapi.EventInterval) bool {
+	if strings.Contains(eventInterval.Locator, duplicateevents.InterestingMark) || strings.Contains(eventInterval.Locator, duplicateevents.PathologicalMark) {
+		return true
+	}
+	return false
+}
+
 func BelongsInSpyglass(eventInterval monitorapi.EventInterval) bool {
 	if isLessInterestingAlert(eventInterval) {
 		return false
@@ -87,7 +95,12 @@ func BelongsInSpyglass(eventInterval monitorapi.EventInterval) bool {
 	if IsPodLifecycle(eventInterval) {
 		return false
 	}
-
+	if isInterestingOrPathological(eventInterval) {
+		ns := monitorapi.NamespaceFromLocator(eventInterval.Locator)
+		if strings.Contains(ns, "e2e") {
+			return false
+		}
+	}
 	return true
 }
 

--- a/pkg/synthetictests/apiserver.go
+++ b/pkg/synthetictests/apiserver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/origin/pkg/duplicateevents"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 )
@@ -32,15 +33,15 @@ func testPodNodeNameIsImmutable(events monitorapi.Intervals) []*junitapi.JUnitTe
 
 func testOauthApiserverProbeErrorLiveness(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[bz-apiserver-auth] openshift-oauth-apiserver should not get probe error on liveiness probe due to timeout"
-	return makeProbeTest(testName, events, probeErrorLivenessMessageRegExpStr, "openshift-oauth-apiserver", duplicateEventThreshold)
+	return makeProbeTest(testName, events, duplicateevents.ProbeErrorLivenessMessageRegExpStr, "openshift-oauth-apiserver", duplicateevents.DuplicateEventThreshold)
 }
 
 func testOauthApiserverProbeErrorReadiness(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[bz-apiserver-auth] openshift-oauth-apiserver should not get probe error on readiiness probe due to timeout"
-	return makeProbeTest(testName, events, probeErrorReadinessMessageRegExpStr, "openshift-oauth-apiserver", duplicateEventThreshold)
+	return makeProbeTest(testName, events, duplicateevents.ProbeErrorReadinessMessageRegExpStr, "openshift-oauth-apiserver", duplicateevents.DuplicateEventThreshold)
 }
 
 func testOauthApiserverProbeErrorConnectionRefused(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[bz-apiserver-auth] openshift-oauth-apiserver should not get probe error on readiiness probe due to connection refused"
-	return makeProbeTest(testName, events, probeErrorConnectionRefusedRegExpStr, "openshift-oauth-apiserver", duplicateEventThreshold)
+	return makeProbeTest(testName, events, duplicateevents.ProbeErrorConnectionRefusedRegExpStr, "openshift-oauth-apiserver", duplicateevents.DuplicateEventThreshold)
 }

--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -2,7 +2,6 @@ package synthetictests
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -11,22 +10,14 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	"github.com/openshift/origin/pkg/duplicateevents"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
-)
-
-const (
-	duplicateEventThreshold                 = 20
-	duplicateSingleNodeEventThreshold       = 30
-	ovnReadinessRegExpStr                   = `ns/(?P<NS>openshift-ovn-kubernetes) pod/(?P<POD>ovnkube-node-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>Unhealthy) (?P<MSG>Readiness probe failed:.*$)`
-	consoleReadinessRegExpStr               = `ns/(?P<NS>openshift-console) pod/(?P<POD>console-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>ProbeError) (?P<MSG>Readiness probe error:.* connect: connection refused$)`
-	marketplaceStartupProbeFailureRegExpStr = `ns/(?P<NS>openshift-marketplace) pod/(?P<POD>(community-operators|redhat-operators)-[a-z0-9-]+).*Startup probe failed`
 )
 
 func combinedRegexp(arr ...*regexp.Regexp) *regexp.Regexp {
@@ -40,211 +31,12 @@ func combinedRegexp(arr ...*regexp.Regexp) *regexp.Regexp {
 	return regexp.MustCompile(s)
 }
 
-var allowedRepeatedEventPatterns = []*regexp.Regexp{
-	// [sig-apps] StatefulSet Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod's predecessor fails [Suite:openshift/conformance/parallel] [Suite:k8s]
-	// PauseNewPods intentionally causes readiness probe to fail.
-	regexp.MustCompile(`ns/e2e-statefulset-[0-9]+ pod/ss-[0-9] node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: `),
-
-	// [sig-apps] StatefulSet Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
-	// breakPodHTTPProbe intentionally causes readiness probe to fail.
-	regexp.MustCompile(`ns/e2e-statefulset-[0-9]+ pod/ss2-[0-9] node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: HTTP probe failed with statuscode: 404`),
-
-	// [sig-node] Probing container ***
-	// these tests intentionally cause repeated probe failures to ensure good handling
-	regexp.MustCompile(`ns/e2e-container-probe-[0-9]+ .* probe failed: `),
-	regexp.MustCompile(`ns/e2e-container-probe-[0-9]+ .* probe warning: `),
-
-	// Kubectl Port forwarding ***
-	// The same pod name is used many times for all these tests with a tight readiness check to make the tests fast.
-	// This results in hundreds of events while the pod isn't ready.
-	regexp.MustCompile(`ns/e2e-port-forwarding-[0-9]+ pod/pfpod node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed:`),
-
-	// should not start app containers if init containers fail on a RestartAlways pod
-	// the init container intentionally fails to start
-	regexp.MustCompile(`ns/e2e-init-container-[0-9]+ pod/pod-init-[a-z0-9.-]+ node/[a-z0-9.-]+ - reason/BackOff Back-off restarting failed container`),
-
-	// TestAllowedSCCViaRBAC and TestPodUpdateSCCEnforcement
-	// The pod is shaped to intentionally not be scheduled.  Looks like an artifact of the old integration testing.
-	regexp.MustCompile(`ns/e2e-test-scc-[a-z0-9]+ pod/.* - reason/FailedScheduling.*`),
-
-	// Security Context ** should not run with an explicit root user ID
-	// Security Context ** should not run without a specified user ID
-	// This container should never run
-	regexp.MustCompile(`ns/e2e-security-context-test-[0-9]+ pod/.*-root-uid node/[a-z0-9.-]+ - reason/Failed Error: container's runAsUser breaks non-root policy.*"`),
-
-	// PersistentVolumes-local tests should not run the pod when there is a volume node
-	// affinity and node selector conflicts.
-	regexp.MustCompile(`ns/e2e-persistent-local-volumes-test-[0-9]+ pod/pod-[a-z0-9.-]+ reason/FailedScheduling`),
-
-	// various DeploymentConfig tests trigger this by canceling multiple rollouts
-	regexp.MustCompile(`reason/DeploymentAwaitingCancellation Deployment of version [0-9]+ awaiting cancellation of older running deployments`),
-
-	// this image is used specifically to be one that cannot be pulled in our tests
-	regexp.MustCompile(`.*reason/BackOff Back-off pulling image "webserver:404"`),
-
-	// If image pulls in e2e namespaces fail catastrophically we'd expect them to lead to test failures
-	// We are deliberately not ignoring image pull failures for core component namespaces
-	regexp.MustCompile(`ns/e2e-.* reason/BackOff Back-off pulling image`),
-
-	// promtail crashlooping as its being started by sideloading manifests.  per @vrutkovs
-	regexp.MustCompile("ns/openshift-e2e-loki pod/loki-promtail.*Readiness probe"),
-
-	// Related to known bug below, but we do not need to report on loki: https://bugzilla.redhat.com/show_bug.cgi?id=1986370
-	regexp.MustCompile("ns/openshift-e2e-loki pod/loki-promtail.*reason/NetworkNotReady"),
-
-	// kube-apiserver guard probe failing due to kube-apiserver operands getting rolled out
-	// multiple times during the bootstrapping phase of a cluster installation
-	regexp.MustCompile("ns/openshift-kube-apiserver pod/kube-apiserver-guard.*ProbeError Readiness probe error"),
-	// the same thing happens for kube-controller-manager and kube-scheduler
-	regexp.MustCompile("ns/openshift-kube-controller-manager pod/kube-controller-manager-guard.*ProbeError Readiness probe error"),
-	regexp.MustCompile("ns/openshift-kube-scheduler pod/kube-scheduler-guard.*ProbeError Readiness probe error"),
-
-	// this is the less specific even sent by the kubelet when a probe was executed successfully but returned false
-	// we ignore this event because openshift has a patch in patch_prober that sends a more specific event about
-	// readiness failures in openshift-* namespaces.  We will catch the more specific ProbeError events.
-	regexp.MustCompile("Unhealthy Readiness probe failed"),
-	// readiness probe errors during pod termination are expected, so we do not fail on them.
-	regexp.MustCompile("TerminatingPodProbeError"),
-
-	// we have a separate test for this
-	regexp.MustCompile(ovnReadinessRegExpStr),
-
-	// Separated out in testBackoffPullingRegistryRedhatImage
-	regexp.MustCompile(imagePullRedhatRegEx),
-
-	// Separated out in testRequiredInstallerResourcesMissing
-	regexp.MustCompile(requiredResourcesMissingRegEx),
-
-	// Separated out in testBackoffStartingFailedContainer
-	regexp.MustCompile(backoffRestartingFailedRegEx),
-
-	// Separated out in testErrorUpdatingEndpointSlices
-	regexp.MustCompile(errorUpdatingEndpointSlicesRegex),
-
-	// If you see this error, it means enough was working to get this event which implies enough retries happened to allow initial openshift
-	// installation to succeed. Hence, we can ignore it.
-	regexp.MustCompile(`reason/FailedCreate .* error creating EC2 instance: InsufficientInstanceCapacity: We currently do not have sufficient .* capacity in the Availability Zone you requested`),
-
-	// Separated out in testNodeHasNoDiskPressure
-	regexp.MustCompile(nodeHasNoDiskPressureRegExpStr),
-
-	// Separated out in testNodeHasSufficientMemory
-	regexp.MustCompile(nodeHasSufficientMemoryRegExpStr),
-
-	// Separated out in testNodeHasSufficientPID
-	regexp.MustCompile(nodeHasSufficientPIDRegExpStr),
-
-	// Separated out in testMarketplaceStartupProbeFailure
-	regexp.MustCompile(marketplaceStartupProbeFailureRegExpStr),
-}
-
-var allowedRepeatedEventFns = []isRepeatedEventOKFunc{
-	isConsoleReadinessDuringInstallation,
-	isConfigOperatorReadinessFailed,
-	isConfigOperatorProbeErrorReadinessFailed,
-	isConfigOperatorProbeErrorLivenessFailed,
-	isOauthApiserverProbeErrorReadinessFailed,
-	isOauthApiserverProbeErrorLivenessFailed,
-	isOauthApiserverProbeErrorConnectionRefusedFailed,
-}
-
-var allowedSingleNodeRepeatedEventFns = []isRepeatedEventOKFunc{
-	isConnectionRefusedOnSingleNode,
-}
-
-// allowedUpgradeRepeatedEventPatterns are patterns of events that we should only allow during upgrades, not during normal execution.
-var allowedUpgradeRepeatedEventPatterns = []*regexp.Regexp{
-	// Operators that use library-go can report about multiple versions during upgrades.
-	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/MultipleVersions multiple versions found, probably in transition: .*`),
-	regexp.MustCompile(`ns/openshift-kube-apiserver-operator deployment/kube-apiserver-operator - reason/MultipleVersions multiple versions found, probably in transition: .*`),
-	regexp.MustCompile(`ns/openshift-kube-controller-manager-operator deployment/kube-controller-manager-operator - reason/MultipleVersions multiple versions found, probably in transition: .*`),
-	regexp.MustCompile(`ns/openshift-kube-scheduler-operator deployment/openshift-kube-scheduler-operator - reason/MultipleVersions multiple versions found, probably in transition: .*`),
-
-	// etcd-quorum-guard can fail during upgrades.
-	regexp.MustCompile(`ns/openshift-etcd pod/etcd-quorum-guard-[a-z0-9-]+ node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: `),
-	// etcd can have unhealthy members during an upgrade
-	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/UnhealthyEtcdMember unhealthy members: .*`),
-	// etcd-operator began to version etcd-endpoints configmap in 4.10 as part of static-pod-resource. During upgrade existing revisions will not contain the resource.
-	// The condition reconciles with the next revision which the result of the upgrade. TODO(hexfusion) remove in 4.11
-	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/RequiredInstallerResourcesMissing configmaps: etcd-endpoints-[0-9]+`),
-	// There is a separate test to catch this specific case
-	regexp.MustCompile(requiredResourcesMissingRegEx),
-
-	// Separated out in testMarketplaceStartupProbeFailure
-	regexp.MustCompile(marketplaceStartupProbeFailureRegExpStr),
-}
-
-var knownEventsBugs = []knownProblem{
-	{
-		Regexp: regexp.MustCompile(`ns/openshift-multus pod/network-metrics-daemon-[a-z0-9]+ node/[a-z0-9.-]+ - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net\.d/\. Has your network provider started\?`),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
-	},
-	{
-		Regexp: regexp.MustCompile(`ns/openshift-e2e-loki pod/loki-promtail-[a-z0-9]+ node/[a-z0-9.-]+ - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net\.d/\. Has your network provider started\?`),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
-	},
-	{
-		Regexp: regexp.MustCompile(`ns/openshift-network-diagnostics pod/network-check-target-[a-z0-9]+ node/[a-z0-9.-]+ - reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net\.d/\. Has your network provider started\?`),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1986370",
-	},
-	{
-		Regexp: regexp.MustCompile(`ns/.* service/.* - reason/FailedToDeleteOVNLoadBalancer .*`),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1990631",
-	},
-	{
-		Regexp: regexp.MustCompile(`ns/.*horizontalpodautoscaler.*failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API.*`),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1993985",
-	},
-	{
-		Regexp: regexp.MustCompile(`ns/.*unable to ensure pod container exists: failed to create container.*slice already exists.*`),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=1993980",
-	},
-	{
-		Regexp: regexp.MustCompile(`ns/openshift-etcd pod/etcd-quorum-guard-[a-z0-9-]+ node/[a-z0-9.-]+ - reason/Unhealthy Readiness probe failed: `),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2000234",
-	},
-	{
-		Regexp: regexp.MustCompile(`ns/openshift-etcd pod/etcd-guard-.* node/.* - reason/ProbeError Readiness probe error: .* connect: connection refused`),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2075204",
-	},
-	{
-		Regexp: regexp.MustCompile("ns/openshift-etcd-operator namespace/openshift-etcd-operator -.*rpc error: code = Canceled desc = grpc: the client connection is closing.*"),
-		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
-	},
-	{
-		Regexp: regexp.MustCompile("reason/TopologyAwareHintsDisabled"),
-		BZ:     "https://issues.redhat.com/browse/OCPBUGS-5943",
-	},
-	{
-		Regexp:   regexp.MustCompile("ns/.*reason/.*APICheckFailed.*503.*"),
-		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
-		Topology: topologyPointer(v1.SingleReplicaTopologyMode),
-	},
-	// builds tests trigger many changes in the config which creates new rollouts -> event for each pod
-	// working as intended (not a bug) and needs to be tolerated
-	{
-		Regexp:    regexp.MustCompile(`ns/openshift-route-controller-manager deployment/route-controller-manager - reason/ScalingReplicaSet \(combined from similar events\): Scaled (down|up) replica set route-controller-manager-[a-z0-9-]+ to [0-9]+`),
-		TestSuite: stringPointer("openshift/build"),
-	},
-	// builds tests trigger many changes in the config which creates new rollouts -> event for each pod
-	// working as intended (not a bug) and needs to be tolerated
-	{
-		Regexp:    regexp.MustCompile(`ns/openshift-controller-manager deployment/controller-manager - reason/ScalingReplicaSet \(combined from similar events\): Scaled (down|up) replica set controller-manager-[a-z0-9-]+ to [0-9]+`),
-		TestSuite: stringPointer("openshift/build"),
-	},
-	//{ TODO this should only be skipped for single-node
-	//	name:    "single=node-storage",
-	//  BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1990662
-	//	message: "ns/openshift-cluster-csi-drivers pod/aws-ebs-csi-driver-controller-66469455cd-2thfv node/ip-10-0-161-38.us-east-2.compute.internal - reason/BackOff Back-off restarting failed container",
-	//},
-}
-
 type duplicateEventsEvaluator struct {
 	allowedRepeatedEventPatterns []*regexp.Regexp
-	allowedRepeatedEventFns      []isRepeatedEventOKFunc
+	allowedRepeatedEventFns      []duplicateevents.IsRepeatedEventOKFunc
 
 	// knownRepeatedEventsBugs are duplicates that are considered bugs and should flake, but not  fail a test
-	knownRepeatedEventsBugs []knownProblem
+	knownRepeatedEventsBugs []duplicateevents.KnownProblem
 
 	// platform contains the current platform of the cluster under test.
 	platform v1.PlatformType
@@ -256,29 +48,15 @@ type duplicateEventsEvaluator struct {
 	testSuite string
 }
 
-type knownProblem struct {
-	Regexp *regexp.Regexp
-	BZ     string
-
-	// Platform limits the exception to a specific OpenShift platform.
-	Platform *v1.PlatformType
-
-	// Topology limits the exception to a specific topology (e.g. single replica)
-	Topology *v1.TopologyMode
-
-	// TestSuite limits the exception to a specific test suite (e.g. openshift/builds)
-	TestSuite *string
-}
-
 func testDuplicatedEventForUpgrade(events monitorapi.Intervals, kubeClientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
 	allowedPatterns := []*regexp.Regexp{}
-	allowedPatterns = append(allowedPatterns, allowedRepeatedEventPatterns...)
-	allowedPatterns = append(allowedPatterns, allowedUpgradeRepeatedEventPatterns...)
+	allowedPatterns = append(allowedPatterns, duplicateevents.AllowedRepeatedEventPatterns...)
+	allowedPatterns = append(allowedPatterns, duplicateevents.AllowedUpgradeRepeatedEventPatterns...)
 
 	evaluator := duplicateEventsEvaluator{
 		allowedRepeatedEventPatterns: allowedPatterns,
-		allowedRepeatedEventFns:      allowedRepeatedEventFns,
-		knownRepeatedEventsBugs:      knownEventsBugs,
+		allowedRepeatedEventFns:      duplicateevents.AllowedRepeatedEventFns,
+		knownRepeatedEventsBugs:      duplicateevents.KnownEventsBugs,
 		testSuite:                    testSuite,
 	}
 
@@ -287,7 +65,7 @@ func testDuplicatedEventForUpgrade(events monitorapi.Intervals, kubeClientConfig
 	}
 
 	if evaluator.topology == v1.SingleReplicaTopologyMode {
-		evaluator.allowedRepeatedEventFns = append(evaluator.allowedRepeatedEventFns, allowedSingleNodeRepeatedEventFns...)
+		evaluator.allowedRepeatedEventFns = append(evaluator.allowedRepeatedEventFns, duplicateevents.AllowedSingleNodeRepeatedEventFns...)
 	}
 
 	tests := []*junitapi.JUnitTestCase{}
@@ -297,10 +75,11 @@ func testDuplicatedEventForUpgrade(events monitorapi.Intervals, kubeClientConfig
 }
 
 func testDuplicatedEventForStableSystem(events monitorapi.Intervals, clientConfig *rest.Config, testSuite string) []*junitapi.JUnitTestCase {
+
 	evaluator := duplicateEventsEvaluator{
-		allowedRepeatedEventPatterns: allowedRepeatedEventPatterns,
-		allowedRepeatedEventFns:      allowedRepeatedEventFns,
-		knownRepeatedEventsBugs:      knownEventsBugs,
+		allowedRepeatedEventPatterns: duplicateevents.AllowedRepeatedEventPatterns,
+		allowedRepeatedEventFns:      duplicateevents.AllowedRepeatedEventFns,
+		knownRepeatedEventsBugs:      duplicateevents.KnownEventsBugs,
 		testSuite:                    testSuite,
 	}
 
@@ -319,7 +98,7 @@ func testDuplicatedEventForStableSystem(events monitorapi.Intervals, clientConfi
 	}
 
 	if evaluator.topology == v1.SingleReplicaTopologyMode {
-		evaluator.allowedRepeatedEventFns = append(evaluator.allowedRepeatedEventFns, allowedSingleNodeRepeatedEventFns...)
+		evaluator.allowedRepeatedEventFns = append(evaluator.allowedRepeatedEventFns, duplicateevents.AllowedSingleNodeRepeatedEventFns...)
 	}
 
 	tests := []*junitapi.JUnitTestCase{}
@@ -327,11 +106,6 @@ func testDuplicatedEventForStableSystem(events monitorapi.Intervals, clientConfi
 	tests = append(tests, evaluator.testDuplicatedE2ENamespaceEvents(events, clientConfig)...)
 	return tests
 }
-
-// isRepeatedEventOKFunc takes a monitorEvent as input and returns true if the repeated event is OK.
-// This commonly happens for known bugs and for cases where events are repeated intentionally by tests.
-// Use this to handle cases where, "if X is true, then the repeated event is ok".
-type isRepeatedEventOKFunc func(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, times int) (bool, error)
 
 // we want to identify events based on the monitor because it is (currently) our only spot that tracks events over time
 // for every run. this means we see events that are created during updates and in e2e tests themselves.  A [late] test
@@ -365,46 +139,44 @@ func appendToFirstLine(s string, add string) string {
 // is easier to author, but less complete in its view.
 // I hate regexes, so I only do this because I really have to.
 func (d duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOnly bool, events monitorapi.Intervals, kubeClientConfig *rest.Config) []*junitapi.JUnitTestCase {
-	allowedRepeatedEventsRegex := combinedRegexp(d.allowedRepeatedEventPatterns...)
+
+	type pathologicalEvents struct {
+		count        int    // max number of times the message occurred
+		eventMessage string // holds original message so you can compare with d.knownRepeatedEventsBugs
+	}
 
 	var failures []string
-	displayToCount := map[string]int{}
+	displayToCount := map[string]*pathologicalEvents{}
 	for _, event := range events {
 		eventDisplayMessage, times := getTimesAnEventHappened(fmt.Sprintf("%s - %s", event.Locator, event.Message))
-		if times > duplicateEventThreshold {
-			if allowedRepeatedEventsRegex.MatchString(eventDisplayMessage) {
+		if times > duplicateevents.DuplicateEventThreshold {
+
+			// If we marked this message earlier in recordAddOrUpdateEvent as interesting/true, we know it matched one of
+			// the existing patterns or one of the AllowedRepeatedEventFns functions returned true.
+			if strings.Contains(eventDisplayMessage, duplicateevents.InterestingMark) {
 				continue
 			}
 
-			allowed := false
-			for _, allowRepeatedEventFn := range d.allowedRepeatedEventFns {
-				var err error
-				allowed, err = allowRepeatedEventFn(event, kubeClientConfig, times)
-				if err != nil {
-					failures = append(failures, fmt.Sprintf("error: [%v] when processing event %v", err, eventDisplayMessage))
-					allowed = false
-					continue
+			eventMessageString := eventDisplayMessage + " From: " + event.From.Format("15:04:05Z") + " To: " + event.To.Format("15:04:05Z")
+			if _, ok := displayToCount[eventMessageString]; !ok {
+				tmp := &pathologicalEvents{
+					count:        times,
+					eventMessage: eventDisplayMessage,
 				}
-				if allowed {
-					break
-				}
+				displayToCount[eventMessageString] = tmp
 			}
-			if allowed {
-				continue
-			}
-
-			if times > displayToCount[eventDisplayMessage] {
-				displayToCount[eventDisplayMessage] = times
+			if times > displayToCount[eventMessageString].count {
+				displayToCount[eventMessageString].count = times
 			}
 		}
 	}
 
 	var flakes []string
-	for display, count := range displayToCount {
-		msg := fmt.Sprintf("event happened %d times, something is wrong: %v", count, display)
+	for msgWithTime, pathoItem := range displayToCount {
+		msg := fmt.Sprintf("event happened %d times, something is wrong: %v", pathoItem.count, msgWithTime)
 		flake := false
 		for _, kp := range d.knownRepeatedEventsBugs {
-			if kp.Regexp != nil && kp.Regexp.MatchString(display) {
+			if kp.Regexp != nil && kp.Regexp.MatchString(pathoItem.eventMessage) {
 				// Check if this exception only applies to our specific platform
 				if kp.Platform != nil && *kp.Platform != d.platform {
 					continue
@@ -461,10 +233,8 @@ func (d duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOnl
 	return tests
 }
 
-var eventCountExtractor = regexp.MustCompile(`(?s)(.*) \((\d+) times\).*`)
-
 func getTimesAnEventHappened(message string) (string, int) {
-	matches := eventCountExtractor.FindAllStringSubmatch(message, -1)
+	matches := duplicateevents.EventCountExtractor.FindAllStringSubmatch(message, -1)
 	if len(matches) != 1 { // not present or weird
 		return "", 0
 	}
@@ -476,197 +246,6 @@ func getTimesAnEventHappened(message string) (string, int) {
 		return "", 0
 	}
 	return matches[0][1], int(times)
-}
-
-func getInstallCompletionTime(kubeClientConfig *rest.Config) *metav1.Time {
-	configClient, err := configclient.NewForConfig(kubeClientConfig)
-	if err != nil {
-		return nil
-	}
-	clusterVersion, err := configClient.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
-	if err != nil {
-		return nil
-	}
-	if len(clusterVersion.Status.History) == 0 {
-		return nil
-	}
-	return clusterVersion.Status.History[len(clusterVersion.Status.History)-1].CompletionTime
-}
-
-func getMatchedElementsFromMonitorEventMsg(regExp *regexp.Regexp, message string) (string, string, string, string, string, error) {
-	var namespace, pod, node, reason, msg string
-	if !regExp.MatchString(message) {
-		return namespace, pod, node, reason, msg, errors.New("regex match error")
-	}
-	subMatches := regExp.FindStringSubmatch(message)
-	subNames := regExp.SubexpNames()
-	for i, name := range subNames {
-		switch name {
-		case "NS":
-			namespace = subMatches[i]
-		case "POD":
-			pod = subMatches[i]
-		case "NODE":
-			node = subMatches[i]
-		case "REASON":
-			reason = subMatches[i]
-		case "MSG":
-			msg = subMatches[i]
-		}
-	}
-	if len(namespace) == 0 ||
-		len(pod) == 0 ||
-		len(node) == 0 ||
-		len(msg) == 0 {
-		return namespace, pod, node, reason, msg, fmt.Errorf("regex match expects non-empty elements, got namespace: %s, pod: %s, node: %s, msg: %s", namespace, pod, node, msg)
-	}
-	return namespace, pod, node, reason, msg, nil
-}
-
-// isEventDuringInstallation returns true if the monitorEvent represents a real event that happened after installation.
-// regExp defines the pattern of the monitorEvent message. Named match is used in the pattern using `(?P<>)`. The names are placed inside <>. See example below
-// `ns/(?P<NS>openshift-ovn-kubernetes) pod/(?P<POD>ovnkube-node-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>Unhealthy) (?P<MSG>Readiness probe failed:.*$`
-func isEventDuringInstallation(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, regExp *regexp.Regexp) (bool, error) {
-	if kubeClientConfig == nil {
-		// default to OK
-		return true, nil
-	}
-	installCompletionTime := getInstallCompletionTime(kubeClientConfig)
-	if installCompletionTime == nil {
-		return true, nil
-	}
-
-	message := fmt.Sprintf("%s - %s", monitorEvent.Locator, monitorEvent.Message)
-	namespace, pod, _, reason, msg, err := getMatchedElementsFromMonitorEventMsg(regExp, message)
-	if err != nil {
-		return false, err
-	}
-	kubeClient, err := kubernetes.NewForConfig(kubeClientConfig)
-	if err != nil {
-		return true, nil
-	}
-	kubeEvents, err := kubeClient.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return true, nil
-	}
-	for _, event := range kubeEvents.Items {
-		if event.Related == nil ||
-			event.Related.Name != pod ||
-			event.Reason != reason ||
-			!strings.Contains(event.Message, msg) {
-			continue
-		}
-
-		if event.FirstTimestamp.After(installCompletionTime.Time) {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-// isConsoleReadinessDuringInstallation returns true if the event is for console readiness and it happens during the
-// initial installation of the cluster.
-// we're looking for something like
-// > ns/openshift-console pod/console-7c6f797fd9-5m94j node/ip-10-0-158-106.us-west-2.compute.internal - reason/ProbeError Readiness probe error: Get "https://10.129.0.49:8443/health": dial tcp 10.129.0.49:8443: connect: connection refused
-// with a firstTimestamp before the cluster completed the initial installation
-func isConsoleReadinessDuringInstallation(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, _ int) (bool, error) {
-	if !strings.Contains(monitorEvent.Locator, "ns/openshift-console") {
-		return false, nil
-	}
-	if !strings.Contains(monitorEvent.Locator, "pod/console-") {
-		return false, nil
-	}
-	if !strings.Contains(monitorEvent.Locator, "Readiness probe") {
-		return false, nil
-	}
-	if !strings.Contains(monitorEvent.Locator, "connect: connection refused") {
-		return false, nil
-	}
-
-	regExp := regexp.MustCompile(consoleReadinessRegExpStr)
-	// if the readiness probe failure for this pod happened AFTER the initial installation was complete,
-	// then this probe failure is unexpected and should fail.
-	return isEventDuringInstallation(monitorEvent, kubeClientConfig, regExp)
-}
-
-// isConfigOperatorReadinessFailed returns true if the event matches a readinessFailed error that timed out
-// in the openshift-config-operator.
-// like this:
-// ...ReadinessFailed Get \"https://10.130.0.16:8443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-func isConfigOperatorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
-	regExp := regexp.MustCompile(readinessFailedMessageRegExpStr)
-	return isOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
-}
-
-// isConfigOperatorProbeErrorReadinessFailed returns true if the event matches a ProbeError Readiness Probe message
-// in the openshift-config-operator.
-// like this:
-// reason/ProbeError Readiness probe error: Get "https://10.130.0.15:8443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-func isConfigOperatorProbeErrorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
-	regExp := regexp.MustCompile(probeErrorReadinessMessageRegExpStr)
-	return isOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
-}
-
-// isConfigOperatorProbeErrorLivenessFailed returns true if the event matches a ProbeError Liveness Probe message
-// in the openshift-config-operator.
-// like this:
-// ...reason/ProbeError Liveness probe error: Get "https://10.128.0.21:8443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-func isConfigOperatorProbeErrorLivenessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
-	regExp := regexp.MustCompile(probeErrorLivenessMessageRegExpStr)
-	return isOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
-}
-
-// isOauthApiserverProbeErrorReadinessFailed returns true if the event matches a ProbeError Readiness Probe message
-// in the openshift-oauth-operator.
-// like this:
-// ...ns/openshift-oauth-apiserver pod/apiserver-65fd7ffc59-bt5sf node/q72hs3bx-ac890-4pxpm-master-2 - reason/ProbeError Readiness probe error: Get "https://10.129.0.8:8443/readyz": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
-func isOauthApiserverProbeErrorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
-	regExp := regexp.MustCompile(probeErrorReadinessMessageRegExpStr)
-	return isOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
-}
-
-// isOauthApiserverProbeErrorLivenessFailed returns true if the event matches a ProbeError Liveness Probe message
-// in the openshift-oauth-operator.
-// like this:
-// ...reason/ProbeError Liveness probe error: Get "https://10.130.0.68:8443/healthz": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
-func isOauthApiserverProbeErrorLivenessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
-	regExp := regexp.MustCompile(probeErrorLivenessMessageRegExpStr)
-	return isOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
-}
-
-// isOauthApiserverProbeErrorConnectionRefusedFailed returns true if the event matches a ProbeError Readiness Probe connection refused message
-// in the openshift-oauth-operator.
-// like this:
-// ...ns/openshift-oauth-apiserver pod/apiserver-647fc6c7bf-s8b4h node/ip-10-0-150-209.us-west-1.compute.internal - reason/ProbeError Readiness probe error: Get "https://10.128.0.38:8443/readyz": dial tcp 10.128.0.38:8443: connect: connection refused
-func isOauthApiserverProbeErrorConnectionRefusedFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
-	regExp := regexp.MustCompile(probeErrorConnectionRefusedRegExpStr)
-	return isOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
-}
-
-// isConnectionRefusedOnSingleNode returns true if the event matched has a connection refused message for single node events and is with in threshold.
-func isConnectionRefusedOnSingleNode(monitorEvent monitorapi.EventInterval, _ *rest.Config, count int) (bool, error) {
-	regExp := regexp.MustCompile(singleNodeErrorConnectionRefusedRegExpStr)
-	return regExp.MatchString(monitorEvent.String()) && count < duplicateSingleNodeEventThreshold, nil
-}
-
-// isOperatorMatchRegexMessage returns true if this monitorEvent is for the operator identified by the operatorName
-// and its message matches the given regex.
-func isOperatorMatchRegexMessage(monitorEvent monitorapi.EventInterval, operatorName string, regExp *regexp.Regexp) bool {
-	locatorParts := monitorapi.LocatorParts(monitorEvent.Locator)
-	if ns, ok := locatorParts["ns"]; ok {
-		if ns != operatorName {
-			return false
-		}
-	}
-	if pod, ok := locatorParts["pod"]; ok {
-		if !strings.HasPrefix(pod, operatorName) {
-			return false
-		}
-	}
-	if !regExp.MatchString(monitorEvent.Message) {
-		return false
-	}
-	return true
 }
 
 func (d *duplicateEventsEvaluator) getClusterInfo(c *rest.Config) (err error) {
@@ -692,18 +271,6 @@ func (d *duplicateEventsEvaluator) getClusterInfo(c *rest.Config) (err error) {
 	}
 
 	return nil
-}
-
-func topologyPointer(topology v1.TopologyMode) *v1.TopologyMode {
-	return &topology
-}
-
-func platformPointer(platform v1.PlatformType) *v1.PlatformType {
-	return &platform
-}
-
-func stringPointer(testSuite string) *string {
-	return &testSuite
 }
 
 type etcdRevisionChangeAllowance struct {

--- a/pkg/synthetictests/duplicated_events_special.go
+++ b/pkg/synthetictests/duplicated_events_special.go
@@ -8,28 +8,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/openshift/origin/pkg/duplicateevents"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
-)
-
-const (
-	imagePullRedhatRegEx                       = `reason/[a-zA-Z]+ .*Back-off pulling image .*registry.redhat.io`
-	imagePullRedhatFlakeThreshold              = 5
-	requiredResourcesMissingRegEx              = `reason/RequiredInstallerResourcesMissing secrets: etcd-all-certs-[0-9]+`
-	requiredResourceMissingFlakeThreshold      = 10
-	backoffRestartingFailedRegEx               = `reason/BackOff Back-off restarting failed container`
-	backoffRestartingFlakeThreshold            = 10
-	errorUpdatingEndpointSlicesRegex           = `reason/FailedToUpdateEndpointSlices Error updating Endpoint Slices`
-	errorUpdatingEndpointSlicesFailedThreshold = -1 // flake only
-	errorUpdatingEndpointSlicesFlakeThreshold  = 10
-	readinessFailedMessageRegExpStr            = "reason/ReadinessFailed.*Get.*healthz.*net/http.*request canceled while waiting for connection.*Client.Timeout exceeded"
-	probeErrorReadinessMessageRegExpStr        = "reason/ProbeError.*Readiness probe error.*Client.Timeout exceeded while awaiting headers"
-	probeErrorLivenessMessageRegExpStr         = "reason/(ProbeError|Unhealthy).*Liveness probe error.*Client.Timeout exceeded while awaiting headers"
-	probeErrorConnectionRefusedRegExpStr       = "reason/ProbeError.*Readiness probe error.*connection refused"
-	nodeHasNoDiskPressureRegExpStr             = "reason/NodeHasNoDiskPressure.*status is now: NodeHasNoDiskPressure"
-	nodeHasSufficientMemoryRegExpStr           = "reason/NodeHasSufficientMemory.*status is now: NodeHasSufficientMemory"
-	nodeHasSufficientPIDRegExpStr              = "reason/NodeHasSufficientPID.*status is now: NodeHasSufficientPID"
-	singleNodeErrorConnectionRefusedRegExpStr  = "reason/.*dial tcp.*connection refused"
 )
 
 type eventRecognizerFunc func(event monitorapi.EventInterval) bool
@@ -111,7 +92,7 @@ func newSingleEventCheckRegex(testName, regex string, failThreshold, flakeThresh
 // to happen over a certain threshold and marks it as a failure or flake accordingly.
 func testBackoffPullingRegistryRedhatImage(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[sig-arch] should not see excessive pull back-off on registry.redhat.io"
-	return newSingleEventCheckRegex(testName, imagePullRedhatRegEx, math.MaxInt, imagePullRedhatFlakeThreshold).test(events)
+	return newSingleEventCheckRegex(testName, duplicateevents.ImagePullRedhatRegEx, math.MaxInt, duplicateevents.ImagePullRedhatFlakeThreshold).test(events)
 }
 
 // testRequiredInstallerResourcesMissing looks for this symptom:
@@ -122,7 +103,7 @@ func testBackoffPullingRegistryRedhatImage(events monitorapi.Intervals) []*junit
 // flake threshold.  See https://bugzilla.redhat.com/show_bug.cgi?id=2031564.
 func testRequiredInstallerResourcesMissing(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[bz-etcd] should not see excessive RequiredInstallerResourcesMissing secrets"
-	return newSingleEventCheckRegex(testName, requiredResourcesMissingRegEx, duplicateEventThreshold, requiredResourceMissingFlakeThreshold).test(events)
+	return newSingleEventCheckRegex(testName, duplicateevents.RequiredResourcesMissingRegEx, duplicateevents.DuplicateEventThreshold, duplicateevents.RequiredResourceMissingFlakeThreshold).test(events)
 }
 
 // testBackoffStartingFailedContainer looks for this symptom in core namespaces:
@@ -131,7 +112,7 @@ func testRequiredInstallerResourcesMissing(events monitorapi.Intervals) []*junit
 func testBackoffStartingFailedContainer(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[sig-cluster-lifecycle] should not see excessive Back-off restarting failed containers"
 
-	return newSingleEventCheckRegex(testName, backoffRestartingFailedRegEx, duplicateEventThreshold, backoffRestartingFlakeThreshold).
+	return newSingleEventCheckRegex(testName, duplicateevents.BackoffRestartingFailedRegEx, duplicateevents.DuplicateEventThreshold, duplicateevents.BackoffRestartingFlakeThreshold).
 		test(events.Filter(monitorapi.Not(monitorapi.IsInE2ENamespace)))
 }
 
@@ -142,51 +123,51 @@ func testBackoffStartingFailedContainerForE2ENamespaces(events monitorapi.Interv
 	testName := "[sig-cluster-lifecycle] should not see excessive Back-off restarting failed containers in e2e namespaces"
 
 	// always flake for now
-	return newSingleEventCheckRegex(testName, backoffRestartingFailedRegEx, math.MaxInt, backoffRestartingFlakeThreshold).
+	return newSingleEventCheckRegex(testName, duplicateevents.BackoffRestartingFailedRegEx, math.MaxInt, duplicateevents.BackoffRestartingFlakeThreshold).
 		test(events.Filter(monitorapi.IsInE2ENamespace))
 }
 
 func testErrorUpdatingEndpointSlices(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[sig-networking] should not see excessive FailedToUpdateEndpointSlices Error updating Endpoint Slices"
 
-	return newSingleEventCheckRegex(testName, errorUpdatingEndpointSlicesRegex, errorUpdatingEndpointSlicesFailedThreshold, errorUpdatingEndpointSlicesFlakeThreshold).
+	return newSingleEventCheckRegex(testName, duplicateevents.ErrorUpdatingEndpointSlicesRegex, duplicateevents.ErrorUpdatingEndpointSlicesFailedThreshold, duplicateevents.ErrorUpdatingEndpointSlicesFlakeThreshold).
 		test(events.Filter(monitorapi.IsInNamespaces(sets.NewString("openshift-ovn-kubernetes"))))
 }
 
 func testConfigOperatorProbeErrorReadinessProbe(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] openshift-config-operator should not get probe error on readiness probe due to timeout"
-	return makeProbeTest(testName, events, "openshift-config-operator", probeErrorReadinessMessageRegExpStr, duplicateEventThreshold)
+	return makeProbeTest(testName, events, "openshift-config-operator", duplicateevents.ProbeErrorReadinessMessageRegExpStr, duplicateevents.DuplicateEventThreshold)
 }
 
 func testConfigOperatorProbeErrorLivenessProbe(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] openshift-config-operator should not get probe error on liveness probe due to timeout"
-	return makeProbeTest(testName, events, "openshift-config-operator", probeErrorLivenessMessageRegExpStr, duplicateEventThreshold)
+	return makeProbeTest(testName, events, "openshift-config-operator", duplicateevents.ProbeErrorLivenessMessageRegExpStr, duplicateevents.DuplicateEventThreshold)
 }
 
 func testConfigOperatorReadinessProbe(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] openshift-config-operator readiness probe should not fail due to timeout"
-	return makeProbeTest(testName, events, "openshift-config-operator", readinessFailedMessageRegExpStr, duplicateEventThreshold)
+	return makeProbeTest(testName, events, "openshift-config-operator", duplicateevents.ReadinessFailedMessageRegExpStr, duplicateevents.DuplicateEventThreshold)
 }
 
 func testNodeHasNoDiskPressure(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] Test the NodeHasNoDiskPressure condition does not occur too often"
-	return eventExprMatchThresholdTest(testName, events, nodeHasNoDiskPressureRegExpStr, duplicateEventThreshold)
+	return eventExprMatchThresholdTest(testName, events, duplicateevents.NodeHasNoDiskPressureRegExpStr, duplicateevents.DuplicateEventThreshold)
 }
 
 func testNodeHasSufficientMemory(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] Test the NodeHasSufficeintMemory condition does not occur too often"
-	return eventExprMatchThresholdTest(testName, events, nodeHasSufficientMemoryRegExpStr, duplicateEventThreshold)
+	return eventExprMatchThresholdTest(testName, events, duplicateevents.NodeHasSufficientMemoryRegExpStr, duplicateevents.DuplicateEventThreshold)
 }
 
 func testNodeHasSufficientPID(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] Test the NodeHasSufficientPID condition does not occur too often"
-	return eventExprMatchThresholdTest(testName, events, nodeHasSufficientPIDRegExpStr, duplicateEventThreshold)
+	return eventExprMatchThresholdTest(testName, events, duplicateevents.NodeHasSufficientPIDRegExpStr, duplicateevents.DuplicateEventThreshold)
 }
 
 func makeProbeTest(testName string, events monitorapi.Intervals, operatorName string, regExStr string, eventFlakeThreshold int) []*junitapi.JUnitTestCase {
 	messageRegExp := regexp.MustCompile(regExStr)
 	return eventMatchThresholdTest(testName, events, func(event monitorapi.EventInterval) bool {
-		return isOperatorMatchRegexMessage(event, operatorName, messageRegExp)
+		return duplicateevents.IsOperatorMatchRegexMessage(event, operatorName, messageRegExp)
 	}, eventFlakeThreshold)
 }
 

--- a/pkg/synthetictests/marketplace.go
+++ b/pkg/synthetictests/marketplace.go
@@ -1,6 +1,7 @@
 package synthetictests
 
 import (
+	"github.com/openshift/origin/pkg/duplicateevents"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -8,5 +9,5 @@ import (
 
 func testMarketplaceStartupProbeFailure(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-arch] openshift-marketplace pods should not get excessive startupProbe failures"
-	return eventExprMatchThresholdTest(testName, events, marketplaceStartupProbeFailureRegExpStr, duplicateEventThreshold)
+	return eventExprMatchThresholdTest(testName, events, duplicateevents.MarketplaceStartupProbeFailureRegExpStr, duplicateevents.DuplicateEventThreshold)
 }

--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/pkg/duplicateevents"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
@@ -257,7 +258,7 @@ func getPodDeletionTime(events monitorapi.Intervals, podLocator string) *time.Ti
 // bug is tracked here: https://bugzilla.redhat.com/show_bug.cgi?id=2057181
 func testOvnNodeReadinessProbe(events monitorapi.Intervals, kubeClientConfig *rest.Config) []*junitapi.JUnitTestCase {
 	const testName = "[bz-networking] ovnkube-node readiness probe should not fail repeatedly"
-	regExp := regexp.MustCompile(ovnReadinessRegExpStr)
+	regExp := regexp.MustCompile(duplicateevents.OvnReadinessRegExpStr)
 	var tests []*junitapi.JUnitTestCase
 	var failureOutput string
 	msgMap := map[string]bool{}
@@ -267,10 +268,10 @@ func testOvnNodeReadinessProbe(events monitorapi.Intervals, kubeClientConfig *re
 			if _, ok := msgMap[msg]; !ok {
 				msgMap[msg] = true
 				eventDisplayMessage, times := getTimesAnEventHappened(msg)
-				if times > duplicateEventThreshold {
+				if times > duplicateevents.DuplicateEventThreshold {
 					// if the readiness probe failure for this pod happened AFTER the initial installation was complete,
 					// then this probe failure is unexpected and should fail.
-					isDuringInstall, err := isEventDuringInstallation(event, kubeClientConfig, regExp)
+					isDuringInstall, err := duplicateevents.IsEventDuringInstallation(event, kubeClientConfig, regExp)
 					if err != nil {
 						failureOutput += fmt.Sprintf("error [%v] happened when processing event [%s]\n", err, eventDisplayMessage)
 					} else if !isDuringInstall {


### PR DESCRIPTION
[TRT-685](https://issues.redhat.com//browse/TRT-685)

The two tests that look for pathological events:

* `[sig-arch] events should not repeat pathologically`
* `[sig-arch] events should not repeat pathologically in e2e namespaces`

will fail for events that repeat more than 20 times (those events are often referred to as  "pathological" or "duplicate" events).  Eventually more tests are created to look for specific regex patterns for those events.

This PR:

* Adds a new section at the bottom of the spyglass charts called "interesting-events".  The pathological/duplicate events are rendered on that section.
* Adds timestamps for events mentioned in the two tests mentioned above

This should aid debugging by making it easier to see when events happen relative to other things going on at the same time.

Types of messages:
* interesting: previously known and matches one of our regex/function patterns; color=gray
* pathological and interesting: previously known and occurs > 20 times; color=blue
* pathological and unknown: event is not known and occurs > 20 times; color=red

NOTE:

I moved the regex patterns into their own package called `duplicateevents` so they could be shared between:
  * the existing logic that processes pathological/duplicate events in synthetic tests
  * the new code that creates Intervals so they will show up in the spyglass charts

Interesting jobs:

* [this one](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27649/pull-ci-openshift-origin-master-e2e-aws-ovn-cgroupsv2/1623133938996219904) shows multiple events on one line (see the lines in "interesting-events" section where it goes 2 times, 3 times, 4 times, etc.
* [this one](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27649/pull-ci-openshift-origin-master-e2e-aws-ovn-single-node/1623133939134631936) shows kube-apiserver-startup-monitor with hundreds of times