### PR TITLE
move disruption locators to monitorapi

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
@@ -44,7 +44,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 
 	type fields struct {
 		disruptionBackendName string
-		connectionType        BackendConnectionType
+		connectionType        monitorapi.BackendConnectionType
 		path                  string
 		expect                string
 		expectRegexp          string
@@ -60,7 +60,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 			name: "simple-200",
 			fields: fields{
 				disruptionBackendName: "simple-200",
-				connectionType:        NewConnectionType,
+				connectionType:        monitorapi.NewConnectionType,
 				path:                  "/200",
 				expect:                "200",
 			},
@@ -70,7 +70,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 			name: "200-bad-exect",
 			fields: fields{
 				disruptionBackendName: "simple-200",
-				connectionType:        NewConnectionType,
+				connectionType:        monitorapi.NewConnectionType,
 				path:                  "/200",
 				expect:                "other",
 			},
@@ -81,7 +81,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 			name: "302-no-expect-bad-response",
 			fields: fields{
 				disruptionBackendName: "302-bad-response",
-				connectionType:        NewConnectionType,
+				connectionType:        monitorapi.NewConnectionType,
 				path:                  "/302-bad-response",
 			},
 			// TODO: should this be error when Location header is not set?
@@ -91,7 +91,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 			name: "302-no-expect",
 			fields: fields{
 				disruptionBackendName: "302",
-				connectionType:        NewConnectionType,
+				connectionType:        monitorapi.NewConnectionType,
 				path:                  "/302",
 			},
 			wantErr: false,
@@ -100,7 +100,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 			name: "503",
 			fields: fields{
 				disruptionBackendName: "503",
-				connectionType:        NewConnectionType,
+				connectionType:        monitorapi.NewConnectionType,
 				path:                  "/503",
 			},
 			wantErr: true,
@@ -109,7 +109,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 			name: "timeout",
 			fields: fields{
 				disruptionBackendName: "timeout",
-				connectionType:        NewConnectionType,
+				connectionType:        monitorapi.NewConnectionType,
 				path:                  "/timeout",
 			},
 			wantErr: true,
@@ -118,7 +118,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 			name: "cancel-immediately",
 			fields: fields{
 				disruptionBackendName: "timeout",
-				connectionType:        NewConnectionType,
+				connectionType:        monitorapi.NewConnectionType,
 				path:                  "/timeout",
 				cancelImmediately:     true,
 			},
@@ -335,7 +335,7 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			parent := NewSimpleBackend("host", "backend", "path", NewConnectionType)
+			parent := NewSimpleBackend("host", "backend", "path", monitorapi.NewConnectionType)
 			backendSampler := newDisruptionSampler(parent)
 			interval := 1 * time.Second
 			monitor := newSimpleMonitor()

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -6,6 +6,21 @@ import (
 	"strings"
 )
 
+type BackendConnectionType string
+
+const (
+	NewConnectionType    BackendConnectionType = "new"
+	ReusedConnectionType BackendConnectionType = "reused"
+)
+
+func LocateRouteForDisruptionCheck(ns, name, disruptionBackendName string, connectionType BackendConnectionType) string {
+	return fmt.Sprintf("ns/%s route/%s disruption/%s connection/%s", ns, name, disruptionBackendName, connectionType)
+}
+
+func LocateDisruptionCheck(disruptionBackendName string, connectionType BackendConnectionType) string {
+	return fmt.Sprintf("disruption/%s connection/%s", disruptionBackendName, connectionType)
+}
+
 func E2ETestLocator(testName string) string {
 	return fmt.Sprintf("e2e-test/%q", testName)
 }

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+
 	"github.com/onsi/ginkgo/v2"
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -45,7 +47,7 @@ func NewServiceLoadBalancerWithNewConnectionsTest() upgrades.Test {
 				serviceLBTest.hostGetter,
 				"service-load-balancer-with-pdb",
 				"/echo?msg=Hello",
-				backenddisruption.NewConnectionType).
+				monitorapi.NewConnectionType).
 				WithExpectedBody("Hello"),
 		).
 			WithPreSetup(serviceLBTest.loadBalancerSetup)
@@ -64,7 +66,7 @@ func NewServiceLoadBalancerWithReusedConnectionsTest() upgrades.Test {
 				serviceLBTest.hostGetter,
 				"service-load-balancer-with-pdb",
 				"/echo?msg=Hello",
-				backenddisruption.ReusedConnectionType).
+				monitorapi.ReusedConnectionType).
 				WithExpectedBody("Hello"),
 		).
 			WithPreSetup(serviceLBTest.loadBalancerSetup)

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/synthetictests/allowedbackenddisruption"
+	"github.com/openshift/origin/pkg/synthetictests/platformidentification"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -18,7 +18,7 @@ import (
 )
 
 type BackendSampler interface {
-	GetConnectionType() backenddisruption.BackendConnectionType
+	GetConnectionType() monitorapi.BackendConnectionType
 	GetDisruptionBackendName() string
 	GetLocator() string
 	GetURL() (string, error)

--- a/test/extended/util/disruption/controlplane/known_backends.go
+++ b/test/extended/util/disruption/controlplane/known_backends.go
@@ -4,9 +4,8 @@ import (
 	"context"
 
 	"github.com/openshift/origin/pkg/monitor"
-
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
-
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"k8s.io/client-go/rest"
 )
 
@@ -147,70 +146,70 @@ func startOAuthAPIMonitoringWithConnectionReuseAgainstAPICache(ctx context.Conte
 }
 
 func createKubeAPIMonitoringWithNewConnections(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
-	return createAPIServerBackendSampler(clusterConfig, "kube-api", "/api/v1/namespaces/default", backenddisruption.NewConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "kube-api", "/api/v1/namespaces/default", monitorapi.NewConnectionType)
 }
 
 func createKubeAPIMonitoringWithNewConnectionsAgainstAPICache(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// by setting resourceVersion="0" we instruct the server to get the data from the memory cache and avoid contacting with the etcd.
-	return createAPIServerBackendSampler(clusterConfig, "cache-kube-api", "/api/v1/namespaces/default?resourceVersion=0", backenddisruption.NewConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "cache-kube-api", "/api/v1/namespaces/default?resourceVersion=0", monitorapi.NewConnectionType)
 }
 
 func createOpenShiftAPIMonitoringWithNewConnections(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// this request should never 404, but should be empty/small
-	return createAPIServerBackendSampler(clusterConfig, "openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams", backenddisruption.NewConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams", monitorapi.NewConnectionType)
 }
 
 func createOpenShiftAPIMonitoringWithNewConnectionsAgainstAPICache(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// by setting resourceVersion="0" we instruct the server to get the data from the memory cache and avoid contacting with the etcd.
 	// this request should never 404, but should be empty/small
-	return createAPIServerBackendSampler(clusterConfig, "cache-openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams?resourceVersion=0", backenddisruption.NewConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "cache-openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams?resourceVersion=0", monitorapi.NewConnectionType)
 }
 
 func createOAuthAPIMonitoringWithNewConnections(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// this should be relatively small and should not ever 404
-	return createAPIServerBackendSampler(clusterConfig, "oauth-api", "/apis/oauth.openshift.io/v1/oauthclients", backenddisruption.NewConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "oauth-api", "/apis/oauth.openshift.io/v1/oauthclients", monitorapi.NewConnectionType)
 }
 
 func createOAuthAPIMonitoringWithNewConnectionsAgainstAPICache(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// by setting resourceVersion="0" we instruct the server to get the data from the memory cache and avoid contacting with the etcd.
 	// this should be relatively small and should not ever 404
-	return createAPIServerBackendSampler(clusterConfig, "cache-oauth-api", "/apis/oauth.openshift.io/v1/oauthclients?resourceVersion=0", backenddisruption.NewConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "cache-oauth-api", "/apis/oauth.openshift.io/v1/oauthclients?resourceVersion=0", monitorapi.NewConnectionType)
 }
 
 func createKubeAPIMonitoringWithConnectionReuse(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// default gets auto-created, so this should always exist
-	return createAPIServerBackendSampler(clusterConfig, "kube-api", "/api/v1/namespaces/default", backenddisruption.ReusedConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "kube-api", "/api/v1/namespaces/default", monitorapi.ReusedConnectionType)
 }
 
 func createKubeAPIMonitoringWithConnectionReuseAgainstAPICache(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// by setting resourceVersion="0" we instruct the server to get the data from the memory cache and avoid contacting with the etcd.
 	// default gets auto-created, so this should always exist
-	return createAPIServerBackendSampler(clusterConfig, "cache-kube-api", "/api/v1/namespaces/default?resourceVersion=0", backenddisruption.ReusedConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "cache-kube-api", "/api/v1/namespaces/default?resourceVersion=0", monitorapi.ReusedConnectionType)
 }
 
 func createOpenShiftAPIMonitoringWithConnectionReuse(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// this request should never 404, but should be empty/small
-	return createAPIServerBackendSampler(clusterConfig, "openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams", backenddisruption.ReusedConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams", monitorapi.ReusedConnectionType)
 }
 
 func createOpenShiftAPIMonitoringWithConnectionReuseAgainstAPICache(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// by setting resourceVersion="0" we instruct the server to get the data from the memory cache and avoid contacting with the etcd.
 	// this request should never 404, but should be empty/small
-	return createAPIServerBackendSampler(clusterConfig, "cache-openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams?resourceVersion=0", backenddisruption.ReusedConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "cache-openshift-api", "/apis/image.openshift.io/v1/namespaces/default/imagestreams?resourceVersion=0", monitorapi.ReusedConnectionType)
 }
 
 func createOAuthAPIMonitoringWithConnectionReuse(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// this should be relatively small and should not ever 404
-	return createAPIServerBackendSampler(clusterConfig, "oauth-api", "/apis/oauth.openshift.io/v1/oauthclients", backenddisruption.ReusedConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "oauth-api", "/apis/oauth.openshift.io/v1/oauthclients", monitorapi.ReusedConnectionType)
 }
 
 func createOAuthAPIMonitoringWithConnectionReuseAgainstAPICache(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {
 	// by setting resourceVersion="0" we instruct the server to get the data from the memory cache and avoid contacting with the etcd.
 	// this should be relatively small and should not ever 404
-	return createAPIServerBackendSampler(clusterConfig, "cache-oauth-api", "/apis/oauth.openshift.io/v1/oauthclients?resourceVersion=0", backenddisruption.ReusedConnectionType)
+	return createAPIServerBackendSampler(clusterConfig, "cache-oauth-api", "/apis/oauth.openshift.io/v1/oauthclients?resourceVersion=0", monitorapi.ReusedConnectionType)
 }
 
-func createAPIServerBackendSampler(clusterConfig *rest.Config, disruptionBackendName, url string, connectionType backenddisruption.BackendConnectionType) (*backenddisruption.BackendSampler, error) {
+func createAPIServerBackendSampler(clusterConfig *rest.Config, disruptionBackendName, url string, connectionType monitorapi.BackendConnectionType) (*backenddisruption.BackendSampler, error) {
 	// default gets auto-created, so this should always exist
 	backendSampler, err := backenddisruption.NewAPIServerBackend(clusterConfig, disruptionBackendName, url, connectionType)
 	if err != nil {

--- a/test/extended/util/disruption/externalservice/known_backends.go
+++ b/test/extended/util/disruption/externalservice/known_backends.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"k8s.io/client-go/rest"
 )
 
@@ -32,7 +33,7 @@ func startExternalServiceMonitoringWithNewConnections(ctx context.Context, m mon
 		externalServiceURL,
 		LivenessProbeBackend,
 		"",
-		backenddisruption.NewConnectionType)
+		monitorapi.NewConnectionType)
 	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
 }
 
@@ -41,6 +42,6 @@ func startExternalServiceMonitoringWithReusedConnections(ctx context.Context, m 
 		externalServiceURL,
 		LivenessProbeBackend,
 		"",
-		backenddisruption.ReusedConnectionType)
+		monitorapi.ReusedConnectionType)
 	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
 }

--- a/test/extended/util/disruption/frontends/known_backends.go
+++ b/test/extended/util/disruption/frontends/known_backends.go
@@ -7,6 +7,7 @@ import (
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/cluster"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -92,7 +93,7 @@ func createOAuthRouteAvailableWithNewConnections() *backenddisruption.BackendSam
 		oauthRouteName,
 		"ingress-to-oauth-server",
 		"/healthz",
-		backenddisruption.NewConnectionType).
+		monitorapi.NewConnectionType).
 		WithExpectedBody("ok")
 }
 
@@ -105,7 +106,7 @@ func createOAuthRouteAvailableWithConnectionReuse() *backenddisruption.BackendSa
 		oauthRouteName,
 		"ingress-to-oauth-server",
 		"/healthz",
-		backenddisruption.ReusedConnectionType).
+		monitorapi.ReusedConnectionType).
 		WithExpectedBody("ok")
 }
 
@@ -118,7 +119,7 @@ func createConsoleRouteAvailableWithNewConnections() *backenddisruption.BackendS
 		"console",
 		"ingress-to-console",
 		"/healthz",
-		backenddisruption.NewConnectionType).
+		monitorapi.NewConnectionType).
 		WithExpectedBodyRegex(`(Red Hat OpenShift|OKD)`)
 }
 
@@ -131,6 +132,6 @@ func createConsoleRouteAvailableWithConnectionReuse() *backenddisruption.Backend
 		"console",
 		"ingress-to-console",
 		"/healthz",
-		backenddisruption.ReusedConnectionType).
+		monitorapi.ReusedConnectionType).
 		WithExpectedBodyRegex(`(Red Hat OpenShift|OKD)`)
 }

--- a/test/extended/util/disruption/imageregistry/imageregistry.go
+++ b/test/extended/util/disruption/imageregistry/imageregistry.go
@@ -1,6 +1,7 @@
 package imageregistry
 
 import (
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/test/extended/util/imageregistryutil"
 
 	"github.com/openshift/origin/pkg/monitor"
@@ -21,7 +22,7 @@ func NewImageRegistryAvailableWithNewConnectionsTest() upgrades.Test {
 			"test-disruption-new",
 			"image-registry",
 			"/healthz",
-			backenddisruption.NewConnectionType),
+			monitorapi.NewConnectionType),
 	).
 		WithPreSetup(imageregistryutil.SetupImageRegistryFor("test-disruption-new")).
 		WithPostTeardown(imageregistryutil.TeardownImageRegistryFor("test-disruption-new"))
@@ -39,7 +40,7 @@ func NewImageRegistryAvailableWithReusedConnectionsTest() upgrades.Test {
 			"test-disruption-reused",
 			"image-registry",
 			"/healthz",
-			backenddisruption.ReusedConnectionType),
+			monitorapi.ReusedConnectionType),
 	).
 		WithPreSetup(imageregistryutil.SetupImageRegistryFor("test-disruption-reused")).
 		WithPostTeardown(imageregistryutil.TeardownImageRegistryFor("test-disruption-reused"))


### PR DESCRIPTION
refactor that makes watching load balancer availability easier.