### PR TITLE
Fix missing disruption data again.

### DIFF
--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -175,10 +175,6 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 
 	allowedDisruption, disruptionDetails, err := t.getAllowedDisruption(f)
 	framework.ExpectNoError(err)
-	if allowedDisruption == nil {
-		framework.Logf(fmt.Sprintf("Skipping: %s: No historical data", t.testName))
-		return
-	}
 
 	end := time.Now()
 
@@ -187,7 +183,8 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 	ginkgo.By(fmt.Sprintf("writing results: %s", t.backend.GetLocator()))
 	ExpectNoDisruptionForDuration(
 		f,
-		*allowedDisruption,
+		t.testName,
+		allowedDisruption,
 		end.Sub(start),
 		events,
 		fmt.Sprintf("%s was unreachable during disruption: %v", t.backend.GetLocator(), disruptionDetails),

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -94,6 +94,7 @@ func (t *backendDisruptionTest) historicalAllowedDisruption(f *framework.Framewo
 	if err != nil {
 		return nil, "", err
 	}
+	framework.Logf("checking allowed disruption for job type: %+v", *jobType)
 
 	return allowedbackenddisruption.GetAllowedDisruption(backendName, *jobType)
 }


### PR DESCRIPTION
Previous attempt did not work, as we were still bypassing
FrameworkEventIntervals() which is needed to add the test summary, which
eventually results in the AdditionalEvents json files in artifacts,
which are then merged into the overall events and disruption data files.
Without calling it, we still get no disruption data uploaded.

Move the nil check into the ExpectNoDisruption function, and allow
FrameworkEventIntervals to run as it should.

[TRT-760](https://issues.redhat.com//browse/TRT-760)
