### PR TITLE
WIP Revert "TRT-813: Disabling disruption fallback for upgrades"

### DIFF
--- a/pkg/monitor/resourcewatch/operator/starter.go
+++ b/pkg/monitor/resourcewatch/operator/starter.go
@@ -60,6 +60,7 @@ func RunOperator(ctx context.Context, controllerCtx *controllercmd.ControllerCon
 		appResource("statefulsets"),
 		appResource("replicasets"),
 		resource("events.k8s.io", "v1", "events"),
+		resource("policy", "v1", "PodDisruptionBudget"),
 		coreResource("pods"),
 		coreResource("nodes"),
 		coreResource("replicationcontrollers"),

--- a/pkg/synthetictests/allowedbackenddisruption/matches_test.go
+++ b/pkg/synthetictests/allowedbackenddisruption/matches_test.go
@@ -122,7 +122,7 @@ func TestGetClosestP95Value(t *testing.T) {
 				backendName: "kube-api-new-connections",
 				jobType: platformidentification.JobType{
 					Release:      "4.12",
-					FromRelease:  "4.11",
+					FromRelease:  "4.12",
 					Platform:     "aws",
 					Architecture: "amd64",
 					Network:      "ovn",

--- a/pkg/synthetictests/historicaldata/next_best_guess.go
+++ b/pkg/synthetictests/historicaldata/next_best_guess.go
@@ -12,10 +12,10 @@ import (
 // TODO building a cross multiply would likely be beneficial
 var nextBestGuessers = []NextBestKey{
 	MicroReleaseUpgrade,
-	//	MinorReleaseUpgrade,
+	MinorReleaseUpgrade,
 	PreviousReleaseUpgrade,
 	combine(PreviousReleaseUpgrade, MicroReleaseUpgrade),
-	//	combine(PreviousReleaseUpgrade, MinorReleaseUpgrade),
+	combine(PreviousReleaseUpgrade, MinorReleaseUpgrade),
 
 	OnArchitecture("amd64"),
 	OnArchitecture("ppc64le"),
@@ -27,10 +27,10 @@ var nextBestGuessers = []NextBestKey{
 	combine(OnArchitecture("s390x"), MicroReleaseUpgrade),
 	combine(OnArchitecture("arm64"), MicroReleaseUpgrade),
 
-	//	combine(OnArchitecture("amd64"), MinorReleaseUpgrade),
-	//	combine(OnArchitecture("ppc64le"), MinorReleaseUpgrade),
-	//	combine(OnArchitecture("s390x"), MinorReleaseUpgrade),
-	//	combine(OnArchitecture("arm64"), MinorReleaseUpgrade),
+	combine(OnArchitecture("amd64"), MinorReleaseUpgrade),
+	combine(OnArchitecture("ppc64le"), MinorReleaseUpgrade),
+	combine(OnArchitecture("s390x"), MinorReleaseUpgrade),
+	combine(OnArchitecture("arm64"), MinorReleaseUpgrade),
 
 	combine(OnArchitecture("amd64"), PreviousReleaseUpgrade),
 	combine(OnArchitecture("ppc64le"), PreviousReleaseUpgrade),
@@ -42,10 +42,10 @@ var nextBestGuessers = []NextBestKey{
 	combine(OnArchitecture("s390x"), PreviousReleaseUpgrade, MicroReleaseUpgrade),
 	combine(OnArchitecture("arm64"), PreviousReleaseUpgrade, MicroReleaseUpgrade),
 
-	//	combine(OnArchitecture("amd64"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
-	//	combine(OnArchitecture("ppc64le"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
-	//	combine(OnArchitecture("s390x"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
-	//	combine(OnArchitecture("arm64"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
+	combine(OnArchitecture("amd64"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
+	combine(OnArchitecture("ppc64le"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
+	combine(OnArchitecture("s390x"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
+	combine(OnArchitecture("arm64"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
 
 	combine(ForTopology("single"), OnSDN),
 	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade),

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -82,7 +82,7 @@ func (t *serviceLoadBalancerUpgradeTest) RequiresKubeNamespace() bool {
 	return true
 }
 
-func shouldTestPDBs() bool { return true }
+func shouldTestPDBs() bool { return false }
 
 func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framework, backendSampler disruption.BackendSampler) error {
 	// we must update our namespace to bypass SCC so that we can avoid default mutation of our pod and SCC evaluation.


### PR DESCRIPTION
Reverts openshift/origin#27701

Use this to experiment further GCP disruption investigation. 