### PR TITLE
[release-4.12] OCPBUGS-8024: Backport fixes to resume gathering CI disruption data for SLB and image registry

### DIFF
--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -175,10 +175,6 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 
 	allowedDisruption, disruptionDetails, err := t.getAllowedDisruption(f)
 	framework.ExpectNoError(err)
-	if allowedDisruption == nil {
-		framework.Logf(fmt.Sprintf("Skipping: %s: No historical data", t.testName))
-		return
-	}
 
 	end := time.Now()
 
@@ -187,7 +183,8 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 	ginkgo.By(fmt.Sprintf("writing results: %s", t.backend.GetLocator()))
 	ExpectNoDisruptionForDuration(
 		f,
-		*allowedDisruption,
+		t.testName,
+		allowedDisruption,
 		end.Sub(start),
 		events,
 		fmt.Sprintf("%s was unreachable during disruption: %v", t.backend.GetLocator(), disruptionDetails),

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -134,13 +134,6 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	allowedDisruption, disruptionDetails, err := t.getAllowedDisruption(f)
-	framework.ExpectNoError(err)
-	if allowedDisruption == nil {
-		framework.Logf(fmt.Sprintf("Skipping: %s: No historical data", t.testName))
-		return
-	}
-
 	newBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: f.ClientSet.EventsV1()})
 	eventRecorder := newBroadcaster.NewRecorder(scheme.Scheme, "openshift.io/"+t.backend.GetDisruptionBackendName())
 	newBroadcaster.StartRecordingToSink(stopCh)
@@ -178,6 +171,13 @@ func (t *backendDisruptionTest) Test(f *framework.Framework, done <-chan struct{
 	}
 	if disruptionErr != nil {
 		framework.Logf(fmt.Sprintf("unable to finish: %s", t.backend.GetLocator()))
+	}
+
+	allowedDisruption, disruptionDetails, err := t.getAllowedDisruption(f)
+	framework.ExpectNoError(err)
+	if allowedDisruption == nil {
+		framework.Logf(fmt.Sprintf("Skipping: %s: No historical data", t.testName))
+		return
 	}
 
 	end := time.Now()

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -94,6 +94,7 @@ func (t *backendDisruptionTest) historicalAllowedDisruption(f *framework.Framewo
 	if err != nil {
 		return nil, "", err
 	}
+	framework.Logf("checking allowed disruption for job type: %+v", *jobType)
 
 	return allowedbackenddisruption.GetAllowedDisruption(backendName, *jobType)
 }

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -323,16 +323,26 @@ func createTestFrameworks(tests []upgrades.Test) map[string]*framework.Framework
 
 // ExpectNoDisruptionForDuration fails if the sum of the duration of all events exceeds allowedDisruption, reports a
 // disruption flake if any disruption occurs, and uses reason to prefix the message.
-func ExpectNoDisruptionForDuration(f *framework.Framework, allowedDisruption time.Duration, total time.Duration, events monitorapi.Intervals, reason string) {
+func ExpectNoDisruptionForDuration(f *framework.Framework, testName string, allowedDisruption *time.Duration, total time.Duration, events monitorapi.Intervals, reason string) {
+	// This step records the test summaries data we need to result in AdditionalEvents json files in
+	// the openshift-e2e-test artifacts.
 	FrameworkEventIntervals(f, events)
 	describe := events.Strings()
+
+	// Indicates there is no entry in the query_results.json data file, nor a valid fallback,
+	// we do not wish to run the test. (this likely implies we do not have the required number of
+	// runs in 3 weeks to do a reliable P99)
+	if allowedDisruption == nil {
+		framework.Logf(fmt.Sprintf("Skipping: %s: No historical data to calculate allowedDisruption", testName))
+		return
+	}
 
 	errorEvents := events.Filter(monitorapi.IsErrorEvent)
 	disruptionDuration := errorEvents.Duration(1 * time.Second)
 	roundedAllowedDisruption := allowedDisruption.Round(time.Second)
 	if allowedDisruption.Milliseconds() == DefaultAllowedDisruption {
 		// don't round if we're using the default value so we can find this.
-		roundedAllowedDisruption = allowedDisruption
+		roundedAllowedDisruption = *allowedDisruption
 	}
 	roundedDisruptionDuration := disruptionDuration.Round(time.Second)
 	if roundedDisruptionDuration > roundedAllowedDisruption {


### PR DESCRIPTION
These three commits were part of #27636 and #27651 which fixed a problem where we stopped collecting disruption data for these two backends in CI testing. Unfortunately the fix was not backported to 4.12 when we discovered it. This corrects that.

[TRT-825](https://issues.redhat.com//browse/TRT-825)