### PR TITLE
Fix nil pointer dereference for createDNSPod.

### DIFF
--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -43,7 +43,9 @@ func createDNSPod(namespace, probeCmd string) *kapiv1.Pod {
 			Namespace: namespace,
 		},
 		Spec: kapiv1.PodSpec{
-			NodeSelector: nodeSelector,
+			RestartPolicy:   kapiv1.RestartPolicyNever,
+			SecurityContext: e2epod.GetRestrictedPodSecurityContext(),
+			NodeSelector:    nodeSelector,
 			Tolerations: []kapiv1.Toleration{
 				{
 					Effect:   "NoSchedule",


### PR DESCRIPTION
Introduced here https://github.com/openshift/origin/pull/27650
Failure example https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ovn-kubernetes/1474/pull-ci-openshift-ovn-kubernetes-master-e2e-metal-ipi-ovn-dualstack/1614322843753910272

Original PR only intended to add new fields to the pod.Spec, and not delete RestartPolicy and SecurityContext
@deepsm007 @trozet @kyrtapz 