### PR TITLE
Add subdued color for disruption with DNS timeouts

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -259,6 +259,13 @@
         return [item.locator, ` (${roles},updates)`, "Update"];
     }
 
+    function disruptionStateValue(item) {
+        if (item.message.includes("reason/DisruptionSamplerOutageBegan DNS lookup timeouts began")) {
+            return [item.locator, ` (DNS timeouts)`, "DNSTimeouts"];
+        }
+        return [item.locator, ``, "Disruption"];
+    }
+
     function alertSeverity(item) {
         // the other types can be pending, so check pending first
         let pendingIndex = item.message.indexOf("pending")
@@ -400,7 +407,7 @@
         })
 
         timelineGroups.push({group: "endpoint-availability", data: []})
-        createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEndpointConnectivity, regex)
+        createTimelineData(disruptionStateValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEndpointConnectivity, regex)
 
         timelineGroups.push({group: "e2e-test-failed", data: []})
         createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed, regex)
@@ -442,14 +449,14 @@
                 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', // nodes
                 'Passed', 'Skipped', 'Flaked', 'Failed',  // tests
                 'PodCreated', 'PodScheduled', 'PodTerminating','ContainerWait', 'ContainerStart', 'ContainerNotReady', 'ContainerReady', 'ContainerReadinessFailed', 'ContainerReadinessErrored',  'StartupProbeFailed', // pods
-                'Degraded', 'Upgradeable', 'False', 'Unknown'])
+                'Degraded', 'Upgradeable', 'False', 'Unknown', 'Disruption', 'DNSTimeouts'])
             .range([
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators
                 '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes
                 '#3cb043', '#ceba76', '#ffa500', '#d0312d', // tests
                 '#96cbff', '#1e7bd9', '#ffa500', '#ca8dfd', '#9300ff', '#fada5e','#3cb043', '#d0312d', '#d0312d', '#c90076', // pods
-                '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
+                '#b65049', '#32b8b6', '#ffffff', '#bbbbbb', '#d0312d', '#cdcdcd']);
         myChart.
         data(timelineGroups).
         useUtc(true).

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -49351,6 +49351,13 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return [item.locator, ` + "`" + ` (${roles},updates)` + "`" + `, "Update"];
     }
 
+    function disruptionStateValue(item) {
+        if (item.message.includes("reason/DisruptionSamplerOutageBegan DNS lookup timeouts began")) {
+            return [item.locator, ` + "`" + ` (DNS timeouts)` + "`" + `, "DNSTimeouts"];
+        }
+        return [item.locator, ` + "`" + `` + "`" + `, "Disruption"];
+    }
+
     function alertSeverity(item) {
         // the other types can be pending, so check pending first
         let pendingIndex = item.message.indexOf("pending")
@@ -49492,7 +49499,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         })
 
         timelineGroups.push({group: "endpoint-availability", data: []})
-        createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEndpointConnectivity, regex)
+        createTimelineData(disruptionStateValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEndpointConnectivity, regex)
 
         timelineGroups.push({group: "e2e-test-failed", data: []})
         createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed, regex)
@@ -49534,14 +49541,14 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
                 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', // nodes
                 'Passed', 'Skipped', 'Flaked', 'Failed',  // tests
                 'PodCreated', 'PodScheduled', 'PodTerminating','ContainerWait', 'ContainerStart', 'ContainerNotReady', 'ContainerReady', 'ContainerReadinessFailed', 'ContainerReadinessErrored',  'StartupProbeFailed', // pods
-                'Degraded', 'Upgradeable', 'False', 'Unknown'])
+                'Degraded', 'Upgradeable', 'False', 'Unknown', 'Disruption', 'DNSTimeouts'])
             .range([
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators
                 '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes
                 '#3cb043', '#ceba76', '#ffa500', '#d0312d', // tests
                 '#96cbff', '#1e7bd9', '#ffa500', '#ca8dfd', '#9300ff', '#fada5e','#3cb043', '#d0312d', '#d0312d', '#c90076', // pods
-                '#b65049', '#32b8b6', '#ffffff', '#bbbbbb']);
+                '#b65049', '#32b8b6', '#ffffff', '#bbbbbb', '#d0312d', '#cdcdcd']);
         myChart.
         data(timelineGroups).
         useUtc(true).


### PR DESCRIPTION
There are times when disruption happens due to DNS timeouts. This type of disruption is something we can ignore because it is related to the cluster upon which the test is running rather than the cluster under test.  Here's an [example](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.13-upgrade-from-stable-4.12-e2e-azure-sdn-upgrade/1616949517985255424).  Goto the "endpoint-availability" section of the first spyglass chart and you can see a lot of red lines; the vast majority of those can be ignored.

This PR makes the lines associated with DNS timeouts subdued (gray) so that we can focus on the disruption we are interested in.

Then, this (somewhat alarming) endpoint-availability chart:
<img width="1600" alt="Screen Shot 2023-01-27 at 2 08 17 PM" src="https://user-images.githubusercontent.com/93946516/215174520-50e712f1-91e6-4f68-a2c3-4ac098aa979d.png">

Becomes this (color = `b3b3b3`):
<img width="1889" alt="Screen Shot 2023-01-27 at 2 08 55 PM" src="https://user-images.githubusercontent.com/93946516/215174458-fc4490eb-1c3c-4659-9212-fc560afcbc4f.png">

Or this (color = `cdcdcd`):
<img width="1808" alt="Screen Shot 2023-01-27 at 3 27 18 PM" src="https://user-images.githubusercontent.com/93946516/215191175-6b1bb737-35fe-4bf3-846d-99a66bfcd569.png">

Charts with no DNS timeout disruption will look the same as before.