### PR TITLE
WIP: ETCD-364: add OpenShiftAPICheckFailed timeline

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -125,6 +125,13 @@
         return false
     }
 
+    function isOpenShiftAPICheckFailed(eventInterval) {
+        if (eventInterval.locator.startsWith("deployment/authentication-operator") && (eventInterval.message.includes("reason/OpenShiftAPICheckFailed") || eventInterval.message.startsWith("oauth.openshift.io.v1 failed with an attempt failed with statusCode = 503"))) {
+            return true
+        }
+        return false
+    }
+
     function isKubeletReadinessCheck(eventInterval) {
         if (eventInterval.locator.includes("container/") && (eventInterval.message.includes("reason/ReadinessFailed") || eventInterval.message.includes("reason/ReadinessErrored"))) {
             return true
@@ -168,6 +175,9 @@
             return true
         }
         if (eventInterval.locator.startsWith("ns/e2e-k8s-service-lb-available")) {
+            return true
+        }
+        if (eventInterval.locator.startsWith("ns/openshift-authentication-operator")) {
             return true
         }
         if (eventInterval.locator.includes(" route/")) {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -49217,6 +49217,13 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return false
     }
 
+    function isOpenShiftAPICheckFailed(eventInterval) {
+        if (eventInterval.locator.startsWith("deployment/authentication-operator") && (eventInterval.message.includes("reason/OpenShiftAPICheckFailed") || eventInterval.message.startsWith("oauth.openshift.io.v1 failed with an attempt failed with statusCode = 503"))) {
+            return true
+        }
+        return false
+    }
+
     function isKubeletReadinessCheck(eventInterval) {
         if (eventInterval.locator.includes("container/") && (eventInterval.message.includes("reason/ReadinessFailed") || eventInterval.message.includes("reason/ReadinessErrored"))) {
             return true
@@ -49260,6 +49267,9 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             return true
         }
         if (eventInterval.locator.startsWith("ns/e2e-k8s-service-lb-available")) {
+            return true
+        }
+        if (eventInterval.locator.startsWith("ns/openshift-authentication-operator")) {
             return true
         }
         if (eventInterval.locator.includes(" route/")) {


### PR DESCRIPTION
During vertical scaling tests, we found a lot of failures due to `OpenShiftAPICheckFailed` mainly from `openshift-authentication-operator`

This PR adds a timeline for the generation of these events.

resolves https://issues.redhat.com/browse/ETCD-364
