### PR TITLE
extended: security: do not explicitly set api audience on token request

### DIFF
--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -530,13 +530,8 @@ func createPodSecurityPolicySelfSubjectReviewsRoleBindingOrDie(ctx context.Conte
 
 func createClientFromServiceAccount(oc *exutil.CLI, sa *corev1.ServiceAccount) (*kubernetes.Clientset, *securityv1client.SecurityV1Client) {
 	// create a new token request for the service account and use it to build a client for it
-	tokenRequest := &authenticationv1.TokenRequest{
-		Spec: authenticationv1.TokenRequestSpec{
-			Audiences: []string{"https://kubernetes.default.svc"},
-		},
-	}
 	framework.Logf("Creating service account token")
-	bootstrapperToken, err := oc.AdminKubeClient().CoreV1().ServiceAccounts(sa.Namespace).CreateToken(context.TODO(), sa.Name, tokenRequest, metav1.CreateOptions{})
+	bootstrapperToken, err := oc.AdminKubeClient().CoreV1().ServiceAccounts(sa.Namespace).CreateToken(context.TODO(), sa.Name, &authenticationv1.TokenRequest{}, metav1.CreateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	saClientConfig := restclient.AnonymousClientConfig(oc.AdminConfig())


### PR DESCRIPTION
Hypershift does not use `kubernetes.default.svc` as the api audience on the KAS.  It is set to the URL of the OIDC provider.  ROSA also does this so I don't imagine this test passes for it either at the moment.

Explicit setting of the `Audiences` on the `TokenRequest` is not required.  If not set, it will just default to the audiences configured in the KAS.

Causing conformance failure for hypershift
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-conformance-aws-ovn/1620240601058381824