### PR TITLE
BUILD-64: Replacing `registry.redhat.io` images with equivalent images in `quay.io`

### DIFF
--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 
 		g.It("should succeed with a --name of 58 characters [apigroup:build.openshift.io]", func() {
 			g.By("calling oc new-app")
-			err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--name", a58, "--build-env=BUILD_LOGLEVEL=5").Execute()
+			err := oc.Run("new-app").Args("quay.io/app-sre/ubi8-nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--name", a58, "--build-env=BUILD_LOGLEVEL=5").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the build to complete")
@@ -81,7 +81,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 
 		g.It("should fail with a --name longer than 58 characters [apigroup:build.openshift.io]", func() {
 			g.By("calling oc new-app")
-			out, err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--name", a59).Output()
+			out, err := oc.Run("new-app").Args("quay.io/app-sre/ubi8-nodejs-16:latest:latest~https://github.com/sclorg/nodejs-ex", "--name", a59).Output()
 			o.Expect(err).To(o.HaveOccurred())
 			o.Expect(out).To(o.ContainSubstring("error: invalid name: "))
 		})
@@ -92,7 +92,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 			// Note: the imagestream used here does not matter (does not have to a valid builder) since we are not checking
 			// the output results.  Since we can't rely on the samples operator being present to install sample s2i-enabled
 			// imagestreams, just use one of the static imagestreams instead (cli:latest)
-			out, err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--image-stream=cli:latest").Output()
+			out, err := oc.Run("new-app").Args("quay.io/app-sre/ubi8-nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--image-stream=cli:latest").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(out).NotTo(o.ContainSubstring("error:"))
 		})

--- a/test/extended/builds/service.go
+++ b/test/extended/builds/service.go
@@ -44,7 +44,7 @@ RUN curl -vvv hello-nodejs:8080
 		g.Describe("with a build being created from new-build", func() {
 			g.It("should be able to run a build that references a cluster service [apigroup:build.openshift.io]", func() {
 				g.By("standing up a new hello world nodejs service via oc new-app")
-				err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex.git", "--name", "hello-nodejs").Execute()
+				err := oc.Run("new-app").Args("quay.io/app-sre/ubi8-nodejs-16:latest~https://github.com/sclorg/nodejs-ex.git", "--name", "hello-nodejs").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				err = exutil.WaitForABuild(oc.BuildClient().BuildV1().Builds(oc.Namespace()), "hello-nodejs-1", nil, nil, nil)

--- a/test/extended/testdata/builds/docker-add/docker-add-env/Dockerfile
+++ b/test/extended/testdata/builds/docker-add/docker-add-env/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.redhat.io/ubi8/ubi-minimal
+FROM quay.io/app-sre/ubi8-ubi-minimal
 ENV foo=foo
 ADD ./${foo} /tmp/foo

--- a/test/extended/testdata/builds/pullsecret/pullsecret-nodejs-bc.yaml
+++ b/test/extended/testdata/builds/pullsecret/pullsecret-nodejs-bc.yaml
@@ -11,6 +11,6 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: registry.redhat.io/ubi8/nodejs-14:latest
+        name: quay.io/app-sre/ubi8-nodejs-14:latest
       pullSecret:
         name: local-ps

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -104,7 +104,7 @@ items:
     mountTrustedCA: true
     source:
       dockerfile: |
-        FROM registry.redhat.io/ubi8/ubi:latest
+        FROM quay.io/app-sre/ubi8-ubi:latest
         RUN cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     strategy:
       dockerStrategy:

--- a/test/extended/testdata/builds/test-imagechangetriggers.yaml
+++ b/test/extended/testdata/builds/test-imagechangetriggers.yaml
@@ -10,7 +10,7 @@ items:
     - name: latest
       from:
         kind: DockerImage
-        name: registry.redhat.io/ubi8/nodejs-12:latest
+        name: quay.io/app-sre/ubi8-nodejs-12:latest
 
 - kind: BuildConfig
   apiVersion: build.openshift.io/v1


### PR DESCRIPTION
Could find mirrors for some of the images in `quay.io`, and rest were modified considering the behavior of the original image.