### PR TITLE
Add legacy azure LB annotations for in-tree provider

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -145,6 +145,11 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 		// - Azure is hardcoded to 15s (2 failed with 5s interval in 1.17) and is sufficient, however, it
 		// is testing against the `/healthz` path by default, switch to the `/readyz` path
 		s.Annotations[fmt.Sprintf("service.beta.kubernetes.io/port_%d_health-probe_request-path", s.Spec.Ports[0].Port)] = "/readyz"
+		// The generic annotation should apply to all platforms, but is not supported by Azure in tree.
+		// Set azure in-tree specific annotations until we move to out of tree.
+		s.Annotations["service.beta.kubernetes.io/azure-load-balancer-health-probe-protocol"] = "HTTP"
+		s.Annotations["service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path"] = "/readyz"
+
 		// - GCP has a non-configurable interval of 32s (3 failed health checks with 8s interval in 1.17)
 		//   - thus pods need to stay up for > 32s, so pod shutdown period will will be 45s
 	})


### PR DESCRIPTION
Based on https://github.com/kubernetes/legacy-cloud-providers/blob/0faac86d4ae7d2afe56bdde583436405ab6fea4a/azure/azure_loadbalancer.go#L1596-L1611, it looks like (and I've manually tested this) within the in-tree provider, unless you explicitly set these two annotations, you will get a TCP based health check, for which, we cannot modify the health check parameters.

Based on this test, we should be checking the HTTP /readyz path, as this we can control during the graceful shutdown process.