### PR TITLE
ignore repeated TopologyAwareHintsDisabled events

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -212,6 +212,10 @@ var knownEventsBugs = []knownProblem{
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
 	},
 	{
+		Regexp: regexp.MustCompile("reason/TopologyAwareHintsDisabled Insufficient Node information"),
+		BZ:     "https://issues.redhat.com/browse/OCPBUGS-5943",
+	},
+	{
 		Regexp:   regexp.MustCompile("ns/.*reason/.*APICheckFailed.*503.*"),
 		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
 		Topology: topologyPointer(v1.SingleReplicaTopologyMode),


### PR DESCRIPTION
Kube 1.26 introduced the warning level `TopologyAwareHintsDisabled` event. `TopologyAwareHintsDisabled` is fired by the `EndpointSliceController` whenever reconciling a service that has activated topology aware hints via the `service.kubernetes.io/topology-aware-hints` annotation, but there is not enough information cluster resources (typically nodes) to apply the topology aware hints. 

The `service.kubernetes.io/topology-aware-hints=auto` annotation [was added to the `dns-default` service](https://bugzilla.redhat.com/show_bug.cgi?id=2095941) to make it topology aware when using third party CNI plugins that support that feature.

Unfortunately, the OpenShift CNI plugins (sdn & ovn) do not support the topology-aware feature, so we now see these `TopologyAwareHintsDisabled` events during test runs.

See https://issues.redhat.com/browse/OCPBUGS-5943