### PR TITLE
Do not bail on producing artifacts when nodes are dead

### DIFF
--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -117,7 +117,7 @@ func IntervalsFromNodeLogs(ctx context.Context, kubeClient kubernetes.Interface,
 
 	allNodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return ret, err
 	}
 
 	collectionStart := time.Now()
@@ -132,6 +132,7 @@ func IntervalsFromNodeLogs(ctx context.Context, kubeClient kubernetes.Interface,
 			// TODO limit by begin/end here instead of post-processing
 			nodeLogs, err := nodedetails.GetNodeLog(ctx, kubeClient, nodeName, "kubelet")
 			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting node logs from %s: %s", nodeName, err.Error())
 				errCh <- err
 				return
 			}
@@ -144,7 +145,7 @@ func IntervalsFromNodeLogs(ctx context.Context, kubeClient kubernetes.Interface,
 	}
 	wg.Wait()
 	collectionEnd := time.Now()
-	fmt.Fprintf(os.Stderr, "Collection of node logs and analysis took: %v\n", collectionEnd.Sub(collectionStart))
+	fmt.Fprintf(os.Stdout, "Collection of node logs and analysis took: %v\n", collectionEnd.Sub(collectionStart))
 
 	errs := []error{}
 	for len(errCh) > 0 {

--- a/pkg/test/ginkgo/options_monitor_events.go
+++ b/pkg/test/ginkgo/options_monitor_events.go
@@ -114,12 +114,12 @@ func (o *MonitorEventsOptions) End(ctx context.Context, restConfig *rest.Config,
 	// this happens before calculation because events collected here could be used to drive later calculations
 	events, err = intervalcreation.InsertIntervalsFromCluster(ctx, restConfig, events, o.recordedResources, fromTime, endTime)
 	if err != nil {
-		return fmt.Errorf("InsertIntervalsFromClusterError: %w", err)
+		fmt.Fprintf(o.ErrOut, "InsertIntervalsFromCluster error but continuing processing: %v", err)
 	}
 	// add events from alerts so we can create the intervals
 	alertEventIntervals, err := monitor.FetchEventIntervalsForAllAlerts(ctx, restConfig, *o.startTime)
 	if err != nil {
-		return fmt.Errorf("AlertErr: %w", err)
+		fmt.Fprintf(o.ErrOut, "FetchEventIntervalsForAllAlerts error but continuing processing: %v", err)
 	}
 	events = append(events, alertEventIntervals...)
 	events = intervalcreation.InsertCalculatedIntervals(events, o.recordedResources, fromTime, endTime)


### PR DESCRIPTION
Discovered that conformance test artifacts may not appear at all if
nodes are dead, due to recent work to query their logs for interval
creation.

Code modified to proceed even when errors happen here after logging the
problem.

[TRT-855](https://issues.redhat.com//browse/TRT-855)
