### PR TITLE
Capture and display the time for each pathological event

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	v1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -360,8 +361,15 @@ func (d duplicateEventsEvaluator) testDuplicatedE2ENamespaceEvents(events monito
 func (d duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOnly bool, events monitorapi.Intervals, kubeClientConfig *rest.Config) []*junitapi.JUnitTestCase {
 	allowedRepeatedEventsRegex := combinedRegexp(d.allowedRepeatedEventPatterns...)
 
+	type pathologicalEvents struct {
+		count        int
+		eventMessage string
+		from         time.Time
+		to           time.Time
+	}
+
 	var failures []string
-	displayToCount := map[string]int{}
+	displayToCount := map[string]*pathologicalEvents{}
 	for _, event := range events {
 		eventDisplayMessage, times := getTimesAnEventHappened(fmt.Sprintf("%s - %s", event.Locator, event.Message))
 		if times > duplicateEventThreshold {
@@ -386,18 +394,28 @@ func (d duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOnl
 				continue
 			}
 
-			if times > displayToCount[eventDisplayMessage] {
-				displayToCount[eventDisplayMessage] = times
+			eventMessageString := eventDisplayMessage + " From: " + event.From.Format("2006-01-02T15:04:05Z") + " To: " + event.To.Format("2006-01-02T15:04:05Z")
+			if _, ok := displayToCount[eventMessageString]; !ok {
+				tmp := &pathologicalEvents{
+					count:        times,
+					eventMessage: eventDisplayMessage,
+					from:         event.From,
+					to:           event.To,
+				}
+				displayToCount[eventMessageString] = tmp
+			}
+			if times > displayToCount[eventMessageString].count {
+				displayToCount[eventMessageString].count = times
 			}
 		}
 	}
 
 	var flakes []string
-	for display, count := range displayToCount {
-		msg := fmt.Sprintf("event happened %d times, something is wrong: %v", count, display)
+	for msgWithTime, pathoItem := range displayToCount {
+		msg := fmt.Sprintf("event happened %d times, something is wrong: %v", pathoItem.count, msgWithTime)
 		flake := false
 		for _, kp := range d.knownRepeatedEventsBugs {
-			if kp.Regexp != nil && kp.Regexp.MatchString(display) {
+			if kp.Regexp != nil && kp.Regexp.MatchString(pathoItem.eventMessage) {
 				// Check if this exception only applies to our specific platform
 				if kp.Platform != nil && *kp.Platform != d.platform {
 					continue

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -295,8 +295,8 @@ func TestKnownBugEventsGroup(t *testing.T) {
 				events = append(events,
 					monitorapi.EventInterval{
 						Condition: monitorapi.Condition{Message: message},
-						From:      time.Unix(1, 0),
-						To:        time.Unix(1, 0)},
+						From:      time.Unix(872827200, 0),
+						To:        time.Unix(872827200, 0)},
 				)
 			}
 

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -268,21 +268,21 @@ func TestKnownBugEventsGroup(t *testing.T) {
 			platform: v1.AWSPlatformType,
 			topology: v1.SingleReplicaTopologyMode,
 			//expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
-			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1969-12-31T19:00:01Z To: 1969-12-31T19:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1970-01-01T00:00:01Z To: 1970-01-01T00:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 		{
 			name:            "matches 25 after",
 			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (21 times)`, `ns/e2e - reason/SomeEvent1 foo (25 times)`},
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 25 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1969-12-31T19:00:01Z To: 1969-12-31T19:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 25 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1970-01-01T00:00:01Z To: 1970-01-01T00:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 		{
 			name:            "matches 22 below with below threshold following",
 			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (22 times)`, `ns/e2e - reason/SomeEvent1 foo (5 times)`},
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1969-12-31T19:00:01Z To: 1969-12-31T19:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1970-01-01T00:00:01Z To: 1970-01-01T00:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 	}
 

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -263,25 +263,26 @@ func TestKnownBugEventsGroup(t *testing.T) {
 		expectedMessage string
 	}{
 		{
-			name:            "matches 22 before",
-			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (22 times)`, `ns/e2e - reason/SomeEvent1 foo (21 times)`},
-			platform:        v1.AWSPlatformType,
-			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			name:     "matches 22 before",
+			messages: []string{`ns/e2e - reason/SomeEvent1 foo (22 times)`, `ns/e2e - reason/SomeEvent1 foo (21 times)`},
+			platform: v1.AWSPlatformType,
+			topology: v1.SingleReplicaTopologyMode,
+			//expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1969-12-31T19:00:01Z To: 1969-12-31T19:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 		{
 			name:            "matches 25 after",
 			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (21 times)`, `ns/e2e - reason/SomeEvent1 foo (25 times)`},
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 25 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 25 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1969-12-31T19:00:01Z To: 1969-12-31T19:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 		{
 			name:            "matches 22 below with below threshold following",
 			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (22 times)`, `ns/e2e - reason/SomeEvent1 foo (5 times)`},
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1969-12-31T19:00:01Z To: 1969-12-31T19:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 	}
 

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -268,21 +268,21 @@ func TestKnownBugEventsGroup(t *testing.T) {
 			platform: v1.AWSPlatformType,
 			topology: v1.SingleReplicaTopologyMode,
 			//expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
-			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1970-01-01T00:00:01Z To: 1970-01-01T00:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T00:00:00Z To: 1997-08-29T00:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 		{
 			name:            "matches 25 after",
 			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (21 times)`, `ns/e2e - reason/SomeEvent1 foo (25 times)`},
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 25 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1970-01-01T00:00:01Z To: 1970-01-01T00:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 25 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T00:00:00Z To: 1997-08-29T00:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 		{
 			name:            "matches 22 below with below threshold following",
 			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (22 times)`, `ns/e2e - reason/SomeEvent1 foo (5 times)`},
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1970-01-01T00:00:01Z To: 1970-01-01T00:00:01Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T00:00:00Z To: 1997-08-29T00:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 	}
 

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -268,21 +268,21 @@ func TestKnownBugEventsGroup(t *testing.T) {
 			platform: v1.AWSPlatformType,
 			topology: v1.SingleReplicaTopologyMode,
 			//expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
-			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T00:00:00Z To: 1997-08-29T00:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T04:00:00Z To: 1997-08-29T04:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 		{
 			name:            "matches 25 after",
 			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (21 times)`, `ns/e2e - reason/SomeEvent1 foo (25 times)`},
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 25 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T00:00:00Z To: 1997-08-29T00:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 25 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T04:00:00Z To: 1997-08-29T04:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 		{
 			name:            "matches 22 below with below threshold following",
 			messages:        []string{`ns/e2e - reason/SomeEvent1 foo (22 times)`, `ns/e2e - reason/SomeEvent1 foo (5 times)`},
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T00:00:00Z To: 1997-08-29T00:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
+			expectedMessage: "1 events with known BZs\n\nevent happened 22 times, something is wrong:  - ns/e2e - reason/SomeEvent1 foo From: 1997-08-29T04:00:00Z To: 1997-08-29T04:00:00Z - https://bugzilla.redhat.com/show_bug.cgi?id=1234567 result=allow ",
 		},
 	}
 


### PR DESCRIPTION
[TRT-685](https://issues.redhat.com//browse/TRT-685)

Instead of trying to put the events in the spyglass charts, let's at least get timestamps so we can see where they occur.