### PR TITLE
OCPBUGS-8092: mark volume expansion test as Flaky

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -15849,7 +15849,7 @@ var Annotations = map[string]string{
 
 	"[sig-storage] Managed cluster should have no crashlooping recycler pods over four minutes": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-storage] Mounted volume expand [Feature:StorageProvider] Should verify mounted devices can be resized": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[sig-storage] Mounted volume expand [Feature:StorageProvider] Should verify mounted devices can be resized": " [Flaky] [Skipped:NoOptionalCapabilities] [Suite:k8s]",
 
 	"[sig-storage] Multi-AZ Cluster Volumes should schedule pods in the same zones as statically provisioned PVs": " [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -107,7 +107,8 @@ var (
 		"[Slow]": {},
 		// tests that are known flaky
 		"[Flaky]": {
-			`openshift mongodb replication creating from a template`, // flaking on deployment
+			`openshift mongodb replication creating from a template`,                                                         // flaking on deployment
+			`\[sig-storage\] Mounted volume expand \[Feature:StorageProvider\] Should verify mounted devices can be resized`, // https://issues.redhat.com/browse/OCPBUGS-8092
 		},
 		// tests that must be run without competition
 		"[Serial]": {


### PR DESCRIPTION
Marking the test as flaky to unblock merges. We'll continue investigating the issue.

/assign @dgoodwin 
CC @openshift/storage
