### PR TITLE
audit inspection

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/nodedetails"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -75,6 +77,7 @@ func main() {
 		newImagesCommand(),
 		newRunTestCommand(),
 		newRunMonitorCommand(),
+		newMonitorCommand(),
 		newTestFailureRiskAnalysisCommand(),
 		cmd.NewRunResourceWatchCommand(),
 		monitor_cmd.NewTimelineCommand(genericclioptions.IOStreams{
@@ -130,6 +133,17 @@ func newRunMonitorCommand() *cobra.Command {
 	cmd.Flags().StringVar(&monitorOpt.ArtifactDir,
 		"artifact-dir", monitorOpt.ArtifactDir,
 		"The directory where monitor events will be stored.")
+	return cmd
+}
+
+func newMonitorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "monitor",
+		SilenceErrors: true,
+	}
+	cmd.AddCommand(
+		nodedetails.AuditLogSummaryCommand(),
+	)
 	return cmd
 }
 

--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -155,6 +155,19 @@ func IntervalsFromNodeLogs(ctx context.Context, kubeClient kubernetes.Interface,
 	return ret, utilerrors.NewAggregate(errs)
 }
 
+func IntervalsFromAuditLogs(ctx context.Context, kubeClient kubernetes.Interface, beginning, end time.Time) (*nodedetails.AuditLogSummary, monitorapi.Intervals, error) {
+	ret := monitorapi.Intervals{}
+
+	// TODO honor begin and end times.  maybe
+	auditLogSummary, err := nodedetails.GetKubeAuditLogSummary(ctx, kubeClient)
+	if err != nil {
+		// TODO report the error AND the best possible summary we have
+		return auditLogSummary, nil, err
+	}
+
+	return auditLogSummary, ret, nil
+}
+
 // eventsFromKubeletLogs returns the produced intervals.  Any errors during this creation are logged, but
 // not returned because this is a best effort step
 func eventsFromKubeletLogs(nodeName string, kubeletLog []byte) monitorapi.Intervals {

--- a/pkg/monitor/nodedetails/audit_log_loadbalancer_summary.go
+++ b/pkg/monitor/nodedetails/audit_log_loadbalancer_summary.go
@@ -1,0 +1,89 @@
+package nodedetails
+
+import (
+	"strings"
+
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+)
+
+type LoadBalancerCheckSummary struct {
+	perNodeLoadBalancerCheckSummary map[string]*PerNodeLoadBalancerCheckSummary
+}
+
+type PerNodeLoadBalancerCheckSummary struct {
+	nodeName string
+
+	// this uses the external load balancer. If these are present more than 10s after termination started
+	// it means the LB is not set up well. If they are veryLate, then it's
+	// very bad.
+	duringTerminationDisruptionRequestsReceived []*auditv1.Event
+	veryLateDisruptionRequestsReceived          []*auditv1.Event
+
+	// nodes use the internal load balancer. If these are present more than 10s after termination started
+	// it means the LB is not set up well. If they are veryLate, then it's
+	// very bad.
+	duringTerminationNodeRequestsReceived []*auditv1.Event
+	veryLateNodeRequestsReceived          []*auditv1.Event
+
+	// platform requests use the internal service load balancer. If these are present more than 10s after termination started
+	// it means the service network is not set up well. If they are veryLate, then it's
+	// very bad.
+	// these will have to be checked periodically to be sure we are not accidentally
+	// including internal LB connections as from the CVO and the network operator.
+	duringTerminationPlatformRequestsReceived []*auditv1.Event
+	veryLatePlatformRequestsReceived          []*auditv1.Event
+}
+
+func (s *PerNodeLoadBalancerCheckSummary) Add(auditEvent *auditv1.Event, auditEventInfo auditEventInfo) {
+	info, isDuringTermination := auditEvent.Annotations["openshift.io/during-termination"]
+	if !isDuringTermination {
+		return
+	}
+	// don't care about loopback
+	if strings.Contains(info, "loopback=true") {
+		return
+	}
+	veryLateInfo, isVeryLate := auditEvent.Annotations["openshift.io/during-graceful"]
+	if strings.Contains(veryLateInfo, "loopback=true") {
+		return
+	}
+	isNode := false
+	for _, group := range auditEvent.User.Groups {
+		if group == "system:nodes" {
+			isNode = true
+			break
+		}
+	}
+	isPlatform := false
+	for _, group := range auditEvent.User.Groups {
+		if group == "system:serviceaccounts:openshift-network-operator" { // uses internal LB
+			break
+		}
+		if group == "system:serviceaccounts:openshift-cluster-version" { // sometimes uses internal LB
+			break
+		}
+		if strings.HasPrefix(group, "system:serviceaccounts:openshift-") { // the rest should use the service network
+			isPlatform = true
+			break
+		}
+	}
+	isDisruption := false
+
+	switch {
+	case isDisruption:
+		s.duringTerminationDisruptionRequestsReceived = append(s.duringTerminationDisruptionRequestsReceived, auditEvent)
+		if isVeryLate {
+			s.veryLateDisruptionRequestsReceived = append(s.veryLateDisruptionRequestsReceived, auditEvent)
+		}
+	case isNode:
+		s.duringTerminationNodeRequestsReceived = append(s.duringTerminationNodeRequestsReceived, auditEvent)
+		if isVeryLate {
+			s.veryLateNodeRequestsReceived = append(s.veryLateNodeRequestsReceived, auditEvent)
+		}
+	case isPlatform:
+		s.duringTerminationPlatformRequestsReceived = append(s.duringTerminationPlatformRequestsReceived, auditEvent)
+		if isVeryLate {
+			s.veryLatePlatformRequestsReceived = append(s.veryLatePlatformRequestsReceived, auditEvent)
+		}
+	}
+}

--- a/pkg/monitor/nodedetails/audit_log_summarizer.go
+++ b/pkg/monitor/nodedetails/audit_log_summarizer.go
@@ -1,0 +1,417 @@
+package nodedetails
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+)
+
+// every audit log summarizer is not threadsafe. The idea is that you use one per thread and
+// later combine the summarizers together into an overall summary
+type AuditLogSummary struct {
+	lineReadFailureCount    int
+	requestCounts           RequestCounts
+	perUserRequestCount     map[string]*PerUserRequestCount
+	perResourceRequestCount map[schema.GroupVersionResource]*PerResourceRequestCount
+	perStatusRequestCount   map[int32]*PerStatusRequestCount
+}
+
+type RequestCounts struct {
+	requestStartedCount       int
+	requestFinishedCount      int
+	clientFailedRequestCount  int
+	serverFailedRequestCount  int
+	perHTTPStatusRequestCount map[int32]int
+}
+
+type PerStatusRequestCount struct {
+	httpStatus              int32
+	requestCounts           RequestCounts
+	perResourceRequestCount map[schema.GroupVersionResource]*RequestCounts
+	perUserRequestCount     map[string]*RequestCounts
+}
+
+type PerUserRequestCount struct {
+	user                    string
+	requestCounts           RequestCounts
+	perResourceRequestCount map[schema.GroupVersionResource]*RequestCounts
+	perVerbRequestCount     map[string]*RequestCounts
+}
+
+type PerResourceRequestCount struct {
+	groupVersionResource schema.GroupVersionResource
+	requestCounts        RequestCounts
+	perUserRequestCount  map[string]*RequestCounts
+	perVerbRequestCount  map[string]*RequestCounts
+}
+
+type auditEventInfo struct {
+	auditID              types.UID
+	groupVersionResource *schema.GroupVersionResource
+}
+
+func (i *auditEventInfo) getGroupVersionResource(auditEvent *auditv1.Event) schema.GroupVersionResource {
+	if len(i.auditID) > 0 && i.auditID != auditEvent.AuditID {
+		panic(fmt.Sprintf("mismatched auditID: have %v, need %v", i.auditID, auditEvent.AuditID))
+	}
+	i.auditID = auditEvent.AuditID
+
+	if i.groupVersionResource != nil {
+		return *i.groupVersionResource
+	}
+
+	_, gvr, _, _ := URIToParts(auditEvent.RequestURI)
+	i.groupVersionResource = &gvr
+	return *i.groupVersionResource
+}
+
+func (s *AuditLogSummary) Add(auditEvent *auditv1.Event, auditEventInfo auditEventInfo) {
+	if auditEvent == nil {
+		s.lineReadFailureCount++
+		return
+	}
+
+	s.requestCounts.Add(auditEvent)
+
+	gvr := auditEventInfo.getGroupVersionResource(auditEvent)
+	if _, ok := s.perResourceRequestCount[gvr]; !ok {
+		s.perResourceRequestCount[gvr] = NewPerResourceRequestCount(gvr)
+	}
+	s.perResourceRequestCount[gvr].Add(auditEvent, auditEventInfo)
+
+	if _, ok := s.perUserRequestCount[auditEvent.User.Username]; !ok {
+		s.perUserRequestCount[auditEvent.User.Username] = NewPerUserRequestCount(auditEvent.User.Username)
+	}
+	s.perUserRequestCount[auditEvent.User.Username].Add(auditEvent, auditEventInfo)
+
+	if auditEvent.ResponseStatus != nil {
+		httpStatus := auditEvent.ResponseStatus.Code
+		if _, ok := s.perStatusRequestCount[httpStatus]; !ok {
+			s.perStatusRequestCount[httpStatus] = NewPerStatusRequestCount(httpStatus)
+		}
+		s.perStatusRequestCount[httpStatus].Add(auditEvent, auditEventInfo)
+	}
+}
+
+func (s *RequestCounts) Add(auditEvent *auditv1.Event) {
+	switch auditEvent.Stage {
+	case auditv1.StageRequestReceived:
+		s.requestStartedCount++
+	case auditv1.StageResponseComplete:
+		s.requestFinishedCount++
+	}
+
+	if auditEvent.ResponseStatus != nil {
+		httpStatus := auditEvent.ResponseStatus.Code
+		s.perHTTPStatusRequestCount[httpStatus] = s.perHTTPStatusRequestCount[httpStatus] + 1
+		switch {
+		case httpStatus >= 400 && httpStatus < 500:
+			s.clientFailedRequestCount++
+		case httpStatus >= 500 && httpStatus < 600:
+			s.serverFailedRequestCount++
+		default:
+			// nothing special
+		}
+	}
+}
+
+func (s *PerStatusRequestCount) Add(auditEvent *auditv1.Event, auditEventInfo auditEventInfo) {
+	if auditEvent.ResponseStatus == nil {
+		return
+	}
+	if auditEvent.ResponseStatus.Code != s.httpStatus {
+		return
+	}
+	s.requestCounts.Add(auditEvent)
+
+	gvr := auditEventInfo.getGroupVersionResource(auditEvent)
+	if _, ok := s.perResourceRequestCount[gvr]; !ok {
+		s.perResourceRequestCount[gvr] = NewRequestCounts()
+	}
+	s.perResourceRequestCount[gvr].Add(auditEvent)
+
+	if _, ok := s.perUserRequestCount[auditEvent.User.Username]; !ok {
+		s.perUserRequestCount[auditEvent.User.Username] = NewRequestCounts()
+	}
+	s.perUserRequestCount[auditEvent.User.Username].Add(auditEvent)
+}
+
+func (s *PerUserRequestCount) Add(auditEvent *auditv1.Event, auditEventInfo auditEventInfo) {
+	if auditEvent.User.Username != s.user {
+		return
+	}
+	s.requestCounts.Add(auditEvent)
+
+	gvr := auditEventInfo.getGroupVersionResource(auditEvent)
+	if _, ok := s.perResourceRequestCount[gvr]; !ok {
+		s.perResourceRequestCount[gvr] = NewRequestCounts()
+	}
+	s.perResourceRequestCount[gvr].Add(auditEvent)
+
+	if _, ok := s.perVerbRequestCount[auditEvent.Verb]; !ok {
+		s.perVerbRequestCount[auditEvent.Verb] = NewRequestCounts()
+	}
+	s.perVerbRequestCount[auditEvent.Verb].Add(auditEvent)
+}
+
+func (s *PerResourceRequestCount) Add(auditEvent *auditv1.Event, auditEventInfo auditEventInfo) {
+	gvr := auditEventInfo.getGroupVersionResource(auditEvent)
+	if gvr != s.groupVersionResource {
+		return
+	}
+	s.requestCounts.Add(auditEvent)
+
+	if _, ok := s.perUserRequestCount[auditEvent.User.Username]; !ok {
+		s.perUserRequestCount[auditEvent.User.Username] = NewRequestCounts()
+	}
+	s.perUserRequestCount[auditEvent.User.Username].Add(auditEvent)
+
+	if _, ok := s.perVerbRequestCount[auditEvent.Verb]; !ok {
+		s.perVerbRequestCount[auditEvent.Verb] = NewRequestCounts()
+	}
+	s.perVerbRequestCount[auditEvent.Verb].Add(auditEvent)
+}
+
+func (s *AuditLogSummary) AddSummary(rhs *AuditLogSummary) {
+	s.lineReadFailureCount += rhs.lineReadFailureCount
+	s.requestCounts.AddSummary(&rhs.requestCounts)
+
+	for k, v := range rhs.perUserRequestCount {
+		if _, ok := s.perUserRequestCount[k]; !ok {
+			s.perUserRequestCount[k] = NewPerUserRequestCount(k)
+		}
+		s.perUserRequestCount[k].AddSummary(v)
+	}
+	for k, v := range rhs.perResourceRequestCount {
+		if _, ok := s.perResourceRequestCount[k]; !ok {
+			s.perResourceRequestCount[k] = NewPerResourceRequestCount(k)
+		}
+		s.perResourceRequestCount[k].AddSummary(v)
+	}
+	for k, v := range rhs.perStatusRequestCount {
+		if _, ok := s.perStatusRequestCount[k]; !ok {
+			s.perStatusRequestCount[k] = NewPerStatusRequestCount(k)
+		}
+		s.perStatusRequestCount[k].AddSummary(v)
+	}
+}
+
+func (s *RequestCounts) AddSummary(rhs *RequestCounts) {
+	s.requestStartedCount += rhs.requestStartedCount
+	s.requestFinishedCount += rhs.requestFinishedCount
+	s.clientFailedRequestCount += rhs.clientFailedRequestCount
+	s.serverFailedRequestCount += rhs.serverFailedRequestCount
+	for k, v := range rhs.perHTTPStatusRequestCount {
+		s.perHTTPStatusRequestCount[k] = s.perHTTPStatusRequestCount[k] + v
+	}
+}
+
+func (s *PerStatusRequestCount) AddSummary(rhs *PerStatusRequestCount) {
+	if s.httpStatus != rhs.httpStatus {
+		panic(fmt.Sprintf("mismatching key: have %v, need %v", s.httpStatus, rhs.httpStatus))
+	}
+	s.requestCounts.AddSummary(&rhs.requestCounts)
+	for k, v := range rhs.perResourceRequestCount {
+		if _, ok := s.perResourceRequestCount[k]; !ok {
+			s.perResourceRequestCount[k] = NewRequestCounts()
+		}
+		s.perResourceRequestCount[k].AddSummary(v)
+	}
+	for k, v := range rhs.perUserRequestCount {
+		if _, ok := s.perUserRequestCount[k]; !ok {
+			s.perUserRequestCount[k] = NewRequestCounts()
+		}
+		s.perUserRequestCount[k].AddSummary(v)
+	}
+}
+
+func (s *PerUserRequestCount) AddSummary(rhs *PerUserRequestCount) {
+	if s.user != rhs.user {
+		panic(fmt.Sprintf("mismatching key: have %v, need %v", s.user, rhs.user))
+	}
+	s.requestCounts.AddSummary(&rhs.requestCounts)
+	for k, v := range rhs.perResourceRequestCount {
+		if _, ok := s.perResourceRequestCount[k]; !ok {
+			s.perResourceRequestCount[k] = NewRequestCounts()
+		}
+		s.perResourceRequestCount[k].AddSummary(v)
+	}
+	for k, v := range rhs.perVerbRequestCount {
+		if _, ok := s.perVerbRequestCount[k]; !ok {
+			s.perVerbRequestCount[k] = NewRequestCounts()
+		}
+		s.perVerbRequestCount[k].AddSummary(v)
+	}
+}
+
+func (s *PerResourceRequestCount) AddSummary(rhs *PerResourceRequestCount) {
+	if s.groupVersionResource != rhs.groupVersionResource {
+		panic(fmt.Sprintf("mismatching key: have %v, need %v", s.groupVersionResource, rhs.groupVersionResource))
+	}
+	s.requestCounts.AddSummary(&rhs.requestCounts)
+	for k, v := range rhs.perUserRequestCount {
+		if _, ok := s.perUserRequestCount[k]; !ok {
+			s.perUserRequestCount[k] = NewRequestCounts()
+		}
+		s.perUserRequestCount[k].AddSummary(v)
+	}
+	for k, v := range rhs.perVerbRequestCount {
+		if _, ok := s.perUserRequestCount[k]; !ok {
+			s.perUserRequestCount[k] = NewRequestCounts()
+		}
+		s.perVerbRequestCount[k].AddSummary(v)
+	}
+}
+
+func NewAuditLogSummary() *AuditLogSummary {
+	return &AuditLogSummary{
+		lineReadFailureCount:    0,
+		requestCounts:           *NewRequestCounts(),
+		perUserRequestCount:     map[string]*PerUserRequestCount{},
+		perResourceRequestCount: map[schema.GroupVersionResource]*PerResourceRequestCount{},
+		perStatusRequestCount:   map[int32]*PerStatusRequestCount{},
+	}
+}
+func NewRequestCounts() *RequestCounts {
+	return &RequestCounts{
+		perHTTPStatusRequestCount: map[int32]int{},
+	}
+}
+func NewPerStatusRequestCount(httpStatus int32) *PerStatusRequestCount {
+	return &PerStatusRequestCount{
+		httpStatus:              httpStatus,
+		requestCounts:           *NewRequestCounts(),
+		perResourceRequestCount: map[schema.GroupVersionResource]*RequestCounts{},
+		perUserRequestCount:     map[string]*RequestCounts{},
+	}
+}
+func NewPerUserRequestCount(user string) *PerUserRequestCount {
+	return &PerUserRequestCount{
+		user:                    user,
+		requestCounts:           *NewRequestCounts(),
+		perResourceRequestCount: map[schema.GroupVersionResource]*RequestCounts{},
+		perVerbRequestCount:     map[string]*RequestCounts{},
+	}
+}
+func NewPerResourceRequestCount(gvr schema.GroupVersionResource) *PerResourceRequestCount {
+	return &PerResourceRequestCount{
+		groupVersionResource: gvr,
+		requestCounts:        *NewRequestCounts(),
+		perUserRequestCount:  map[string]*RequestCounts{},
+		perVerbRequestCount:  map[string]*RequestCounts{},
+	}
+}
+
+func URIToParts(uri string) (string, schema.GroupVersionResource, string, string) {
+	ns := ""
+	gvr := schema.GroupVersionResource{}
+	name := ""
+
+	if len(uri) >= 1 {
+		if uri[0] == '/' {
+			uri = uri[1:]
+		}
+	}
+
+	// some request URL has query parameters like: /apis/image.openshift.io/v1/images?limit=500&resourceVersion=0
+	// we are not interested in the query parameters.
+	uri = strings.Split(uri, "?")[0]
+	parts := strings.Split(uri, "/")
+	if len(parts) == 0 {
+		return ns, gvr, name, ""
+	}
+	// /api/v1/namespaces/<name>
+	if parts[0] == "api" {
+		if len(parts) >= 2 {
+			gvr.Version = parts[1]
+		}
+		if len(parts) < 3 {
+			return ns, gvr, name, ""
+		}
+
+		switch {
+		case parts[2] != "namespaces": // cluster scoped request that is not a namespace
+			gvr.Resource = parts[2]
+			if len(parts) >= 4 {
+				name = parts[3]
+				return ns, gvr, name, ""
+			}
+		case len(parts) == 3 && parts[2] == "namespaces": // a namespace request /api/v1/namespaces
+			gvr.Resource = parts[2]
+			return "", gvr, "", ""
+
+		case len(parts) == 4 && parts[2] == "namespaces": // a namespace request /api/v1/namespaces/<name>
+			gvr.Resource = parts[2]
+			name = parts[3]
+			ns = parts[3]
+			return ns, gvr, name, ""
+
+		case len(parts) == 5 && parts[2] == "namespaces" && parts[4] == "finalize", // a namespace request /api/v1/namespaces/<name>/finalize
+			len(parts) == 5 && parts[2] == "namespaces" && parts[4] == "status": // a namespace request /api/v1/namespaces/<name>/status
+			gvr.Resource = parts[2]
+			name = parts[3]
+			ns = parts[3]
+			return ns, gvr, name, parts[4]
+
+		default:
+			// this is not a cluster scoped request and not a namespace request we recognize
+		}
+
+		if len(parts) < 4 {
+			return ns, gvr, name, ""
+		}
+
+		ns = parts[3]
+		if len(parts) >= 5 {
+			gvr.Resource = parts[4]
+		}
+		if len(parts) >= 6 {
+			name = parts[5]
+		}
+		if len(parts) >= 7 {
+			return ns, gvr, name, strings.Join(parts[6:], "/")
+		}
+		return ns, gvr, name, ""
+	}
+
+	if parts[0] != "apis" {
+		return ns, gvr, name, ""
+	}
+
+	// /apis/group/v1/namespaces/<name>
+	if len(parts) >= 2 {
+		gvr.Group = parts[1]
+	}
+	if len(parts) >= 3 {
+		gvr.Version = parts[2]
+	}
+	if len(parts) < 4 {
+		return ns, gvr, name, ""
+	}
+
+	if parts[3] != "namespaces" {
+		gvr.Resource = parts[3]
+		if len(parts) >= 5 {
+			name = parts[4]
+			return ns, gvr, name, ""
+		}
+	}
+	if len(parts) < 5 {
+		return ns, gvr, name, ""
+	}
+
+	ns = parts[4]
+	if len(parts) >= 6 {
+		gvr.Resource = parts[5]
+	}
+	if len(parts) >= 7 {
+		name = parts[6]
+	}
+	if len(parts) >= 8 {
+		return ns, gvr, name, strings.Join(parts[7:], "/")
+	}
+	return ns, gvr, name, ""
+}

--- a/pkg/monitor/nodedetails/audit_log_summary_serialization.go
+++ b/pkg/monitor/nodedetails/audit_log_summary_serialization.go
@@ -1,0 +1,249 @@
+package nodedetails
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// These types exist because JSON cannot represent compound keys in maps and schema.GroupVersionResource is a compound
+// key in many of our maps.  These types handle serialization and consistent ordering.
+
+type SerializedAuditLogSummary struct {
+	LineReadFailureCount      int
+	RequestCounts             SerializedRequestCounts
+	PerUserRequestCount       []SerializedPerUserRequestCount
+	PerResourceRequestCount   []SerializedPerResourceRequestCount
+	PerHTTPStatusRequestCount []SerializedPerHTTPStatusRequestCount
+}
+
+type SerializedRequestCounts struct {
+	RequestStartedCount       int
+	RequestFinishedCount      int
+	ClientFailedRequestCount  int
+	ServerFailedRequestCount  int
+	PerHTTPStatusRequestCount []SerializedPerHTTPStatusCount
+}
+
+func mostRequestsFirst(lhs, rhs SerializedRequestCounts) bool {
+	return lhs.RequestFinishedCount > rhs.RequestFinishedCount
+}
+
+type SerializedPerHTTPStatusCount struct {
+	HTTPStatus int32
+	Count      int
+}
+
+type httpStatusByBiggestCount []SerializedPerHTTPStatusCount
+
+func (a httpStatusByBiggestCount) Len() int      { return len(a) }
+func (a httpStatusByBiggestCount) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a httpStatusByBiggestCount) Less(i, j int) bool {
+	if a[i].Count > a[j].Count {
+		return true
+	}
+	return a[i].HTTPStatus < a[j].HTTPStatus
+}
+
+type SerializedPerHTTPStatusRequestCount struct {
+	HTTPStatus              int32
+	RequestCounts           SerializedRequestCounts
+	PerResourceRequestCount []SerializedPerResourceCountOnly
+	PerUserRequestCount     []SerializedPerUserCountOnly
+}
+
+type statusCountByBiggestCount []SerializedPerHTTPStatusRequestCount
+
+func (a statusCountByBiggestCount) Len() int      { return len(a) }
+func (a statusCountByBiggestCount) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a statusCountByBiggestCount) Less(i, j int) bool {
+	return mostRequestsFirst(a[i].RequestCounts, a[j].RequestCounts)
+}
+
+type SerializedPerUserRequestCount struct {
+	User                    string
+	RequestCounts           SerializedRequestCounts
+	PerResourceRequestCount []SerializedPerResourceCountOnly
+	PerVerbRequestCount     []SerializedPerVerbCountOnly
+}
+
+type userCountByBiggestCount []SerializedPerUserRequestCount
+
+func (a userCountByBiggestCount) Len() int      { return len(a) }
+func (a userCountByBiggestCount) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a userCountByBiggestCount) Less(i, j int) bool {
+	return mostRequestsFirst(a[i].RequestCounts, a[j].RequestCounts)
+}
+
+type SerializedPerResourceRequestCount struct {
+	GroupVersionResource schema.GroupVersionResource
+	RequestCounts        SerializedRequestCounts
+	PerUserRequestCount  []SerializedPerUserCountOnly
+	PerVerbRequestCount  []SerializedPerVerbCountOnly
+}
+
+type resourceCountByBiggestCount []SerializedPerResourceRequestCount
+
+func (a resourceCountByBiggestCount) Len() int      { return len(a) }
+func (a resourceCountByBiggestCount) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a resourceCountByBiggestCount) Less(i, j int) bool {
+	return mostRequestsFirst(a[i].RequestCounts, a[j].RequestCounts)
+}
+
+type SerializedPerVerbCountOnly struct {
+	Verb          string
+	RequestCounts SerializedRequestCounts
+}
+
+type verbCountOnlyByBiggestCount []SerializedPerVerbCountOnly
+
+func (a verbCountOnlyByBiggestCount) Len() int      { return len(a) }
+func (a verbCountOnlyByBiggestCount) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a verbCountOnlyByBiggestCount) Less(i, j int) bool {
+	return mostRequestsFirst(a[i].RequestCounts, a[j].RequestCounts)
+}
+
+type SerializedPerUserCountOnly struct {
+	User          string
+	RequestCounts SerializedRequestCounts
+}
+
+type userCountOnlyByBiggestCount []SerializedPerUserCountOnly
+
+func (a userCountOnlyByBiggestCount) Len() int      { return len(a) }
+func (a userCountOnlyByBiggestCount) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a userCountOnlyByBiggestCount) Less(i, j int) bool {
+	return mostRequestsFirst(a[i].RequestCounts, a[j].RequestCounts)
+}
+
+type SerializedPerResourceCountOnly struct {
+	GroupVersionResource schema.GroupVersionResource
+	RequestCounts        SerializedRequestCounts
+}
+
+type resourceCountOnlyByBiggestCount []SerializedPerResourceCountOnly
+
+func (a resourceCountOnlyByBiggestCount) Len() int      { return len(a) }
+func (a resourceCountOnlyByBiggestCount) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a resourceCountOnlyByBiggestCount) Less(i, j int) bool {
+	return mostRequestsFirst(a[i].RequestCounts, a[j].RequestCounts)
+}
+
+func NewSerializedAuditLogSummary(summary AuditLogSummary) SerializedAuditLogSummary {
+	ret := SerializedAuditLogSummary{
+		LineReadFailureCount:      summary.lineReadFailureCount,
+		RequestCounts:             NewSerializedRequestCounts(summary.requestCounts),
+		PerUserRequestCount:       []SerializedPerUserRequestCount{},
+		PerResourceRequestCount:   []SerializedPerResourceRequestCount{},
+		PerHTTPStatusRequestCount: []SerializedPerHTTPStatusRequestCount{},
+	}
+	for _, v := range summary.perUserRequestCount {
+		ret.PerUserRequestCount = append(ret.PerUserRequestCount, NewSerializedPerUserRequestCount(*v))
+	}
+	for _, v := range summary.perResourceRequestCount {
+		ret.PerResourceRequestCount = append(ret.PerResourceRequestCount, NewSerializedPerResourceRequestCount(*v))
+	}
+	for _, v := range summary.perHTTPStatusRequestCount {
+		ret.PerHTTPStatusRequestCount = append(ret.PerHTTPStatusRequestCount, NewSerializedPerStatusRequestCount(*v))
+	}
+	sort.Sort(userCountByBiggestCount(ret.PerUserRequestCount))
+	sort.Sort(resourceCountByBiggestCount(ret.PerResourceRequestCount))
+	sort.Sort(statusCountByBiggestCount(ret.PerHTTPStatusRequestCount))
+
+	return ret
+}
+
+func NewSerializedRequestCounts(summary RequestCounts) SerializedRequestCounts {
+	ret := SerializedRequestCounts{
+		RequestStartedCount:       summary.requestStartedCount,
+		RequestFinishedCount:      summary.requestFinishedCount,
+		ClientFailedRequestCount:  summary.clientFailedRequestCount,
+		ServerFailedRequestCount:  summary.serverFailedRequestCount,
+		PerHTTPStatusRequestCount: []SerializedPerHTTPStatusCount{},
+	}
+	for k, v := range summary.perHTTPStatusRequestCount {
+		ret.PerHTTPStatusRequestCount = append(ret.PerHTTPStatusRequestCount, SerializedPerHTTPStatusCount{
+			HTTPStatus: k,
+			Count:      v,
+		})
+	}
+	sort.Sort(httpStatusByBiggestCount(ret.PerHTTPStatusRequestCount))
+
+	return ret
+}
+
+func NewSerializedPerStatusRequestCount(summary PerHTTPStatusRequestCount) SerializedPerHTTPStatusRequestCount {
+	ret := SerializedPerHTTPStatusRequestCount{
+		HTTPStatus:              summary.httpStatus,
+		RequestCounts:           NewSerializedRequestCounts(summary.requestCounts),
+		PerResourceRequestCount: []SerializedPerResourceCountOnly{},
+		PerUserRequestCount:     []SerializedPerUserCountOnly{},
+	}
+	for k, v := range summary.perResourceRequestCount {
+		ret.PerResourceRequestCount = append(ret.PerResourceRequestCount, NewSerializedPerResourceCountOnly(k, *v))
+	}
+	for k, v := range summary.perUserRequestCount {
+		ret.PerUserRequestCount = append(ret.PerUserRequestCount, NewSerializedPerUserCountOnly(k, *v))
+	}
+	sort.Sort(resourceCountOnlyByBiggestCount(ret.PerResourceRequestCount))
+	sort.Sort(userCountOnlyByBiggestCount(ret.PerUserRequestCount))
+
+	return ret
+}
+
+func NewSerializedPerUserRequestCount(summary PerUserRequestCount) SerializedPerUserRequestCount {
+	ret := SerializedPerUserRequestCount{
+		User:                    summary.user,
+		RequestCounts:           NewSerializedRequestCounts(summary.requestCounts),
+		PerResourceRequestCount: []SerializedPerResourceCountOnly{},
+		PerVerbRequestCount:     []SerializedPerVerbCountOnly{},
+	}
+	for k, v := range summary.perResourceRequestCount {
+		ret.PerResourceRequestCount = append(ret.PerResourceRequestCount, NewSerializedPerResourceCountOnly(k, *v))
+	}
+	for k, v := range summary.perVerbRequestCount {
+		ret.PerVerbRequestCount = append(ret.PerVerbRequestCount, NewSerializedPerVerbCountOnly(k, *v))
+	}
+	sort.Sort(resourceCountOnlyByBiggestCount(ret.PerResourceRequestCount))
+	sort.Sort(verbCountOnlyByBiggestCount(ret.PerVerbRequestCount))
+
+	return ret
+}
+
+func NewSerializedPerResourceRequestCount(summary PerResourceRequestCount) SerializedPerResourceRequestCount {
+	ret := SerializedPerResourceRequestCount{
+		GroupVersionResource: summary.groupVersionResource,
+		RequestCounts:        NewSerializedRequestCounts(summary.requestCounts),
+		PerUserRequestCount:  []SerializedPerUserCountOnly{},
+		PerVerbRequestCount:  []SerializedPerVerbCountOnly{},
+	}
+	for k, v := range summary.perUserRequestCount {
+		ret.PerUserRequestCount = append(ret.PerUserRequestCount, NewSerializedPerUserCountOnly(k, *v))
+	}
+	for k, v := range summary.perVerbRequestCount {
+		ret.PerVerbRequestCount = append(ret.PerVerbRequestCount, NewSerializedPerVerbCountOnly(k, *v))
+	}
+	sort.Sort(userCountOnlyByBiggestCount(ret.PerUserRequestCount))
+	sort.Sort(verbCountOnlyByBiggestCount(ret.PerVerbRequestCount))
+
+	return ret
+}
+
+func NewSerializedPerVerbCountOnly(verb string, count RequestCounts) SerializedPerVerbCountOnly {
+	return SerializedPerVerbCountOnly{
+		Verb:          verb,
+		RequestCounts: NewSerializedRequestCounts(count),
+	}
+}
+func NewSerializedPerUserCountOnly(user string, count RequestCounts) SerializedPerUserCountOnly {
+	return SerializedPerUserCountOnly{
+		User:          user,
+		RequestCounts: NewSerializedRequestCounts(count),
+	}
+}
+func NewSerializedPerResourceCountOnly(gvr schema.GroupVersionResource, count RequestCounts) SerializedPerResourceCountOnly {
+	return SerializedPerResourceCountOnly{
+		GroupVersionResource: gvr,
+		RequestCounts:        NewSerializedRequestCounts(count),
+	}
+}

--- a/pkg/monitor/nodedetails/cmd.go
+++ b/pkg/monitor/nodedetails/cmd.go
@@ -1,0 +1,66 @@
+package nodedetails
+
+import (
+	"context"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/spf13/cobra"
+)
+
+type auditLogSummaryOptions struct {
+	ArtifactDir string
+
+	ConfigFlags *genericclioptions.ConfigFlags
+	IOStreams   genericclioptions.IOStreams
+}
+
+func AuditLogSummaryCommand() *cobra.Command {
+	o := &auditLogSummaryOptions{
+		ConfigFlags: genericclioptions.NewConfigFlags(true),
+		IOStreams: genericclioptions.IOStreams{
+			In:     os.Stdin,
+			Out:    os.Stdout,
+			ErrOut: os.Stderr,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "summarize-audit-logs",
+		Short: "Download and inspect audit logs for interesting things.",
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Run(context.Background())
+		},
+	}
+
+	cmd.Flags().StringVar(&o.ArtifactDir, "artifact-dir", o.ArtifactDir, "The directory where monitor events will be stored.")
+	o.ConfigFlags.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (o auditLogSummaryOptions) Run(ctx context.Context) error {
+	restConfig, err := o.ConfigFlags.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	auditLogSummary, err := GetKubeAuditLogSummary(ctx, kubeClient)
+	if err != nil {
+		return err
+	}
+
+	if err := WriteAuditLogSummary(o.ArtifactDir, "", auditLogSummary); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/monitor/nodedetails/node_log.go
+++ b/pkg/monitor/nodedetails/node_log.go
@@ -1,8 +1,16 @@
 package nodedetails
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"sync"
+
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 
 	"k8s.io/client-go/kubernetes"
 )
@@ -26,4 +34,114 @@ func GetNodeLog(ctx context.Context, client kubernetes.Interface, nodeName, syst
 	defer in.Close()
 
 	return ioutil.ReadAll(in)
+}
+
+// GetAuditLogBytes returns logs for a particular systemd service on a given node.
+// We're count on these logs to fit into some reasonable memory size.
+func GetKubeAuditLogSummary(ctx context.Context, client kubernetes.Interface, nodeName string) (*AuditLogSummary, error) {
+	return getAuditLogSummary(ctx, client, nodeName, "kube-apiserver")
+}
+func getAuditLogSummary(ctx context.Context, client kubernetes.Interface, nodeName, apiserver string) (*AuditLogSummary, error) {
+	auditLogFilenames, err := getAuditLogFilenames(ctx, client, nodeName, apiserver)
+	if err != nil {
+		return nil, err
+	}
+
+	// we do not have enough memory to read all the content and then navigate it all in memory.
+	// I mean, maybe we do, but we are looking at a number of bytes read measured in gigs, then the deserialization buffers,
+	// and then the maps to actually store the content.
+	// Instead, we will stream, deserialize as we consume, and run a summarize function to get aggregate values.
+	wg := sync.WaitGroup{}
+
+	errCh := make(chan error, len(auditLogFilenames))
+	auditLogSummaries := make(chan *AuditLogSummary, len(auditLogFilenames))
+	for _, auditLogFilename := range auditLogFilenames {
+		wg.Add(1)
+		go func(ctx context.Context) {
+			defer wg.Done()
+
+			auditStream, err := streamNodeLogFile(ctx, client, nodeName, auditLogFilename)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			auditLogSummary := NewAuditLogSummary()
+			scanner := bufio.NewScanner(auditStream)
+			line := 0
+			for scanner.Scan() {
+				line++
+				auditLine := scanner.Bytes()
+
+				if len(auditLine) == 0 {
+					continue
+				}
+
+				auditEvent := &auditv1.Event{}
+				if err := json.Unmarshal(auditLine, auditEvent); err != nil {
+					auditLogSummary.lineReadFailureCount++
+					fmt.Printf("unable to decode %q line %d: %s to audit event: %v\n", auditLogFilename, line, string(auditLine), err)
+					continue
+				}
+
+				auditLogSummary.Add(auditEvent, auditEventInfo{})
+			}
+
+		}(ctx)
+	}
+	wg.Wait()
+	close(errCh)
+	close(auditLogSummaries)
+
+	errs := []error{}
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+
+	fullSummary := NewAuditLogSummary()
+	for auditLogSummary := range auditLogSummaries {
+		fullSummary.AddSummary(auditLogSummary)
+	}
+
+	return fullSummary, nil
+}
+
+func streamNodeLogFile(ctx context.Context, client kubernetes.Interface, nodeName, filename string) (io.ReadCloser, error) {
+	path := client.CoreV1().RESTClient().Get().
+		Namespace("").Name(nodeName).
+		Resource("nodes").SubResource("proxy", "logs").Suffix(filename).URL().Path
+
+	req := client.CoreV1().RESTClient().Get().RequestURI(path).
+		SetHeader("Accept", "text/plain, */*")
+
+	return req.Stream(ctx)
+}
+
+func getNodeLogFile(ctx context.Context, client kubernetes.Interface, nodeName, filename string) ([]byte, error) {
+	in, err := streamNodeLogFile(ctx, client, nodeName, filename)
+	if err != nil {
+		return nil, err
+	}
+	defer in.Close()
+
+	return ioutil.ReadAll(in)
+}
+
+func getAuditLogFilenames(ctx context.Context, client kubernetes.Interface, nodeName, apiserverName string) ([]string, error) {
+	allBytes, err := getNodeLogFile(ctx, client, nodeName, apiserverName)
+	if err != nil {
+		return nil, err
+	}
+
+	filenames := []string{}
+	scanner := bufio.NewScanner(bytes.NewBuffer(allBytes))
+	for scanner.Scan() {
+		filename := string(scanner.Bytes())
+		switch {
+		default:
+			filenames = append(filenames, filename)
+		}
+	}
+
+	return filenames, nil
 }


### PR DESCRIPTION
Allow streaming the kube-apiserver audit logs (not the aggregated ones, yet) through openshift-tests and summarizing them in a file we record. This is the basis of being able to call out interesting auditEvents for invariant testing and timeline insertion.


/assign @tkashem 