### PR TITLE
OCPBUGS-7488: remove test: should not reconcile SC when state is Unmanaged

### DIFF
--- a/test/extended/storage/storageclass.go
+++ b/test/extended/storage/storageclass.go
@@ -70,23 +70,7 @@ var _ = g.Describe("[sig-storage][Feature:DisableStorageClass][Serial]", func() 
 		sctest.SetAllowExpansion(false)
 
 		g.By("verifying the AllowVolumeExpansion reverts to true")
-		sctest.VerifyAllowExpansion(true, nil)
-	})
-
-	g.It("should not reconcile the StorageClass when StorageClassState is Unmanaged", func() {
-		g.By("setting StorageClassState to Unmanaged")
-		sctest.SetSCState(operatorv1.UnmanagedStorageClass)
-
-		g.By("setting AllowVolumeExpansion to false on the StorageClass")
-		sctest.SetAllowExpansion(false)
-
-		g.By("verifying the AllowVolumeExpansion stays set to false")
-		// wait to see if the operator tries to reconcile before checking
-		time.Sleep(sleepInterval * time.Second)
-		sctest.VerifyAllowExpansion(false, func() {
-			// try again if verification fails
-			sctest.SetAllowExpansion(false)
-		})
+		sctest.VerifyAllowExpansion(true)
 	})
 
 	g.It("should remove the StorageClass when StorageClassState is Removed", func() {
@@ -199,7 +183,7 @@ func (d *DisableStorageClassTest) SetAllowExpansion(allowExpansion bool) {
 	}
 }
 
-func (d *DisableStorageClassTest) VerifyAllowExpansion(expected bool, retry func()) {
+func (d *DisableStorageClassTest) VerifyAllowExpansion(expected bool) {
 	for i := 0; i < maxRetries; i++ {
 		sc, err := d.oc.AdminKubeClient().StorageV1().StorageClasses().Get(context.Background(), d.scName, metav1.GetOptions{})
 		if err != nil {
@@ -212,10 +196,6 @@ func (d *DisableStorageClassTest) VerifyAllowExpansion(expected bool, retry func
 		if allowExpansion == expected {
 			e2e.Logf("AllowVolumeExpansion matched %t after %d attempts", expected, maxRetries)
 			return
-		}
-		if retry != nil {
-			e2e.Logf("VerifyAllowExpansion calling retry after %d attempts", i)
-			retry()
 		}
 		time.Sleep(sleepInterval * time.Second)
 	}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -16407,8 +16407,6 @@ var Annotations = map[string]string{
 
 	"[sig-storage][Feature:CSIInlineVolumeAdmission][Serial] restricted namespace should deny pods with inline volumes when the driver uses the privileged label": " [Suite:openshift/conformance/serial]",
 
-	"[sig-storage][Feature:DisableStorageClass][Serial] should not reconcile the StorageClass when StorageClassState is Unmanaged": " [Suite:openshift/conformance/serial]",
-
 	"[sig-storage][Feature:DisableStorageClass][Serial] should reconcile the StorageClass when StorageClassState is Managed": " [Suite:openshift/conformance/serial]",
 
 	"[sig-storage][Feature:DisableStorageClass][Serial] should remove the StorageClass when StorageClassState is Removed": " [Suite:openshift/conformance/serial]",


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-7488
We are still getting test flakes for vsphere ([here](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.13/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22failed_test_names%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-storage%5D%5BFeature%3ADisableStorageClass%5D%5BSerial%5D%20should%20not%20reconcile%20the%20StorageClass%20when%20StorageClassState%20is%20Unmanaged%20%5BSuite%3Aopenshift%2Fconformance%2Fserial%5D%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Afalse%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22amd64%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ha%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&sortField=timestamp&sort=desc) and [here](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.13/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22failed_test_names%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-storage%5D%5BFeature%3ADisableStorageClass%5D%5BSerial%5D%20should%20not%20reconcile%20the%20StorageClass%20when%20StorageClassState%20is%20Unmanaged%20%5BSuite%3Aopenshift%2Fconformance%2Fserial%5D%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Afalse%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22amd64%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ha%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&sortField=timestamp&sort=desc)) after https://github.com/openshift/origin/pull/27726 merged, so this PR removes that test as suggested [here](https://github.com/openshift/origin/pull/27726#issuecomment-1432041736)
/cc @openshift/storage
