### PR TITLE
Revert "perform build csi volume test on GA clusters"

### DIFF
--- a/test/extended/builds/volumes.go
+++ b/test/extended/builds/volumes.go
@@ -136,7 +136,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func()
 	})
 })
 
-var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes", func() {
+var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                     = exutil.NewCLIWithPodSecurityLevel("build-volumes-csi", admissionapi.LevelBaseline)
@@ -162,6 +162,10 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes", fu
 		})
 
 		g.JustBeforeEach(func() {
+			//TODO remove this check once https://github.com/openshift/cluster-storage-operator/pull/335 and https://github.com/openshift/openshift-controller-manager/pull/250 have merged
+			if !isTechPreviewNoUpgrade(oc) {
+				g.Skip("the test is not expected to work within Tech Preview disabled clusters")
+			}
 			// create the secret to share in a new namespace
 			g.By("creating a secret")
 			err := oc.AsAdmin().Run("--namespace=default", "apply").Args("-f", secret).Execute()

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1205,13 +1205,13 @@ var Annotations = map[string]string{
 
 	"[sig-builds][Feature:Builds][volumes] build volumes should mount given secrets and configmaps into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-builds][Feature:Builds][volumes] csi build volumes [apigroup:config.openshift.io] should mount given csi shared resource secret into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
+	"[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-builds][Feature:Builds][volumes] csi build volumes [apigroup:config.openshift.io] should mount given csi shared resource secret into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
+	"[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-builds][Feature:Builds][volumes] csi build volumes [apigroup:config.openshift.io] should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
+	"[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret without resource refresh into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-builds][Feature:Builds][volumes] csi build volumes [apigroup:config.openshift.io] should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
+	"[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-builds][Feature:Builds][webhook] TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
This reverts commit 376971b08a0debc2b32bf9febdacd5826b14ff5c.

see https://redhat-internal.slack.com/archives/C01C8502FMM/p1676472369732279 and https://github.com/openshift/release/pull/36433

after this, I'll update my move to GA PRs in openshift/openshift-controller-manager and openshift/cluster-storage-operator

/assign @coreydaley

@sjenning FYI .... after this merges, I would think the hypershift periodic would no longer cite the test failure that started us down this path, and presumably be green, unless there are tests that check cluster storage operator status perhaps