### PR TITLE
WRKLDS-657: add test for UnhealthyPodEvictionPolicy for PDBs

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/olm"
 	_ "github.com/openshift/origin/test/extended/operators"
+	_ "github.com/openshift/origin/test/extended/poddisruptionbudget"
 	_ "github.com/openshift/origin/test/extended/pods"
 	_ "github.com/openshift/origin/test/extended/project"
 	_ "github.com/openshift/origin/test/extended/prometheus"

--- a/test/extended/poddisruptionbudget/poddisruptionbudget.go
+++ b/test/extended/poddisruptionbudget/poddisruptionbudget.go
@@ -1,0 +1,318 @@
+package poddisruptionbudget
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	policyv1clientset "k8s.io/client-go/kubernetes/typed/policy/v1"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-apps] poddisruptionbudgets", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithPodSecurityLevel("poddisruptionbudgets", admissionapi.LevelRestricted)
+
+	const (
+		podBecomesReadyTimeout = 2 * time.Minute
+	)
+	const (
+		ifHealthyBudgetPDBName   = "if-healthy-budget-policy"
+		alwaysAllowPolicyPDBName = "always-allow-policy"
+	)
+
+	var (
+		nginxWithDelayedReadyDeployment = exutil.FixturePath("testdata", "poddisruptionbudgets", "nginx-with-delayed-ready-deployment.yaml")
+		ifHealthyBudgetPolicyPDB        = exutil.FixturePath("testdata", "poddisruptionbudgets", "if-healthy-budget-policy-pdb.yaml")
+		alwaysAllowPolicyPDB            = exutil.FixturePath("testdata", "poddisruptionbudgets", "always-allow-policy-pdb.yaml")
+	)
+
+	g.Describe("with unhealthyPodEvictionPolicy", func() {
+		var podsLabelSelector labels.Selector
+
+		g.BeforeEach(func() {
+			podsLabelSelector = labels.SelectorFromSet(labels.Set{"app": "nginx-with-delayed-ready"})
+		})
+
+		g.JustBeforeEach(func() {
+			//TODO remove this check once PDBUnhealthyPodEvictionPolicy is graduated to beta and enabled by default
+			if !isTechPreviewNoUpgrade(oc) {
+				g.Skip("the test is not expected to work within Tech Preview disabled clusters")
+			}
+		})
+
+		g.It(fmt.Sprintf("should evict according to the IfHealthyBudget policy"), func() {
+			g.By(fmt.Sprintf("calling oc create -f %q", ifHealthyBudgetPolicyPDB))
+			err := oc.Run("create").Args("-f", ifHealthyBudgetPolicyPDB).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("calling oc create -f %q", nginxWithDelayedReadyDeployment))
+			err = oc.Run("create").Args("-f", nginxWithDelayedReadyDeployment).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("wait for a PDB to initialize its status")
+			expectedStatus := policyv1.PodDisruptionBudgetStatus{
+				DisruptionsAllowed: 0,
+				CurrentHealthy:     0,
+				DesiredHealthy:     2,
+				ExpectedPods:       3,
+			}
+			pdb, err := waitForPDBStatus(oc.KubeClient().PolicyV1(), metav1.ObjectMeta{Name: ifHealthyBudgetPDBName, Namespace: oc.Namespace()}, e2e.PodStartTimeout, expectedStatus)
+			if err != nil {
+				g.Fail(fmt.Sprintf("error occurred while waiting for PDB status: %v\nexpected %#v, got %#v", err, expectedStatus, pdbStatus(pdb)))
+			}
+
+			g.By("wait for pods to be running")
+			pods, err := exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), podsLabelSelector, exutil.CheckPodIsRunning, 3, e2e.PodStartTimeout)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("eviction should not be possible for unready pods guarded by a PDB when none is ready")
+			for _, pod := range pods {
+				eviction := newV1Eviction(oc.Namespace(), pod, metav1.DeleteOptions{})
+				err := oc.KubeClient().PolicyV1().Evictions(oc.Namespace()).Evict(context.Background(), eviction)
+				o.Expect(err).To(o.HaveOccurred())
+			}
+
+			g.By("wait for PDB to become stable")
+			expectedStatus = policyv1.PodDisruptionBudgetStatus{
+				DisruptionsAllowed: 1,
+				CurrentHealthy:     3,
+				DesiredHealthy:     2,
+				ExpectedPods:       3,
+			}
+			pdb, err = waitForPDBStatus(oc.KubeClient().PolicyV1(), metav1.ObjectMeta{Name: ifHealthyBudgetPDBName, Namespace: oc.Namespace()}, e2e.PodStartTimeout+podBecomesReadyTimeout, expectedStatus)
+			if err != nil {
+				g.Fail(fmt.Sprintf("error occurred while waiting for PDB status: %v\nexpected %#v, got %#v", err, expectedStatus, pdbStatus(pdb)))
+			}
+
+			g.By("check pods are ready")
+			pods, err = exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), podsLabelSelector, func(pod v1.Pod) bool {
+				return exutil.CheckPodIsReady(pod) && pod.DeletionTimestamp == nil
+			}, 3, e2e.PodStartTimeout+podBecomesReadyTimeout)
+
+			shouldTerminatePods := sets.New[string]()
+
+			g.By("only one disruption of ready pods allowed")
+			firstToEvictPod := pods[0]
+			eviction := newV1Eviction(oc.Namespace(), firstToEvictPod, metav1.DeleteOptions{})
+			err = oc.KubeClient().PolicyV1().Evictions(oc.Namespace()).Evict(context.Background(), eviction)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			shouldTerminatePods.Insert(firstToEvictPod)
+
+			g.By("second eviction should not succeed")
+			secondToEvictPod := pods[1]
+			eviction = newV1Eviction(oc.Namespace(), secondToEvictPod, metav1.DeleteOptions{})
+			err = oc.KubeClient().PolicyV1().Evictions(oc.Namespace()).Evict(context.Background(), eviction)
+			o.Expect(err).To(o.HaveOccurred())
+
+			g.By("wait for the new pod to be running (running but not ready)")
+			pods, err = exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), podsLabelSelector, func(pod v1.Pod) bool {
+				return exutil.CheckPodIsRunning(pod) && !exutil.CheckPodIsReady(pod) && pod.DeletionTimestamp == nil
+			}, 1, e2e.PodStartTimeout)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("wait for PDB to update CurrentHealthy == 2 and DisruptionsAllowed == 0")
+			expectedStatus = policyv1.PodDisruptionBudgetStatus{
+				DisruptionsAllowed: 0,
+				CurrentHealthy:     2,
+				DesiredHealthy:     2,
+				ExpectedPods:       3,
+			}
+			pdb, err = waitForPDBStatus(oc.KubeClient().PolicyV1(), metav1.ObjectMeta{Name: ifHealthyBudgetPDBName, Namespace: oc.Namespace()}, e2e.PodStartTimeout, expectedStatus)
+			if err != nil {
+				g.Fail(fmt.Sprintf("error occurred while waiting for PDB status: %v\nexpected %#v, got %#v", err, expectedStatus, pdbStatus(pdb)))
+			}
+
+			g.By("eviction of the new running but not ready pod should succeed")
+			thirdNewToEvictPod := pods[0]
+			eviction = newV1Eviction(oc.Namespace(), thirdNewToEvictPod, metav1.DeleteOptions{})
+			err = oc.KubeClient().PolicyV1().Evictions(oc.Namespace()).Evict(context.Background(), eviction)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			shouldTerminatePods.Insert(thirdNewToEvictPod)
+
+			g.By("wait until all evicted pods are either gone or terminating")
+			pods, err = exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), podsLabelSelector, func(pod v1.Pod) bool {
+				return shouldTerminatePods.Has(pod.Name) && pod.DeletionTimestamp == nil
+			}, 0, e2e.PodDeleteTimeout)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("wait for PDB to become stable again")
+			expectedStatus = policyv1.PodDisruptionBudgetStatus{
+				DisruptionsAllowed: 1,
+				CurrentHealthy:     3,
+				DesiredHealthy:     2,
+				ExpectedPods:       3,
+			}
+			pdb, err = waitForPDBStatus(oc.KubeClient().PolicyV1(), metav1.ObjectMeta{Name: ifHealthyBudgetPDBName, Namespace: oc.Namespace()}, e2e.PodStartTimeout+podBecomesReadyTimeout, expectedStatus)
+			if err != nil {
+				g.Fail(fmt.Sprintf("error occurred while waiting for PDB status: %v\nexpected %#v, got %#v", err, expectedStatus, pdbStatus(pdb)))
+			}
+		})
+
+		g.It(fmt.Sprintf("should evict according to the AlwaysAllow policy"), func() {
+			g.By(fmt.Sprintf("calling oc create -f %q", alwaysAllowPolicyPDB))
+			err := oc.Run("create").Args("-f", alwaysAllowPolicyPDB).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("calling oc create -f %q", nginxWithDelayedReadyDeployment))
+			err = oc.Run("create").Args("-f", nginxWithDelayedReadyDeployment).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("wait for a PDB to initialize its status")
+			expectedStatus := policyv1.PodDisruptionBudgetStatus{
+				DisruptionsAllowed: 0,
+				CurrentHealthy:     0,
+				DesiredHealthy:     2,
+				ExpectedPods:       3,
+			}
+			pdb, err := waitForPDBStatus(oc.KubeClient().PolicyV1(), metav1.ObjectMeta{Name: alwaysAllowPolicyPDBName, Namespace: oc.Namespace()}, e2e.PodStartTimeout, expectedStatus)
+			if err != nil {
+				g.Fail(fmt.Sprintf("error occurred while waiting for PDB status: %v\nexpected %#v, got %#v", err, expectedStatus, pdbStatus(pdb)))
+			}
+
+			g.By("wait for pods to be running")
+			pods, err := exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), podsLabelSelector, exutil.CheckPodIsRunning, 3, e2e.PodStartTimeout)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("evict unready pods guarded by a PDB")
+			shouldTerminatePods := sets.New[string]()
+			for _, pod := range pods {
+				eviction := newV1Eviction(oc.Namespace(), pod, metav1.DeleteOptions{})
+				err := oc.KubeClient().PolicyV1().Evictions(oc.Namespace()).Evict(context.Background(), eviction)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				shouldTerminatePods.Insert(pod)
+			}
+
+			g.By("wait until all evicted pods are either gone or terminating")
+			pods, err = exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), podsLabelSelector, func(pod v1.Pod) bool {
+				return shouldTerminatePods.Has(pod.Name) && pod.DeletionTimestamp == nil
+			}, 0, e2e.PodDeleteTimeout)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("wait for PDB to become stable")
+			expectedStatus = policyv1.PodDisruptionBudgetStatus{
+				DisruptionsAllowed: 1,
+				CurrentHealthy:     3,
+				DesiredHealthy:     2,
+				ExpectedPods:       3,
+			}
+			pdb, err = waitForPDBStatus(oc.KubeClient().PolicyV1(), metav1.ObjectMeta{Name: alwaysAllowPolicyPDBName, Namespace: oc.Namespace()}, e2e.PodStartTimeout+podBecomesReadyTimeout, expectedStatus)
+			if err != nil {
+				g.Fail(fmt.Sprintf("error occurred while waiting for PDB status: %v\nexpected %#v, got %#v", err, expectedStatus, pdbStatus(pdb)))
+			}
+
+			g.By("check pods are ready")
+			pods, err = exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), podsLabelSelector, func(pod v1.Pod) bool {
+				return exutil.CheckPodIsReady(pod) && pod.DeletionTimestamp == nil
+			}, 3, e2e.PodStartTimeout+podBecomesReadyTimeout)
+
+			g.By("only one disruption of ready pods allowed")
+			firstToEvictPod := pods[0]
+			eviction := newV1Eviction(oc.Namespace(), firstToEvictPod, metav1.DeleteOptions{})
+			errOne := oc.KubeClient().PolicyV1().Evictions(oc.Namespace()).Evict(context.Background(), eviction)
+			o.Expect(errOne).NotTo(o.HaveOccurred())
+
+			g.By("second eviction should not succeed")
+			secondToEvictPod := pods[1]
+			eviction = newV1Eviction(oc.Namespace(), secondToEvictPod, metav1.DeleteOptions{})
+			errTwo := oc.KubeClient().PolicyV1().Evictions(oc.Namespace()).Evict(context.Background(), eviction)
+			o.Expect(errTwo).To(o.HaveOccurred())
+		})
+	})
+})
+
+func newV1Eviction(ns, evictionName string, deleteOption metav1.DeleteOptions) *policyv1.Eviction {
+	return &policyv1.Eviction{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy/v1",
+			Kind:       "Eviction",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      evictionName,
+			Namespace: ns,
+		},
+		DeleteOptions: &deleteOption,
+	}
+}
+
+func pdbStatus(pdb *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudgetStatus {
+	if pdb == nil {
+		return nil
+	}
+	return &pdb.Status
+}
+
+func waitForPDBStatus(policyClient policyv1clientset.PolicyV1Interface, objMeta metav1.ObjectMeta, timeout time.Duration, expectedStatus policyv1.PodDisruptionBudgetStatus) (*policyv1.PodDisruptionBudget, error) {
+	return waitForPDB(policyClient, objMeta, timeout, func(p *policyv1.PodDisruptionBudget) (bool, error) {
+		return p.Generation == p.Status.ObservedGeneration &&
+				p.Status.DisruptionsAllowed == expectedStatus.DisruptionsAllowed &&
+				p.Status.CurrentHealthy == expectedStatus.CurrentHealthy &&
+				p.Status.DesiredHealthy == expectedStatus.DesiredHealthy &&
+				p.Status.ExpectedPods == expectedStatus.ExpectedPods,
+			nil
+	})
+
+}
+
+func waitForPDB(policyClient policyv1clientset.PolicyV1Interface, objMeta metav1.ObjectMeta, timeout time.Duration, condition func(pdb *policyv1.PodDisruptionBudget) (bool, error)) (*policyv1.PodDisruptionBudget, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", objMeta.Name).String()
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
+			options.FieldSelector = fieldSelector
+			return policyClient.PodDisruptionBudgets(objMeta.Namespace).List(context.Background(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
+			options.FieldSelector = fieldSelector
+			return policyClient.PodDisruptionBudgets(objMeta.Namespace).Watch(context.Background(), options)
+		},
+	}
+
+	event, err := watchtools.UntilWithSync(ctx, lw, &policyv1.PodDisruptionBudget{}, nil, func(event watch.Event) (bool, error) {
+		if event.Type != watch.Modified && (objMeta.ResourceVersion == "" && event.Type != watch.Added) {
+			return true, fmt.Errorf("different kind of event appeared while waiting for PodDisruptionBudget modification: event: %#v", event)
+		}
+		return condition(event.Object.(*policyv1.PodDisruptionBudget))
+	})
+	if err != nil {
+		if event != nil {
+			return event.Object.(*policyv1.PodDisruptionBudget), err
+		}
+		return nil, err
+	}
+	return event.Object.(*policyv1.PodDisruptionBudget), nil
+}
+
+// isTechPreviewNoUpgrade checks if a cluster is a TechPreviewNoUpgrade cluster
+func isTechPreviewNoUpgrade(oc *exutil.CLI) bool {
+	featureGate, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		e2e.Failf("could not retrieve feature-gate: %v", err)
+	}
+
+	return featureGate.Spec.FeatureSet == configv1.TechPreviewNoUpgrade
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -420,6 +420,9 @@
 // test/extended/testdata/oauthserver/oauth-sa.yaml
 // test/extended/testdata/olm/operatorgroup.yaml
 // test/extended/testdata/olm/subscription.yaml
+// test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml
+// test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml
+// test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml
 // test/extended/testdata/releases/payload-1/etcd-operator/image-references
 // test/extended/testdata/releases/payload-1/etcd-operator/manifest.yaml
 // test/extended/testdata/releases/payload-1/image-registry/10_image-registry_crd.yaml
@@ -45771,6 +45774,161 @@ func testExtendedTestdataOlmSubscriptionYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml = []byte(`---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: always-allow-policy
+spec:
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
+  selector:
+    matchLabels:
+      app: nginx-with-delayed-ready
+
+`)
+
+func testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml, nil
+}
+
+func testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml = []byte(`---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: if-healthy-budget-policy
+spec:
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: IfHealthyBudget
+  selector:
+    matchLabels:
+      app: nginx-with-delayed-ready
+
+`)
+
+func testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml, nil
+}
+
+func testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml = []byte(`---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nginx-with-delayed-ready
+  labels:
+    app: nginx-with-delayed-ready
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx-with-delayed-ready
+  template:
+    metadata:
+      labels:
+        app: nginx-with-delayed-ready
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: nginx-with-delayed-ready
+          image: registry.k8s.io/e2e-test-images/nginx:1.15-4
+          command:
+            - /usr/sbin/nginx
+          args:
+            - "-g"
+            - "daemon off;"
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 40
+            successThreshold: 2
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+            - name: tmp
+              mountPath: /var/cache/nginx
+            - name: tmp2
+              mountPath: /var/run
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: conf
+          configMap:
+            name: nginx-conf
+        - name: tmp
+          emptyDir: {}
+        - name: tmp2
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        server_name  localhost;
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
+`)
+
+func testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml, nil
+}
+
+func testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataReleasesPayload1EtcdOperatorImageReferences = []byte(`kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
@@ -46262,7 +46420,7 @@ items:
         mountPath: /etc/nginx
       - name: tmp
         mountPath: /var/cache/nginx
-      - name: tmp
+      - name: tmp2
         mountPath: /var/run
     volumes:
     - name: conf
@@ -50165,6 +50323,9 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/oauthserver/oauth-sa.yaml":                                                       testExtendedTestdataOauthserverOauthSaYaml,
 	"test/extended/testdata/olm/operatorgroup.yaml":                                                          testExtendedTestdataOlmOperatorgroupYaml,
 	"test/extended/testdata/olm/subscription.yaml":                                                           testExtendedTestdataOlmSubscriptionYaml,
+	"test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml":                               testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml,
+	"test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml":                          testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml,
+	"test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml":                   testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml,
 	"test/extended/testdata/releases/payload-1/etcd-operator/image-references":                               testExtendedTestdataReleasesPayload1EtcdOperatorImageReferences,
 	"test/extended/testdata/releases/payload-1/etcd-operator/manifest.yaml":                                  testExtendedTestdataReleasesPayload1EtcdOperatorManifestYaml,
 	"test/extended/testdata/releases/payload-1/image-registry/10_image-registry_crd.yaml":                    testExtendedTestdataReleasesPayload1ImageRegistry10_imageRegistry_crdYaml,
@@ -50884,6 +51045,11 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"olm": {nil, map[string]*bintree{
 					"operatorgroup.yaml": {testExtendedTestdataOlmOperatorgroupYaml, map[string]*bintree{}},
 					"subscription.yaml":  {testExtendedTestdataOlmSubscriptionYaml, map[string]*bintree{}},
+				}},
+				"poddisruptionbudgets": {nil, map[string]*bintree{
+					"always-allow-policy-pdb.yaml":             {testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml, map[string]*bintree{}},
+					"if-healthy-budget-policy-pdb.yaml":        {testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml, map[string]*bintree{}},
+					"nginx-with-delayed-ready-deployment.yaml": {testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml, map[string]*bintree{}},
 				}},
 				"releases": {nil, map[string]*bintree{
 					"payload-1": {nil, map[string]*bintree{

--- a/test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml
+++ b/test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: always-allow-policy
+spec:
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
+  selector:
+    matchLabels:
+      app: nginx-with-delayed-ready
+

--- a/test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml
+++ b/test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: if-healthy-budget-policy
+spec:
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: IfHealthyBudget
+  selector:
+    matchLabels:
+      app: nginx-with-delayed-ready
+

--- a/test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml
+++ b/test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml
@@ -1,0 +1,80 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nginx-with-delayed-ready
+  labels:
+    app: nginx-with-delayed-ready
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx-with-delayed-ready
+  template:
+    metadata:
+      labels:
+        app: nginx-with-delayed-ready
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: nginx-with-delayed-ready
+          image: registry.k8s.io/e2e-test-images/nginx:1.15-4
+          command:
+            - /usr/sbin/nginx
+          args:
+            - "-g"
+            - "daemon off;"
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 40
+            successThreshold: 2
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+            - name: tmp
+              mountPath: /var/cache/nginx
+            - name: tmp2
+              mountPath: /var/run
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: conf
+          configMap:
+            name: nginx-conf
+        - name: tmp
+          emptyDir: {}
+        - name: tmp2
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+data:
+  default.conf: |
+    server {
+        listen 8080;
+        server_name  localhost;
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }

--- a/test/extended/testdata/router/reencrypt-serving-cert.yaml
+++ b/test/extended/testdata/router/reencrypt-serving-cert.yaml
@@ -26,7 +26,7 @@ items:
         mountPath: /etc/nginx
       - name: tmp
         mountPath: /var/cache/nginx
-      - name: tmp
+      - name: tmp2
         mountPath: /var/run
     volumes:
     - name: conf

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -547,6 +547,10 @@ var Annotations = map[string]string{
 
 	"[sig-apps] TTLAfterFinished job should be deleted once it finishes after TTL seconds": " [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
+	"[sig-apps] poddisruptionbudgets with unhealthyPodEvictionPolicy should evict according to the AlwaysAllow policy": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+
+	"[sig-apps] poddisruptionbudgets with unhealthyPodEvictionPolicy should evict according to the IfHealthyBudget policy": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+
 	"[sig-apps][Feature:DeploymentConfig] deploymentconfigs adoption will orphan all RCs and adopt them back when recreated [apigroup:apps.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-apps][Feature:DeploymentConfig] deploymentconfigs generation should deploy based on a status version bump [apigroup:apps.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -196,6 +196,8 @@ var (
 			// Need to access non-cached images like ruby and mongodb
 			`\[sig-apps\]\[Feature:DeploymentConfig\] deploymentconfigs with multiple image change triggers should run a successful deployment with a trigger used by different containers`,
 			`\[sig-apps\]\[Feature:DeploymentConfig\] deploymentconfigs with multiple image change triggers should run a successful deployment with multiple triggers`,
+			`\[sig-apps\] poddisruptionbudgets with unhealthyPodEvictionPolicy should evict according to the AlwaysAllow policy`,
+			`\[sig-apps\] poddisruptionbudgets with unhealthyPodEvictionPolicy should evict according to the IfHealthyBudget policy`,
 
 			// ICSP
 			`\[sig-apps\]\[Feature:DeploymentConfig\] deploymentconfigs should adhere to Three Laws of Controllers`,


### PR DESCRIPTION
`PDBUnhealthyPodEvictionPolicy` was enabled as a tech preview in https://github.com/openshift/api/pull/1396. This PR adds E2E tests to test this feature for openshift (upstream is lacking these tests)