### PR TITLE
test: extended: deployment: use correct apigroup for imagestreamtags

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -483,9 +483,9 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForLatestCondition(oc, dcName, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 
 			g.By("verifying the deployer service account can update imagestreamtags and user can get them")
-			err = exutil.WaitForUserBeAuthorized(oc, oc.Username(), &authorizationv1.ResourceAttributes{Namespace: oc.Namespace(), Verb: "get", Resource: "imagestreamtags"})
+			err = exutil.WaitForUserBeAuthorized(oc, oc.Username(), &authorizationv1.ResourceAttributes{Namespace: oc.Namespace(), Group: "image.openshift.io", Verb: "get", Resource: "imagestreamtags"})
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitForUserBeAuthorized(oc, "system:serviceaccount:"+oc.Namespace()+":deployer", &authorizationv1.ResourceAttributes{Namespace: oc.Namespace(), Verb: "update", Resource: "imagestreamtags"})
+			err = exutil.WaitForUserBeAuthorized(oc, "system:serviceaccount:"+oc.Namespace()+":deployer", &authorizationv1.ResourceAttributes{Namespace: oc.Namespace(), Group: "image.openshift.io", Verb: "update", Resource: "imagestreamtags"})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("verifying the post deployment action happened: tag is set")


### PR DESCRIPTION
AFAICT, the only need for the core apiGroup in this role https://github.com/openshift/cluster-openshift-controller-manager-operator/blob/master/bindata/v3.11.0/openshift-controller-manager/deployer-clusterrole.yaml#L56-L64 is to pass this test because it is using the wrong Group in modern OCP.

cc @deads2k 