### PR TITLE
Switch to readyz path for health probes on Azure

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -142,7 +142,9 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"] = "8"
 		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold"] = "3"
 		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold"] = "2"
-		// - Azure is hardcoded to 15s (2 failed with 5s interval in 1.17) and is sufficient
+		// - Azure is hardcoded to 15s (2 failed with 5s interval in 1.17) and is sufficient, however, it
+		// is testing against the `/healthz` path by default, switch to the `/readyz` path
+		s.Annotations[fmt.Sprintf("service.beta.kubernetes.io/port_%d_health-probe_request-path", s.Spec.Ports[0].Port)] = "/readyz"
 		// - GCP has a non-configurable interval of 32s (3 failed health checks with 8s interval in 1.17)
 		//   - thus pods need to stay up for > 32s, so pod shutdown period will will be 45s
 	})


### PR DESCRIPTION
This is related to the Azure load balancer incident that is currently ongoing.

We believe the readyz is failing correctly for 30s during graceful termination before the pods are actually moved, so we should be able to test the Azure load balancer is correctly removing unhealthy instances before the end of the graceful termination.

We don't currently have any concrete evidence that `/healthz` works or not so, this may not change anything, but it would help us to narrow down the search hopefully