### PR TITLE
DO NOT MERGE: Save raw events to file for later debugging

### DIFF
--- a/pkg/monitor/cmd.go
+++ b/pkg/monitor/cmd.go
@@ -88,6 +88,9 @@ func (opt *Options) Run() error {
 	if len(opt.ArtifactDir) != 0 {
 		recordedEvents := m.Intervals(time.Time{}, time.Time{})
 		recordedResources := m.CurrentResourceState()
+		recordedRawEvents := m.RawEvents
+		fmt.Println("m.rawEvents (recordedRawEvents): ", len(recordedRawEvents))
+
 		timeSuffix := fmt.Sprintf("_%s", time.Now().UTC().Format("20060102-150405"))
 
 		eventDir := fmt.Sprintf("%s/monitor-events", opt.ArtifactDir)
@@ -95,7 +98,7 @@ func (opt *Options) Run() error {
 			fmt.Printf("Failed to create monitor-events directory, err: %v\n", err)
 			return err
 		}
-		err := WriteEventsForJobRun(eventDir, recordedResources, recordedEvents, timeSuffix)
+		err := WriteEventsForJobRun(eventDir, recordedResources, recordedEvents, recordedRawEvents, timeSuffix)
 		if err != nil {
 			fmt.Printf("Failed to write event data, err: %v\n", err)
 			return err

--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -158,7 +158,7 @@ func recordAddOrUpdateEvent(
 	if obj.Type == corev1.EventTypeWarning {
 		condition.Level = monitorapi.Warning
 	}
-	m.RecordAt(t, condition)
+	m.RecordAt(t, obj, condition)
 
 }
 

--- a/pkg/monitor/intervalcreation/rendering.go
+++ b/pkg/monitor/intervalcreation/rendering.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 	"github.com/openshift/origin/test/extended/testdata"
+	corev1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -42,7 +43,7 @@ func NewNonSpyglassEventIntervalRenderer(name string, filter monitorapi.EventInt
 	}
 }
 
-func (r eventIntervalRenderer) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, timeSuffix string) error {
+func (r eventIntervalRenderer) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, _ []corev1.Event, timeSuffix string) error {
 	filenameBase := r.filenameBaseFn(timeSuffix)
 	return r.writeEventData(artifactDir, filenameBase, events, timeSuffix)
 }

--- a/pkg/monitor/intervalcreation/rendering_per_namespace.go
+++ b/pkg/monitor/intervalcreation/rendering_per_namespace.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	corev1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -98,7 +99,7 @@ func NewPodEventIntervalRenderer() podRendering {
 	return podRendering{}
 }
 
-func (r podRendering) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, timeSuffix string) error {
+func (r podRendering) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, _ []corev1.Event, timeSuffix string) error {
 	allNamespaces := sets.NewString()
 	for _, interval := range events {
 		allNamespaces.Insert(monitorapi.NamespaceFromLocator(interval.Locator))
@@ -142,7 +143,7 @@ func (r podRendering) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap
 				}
 				return false
 			})
-		if err := writer.WriteRunData(artifactDir, nil, events, timeSuffix); err != nil {
+		if err := writer.WriteRunData(artifactDir, nil, events, nil, timeSuffix); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -164,7 +165,7 @@ func NewIngressServicePodIntervalRenderer() ingressServicePodRendering {
 // WriteEventData for ingressServicePodRendering writes out a custom spyglass chart to help debug TRT-364 and BZ2101622 where
 // image-registry, console, and oauth pods were experiencing disruption during upgrades.  We wanted one chart that
 // showed those pods, router-default pods, node changes, and disruption.
-func (r ingressServicePodRendering) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, timeSuffix string) error {
+func (r ingressServicePodRendering) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, _ []corev1.Event, timeSuffix string) error {
 	errs := []error{}
 	disruptionReasons := sets.NewString(backenddisruption.DisruptionBeganEventReason,
 		backenddisruption.DisruptionEndedEventReason,
@@ -183,7 +184,7 @@ func (r ingressServicePodRendering) WriteRunData(artifactDir string, _ monitorap
 			return false
 		})
 
-	if err := writer.WriteRunData(artifactDir, nil, events, timeSuffix); err != nil {
+	if err := writer.WriteRunData(artifactDir, nil, events, nil, timeSuffix); err != nil {
 		errs = append(errs, err)
 	}
 	return utilerrors.NewAggregate(errs)

--- a/pkg/monitor/noop.go
+++ b/pkg/monitor/noop.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -14,9 +15,9 @@ func NewNoOpMonitor() Recorder {
 	return &noOpMonitor{}
 }
 
-func (*noOpMonitor) RecordResource(resourceType string, obj runtime.Object)        {}
-func (*noOpMonitor) Record(conditions ...monitorapi.Condition)                     {}
-func (*noOpMonitor) RecordAt(t time.Time, conditions ...monitorapi.Condition)      {}
-func (*noOpMonitor) StartInterval(t time.Time, condition monitorapi.Condition) int { return 0 }
-func (*noOpMonitor) EndInterval(startedInterval int, t time.Time)                  {}
-func (*noOpMonitor) AddSampler(fn SamplerFunc)                                     {}
+func (*noOpMonitor) RecordResource(resourceType string, obj runtime.Object)                      {}
+func (*noOpMonitor) Record(conditions ...monitorapi.Condition)                                   {}
+func (*noOpMonitor) RecordAt(t time.Time, obj *corev1.Event, conditions ...monitorapi.Condition) {}
+func (*noOpMonitor) StartInterval(t time.Time, condition monitorapi.Condition) int               { return 0 }
+func (*noOpMonitor) EndInterval(startedInterval int, t time.Time)                                {}
+func (*noOpMonitor) AddSampler(fn SamplerFunc)                                                   {}

--- a/pkg/monitor/sampler.go
+++ b/pkg/monitor/sampler.go
@@ -41,7 +41,7 @@ func (s *sampler) run(ctx context.Context) {
 		startTime := time.Now().UTC()
 		condition, currentSampleIsAvailable := s.sampleFn(previousSampleWasAvailable)
 		if condition != nil {
-			s.recorder.RecordAt(startTime, *condition)
+			s.recorder.RecordAt(startTime, nil, *condition)
 		}
 		if s.onFailing != nil {
 			switch {

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -25,7 +26,7 @@ type Recorder interface {
 	RecordResource(resourceType string, obj runtime.Object)
 
 	Record(conditions ...monitorapi.Condition)
-	RecordAt(t time.Time, conditions ...monitorapi.Condition)
+	RecordAt(t time.Time, obj *corev1.Event, conditions ...monitorapi.Condition)
 
 	StartInterval(t time.Time, condition monitorapi.Condition) int
 	EndInterval(startedInterval int, t time.Time)

--- a/pkg/monitor/write_job_run_data.go
+++ b/pkg/monitor/write_job_run_data.go
@@ -9,16 +9,18 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/kustomize/kyaml/sets"
 )
 
-func WriteEventsForJobRun(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, timeSuffix string) error {
-	return monitorserialization.EventsToFile(filepath.Join(artifactDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)), events)
+func WriteEventsForJobRun(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, rawEvents []corev1.Event, timeSuffix string) error {
+	return monitorserialization.EventsToFile(filepath.Join(artifactDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)),
+		filepath.Join(artifactDir, fmt.Sprintf("e2e-raw-events%s.json", timeSuffix)), events, rawEvents)
 }
 
-func WriteTrackedResourcesForJobRun(artifactDir string, recordedResources monitorapi.ResourcesMap, _ monitorapi.Intervals, timeSuffix string) error {
+func WriteTrackedResourcesForJobRun(artifactDir string, recordedResources monitorapi.ResourcesMap, _ monitorapi.Intervals, _ []corev1.Event, timeSuffix string) error {
 	errors := []error{}
 
 	// write out the current state of resources that we explicitly tracked.
@@ -32,7 +34,7 @@ func WriteTrackedResourcesForJobRun(artifactDir string, recordedResources monito
 	return utilerrors.NewAggregate(errors)
 }
 
-func WriteBackendDisruptionForJobRun(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, timeSuffix string) error {
+func WriteBackendDisruptionForJobRun(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, _ []corev1.Event, timeSuffix string) error {
 	backendDisruption := computeDisruptionData(events)
 	return writeDisruptionData(filepath.Join(artifactDir, fmt.Sprintf("backend-disruption%s.json", timeSuffix)), backendDisruption)
 }

--- a/pkg/synthetictests/allowedalerts/job_run_data.go
+++ b/pkg/synthetictests/allowedalerts/job_run_data.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func WriteAlertDataForJobRun(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, timeSuffix string) error {
+func WriteAlertDataForJobRun(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, _ []corev1.Event, timeSuffix string) error {
 	alertData := computeAlertData(events)
 	addMissingAlertsForLevel(alertData, WarningAlertLevel)
 	addMissingAlertsForLevel(alertData, CriticalAlertLevel)


### PR DESCRIPTION
Just see if we can save the raw events so that we have something we can test with.

The gather-extra/events.json is there but that seemed to be missing a lot of events.

Goal: for each e2e-events.json file in the junit subdir (in the GCS bucket), we will see e2e-raw-events.json file