### PR TITLE
OCPVE-278: fix: multi build error, only add rt-tests for x86

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -7,8 +7,9 @@ RUN make; \
 
 FROM registry.ci.openshift.org/ocp/4.13:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
-RUN PACKAGES="git gzip util-linux rt-tests" && \
+RUN PACKAGES="git gzip util-linux" && \
     if [ $HOSTTYPE = x86_64 ] || [ $HOSTTYPE = ppc64le ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
+    if [ $HOSTTYPE = x86_64 ]; then PACKAGES="$PACKAGES rt-tests"; fi && \
     yum install --setopt=tsflags=nodocs -y $PACKAGES && \
     yum update -y python3-six && \
     yum clean all && rm -rf /var/cache/yum/* && \


### PR DESCRIPTION
This fixes an error encountered in the previous addition of #27740 for multi arch builds.
Currently, rt-tests are needed on only x86, this PR is limiting install only to that `HOSTTYPE`. 