### PR TITLE
STOR-1066: add e2e tests for CSIInlineVolumeAdmission plugin

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/scheduling"
 	_ "github.com/openshift/origin/test/extended/security"
 	_ "github.com/openshift/origin/test/extended/single_node"
+	_ "github.com/openshift/origin/test/extended/storage"
 	_ "github.com/openshift/origin/test/extended/tbr_health"
 	_ "github.com/openshift/origin/test/extended/templates"
 	_ "github.com/openshift/origin/test/extended/user"

--- a/test/extended/storage/OWNERS
+++ b/test/extended/storage/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - jsafrane
+  - tsmetana
+  - gnufied
+  - bertinatto
+  - dobsonj
+approvers:
+  - jsafrane
+  - tsmetana
+  - gnufied
+  - bertinatto
+  - dobsonj

--- a/test/extended/storage/inline.go
+++ b/test/extended/storage/inline.go
@@ -1,0 +1,391 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	k8simage "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	configv1 "github.com/openshift/api/config/v1"
+	securityv1 "github.com/openshift/api/security/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	csiInlineVolProfileLabel = "security.openshift.io/csi-ephemeral-volume-profile"
+	csiSharedResourceDriver  = "csi.sharedresource.openshift.io"
+	podSecurityEnforceError  = "has a pod security enforce level that is lower than"
+)
+
+// This is [Serial] because it modifies a CSIDriver object that is used by multiple tests.
+var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", func() {
+	defer g.GinkgoRecover()
+	var (
+		ctx                  = context.Background()
+		baseDir              = exutil.FixturePath("testdata", "storage", "inline")
+		secret               = filepath.Join(baseDir, "secret.yaml")
+		csiSharedSecret      = filepath.Join(baseDir, "csi-sharedsecret.yaml")
+		csiSharedRole        = filepath.Join(baseDir, "csi-sharedresourcerole.yaml")
+		csiSharedRoleBinding = filepath.Join(baseDir, "csi-sharedresourcerolebinding.yaml")
+		sccVolumeToggle      *SCCVolumeToggle
+
+		beforeEach = func(oc *exutil.CLI) {
+			if !isTechPreviewNoUpgrade(oc) {
+				g.Skip("this test is only expected to work with TechPreviewNoUpgrade clusters")
+			} else {
+				// TODO: remove the SCCVolumeToggle when CSI volumes are allowed by the default SCC's (i.e. after TechPreview)
+				g.By("adding restricted-v2 SCC permission to use inline CSI volumes")
+				sccVolumeToggle = NewSCCVolumeToggle(oc, "restricted-v2", securityv1.FSTypeCSI)
+				sccVolumeToggle.Enable()
+			}
+			exutil.PreTestDump()
+
+			// create the secret to share in a new namespace
+			g.By("creating a secret")
+			err := oc.AsAdmin().Run("--namespace=default", "apply").Args("-f", secret).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// create the csi shared secret object
+			g.By("creating a csi shared secret resource")
+			err = oc.AsAdmin().Run("apply").Args("-f", csiSharedSecret).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// process the role to grant use of the share
+			g.By("creating a csi shared role resource")
+			err = oc.AsAdmin().Run("apply").Args("-f", csiSharedRole).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// process the rolebinding to grant use of the share
+			g.By("creating a csi shared role binding resource")
+			rolebinding, _, err := oc.AsAdmin().Run("process").Args("-f", csiSharedRoleBinding, "-p", fmt.Sprintf("NAMESPACE=%s", oc.Namespace())).Outputs()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = oc.AsAdmin().Run("apply").Args("-f", "-").InputString(rolebinding).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		afterEach = func(oc *exutil.CLI) {
+			if g.CurrentSpecReport().Failed() {
+				exutil.DumpPodStates(oc)
+			}
+
+			// set this back to the default value at the end of each test
+			g.By("setting the csi-ephemeral-volume-profile label back to restricted")
+			err := setCSIEphemeralVolumeProfile(oc, "restricted")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			sccVolumeToggle.Restore()
+		}
+	)
+
+	g.Context("privileged namespace", func() {
+		var (
+			oc = exutil.NewCLIWithPodSecurityLevel("inline-vol-privileged-ns", admissionapi.LevelPrivileged)
+		)
+
+		g.BeforeEach(func() {
+			beforeEach(oc)
+		})
+
+		g.AfterEach(func() {
+			afterEach(oc)
+		})
+
+		g.It("should allow pods with inline volumes when the driver uses the privileged label", func() {
+			g.By("setting the csi-ephemeral-volume-profile label to privileged")
+			err := setCSIEphemeralVolumeProfile(oc, "privileged")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating test pod with inline volume")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+				getTestPodWithInlineVol(oc.Namespace()),
+				metav1.CreateOptions{},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+		})
+
+		g.It("should allow pods with inline volumes when the driver uses the restricted label", func() {
+			g.By("setting the csi-ephemeral-volume-profile label to restricted")
+			err := setCSIEphemeralVolumeProfile(oc, "restricted")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating test pod with inline volume")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+				getTestPodWithInlineVol(oc.Namespace()),
+				metav1.CreateOptions{},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+		})
+	})
+
+	g.Context("baseline namespace", func() {
+		var (
+			oc = exutil.NewCLIWithPodSecurityLevel("inline-vol-baseline-ns", admissionapi.LevelBaseline)
+		)
+
+		g.BeforeEach(func() {
+			beforeEach(oc)
+		})
+
+		g.AfterEach(func() {
+			afterEach(oc)
+		})
+
+		g.It("should deny pods with inline volumes when the driver uses the privileged label", func() {
+			g.By("setting the csi-ephemeral-volume-profile label to privileged")
+			err := setCSIEphemeralVolumeProfile(oc, "privileged")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating test pod with inline volume")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+				getTestPodWithInlineVol(oc.Namespace()),
+				metav1.CreateOptions{},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring(podSecurityEnforceError))
+			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+		})
+
+		g.It("should allow pods with inline volumes when the driver uses the baseline label", func() {
+			g.By("setting the csi-ephemeral-volume-profile label to baseline")
+			err := setCSIEphemeralVolumeProfile(oc, "baseline")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating test pod with inline volume")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+				getTestPodWithInlineVol(oc.Namespace()),
+				metav1.CreateOptions{},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+		})
+
+		g.It("should allow pods with inline volumes when the driver uses the restricted label", func() {
+			g.By("setting the csi-ephemeral-volume-profile label to restricted")
+			err := setCSIEphemeralVolumeProfile(oc, "restricted")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating test pod with inline volume")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+				getTestPodWithInlineVol(oc.Namespace()),
+				metav1.CreateOptions{},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+		})
+	})
+
+	g.Context("restricted namespace", func() {
+		var (
+			oc = exutil.NewCLIWithPodSecurityLevel("inline-vol-restricted-ns", admissionapi.LevelRestricted)
+		)
+
+		g.BeforeEach(func() {
+			beforeEach(oc)
+		})
+
+		g.AfterEach(func() {
+			afterEach(oc)
+		})
+
+		g.It("should deny pods with inline volumes when the driver uses the privileged label", func() {
+			g.By("setting the csi-ephemeral-volume-profile label to privileged")
+			err := setCSIEphemeralVolumeProfile(oc, "privileged")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating test pod with inline volume")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+				getTestPodWithInlineVol(oc.Namespace()),
+				metav1.CreateOptions{},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring(podSecurityEnforceError))
+			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+		})
+
+		g.It("should deny pods with inline volumes when the driver uses the baseline label", func() {
+			g.By("setting the csi-ephemeral-volume-profile label to baseline")
+			err := setCSIEphemeralVolumeProfile(oc, "baseline")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating test pod with inline volume")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+				getTestPodWithInlineVol(oc.Namespace()),
+				metav1.CreateOptions{},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring(podSecurityEnforceError))
+			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+		})
+
+		g.It("should allow pods with inline volumes when the driver uses the restricted label", func() {
+			g.By("setting the csi-ephemeral-volume-profile label to restricted")
+			err := setCSIEphemeralVolumeProfile(oc, "restricted")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating test pod with inline volume")
+			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+				getTestPodWithInlineVol(oc.Namespace()),
+				metav1.CreateOptions{},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+		})
+	})
+})
+
+// isTechPreviewNoUpgrade checks if a cluster is a TechPreviewNoUpgrade cluster
+func isTechPreviewNoUpgrade(oc *exutil.CLI) bool {
+	featureGate, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		e2e.Failf("could not retrieve feature-gate: %v", err)
+	}
+
+	return featureGate.Spec.FeatureSet == configv1.TechPreviewNoUpgrade
+}
+
+// setCSIEphemeralVolumeProfile sets the security.openshift.io/csi-ephemeral-volume-profile label to the provided
+// value on the csi.sharedresource.openshift.io CSIDriver object.
+func setCSIEphemeralVolumeProfile(oc *exutil.CLI, labelValue string) error {
+	label := fmt.Sprintf("%s=%s", csiInlineVolProfileLabel, labelValue)
+	return oc.AsAdmin().Run("label").Args("--overwrite", "csidriver", csiSharedResourceDriver, label).Execute()
+}
+
+func getTestPod(namespace string) *corev1.Pod {
+	runAsNonRoot := true
+	allowPrivEsc := false
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-" + uuid.New().String(),
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "default",
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &runAsNonRoot,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "test",
+					Image:   k8simage.GetE2EImage(k8simage.BusyBox),
+					Command: []string{"/bin/true"},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivEsc,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+					},
+				},
+			},
+		},
+	}
+	return pod
+}
+
+func getTestPodWithInlineVol(namespace string) *corev1.Pod {
+	pod := getTestPod(namespace)
+	ro := true
+	pod.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "test-vol",
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver:           csiSharedResourceDriver,
+					ReadOnly:         &ro,
+					VolumeAttributes: map[string]string{"sharedSecret": "my-share"},
+				},
+			},
+		},
+	}
+	return pod
+}
+
+type SCCVolumeToggle struct {
+	oc         *exutil.CLI
+	sccName    string
+	fsType     securityv1.FSType
+	originalVL *VolumeList
+	patchedVL  *VolumeList
+}
+
+func NewSCCVolumeToggle(oc *exutil.CLI, sccName string, fsType securityv1.FSType) *SCCVolumeToggle {
+	return &SCCVolumeToggle{
+		oc:      oc,
+		sccName: sccName,
+		fsType:  fsType,
+	}
+}
+
+type VolumeList struct {
+	Volumes []securityv1.FSType `json:"volumes"`
+}
+
+func (s *SCCVolumeToggle) Enable() {
+	// The first time this runs, make a copy of the volume list attached to
+	// the SCC. If s.fsType is missing, then create a "patched" volume list
+	if s.originalVL == nil {
+		scc, err := s.oc.AdminSecurityClient().SecurityV1().SecurityContextConstraints().Get(context.Background(), s.sccName, metav1.GetOptions{})
+		if err != nil {
+			e2e.Failf("failed to get SCC: %v", err)
+		}
+
+		originalVL := &VolumeList{}
+		patchedVL := &VolumeList{}
+		found := false
+		for _, v := range scc.Volumes {
+			if v == s.fsType {
+				found = true
+			}
+			originalVL.Volumes = append(originalVL.Volumes, v)
+			patchedVL.Volumes = append(patchedVL.Volumes, v)
+		}
+		if !found {
+			patchedVL.Volumes = append(patchedVL.Volumes, s.fsType)
+			s.patchedVL = patchedVL
+		}
+		s.originalVL = originalVL
+	}
+
+	// Patch only if s.fsType was not found in the existing SCC
+	if s.patchedVL != nil {
+		s.patchVolumeList(s.patchedVL)
+	}
+}
+
+func (s *SCCVolumeToggle) Restore() {
+	// If this was never patched, there is no reason to restore
+	if s.originalVL == nil || s.patchedVL == nil {
+		return
+	}
+	s.patchVolumeList(s.originalVL)
+}
+
+func (s *SCCVolumeToggle) patchVolumeList(vl *VolumeList) {
+	patch, err := json.Marshal(vl)
+	if err != nil {
+		e2e.Failf("failed to marshal json: %v", err)
+	}
+	_, err = s.oc.AdminSecurityClient().SecurityV1().SecurityContextConstraints().Patch(context.Background(), s.sccName, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		e2e.Failf("failed to patch SCC: %v", err)
+	}
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -445,6 +445,10 @@
 // test/extended/testdata/service-serving-cert/nginx-serving-cert.conf
 // test/extended/testdata/signer-buildconfig.yaml
 // test/extended/testdata/stable-busybox.yaml
+// test/extended/testdata/storage/inline/csi-sharedresourcerole.yaml
+// test/extended/testdata/storage/inline/csi-sharedresourcerolebinding.yaml
+// test/extended/testdata/storage/inline/csi-sharedsecret.yaml
+// test/extended/testdata/storage/inline/secret.yaml
 // test/extended/testdata/templates/crunchydata-pod.json
 // test/extended/testdata/templates/guestbook.json
 // test/extended/testdata/templates/guestbook_list.json
@@ -47457,6 +47461,127 @@ func testExtendedTestdataStableBusyboxYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataStorageInlineCsiSharedresourceroleYaml = []byte(`apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: shared-resource-my-share
+rules:
+- apiGroups:
+    - sharedresource.openshift.io
+  resources:
+    - sharedsecrets
+  resourceNames:
+    - my-share
+  verbs:
+    - use
+`)
+
+func testExtendedTestdataStorageInlineCsiSharedresourceroleYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataStorageInlineCsiSharedresourceroleYaml, nil
+}
+
+func testExtendedTestdataStorageInlineCsiSharedresourceroleYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataStorageInlineCsiSharedresourceroleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/storage/inline/csi-sharedresourcerole.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYaml = []byte(`kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: "inline-volume-csi-roles-template"
+labels:
+  createdBy: "inline-volume-csi-roles-template"
+parameters:
+  - description: "The namespace to create roles in."
+    name: NAMESPACE
+    required: true
+objects:
+  - apiVersion: authorization.openshift.io/v1
+    kind: RoleBinding
+    metadata:
+      name: shared-resource-my-share
+      namespace: ${NAMESPACE}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: shared-resource-my-share
+      namespace: ${NAMESPACE}
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: ${NAMESPACE}
+`)
+
+func testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYaml, nil
+}
+
+func testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/storage/inline/csi-sharedresourcerolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataStorageInlineCsiSharedsecretYaml = []byte(`apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: my-share
+spec:
+  secretRef:
+    name: my-secret
+    namespace: default
+`)
+
+func testExtendedTestdataStorageInlineCsiSharedsecretYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataStorageInlineCsiSharedsecretYaml, nil
+}
+
+func testExtendedTestdataStorageInlineCsiSharedsecretYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataStorageInlineCsiSharedsecretYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/storage/inline/csi-sharedsecret.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataStorageInlineSecretYaml = []byte(`apiVersion: v1
+data:
+  key: bXktc2VjcmV0LXZhbHVl # my-secret-value
+kind: Secret
+metadata:
+  name: my-secret
+type: Opaque
+`)
+
+func testExtendedTestdataStorageInlineSecretYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataStorageInlineSecretYaml, nil
+}
+
+func testExtendedTestdataStorageInlineSecretYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataStorageInlineSecretYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/storage/inline/secret.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataTemplatesCrunchydataPodJson = []byte(`{
   "kind": "Template",
   "apiVersion": "template.openshift.io/v1",
@@ -50200,6 +50325,10 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/service-serving-cert/nginx-serving-cert.conf":                                    testExtendedTestdataServiceServingCertNginxServingCertConf,
 	"test/extended/testdata/signer-buildconfig.yaml":                                                         testExtendedTestdataSignerBuildconfigYaml,
 	"test/extended/testdata/stable-busybox.yaml":                                                             testExtendedTestdataStableBusyboxYaml,
+	"test/extended/testdata/storage/inline/csi-sharedresourcerole.yaml":                                      testExtendedTestdataStorageInlineCsiSharedresourceroleYaml,
+	"test/extended/testdata/storage/inline/csi-sharedresourcerolebinding.yaml":                               testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYaml,
+	"test/extended/testdata/storage/inline/csi-sharedsecret.yaml":                                            testExtendedTestdataStorageInlineCsiSharedsecretYaml,
+	"test/extended/testdata/storage/inline/secret.yaml":                                                      testExtendedTestdataStorageInlineSecretYaml,
 	"test/extended/testdata/templates/crunchydata-pod.json":                                                  testExtendedTestdataTemplatesCrunchydataPodJson,
 	"test/extended/testdata/templates/guestbook.json":                                                        testExtendedTestdataTemplatesGuestbookJson,
 	"test/extended/testdata/templates/guestbook_list.json":                                                   testExtendedTestdataTemplatesGuestbook_listJson,
@@ -50936,6 +51065,14 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				}},
 				"signer-buildconfig.yaml": {testExtendedTestdataSignerBuildconfigYaml, map[string]*bintree{}},
 				"stable-busybox.yaml":     {testExtendedTestdataStableBusyboxYaml, map[string]*bintree{}},
+				"storage": {nil, map[string]*bintree{
+					"inline": {nil, map[string]*bintree{
+						"csi-sharedresourcerole.yaml":        {testExtendedTestdataStorageInlineCsiSharedresourceroleYaml, map[string]*bintree{}},
+						"csi-sharedresourcerolebinding.yaml": {testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYaml, map[string]*bintree{}},
+						"csi-sharedsecret.yaml":              {testExtendedTestdataStorageInlineCsiSharedsecretYaml, map[string]*bintree{}},
+						"secret.yaml":                        {testExtendedTestdataStorageInlineSecretYaml, map[string]*bintree{}},
+					}},
+				}},
 				"templates": {nil, map[string]*bintree{
 					"crunchydata-pod.json":              {testExtendedTestdataTemplatesCrunchydataPodJson, map[string]*bintree{}},
 					"guestbook.json":                    {testExtendedTestdataTemplatesGuestbookJson, map[string]*bintree{}},

--- a/test/extended/testdata/storage/inline/csi-sharedresourcerole.yaml
+++ b/test/extended/testdata/storage/inline/csi-sharedresourcerole.yaml
@@ -1,0 +1,13 @@
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: shared-resource-my-share
+rules:
+- apiGroups:
+    - sharedresource.openshift.io
+  resources:
+    - sharedsecrets
+  resourceNames:
+    - my-share
+  verbs:
+    - use

--- a/test/extended/testdata/storage/inline/csi-sharedresourcerolebinding.yaml
+++ b/test/extended/testdata/storage/inline/csi-sharedresourcerolebinding.yaml
@@ -1,0 +1,25 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: "inline-volume-csi-roles-template"
+labels:
+  createdBy: "inline-volume-csi-roles-template"
+parameters:
+  - description: "The namespace to create roles in."
+    name: NAMESPACE
+    required: true
+objects:
+  - apiVersion: authorization.openshift.io/v1
+    kind: RoleBinding
+    metadata:
+      name: shared-resource-my-share
+      namespace: ${NAMESPACE}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: shared-resource-my-share
+      namespace: ${NAMESPACE}
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: ${NAMESPACE}

--- a/test/extended/testdata/storage/inline/csi-sharedsecret.yaml
+++ b/test/extended/testdata/storage/inline/csi-sharedsecret.yaml
@@ -1,0 +1,8 @@
+apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: my-share
+spec:
+  secretRef:
+    name: my-secret
+    namespace: default

--- a/test/extended/testdata/storage/inline/secret.yaml
+++ b/test/extended/testdata/storage/inline/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  key: bXktc2VjcmV0LXZhbHVl # my-secret-value
+kind: Secret
+metadata:
+  name: my-secret
+type: Opaque

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -16395,6 +16395,22 @@ var Annotations = map[string]string{
 
 	"[sig-storage] vsphere statefulset [Feature:vsphere] vsphere statefulset testing": " [Disabled:Unsupported] [Suite:k8s]",
 
+	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] baseline namespace should allow pods with inline volumes when the driver uses the baseline label": " [Suite:openshift/conformance/serial]",
+
+	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] baseline namespace should allow pods with inline volumes when the driver uses the restricted label": " [Suite:openshift/conformance/serial]",
+
+	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] baseline namespace should deny pods with inline volumes when the driver uses the privileged label": " [Suite:openshift/conformance/serial]",
+
+	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] privileged namespace should allow pods with inline volumes when the driver uses the privileged label": " [Suite:openshift/conformance/serial]",
+
+	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] privileged namespace should allow pods with inline volumes when the driver uses the restricted label": " [Suite:openshift/conformance/serial]",
+
+	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] restricted namespace should allow pods with inline volumes when the driver uses the restricted label": " [Suite:openshift/conformance/serial]",
+
+	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] restricted namespace should deny pods with inline volumes when the driver uses the baseline label": " [Suite:openshift/conformance/serial]",
+
+	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] restricted namespace should deny pods with inline volumes when the driver uses the privileged label": " [Suite:openshift/conformance/serial]",
+
 	"[sig-storage][Late] Metrics should report short attach times": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-storage][Late] Metrics should report short mount times": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-1066
This PR adds an e2e test for the admission plugin that was added in https://github.com/openshift/kubernetes/pull/1384
This also has a dependency on https://github.com/openshift/csi-driver-shared-resource-operator/pull/65 so that the operator will not overwrite `security.openshift.io/csi-ephemeral-volume-profile` during the test. That fix is in `registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-01-24-061922` and newer nightly builds.
To run this test manually against an existing cluster:
```
make && ./openshift-tests run all --dry-run | grep CSIInlineVolumeAdmission | ./openshift-tests run -f -
```
/cc @openshift/storage
