### PR TITLE
OCPBUGS-5506: DNS pod to be created on master node

### DIFF
--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -32,6 +32,7 @@ import (
 )
 
 func createDNSPod(namespace, probeCmd string) *kapiv1.Pod {
+	nodeSelector := map[string]string{"node-role.kubernetes.io/master": ""}
 	pod := &kapiv1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -42,8 +43,14 @@ func createDNSPod(namespace, probeCmd string) *kapiv1.Pod {
 			Namespace: namespace,
 		},
 		Spec: kapiv1.PodSpec{
-			RestartPolicy:   kapiv1.RestartPolicyNever,
-			SecurityContext: e2epod.GetRestrictedPodSecurityContext(),
+			NodeSelector: nodeSelector,
+			Tolerations: []kapiv1.Toleration{
+				{
+					Effect:   "NoSchedule",
+					Key:      "node-role.kubernetes.io/master",
+					Operator: kapiv1.TolerationOpExists,
+				},
+			},
 			Containers: []kapiv1.Container{
 				{
 					Name:            "querier",


### PR DESCRIPTION
[sig-network-edge] DNS should answer queries using the local DNS 
endpoint [Suite:openshift/conformance/parallel] tests is perma failing for heteroenegeneous due to missing manifest list support for image registry.

Assigning the dns pod to master to avoid deploying to the incorrect node and fixing issue for  `exec format error`