### PR TITLE
Don't emit failure junit testcase when a retry is skipped

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -15,10 +15,11 @@ import (
 	"syscall"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/riskanalysis"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -414,11 +415,13 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 		q := newParallelTestQueue(testRunnerContext)
 		q.Execute(testCtx, retries, parallelism, testOutputConfig, abortFn)
 
-		var flaky []string
+		var flaky, skipped []string
 		var repeatFailures []*testCase
 		for _, test := range retries {
 			if test.success {
 				flaky = append(flaky, test.name)
+			} else if test.skipped {
+				skipped = append(skipped, test.name)
 			} else {
 				repeatFailures = append(repeatFailures, test)
 			}
@@ -437,6 +440,23 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 			failing = repeatFailures
 			sort.Strings(flaky)
 			fmt.Fprintf(opt.Out, "Flaky tests:\n\n%s\n\n", strings.Join(flaky, "\n"))
+		}
+		if len(skipped) > 0 {
+			// If a retry test got skipped, it means we very likely failed a precondition in the first failure, so
+			// we need to remove the failure case.
+			var withoutPreconditionFailures []*testCase
+			for _, st := range skipped {
+				for _, t := range tests {
+					if t.name != st {
+						withoutPreconditionFailures = append(withoutPreconditionFailures, t)
+					}
+				}
+			}
+			tests = withoutPreconditionFailures
+			failing = repeatFailures
+			sort.Strings(skipped)
+			fmt.Fprintf(opt.Out, "Skipped tests that failed a precondition:\n\n%s\n\n", strings.Join(skipped, "\n"))
+
 		}
 	}
 

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -445,11 +445,13 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 			// If a retry test got skipped, it means we very likely failed a precondition in the first failure, so
 			// we need to remove the failure case.
 			var withoutPreconditionFailures []*testCase
-			for _, st := range skipped {
-				for _, t := range tests {
-					if t.name != st {
-						withoutPreconditionFailures = append(withoutPreconditionFailures, t)
+		testLoop:
+			for _, t := range tests {
+				for _, st := range skipped {
+					if t.name == st && t.failed {
+						continue testLoop
 					}
+					withoutPreconditionFailures = append(withoutPreconditionFailures, t)
 				}
 			}
 			tests = withoutPreconditionFailures


### PR DESCRIPTION
[TRT-747](https://issues.redhat.com//browse/TRT-747)

If a test fails once and then gets retried, and then the second attempt skips the test, there's a high likelihood the original run was a precondition check failure and we should just omit the original failure.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-origin-27652-ci-4.13-upgrade-from-stable-4.12-e2e-azure-sdn-upgrade/1613252620154048512 shows a run where I simulated the failure + skip case.

Failure:

```
18182-fail [github.com/openshift/origin/test/extended/networking/util.go:459]: Jan 11 22:30:12.737: Oh no I failed
18183-Ginkgo exit error 1: exit with code 1
18184-
18185:failed: (5.4s) 2023-01-11T22:30:13 "[sig-network] network isolation when using a plugin in a mode that does not isolate namespaces by default should allow communication between pods in different namespaces on the same node [Suite:openshift/conformance/parallel]"
```

Skip:

```
20532:started: 5/332/415 "[sig-network] network isolation when using a plugin in a mode that does not isolate namespaces by default should allow communication between pods in different namespaces on different nodes [Suite:openshift/conformance/parallel]"
20533-
20534-skip [github.com/openshift/origin/test/extended/networking/util.go:461]: Second attempt at skipped succeeded
20535-Ginkgo exit error 3: exit with code 3
[...]
Skipped tests that failed a precondition:

[sig-network] network isolation when using a plugin in a mode that does not isolate namespaces by default should allow communication between pods in different namespaces on the same node [Suite:openshift/conformance/parallel]
```

And if you look at junit the failure is omitted, and only the skip remains.