### PR TITLE
Update S2i image tests for dotnet3.1 EOL and add dotnet7.0

### DIFF
--- a/test/extended/image_ecosystem/s2i_images.go
+++ b/test/extended/image_ecosystem/s2i_images.go
@@ -201,18 +201,11 @@ var s2iImages = map[string][]tc{
 			Arches:   []string{"amd64", "arm64", "s390x"},
 		},
 		{
-			Version:  "31",
+			Version:  "70",
 			Cmd:      "dotnet --version",
-			Expected: "3.1",
-			Tag:      "3.1-ubi8",
-			Arches:   []string{"amd64"},
-		},
-		{
-			Version:  "31",
-			Cmd:      "dotnet --version",
-			Expected: "3.1",
-			Tag:      "3.1-el7",
-			Arches:   []string{"amd64"},
+			Expected: "7.0",
+			Tag:      "7.0-ubi8",
+			Arches:   []string{"amd64", "arm64", "s390x"},
 		},
 	},
 }


### PR DESCRIPTION
Update S2i image tests for Dotnet
1. Remove dotnet3.1 (EOL) as per [#438](https://github.com/redhat-developer/s2i-dotnetcore/pull/438) 
2. Add dotnet7.0 tests

Signed-off-by: Feny Mehta <fbm3307@gmail.com>