### PR TITLE
Prevent prometheus test from panicking

### DIFF
--- a/test/extended/prometheus/upgrade.go
+++ b/test/extended/prometheus/upgrade.go
@@ -6,14 +6,15 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	exutil "github.com/openshift/origin/test/extended/util"
-	helper "github.com/openshift/origin/test/extended/util/prometheus"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	helper "github.com/openshift/origin/test/extended/util/prometheus"
 )
 
 // MetricsAvailableAfterUpgradeTest tests that metrics from before an upgrade
@@ -38,6 +39,7 @@ func (t *MetricsAvailableAfterUpgradeTest) Setup(f *e2e.Framework) {
 	preUpgradeQuery := `prometheus_build_info{pod="prometheus-k8s-0"}`
 	preUpgradeResponse, err := helper.RunQuery(ctx, oc.NewPrometheusClient(ctx), preUpgradeQuery)
 	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(preUpgradeResponse).NotTo(o.BeEmpty())
 	o.Expect(preUpgradeResponse.Data.Result).NotTo(o.BeEmpty())
 
 	t.executionTimestamp = preUpgradeResponse.Data.Result[0].Timestamp.Time()


### PR DESCRIPTION
[TRT-799](https://issues.redhat.com//browse/TRT-799)

There's some examples in CI of this test panicking when preUpgradeResponse is nil, e.g. https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-ovn-upgrade/1618360645160275968/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/junit_upgrade_1674689374.xml

Note your browser won't parse this XML.  There's a separate bug in origin that when we have a panic, we render ANSI escape codes. We're tracking in [TRT-799](https://issues.redhat.com//browse/TRT-799).