### PR TITLE
Realtime Kernel Tests

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -446,6 +446,22 @@ var staticSuites = testSuites{
 		},
 		PreSuite: suiteWithProviderPreSuite,
 	},
+	{
+		TestSuite: ginkgo.TestSuite{
+			Name: "openshift/nodes/realtime",
+			Description: templates.LongDesc(`
+		This test suite runs tests to validate realtime functionality on nodes.
+		`),
+			Matches: func(name string) bool {
+				if isDisabled(name) {
+					return false
+				}
+				return strings.Contains(name, "[Suite:openshift/nodes/realtime")
+			},
+			TestTimeout: 30 * time.Minute,
+		},
+		PreSuite: suiteWithProviderPreSuite,
+	},
 }
 
 // isStandardEarlyTest returns true if a test is considered part of the normal

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/images"
 	_ "github.com/openshift/origin/test/extended/images/trigger"
 	_ "github.com/openshift/origin/test/extended/jobs"
+	_ "github.com/openshift/origin/test/extended/kernel"
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
 	_ "github.com/openshift/origin/test/extended/oauth"

--- a/test/extended/kernel/common.go
+++ b/test/extended/kernel/common.go
@@ -1,0 +1,95 @@
+package kernel
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var (
+	realTimeKernelRE = regexp.MustCompile(".*.rt[0-9]+.[0-9]+..*")
+	rtEnvFixture     = exutil.FixturePath("testdata", "kernel", "rt-tests-environment.yaml")
+	rtPodFixture     = exutil.FixturePath("testdata", "kernel", "rt-tests-pod.yaml")
+	rtNamespace      = "ci-realtime-testbed"
+	rtPodName        = "rt-tests"
+)
+
+func failIfNotRT(oc *exutil.CLI) {
+	g.By("checking kernel configuration")
+
+	rtNodes, err := getRealTimeWorkerNodes(oc)
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to retrieve realtime worker nodes")
+	o.Expect(len(rtNodes)).NotTo(o.BeZero(), "no realtime nodes are configured")
+}
+
+func getRealTimeWorkerNodes(oc *exutil.CLI) (nodes map[string]int, err error) {
+	nodes = make(map[string]int)
+
+	kubeNodes, err := oc.AsAdmin().KubeClient().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker="})
+	if err != nil {
+		return nodes, err
+	}
+
+	for _, node := range kubeNodes.Items {
+		if realTimeKernelRE.MatchString(node.Status.NodeInfo.KernelVersion) {
+			nodes[node.Name] = 0
+		}
+	}
+
+	return nodes, nil
+}
+
+// Setup the cluster infra needed for running RT tests
+func configureRealtimeTestEnvironment(oc *exutil.CLI) {
+	g.By("Setting up the privileged environment needed for realtime tests")
+	err := oc.SetNamespace(rtNamespace).Run("apply").Args("-f", rtEnvFixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to create namespace and service accounts for rt-tests")
+}
+
+// Tear down the infra setup we used for testing
+func cleanupRealtimeTestEnvironment(oc *exutil.CLI) {
+	g.By("Cleaning up the privileged environment needed for realtime tests")
+	err := oc.SetNamespace(rtNamespace).Run("delete").Args("-f", rtEnvFixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to clean up the namespace and service accounts for rt-tests")
+
+	err = wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
+		_, err := oc.AsAdmin().ProjectClient().ProjectV1().Projects().Get(context.Background(), rtNamespace, metav1.GetOptions{})
+
+		if err != nil && apierrors.IsNotFound(err) {
+			return true, nil
+		}
+
+		return false, err
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out cleaning up the namespace and service accounts for rt-tests")
+}
+
+// Setup the pod that will be used to run the test
+func startRtTestPod(oc *exutil.CLI) {
+	g.By("Setting up the pod needed for realtime tests")
+	err := oc.SetNamespace(rtNamespace).Run("apply").Args("-f", rtPodFixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to create test pod for rt-tests")
+
+	// Wait for the container to be ready to go
+	_, err = exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(rtNamespace), labels.Everything(), exutil.CheckPodIsRunning, 1, 5*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred(), "test pod for rt-tests never became ready")
+}
+
+// Cleanup the pod used for the test
+func cleanupRtTestPod(oc *exutil.CLI) {
+	g.By("Cleaning up the pod needed for realtime tests")
+	err := oc.SetNamespace(rtNamespace).Run("delete").Args("-f", rtPodFixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to clean up test pod for rt-tests")
+
+	// Wait for the container to be ready to go
+	err = exutil.WaitForNoPodsRunning(oc.SetNamespace(rtNamespace))
+	o.Expect(err).NotTo(o.HaveOccurred(), "test pod for rt-tests never became ready")
+}

--- a/test/extended/kernel/kernel_rt_pi_stress.go
+++ b/test/extended/kernel/kernel_rt_pi_stress.go
@@ -1,0 +1,50 @@
+package kernel
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow", g.Ordered, func() {
+	defer g.GinkgoRecover()
+	var (
+		oc = exutil.NewCLI(rtNamespace).AsAdmin()
+	)
+
+	g.BeforeAll(func() {
+		failIfNotRT(oc)
+		configureRealtimeTestEnvironment(oc)
+	})
+
+	g.BeforeEach(func() {
+		startRtTestPod(oc)
+	})
+
+	g.It("pi_stress to run successfully with the default algorithm", func() {
+		args := []string{rtPodName, "--", "pi_stress", "--duration=600", "--groups=1"}
+		_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the fifo algorithm")
+	})
+
+	g.It("pi_stress to run successfully with the round robin algorithm", func() {
+		args := []string{rtPodName, "--", "pi_stress", "--duration=600", "--groups=1", "--rr"}
+		_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the round robin algorithm")
+	})
+
+	g.It("deadline_test to run successfully", func() {
+		args := []string{rtPodName, "--", "deadline_test"}
+		_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running deadline_test")
+	})
+
+	g.AfterEach(func() {
+		cleanupRtTestPod(oc)
+	})
+
+	g.AfterAll(func() {
+		cleanupRealtimeTestEnvironment(oc)
+	})
+
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -336,6 +336,8 @@
 // test/extended/testdata/image_ecosystem/perl-hotdeploy/index.pl
 // test/extended/testdata/image_ecosystem/perl-hotdeploy/lib/My/Test.pm
 // test/extended/testdata/image_ecosystem/perl-hotdeploy/perl.json
+// test/extended/testdata/kernel/rt-tests-environment.yaml
+// test/extended/testdata/kernel/rt-tests-pod.yaml
 // test/extended/testdata/ldap/groupsync/ad/blacklist_ldap.txt
 // test/extended/testdata/ldap/groupsync/ad/blacklist_openshift.txt
 // test/extended/testdata/ldap/groupsync/ad/ldapgroupuids.txt
@@ -41821,6 +41823,104 @@ func testExtendedTestdataImage_ecosystemPerlHotdeployPerlJson() (*asset, error) 
 	return a, nil
 }
 
+var _testExtendedTestdataKernelRtTestsEnvironmentYaml = []byte(`kind: Project
+apiVersion: project.openshift.io/v1
+metadata:
+  name: ci-realtime-testbed
+  labels:
+    kubernetes.io/metadata.name: rt-tests
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  annotations:
+    workload.openshift.io/allowed: management
+    openshift.io/node-selector: "node-role.kubernetes.io/worker="
+spec: {}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rt-tests
+  namespace: ci-realtime-testbed
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:scc:privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: rt-tests
+    namespace: ci-realtime-testbed`)
+
+func testExtendedTestdataKernelRtTestsEnvironmentYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataKernelRtTestsEnvironmentYaml, nil
+}
+
+func testExtendedTestdataKernelRtTestsEnvironmentYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataKernelRtTestsEnvironmentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/kernel/rt-tests-environment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataKernelRtTestsPodYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: rt-tests
+  namespace: ci-realtime-testbed
+spec:
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  volumes:
+  - name: host
+    hostPath:
+      path: /sys/kernel/debug
+      type: Directory
+  containers:
+    - name: rt-tests
+      image: image-registry.openshift-image-registry.svc:5000/openshift/tests
+      command:
+        - "sh"
+        - "-c"
+        - "sleep 999999"
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /sys/kernel/debug
+        name: host
+  serviceAccount: rt-tests
+  serviceAccountName: rt-tests
+  terminationGracePeriodSeconds: 30`)
+
+func testExtendedTestdataKernelRtTestsPodYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataKernelRtTestsPodYaml, nil
+}
+
+func testExtendedTestdataKernelRtTestsPodYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataKernelRtTestsPodYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/kernel/rt-tests-pod.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataLdapGroupsyncAdBlacklist_ldapTxt = []byte(`group1
 group3
 `)
@@ -50081,6 +50181,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/image_ecosystem/perl-hotdeploy/index.pl":                                         testExtendedTestdataImage_ecosystemPerlHotdeployIndexPl,
 	"test/extended/testdata/image_ecosystem/perl-hotdeploy/lib/My/Test.pm":                                   testExtendedTestdataImage_ecosystemPerlHotdeployLibMyTestPm,
 	"test/extended/testdata/image_ecosystem/perl-hotdeploy/perl.json":                                        testExtendedTestdataImage_ecosystemPerlHotdeployPerlJson,
+	"test/extended/testdata/kernel/rt-tests-environment.yaml":                                                testExtendedTestdataKernelRtTestsEnvironmentYaml,
+	"test/extended/testdata/kernel/rt-tests-pod.yaml":                                                        testExtendedTestdataKernelRtTestsPodYaml,
 	"test/extended/testdata/ldap/groupsync/ad/blacklist_ldap.txt":                                            testExtendedTestdataLdapGroupsyncAdBlacklist_ldapTxt,
 	"test/extended/testdata/ldap/groupsync/ad/blacklist_openshift.txt":                                       testExtendedTestdataLdapGroupsyncAdBlacklist_openshiftTxt,
 	"test/extended/testdata/ldap/groupsync/ad/ldapgroupuids.txt":                                             testExtendedTestdataLdapGroupsyncAdLdapgroupuidsTxt,
@@ -50776,6 +50878,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						}},
 						"perl.json": {testExtendedTestdataImage_ecosystemPerlHotdeployPerlJson, map[string]*bintree{}},
 					}},
+				}},
+				"kernel": {nil, map[string]*bintree{
+					"rt-tests-environment.yaml": {testExtendedTestdataKernelRtTestsEnvironmentYaml, map[string]*bintree{}},
+					"rt-tests-pod.yaml":         {testExtendedTestdataKernelRtTestsPodYaml, map[string]*bintree{}},
 				}},
 				"ldap": {nil, map[string]*bintree{
 					"groupsync": {nil, map[string]*bintree{

--- a/test/extended/testdata/kernel/rt-tests-environment.yaml
+++ b/test/extended/testdata/kernel/rt-tests-environment.yaml
@@ -1,0 +1,36 @@
+kind: Project
+apiVersion: project.openshift.io/v1
+metadata:
+  name: ci-realtime-testbed
+  labels:
+    kubernetes.io/metadata.name: rt-tests
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  annotations:
+    workload.openshift.io/allowed: management
+    openshift.io/node-selector: "node-role.kubernetes.io/worker="
+spec: {}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rt-tests
+  namespace: ci-realtime-testbed
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:scc:privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: rt-tests
+    namespace: ci-realtime-testbed

--- a/test/extended/testdata/kernel/rt-tests-pod.yaml
+++ b/test/extended/testdata/kernel/rt-tests-pod.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rt-tests
+  namespace: ci-realtime-testbed
+spec:
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  volumes:
+  - name: host
+    hostPath:
+      path: /sys/kernel/debug
+      type: Directory
+  containers:
+    - name: rt-tests
+      image: image-registry.openshift-image-registry.svc:5000/openshift/tests
+      command:
+        - "sh"
+        - "-c"
+        - "sleep 999999"
+      resources: {}
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /sys/kernel/debug
+        name: host
+  serviceAccount: rt-tests
+  serviceAccountName: rt-tests
+  terminationGracePeriodSeconds: 30

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -3063,6 +3063,12 @@ var Annotations = map[string]string{
 
 	"[sig-node][Late] should not have pod creation failures due to systemd timeouts": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow deadline_test to run successfully": " [Serial]",
+
+	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the default algorithm": " [Serial]",
+
+	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the round robin algorithm": " [Serial]",
+
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-operator] OLM should be installed with catalogsources at version v1alpha1 [apigroup:operators.coreos.com]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This PR adds a few tests in that validate some realtime kernel tests can still be run when the realtime kernel is active. The tests are grouped into a new realtime specific test suite