### PR TITLE
OCPBUGS-9831: Make unidle test more strict

### DIFF
--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -74,7 +74,7 @@ func tryEchoHTTP(svc *kapiv1.Service, execPod *kapiv1.Pod) error {
 	}
 
 	expected := "It is time to TCP."
-	cmd := fmt.Sprintf("curl --retry-max-time 120 --retry-connrefused --retry 20 --max-time 5 -s -g http://%s/echo?msg=%s",
+	cmd := fmt.Sprintf("curl --max-time 120 -v -g http://%s/echo?msg=%s",
 		net.JoinHostPort(rawIP, tcpPort),
 		url.QueryEscape(expected),
 	)


### PR DESCRIPTION
Trying to reproduce https://bugzilla.redhat.com/show_bug.cgi?id=2091780

Unidled services should be reachable during the first connection attempt, it's important to not retry HTTP requests in tests.

See:
- https://issues.redhat.com/browse/OCPBUGSM-44873
- https://github.com/ovn-org/ovn-kubernetes/pull/3408
