### PR TITLE
Revert "Remove dependency on some router tests on config.openshift.io api group"

### DIFF
--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -27,7 +27,7 @@ import (
 
 const timeoutSeconds = 3 * 60
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc *exutil.CLI

--- a/test/extended/router/subdomain.go
+++ b/test/extended/router/subdomain.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                   *exutil.CLI

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -19,7 +19,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc          *exutil.CLI

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -29,7 +29,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/image"
 )
 
-var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]", func() {
+var _ = g.Describe("[sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:image.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc = exutil.NewCLIWithPodSecurityLevel("weighted-router", admissionapi.LevelBaseline)

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2579,9 +2579,9 @@ var Annotations = map[string]string{
 
 	"[sig-network][Feature:Router][apigroup:config.openshift.io] The HAProxy router should expose the profiling endpoints": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:operator.openshift.io] The HAProxy router should set Forwarded headers appropriately": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:image.openshift.io] The HAProxy router should serve a route that points to two services and respect weights": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][Feature:Router][apigroup:image.openshift.io] The HAProxy router should serve a route that points to two services and respect weights": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][Feature:Router][apigroup:config.openshift.io][apigroup:operator.openshift.io] The HAProxy router should set Forwarded headers appropriately": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:Router][apigroup:operator.openshift.io] The HAProxy router should respond with 503 to unrecognized hosts": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
@@ -2591,21 +2591,21 @@ var Annotations = map[string]string{
 
 	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router converges when multiple routers are writing status": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router reports the expected host names in admitted routes' statuses": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should override the route host for overridden domains with a custom value [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should override the route host with a custom value": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
-
-	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should run even if it has no access to update status [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
-
-	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should serve the correct routes when running with the haproxy config manager": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should serve the correct routes when scoped to a single namespace and label set": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:Router][apigroup:route.openshift.io] when FIPS is disabled the HAProxy router should serve routes when configured with a 1024-bit RSA key": " [Feature:Networking-IPv4] [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:Router][apigroup:route.openshift.io] when FIPS is enabled the HAProxy router should not work when configured with a 1024-bit RSA key": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router reports the expected host names in admitted routes' statuses": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router should run even if it has no access to update status [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io] The HAProxy router should serve the correct routes when running with the haproxy config manager": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:Router][apigroup:route.openshift.io][apigroup:operator.openshift.io] The HAProxy router should support reencrypt to services backed by a serving certificate automatically": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
This reverts commit 075473cfd82afd92dcc31066f59ec96f2d67b39b.

Per [TRT policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get ci and/or nightly payloads flowing again.

This change broke metal-ipi-ovn-ipv6 and the last 4 4.13 payloads, which is a disconnected job, example: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.13-e2e-metal-ipi-ovn-ipv6/1614182397866151936

This test should not actually be running on this job, I believe what happened is that in https://github.com/openshift/origin/blob/master/test/extended/util/annotate/rules.go#L274 we determine whether or not to add the [SKipped:Disconnected] tag based on test name, which was not updated when the apigroup was removed causing the job to break.

To unrevert this revert, revert this PR, and layer an additional separate commit on top that addresses the problem.

Before merging the unrevert, please run these jobs on the  PR and check the result of (job/X or job/X, test/Y tuple) to confirm the fix has corrected the problem.

Presubmit: ci/prow/e2e-metal-ipi-ovn-ipv6 (which seemed to be failing to install on original PR)
-or-
/payload-job periodic-ci-openshift-release-master-nightly-4.13-e2e-metal-ipi-ovn-ipv6

[TRT-777](https://issues.redhat.com//browse/TRT-777)
[WRKLDS-605](https://issues.redhat.com//browse/WRKLDS-605)

cc @ingvagabund 
