### PR TITLE
OCPBUGS-6503: upgrade/adminack: simplify polling and unblock "guaranteed" post-upgrade check

### DIFF
--- a/test/extended/util/openshift/clusterversionoperator/adminack.go
+++ b/test/extended/util/openshift/clusterversionoperator/adminack.go
@@ -51,19 +51,14 @@ func (t *AdminAckTest) Test(ctx context.Context) {
 	exercisedVersions := sets.NewString()
 	success := false
 	var lastError error
-	if err := wait.PollImmediateUntilWithContext(ctx, t.Poll, func(ctx context.Context) (bool, error) {
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		if err := t.test(ctx, exercisedGates, exercisedVersions); err != nil {
 			framework.Logf("Retriable failure to evaluate admin acks: %v", err)
 			lastError = err
 		} else {
 			success = true
 		}
-		return false, nil
-	}); err == nil || err == wait.ErrWaitTimeout {
-		return
-	} else {
-		framework.Fail(err.Error())
-	}
+	}, t.Poll)
 
 	if !success {
 		framework.Failf("Never able to evaluate admin acks.  Most recent failure: %v", lastError)

--- a/test/extended/util/openshift/clusterversionoperator/adminack.go
+++ b/test/extended/util/openshift/clusterversionoperator/adminack.go
@@ -250,9 +250,14 @@ func setAdminGate(ctx context.Context, gateName string, gateValue string, oc *ex
 	return nil
 }
 
+// adminAckDeadline is the upper bound of time for CVO to notice a new adminack
+// gate. CVO sync loop duration is nondeterministic 2-4m interval so we set this
+// slightly above the worst case.
+const adminAckDeadline = 4*time.Minute + 5*time.Second
+
 func waitForAdminAckRequired(ctx context.Context, config *restclient.Config, message string) error {
 	framework.Logf("Waiting for Upgradeable to be AdminAckRequired for %q ...", message)
-	if err := wait.PollImmediate(10*time.Second, 3*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Second, adminAckDeadline, func() (bool, error) {
 		if adminAckRequiredWithMessage(ctx, config, message) {
 			return true, nil
 		}


### PR DESCRIPTION
https://github.com/openshift/origin/pull/27645 intended to add a guaranteed post-upgrade check but I have overlooked how exactly the polling is implemented and terminated, leading to the post-upgrade check never actually execute.

Previously the test used `PollImmediateWithContext` for the each-10-minutes check. The `ConditionFunc` never actually returned `true` or non-nil `err`, so the `PollImmediateWithContext` never terminated by the means of `ConditionFunc`: it was always terminated by the `ctx.Done()` that the framework does on finished upgrade (or a test timeout). This means that `PollImmediateWithContext` always terminated with `err=wait.ErrWaitTimeout` and the `Test` method immediately returned, so the "guaranteed" check code is never reached.

Given our `ConditionFunc` never terminates the polling, we can simplify and use the `wait.UntilWithContext` instead, which is a simpler version that precisely implements the desired loop (poll until context is done).

---

During testing of OCPBUGS-5505, it was discovered that even with shortening the CVO cache TTL, CVO may still only update `Upgradeable` in its sync interval, which may be as high as 4 minutes. Hence the tests needs to wait for that time (I added 5 second buffer on top of that).