### PR TITLE
WIP: Handle missing alert data better

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.32.1
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
@@ -205,7 +206,6 @@ require (
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/smartystreets/assertions v1.1.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/afero v1.6.0 // indirect

--- a/pkg/synthetictests/allowedalerts/all.go
+++ b/pkg/synthetictests/allowedalerts/all.go
@@ -27,6 +27,12 @@ func AllAlertTests(ctx context.Context, clientConfig *rest.Config, duration time
 		}
 	}
 
+	// TODO: the alerts defined here are enforced based on their presence in query_results.json, which is updated
+	// weekly from bigquery. However the query by which it is updated also includes a hardcoded list of alerts
+	// we enforce. Thus these two disjoint lists should be kept in sync but are presently not. Data missing from the
+	// file implies we may not want to run the test?
+	// All due for revamp as we work towards understanding what the set of actual alerts is.
+
 	ret := []AlertTest{}
 	ret = append(ret, newWatchdogAlert())
 	ret = append(ret, newNamespacedAlert("KubePodNotReady").pending().neverFail().toTests()...)

--- a/pkg/synthetictests/allowedalerts/matches.go
+++ b/pkg/synthetictests/allowedalerts/matches.go
@@ -3,7 +3,7 @@ package allowedalerts
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/origin/pkg/synthetictests/historicaldata"
 	"github.com/openshift/origin/pkg/synthetictests/platformidentification"

--- a/pkg/synthetictests/historicaldata/types.go
+++ b/pkg/synthetictests/historicaldata/types.go
@@ -16,7 +16,7 @@ type BestMatcher interface {
 	BestMatch(name string, jopType platformidentification.JobType) (StatisticalData, string, error)
 	// BestMatchDuration returns the best possible match for this historical data.  It attempts a full match first, then
 	// it attempts to match on the most important keys in order, before giving up and returning a default.
-	BestMatchDuration(name string, jopType platformidentification.JobType) (StatisticalDuration, string, error)
+	BestMatchDuration(name string, jopType platformidentification.JobType) (*StatisticalDuration, string, error)
 
 	BestMatchP99(name string, jobType platformidentification.JobType) (*time.Duration, string, error)
 }
@@ -128,25 +128,25 @@ func (b *bestMatcher) BestMatch(name string, jobType platformidentification.JobT
 		nil
 }
 
-func (b *bestMatcher) BestMatchDuration(name string, jobType platformidentification.JobType) (StatisticalDuration, string, error) {
+func (b *bestMatcher) BestMatchDuration(name string, jobType platformidentification.JobType) (*StatisticalDuration, string, error) {
 	rawData, details, err := b.BestMatch(name, jobType)
 	// Empty data implies we have none, and thus do not want to run the test.
 	if rawData == (StatisticalData{}) {
-		return StatisticalDuration{}, details, err
+		return nil, details, err
 	}
 	return toStatisticalDuration(rawData), details, err
 }
 
 func (b *bestMatcher) BestMatchP99(name string, jobType platformidentification.JobType) (*time.Duration, string, error) {
 	rawData, details, err := b.BestMatchDuration(name, jobType)
-	if rawData == (StatisticalDuration{}) {
+	if rawData == nil {
 		return nil, details, err
 	}
 	return &rawData.P99, details, err
 }
 
-func toStatisticalDuration(in StatisticalData) StatisticalDuration {
-	return StatisticalDuration{
+func toStatisticalDuration(in StatisticalData) *StatisticalDuration {
+	return &StatisticalDuration{
 		DataKey: in.DataKey,
 		P95:     DurationOrDie(in.P95),
 		P99:     DurationOrDie(in.P99),


### PR DESCRIPTION
The "at or above info" tests are supposed to be using query_results.json
data to determine the thresholds at which they should fail or flake.
However I've discovered that the hardcoded list of these alert tests
does not match the hardcoded list of alerts used to query and populate
that results file.

Additionally, it looks like we're not properly handling the "no data
case", I suspect we're treating no data as 0s allowed, and thus failing
even though we have no historical basis to do so.

It appears all test authors assumed their alerts are automatically
picked up by the system which is not true today.

This change modifies such that we now skip the test and log a message if
we attempt to run a test against historical data we don't have. Test
will no longer fail.


[TRT-790](https://issues.redhat.com//browse/TRT-790)