### PR TITLE
Add result tag to the end of first line of an event message

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -349,6 +349,13 @@ func (d duplicateEventsEvaluator) testDuplicatedE2ENamespaceEvents(events monito
 	return d.testDuplicatedEvents(testName, true, events.Filter(monitorapi.IsInE2ENamespace), kubeClientConfig)
 }
 
+// appendToFirstLine appends add to the end of the first line of s
+func appendToFirstLine(s string, add string) string {
+	splits := strings.Split(s, "\n")
+	splits[0] += add
+	return strings.Join(splits, "\n")
+}
+
 // we want to identify events based on the monitor because it is (currently) our only spot that tracks events over time
 // for every run. this means we see events that are created during updates and in e2e tests themselves.  A [late] test
 // is easier to author, but less complete in its view.
@@ -415,9 +422,9 @@ func (d duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOnl
 		}
 
 		if flake || flakeOnly {
-			flakes = append(flakes, msg+" result=allow ")
+			flakes = append(flakes, appendToFirstLine(msg, " result=allow "))
 		} else {
-			failures = append(failures, msg+" result=reject ")
+			failures = append(failures, appendToFirstLine(msg, " result=reject "))
 		}
 	}
 

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -283,6 +283,13 @@ func TestKnownBugEventsGroup(t *testing.T) {
 			topology:        v1.SingleReplicaTopologyMode,
 			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
+		{
+			name:            "matches 22 with multiple line message",
+			messages:        []string{"ns/e2e - reason/SomeEvent1 foo \nbody:\n (22 times)"},
+			platform:        v1.AWSPlatformType,
+			topology:        v1.SingleReplicaTopologyMode,
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo  result=allow \nbody:\n - https://bugzilla.redhat.com/show_bug.cgi?id=1234567",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
[TRT-687](https://issues.redhat.com/browse/TRT-687)

Some event messages are multiple line. But all of our analysis focus on only the first line. This PR adds the result tag to the end the first line of the event message. 