### PR TITLE
PSa podspec exporter e2e: don't specifically add seccompProfile to the podspec

### DIFF
--- a/test/extended/authorization/podsecurity_admission.go
+++ b/test/extended/authorization/podsecurity_admission.go
@@ -154,11 +154,6 @@ var _ = g.Describe("[sig-auth][Feature:PodSecurity][Feature:SCC]", func() {
 									Containers: []corev1.Container{
 										tt.container,
 									},
-									SecurityContext: &corev1.PodSecurityContext{
-										SeccompProfile: &corev1.SeccompProfile{
-											Type: corev1.SeccompProfileTypeRuntimeDefault,
-										},
-									},
 								},
 							},
 						},


### PR DESCRIPTION
The restricted-v2 SCC should mutate this instead.

/cc @openshift/openshift-team-auth @deads2k 