### PR TITLE
builds: exercise openshift-manage-dockerfile with HEALTHCHECK

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -44061,6 +44061,7 @@ func testExtendedTestdataGssapiUbuntuKerberos_configuredDockerfile() (*asset, er
 var _testExtendedTestdataHelloBuilderDockerfile = []byte(`FROM openshift/origin-release:latest
 LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 ENV STI_SCRIPTS_PATH=/usr/libexec/s2i
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/usr/bin/true"]
 COPY scripts $STI_SCRIPTS_PATH
 RUN chown 1001 /openshifttmp
 USER 1001 

--- a/test/extended/testdata/hello-builder/Dockerfile
+++ b/test/extended/testdata/hello-builder/Dockerfile
@@ -1,6 +1,7 @@
 FROM openshift/origin-release:latest
 LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 ENV STI_SCRIPTS_PATH=/usr/libexec/s2i
+HEALTHCHECK --interval=60s --timeout=10s CMD ["/usr/bin/true"]
 COPY scripts $STI_SCRIPTS_PATH
 RUN chown 1001 /openshifttmp
 USER 1001 


### PR DESCRIPTION
Add a HEALTHCHECK instruction to one of the Dockerfiles that we build, to ensure that openshift-manage-dockerfile doesn't create a syntax error by incorrectly reconstructing a line for that instruction.