### PR TITLE
Extract Liveness intervals from Kubelet logs

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -142,6 +142,13 @@
         return false
     }
 
+    function isKubeletLivenessCheck(eventInterval) {
+        if (eventInterval.locator.includes("container/") && (eventInterval.message.includes("reason/LivenessFailed") || eventInterval.message.includes("reason/LivenessErrored"))) {
+            return true
+        }
+        return false
+    }
+
     function isKubeletReadinessCheck(eventInterval) {
         if (eventInterval.locator.includes("container/") && (eventInterval.message.includes("reason/ReadinessFailed") || eventInterval.message.includes("reason/ReadinessErrored"))) {
             return true
@@ -250,6 +257,14 @@
             }
             if (m[2] == "Ready") {
                 return [item.locator, ` (container readiness)`, "ContainerReady"];
+            }
+        }
+        if (m && isKubeletLivenessCheck(item)){
+            if (m[2] == "LivenessFailed") {
+                return [item.locator, ` (kubelet container liveness)`, "ContainerLivenessFailed"];
+            }
+            if (m[2] == "LivenessErrored") {
+                return [item.locator, ` (kubelet container liveness)`, "ContainerLivenessErrored"];
             }
         }
         if (m && isKubeletReadinessCheck(item)){

--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -225,7 +225,7 @@ func extractProbeInterval(probeCheck, probeTypeCheck string, outputRegex *regexp
 				Message: monitorapi.ReasonedMessage(reason, message),
 			},
 			From: failureTime,
-			To:   failureTime,
+			To:   failureTime.Add(time.Second),
 		},
 	}
 }

--- a/pkg/monitor/intervalcreation/node_test.go
+++ b/pkg/monitor/intervalcreation/node_test.go
@@ -86,6 +86,32 @@ func TestMonitorApiIntervals(t *testing.T) {
 			},
 		},
 		{
+			name:    "simple liveness failure",
+			logLine: `Jul 05 17:47:52.807876 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: I0606 17:47:52.807876    1599 prober.go:121] "Probe failed" probeType="Liveness" pod="openshift-authentication/oauth-openshift-77f7b95df5-r4xf7" podUID=1af660b3-ac3a-4182-86eb-2f74725d8415 containerName="oauth-openshift" probeResult=failure output="Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   monitorapi.Info,
+					Locator: "ns/openshift-authentication pod/oauth-openshift-77f7b95df5-r4xf7 uid/1af660b3-ac3a-4182-86eb-2f74725d8415 container/oauth-openshift",
+					Message: "reason/LivenessFailed Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+				},
+				From: kubeletLogTime("Jul 05 17:47:52.807876"),
+				To:   kubeletLogTime("Jul 05 17:47:52.807876"),
+			},
+		},
+		{
+			name:    "simple liveness error",
+			logLine: `Jul 05 17:43:12.908344 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: E0606 17:43:12.908344    1500 prober.go:118] "Probe errored" err="rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found" probeType="Liveness" pod="openshift-marketplace/redhat-operators-4jpg4" podUID=0bac4741-a3bd-483c-b119-e97663d64024 containerName="registry-server"`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   monitorapi.Info,
+					Locator: "ns/openshift-marketplace pod/redhat-operators-4jpg4 uid/0bac4741-a3bd-483c-b119-e97663d64024 container/registry-server",
+					Message: "reason/LivenessErrored rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found",
+				},
+				From: kubeletLogTime("Jul 05 17:43:12.908344"),
+				To:   kubeletLogTime("Jul 05 17:43:12.908344"),
+			},
+		},
+		{
 			name:    "signature error",
 			logLine: `Feb 01 05:37:45.731611 ci-op-vyccmv3h-4ef92-xs5k5-master-0 kubenswrapper[2213]: E0201 05:37:45.730879 2213 pod_workers.go:965] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"oauth-proxy\" with ErrImagePull: \"rpc error: code = Unknown desc = copying system image from manifest list: reading signatures: parsing signature https://registry.redhat.io/containers/sigstore/openshift4/ose-oauth-proxy@sha256=f968922564c3eea1c69d6bbe529d8970784d6cae8935afaf674d9fa7c0f72ea3/signature-9: unrecognized signature format, starting with binary 0x3c\"" pod="openshift-e2e-loki/loki-promtail-plm74" podUID=59b26cbf-3421-407c-98ee-986b5a091ef4`,
 			want: monitorapi.EventInterval{

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -116,6 +116,8 @@ const (
 	ContainerReasonContainerExit      = "ContainerExit"
 	ContainerReasonContainerStart     = "ContainerStart"
 	ContainerReasonContainerWait      = "ContainerWait"
+	ContainerReasonLivenessFailed     = "LivenessFailed"
+	ContainerReasonLivenessErrored    = "LivenessErrored"
 	ContainerReasonReadinessFailed    = "ReadinessFailed"
 	ContainerReasonReadinessErrored   = "ReadinessErrored"
 	ContainerReasonStartupProbeFailed = "StartupProbeFailed"

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -49434,6 +49434,13 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return false
     }
 
+    function isKubeletLivenessCheck(eventInterval) {
+        if (eventInterval.locator.includes("container/") && (eventInterval.message.includes("reason/LivenessFailed") || eventInterval.message.includes("reason/LivenessErrored"))) {
+            return true
+        }
+        return false
+    }
+
     function isKubeletReadinessCheck(eventInterval) {
         if (eventInterval.locator.includes("container/") && (eventInterval.message.includes("reason/ReadinessFailed") || eventInterval.message.includes("reason/ReadinessErrored"))) {
             return true
@@ -49542,6 +49549,14 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             }
             if (m[2] == "Ready") {
                 return [item.locator, ` + "`" + ` (container readiness)` + "`" + `, "ContainerReady"];
+            }
+        }
+        if (m && isKubeletLivenessCheck(item)){
+            if (m[2] == "LivenessFailed") {
+                return [item.locator, ` + "`" + ` (kubelet container liveness)` + "`" + `, "ContainerLivenessFailed"];
+            }
+            if (m[2] == "LivenessErrored") {
+                return [item.locator, ` + "`" + ` (kubelet container liveness)` + "`" + `, "ContainerLivenessErrored"];
             }
         }
         if (m && isKubeletReadinessCheck(item)){


### PR DESCRIPTION
We already extract the readiness intervals, but we aren't extracting the liveness intervals at present.
This PR add liveness interval extraction over two commits, the first duplicates the existing readiness checks to match for the liveness probes, the second deduplicates the code. Not sure if we want to keep the second or not, will leave that to maintainers to decide.

Upshot of this though, is we should be able then to see failures in the liveness endpoints and compare these with the readiness failures