### PR TITLE
Update S2i image tests for dotnet3.1 EOL

### DIFF
--- a/test/extended/image_ecosystem/s2i_images.go
+++ b/test/extended/image_ecosystem/s2i_images.go
@@ -200,20 +200,6 @@ var s2iImages = map[string][]tc{
 			Tag:      "6.0-ubi8",
 			Arches:   []string{"amd64", "arm64", "s390x"},
 		},
-		{
-			Version:  "31",
-			Cmd:      "dotnet --version",
-			Expected: "3.1",
-			Tag:      "3.1-ubi8",
-			Arches:   []string{"amd64"},
-		},
-		{
-			Version:  "31",
-			Cmd:      "dotnet --version",
-			Expected: "3.1",
-			Tag:      "3.1-el7",
-			Arches:   []string{"amd64"},
-		},
 	},
 }
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1625,10 +1625,6 @@ var Annotations = map[string]string{
 
 	"[sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should print the usage": "",
-
-	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-ubi8\" should print the usage": "",
-
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:6.0-ubi8\" should print the usage": "",
 
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/nginx:1.20-ubi7\" should print the usage": "",
@@ -1674,10 +1670,6 @@ var Annotations = map[string]string{
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi7\" should print the usage": "",
 
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8\" should print the usage": "",
-
-	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-el7\" should be SCL enabled": "",
-
-	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:3.1-ubi8\" should be SCL enabled": "",
 
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/dotnet:6.0-ubi8\" should be SCL enabled": "",
 


### PR DESCRIPTION
Update S2i image tests for Dotnet
Remove dotnet3.1 (EOL) as per [#438](https://github.com/redhat-developer/s2i-dotnetcore/pull/438) 

Signed-off-by: Feny Mehta <fbm3307@gmail.com>