### PR TITLE
CNF-5652: Add cpu partitioning tests

### DIFF
--- a/test/extended/cpu_partitioning/managed.go
+++ b/test/extended/cpu_partitioning/managed.go
@@ -1,0 +1,189 @@
+package cpu_partitioning
+
+import (
+	"context"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
+)
+
+var _ = g.Describe("[sig-node] CPU Partitioned cluster workloads", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc  = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		ctx = context.Background()
+	)
+
+	g.BeforeEach(func() {
+		skipNonCPUPartitionedCluster(oc)
+	})
+
+	g.Context("in annotated namespaces", func() {
+
+		var (
+			deploymentLabels = map[string]string{"app": "workload-pinned"}
+			namespace        = "workload-pinning"
+			name             = "workload"
+		)
+
+		g.AfterEach(func() {
+			o.Expect(cleanup(oc, namespace)).NotTo(o.HaveOccurred())
+		})
+
+		g.It("should be modified", func() {
+
+			e := createNamespace(oc, namespace, namespaceAnnotation)
+			o.Expect(e).ToNot(o.HaveOccurred(), "error creating namespace %s", namespace)
+
+			e = createDeployment(oc, name, namespace, deploymentLabels, deploymentPodAnnotation)
+			o.Expect(e).ToNot(o.HaveOccurred(), "error creating pinned deployment")
+
+			pods, err := oc.KubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=workload-pinned",
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			for _, pod := range pods.Items {
+				o.Expect(pod.Annotations).To(
+					o.And(
+						o.HaveKey(workloadAnnotations),
+						o.HaveKey(o.MatchRegexp(workloadAnnotationsRegex)),
+					), "pod (%s/%s) does not contain correct annotations", pod.Namespace, pod.Name)
+
+				for _, container := range pod.Spec.Containers {
+					_, ok := container.Resources.Limits[resourceLabel]
+					o.Expect(ok).To(o.BeTrue())
+					_, ok = container.Resources.Requests[resourceLabel]
+					o.Expect(ok).To(o.BeTrue())
+				}
+			}
+		})
+	})
+
+	g.Context("in non-annotated namespaces", func() {
+
+		var (
+			deploymentLabels = map[string]string{"app": "workload"}
+			namespace        = "workload-non-pinning"
+			name             = "workload"
+		)
+
+		g.AfterEach(func() {
+			o.Expect(cleanup(oc, namespace)).NotTo(o.HaveOccurred())
+		})
+
+		g.It("should not be modified", func() {
+
+			e := createNamespace(oc, namespace, nil)
+			o.Expect(e).ToNot(o.HaveOccurred(), "error creating namespace %s", namespace)
+
+			e = createDeployment(oc, name, namespace, deploymentLabels, nil)
+			o.Expect(e).ToNot(o.HaveOccurred(), "error creating pinned deployment")
+
+			pods, err := oc.KubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=workload",
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			for _, pod := range pods.Items {
+				o.Expect(pod.Annotations).NotTo(
+					o.And(
+						o.HaveKey(workloadAnnotations),
+						o.HaveKey(o.MatchRegexp(workloadAnnotationsRegex)),
+					), "pod (%s/%s) does not contain correct annotations", pod.Namespace, pod.Name)
+
+				for _, container := range pod.Spec.Containers {
+					_, ok := container.Resources.Limits[resourceLabel]
+					o.Expect(ok).To(o.BeFalse())
+					_, ok = container.Resources.Requests[resourceLabel]
+					o.Expect(ok).To(o.BeFalse())
+				}
+			}
+		})
+	})
+})
+
+func cleanup(oc *exutil.CLI, namespace string) error {
+	ctx := context.Background()
+	delOpts := metav1.DeleteOptions{}
+	return oc.KubeClient().CoreV1().Namespaces().Delete(ctx, namespace, delOpts)
+}
+
+func createNamespace(oc *exutil.CLI, name string, annotations map[string]string) error {
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+	}
+	_, err := oc.KubeClient().CoreV1().
+		Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
+	return err
+}
+
+func createDeployment(oc *exutil.CLI, name, namespace string, depLabels map[string]string, podAnnotations map[string]string) error {
+	deployment := &appv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    depLabels,
+		},
+		Spec: appv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: depLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      depLabels,
+					Annotations: podAnnotations,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "builder",
+					Containers: []corev1.Container{
+						{
+							Name:  "busy-work",
+							Image: image.ShellImage(),
+							Command: []string{
+								"/bin/bash",
+								"-c",
+								`while true; do echo "Busy working, cycling through the ones and zeros"; sleep 5; done`,
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := oc.KubeClient().AppsV1().
+		Deployments(namespace).
+		Create(context.Background(), deployment, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	_, err = exutil.WaitForPods(
+		oc.KubeClient().CoreV1().Pods(namespace),
+		labels.SelectorFromSet(depLabels),
+		exutil.CheckPodIsRunning, 1, time.Minute*2,
+	)
+	return err
+}

--- a/test/extended/cpu_partitioning/platform.go
+++ b/test/extended/cpu_partitioning/platform.go
@@ -1,0 +1,77 @@
+package cpu_partitioning
+
+import (
+	"context"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("[sig-node] CPU Partitioned cluster infrastructure", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc  = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		ctx = context.Background()
+
+		// The below namespaces are not annotated,
+		// no workload is going to be running in them.
+		ignoreNamespaces = map[string]struct{}{
+			"openshift-config":         {},
+			"openshift-config-managed": {},
+			"openshift-node":           {},
+		}
+	)
+
+	g.BeforeEach(func() {
+		skipNonCPUPartitionedCluster(oc)
+	})
+
+	g.It("should be configured correctly", func() {
+
+		g.By("containing cpu partitioning bootstrap files", func() {
+			outputString, err := oc.Run("get", "mc").Args("-o", "name").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(outputString).To(
+				o.And(
+					o.ContainSubstring("01-master-cpu-partitioning"),
+					o.ContainSubstring("01-worker-cpu-partitioning"),
+				),
+			)
+		})
+
+		g.By("having nodes configured with correct Capacity and Allocatable", func() {
+			nodes, err := oc.KubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			for _, node := range nodes.Items {
+				_, ok := node.Status.Capacity[resourceLabel]
+				o.Expect(ok).To(o.BeTrue(), "capacity is missing from node %s", node.Name)
+				_, ok = node.Status.Allocatable[resourceLabel]
+				o.Expect(ok).To(o.BeTrue(), "allocatable is missing from node %s", node.Name)
+			}
+		})
+
+		g.By("having openshift namespaces with management annotation", func() {
+			projects, err := oc.ProjectClient().ProjectV1().Projects().List(ctx, metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			invalidNamespaces := []string{}
+			for _, project := range projects.Items {
+				if _, ok := ignoreNamespaces[project.Name]; ok {
+					continue
+				}
+				if strings.HasPrefix(project.Name, "openshift-") {
+					if v, ok := project.Annotations[namespaceAnnotationKey]; !ok || v != "management" {
+						invalidNamespaces = append(invalidNamespaces, project.Name)
+					}
+				}
+			}
+			o.Expect(invalidNamespaces).To(o.BeEmpty(),
+				"projects %s do not contain the annotation %s", invalidNamespaces, namespaceAnnotation)
+		})
+	})
+})

--- a/test/extended/cpu_partitioning/platform.go
+++ b/test/extended/cpu_partitioning/platform.go
@@ -2,22 +2,25 @@ package cpu_partitioning
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
+	ocpv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("[sig-node] CPU Partitioned cluster infrastructure", func() {
+var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster infrastructure", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc  = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
-		ctx = context.Background()
+		oc                      = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		ctx                     = context.Background()
+		isClusterCPUPartitioned = false
 
 		// The below namespaces are not annotated,
 		// no workload is going to be running in them.
@@ -29,31 +32,37 @@ var _ = g.Describe("[sig-node] CPU Partitioned cluster infrastructure", func() {
 	)
 
 	g.BeforeEach(func() {
-		skipNonCPUPartitionedCluster(oc)
+		isClusterCPUPartitioned = getCpuPartitionedStatus(oc) == ocpv1.CPUPartitioningAllNodes
 	})
 
 	g.It("should be configured correctly", func() {
 
+		mcMatcher := o.And(
+			o.ContainSubstring("01-master-cpu-partitioning"),
+			o.ContainSubstring("01-worker-cpu-partitioning"),
+		)
+
+		mcMatcher, messageFormat := adjustMatcherAndMessageForCluster(isClusterCPUPartitioned, mcMatcher)
+
 		g.By("containing cpu partitioning bootstrap files", func() {
 			outputString, err := oc.Run("get", "mc").Args("-o", "name").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(outputString).To(
-				o.And(
-					o.ContainSubstring("01-master-cpu-partitioning"),
-					o.ContainSubstring("01-worker-cpu-partitioning"),
-				),
-			)
+			o.Expect(outputString).To(mcMatcher, "cluster is %s contain bootstrap files", messageFormat)
 		})
 
 		g.By("having nodes configured with correct Capacity and Allocatable", func() {
 			nodes, err := oc.KubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
+			var nodeErrs []error
 			for _, node := range nodes.Items {
-				_, ok := node.Status.Capacity[resourceLabel]
-				o.Expect(ok).To(o.BeTrue(), "capacity is missing from node %s", node.Name)
-				_, ok = node.Status.Allocatable[resourceLabel]
-				o.Expect(ok).To(o.BeTrue(), "allocatable is missing from node %s", node.Name)
+				if _, ok := node.Status.Capacity[resourceLabel]; ok != isClusterCPUPartitioned {
+					nodeErrs = append(nodeErrs, fmt.Errorf("capacity %s be present from node %s", messageFormat, node.Name))
+				}
+				if _, ok := node.Status.Allocatable[resourceLabel]; ok != isClusterCPUPartitioned {
+					nodeErrs = append(nodeErrs, fmt.Errorf("allocatable %s be present from node %s", messageFormat, node.Name))
+				}
 			}
+			o.Expect(nodeErrs).To(o.BeEmpty())
 		})
 
 		g.By("having openshift namespaces with management annotation", func() {
@@ -64,7 +73,7 @@ var _ = g.Describe("[sig-node] CPU Partitioned cluster infrastructure", func() {
 				if _, ok := ignoreNamespaces[project.Name]; ok {
 					continue
 				}
-				if strings.HasPrefix(project.Name, "openshift-") {
+				if strings.HasPrefix(project.Name, "openshift-") && !strings.HasPrefix(project.Name, "openshift-e2e-") {
 					if v, ok := project.Annotations[namespaceAnnotationKey]; !ok || v != "management" {
 						invalidNamespaces = append(invalidNamespaces, project.Name)
 					}

--- a/test/extended/cpu_partitioning/pods.go
+++ b/test/extended/cpu_partitioning/pods.go
@@ -1,0 +1,63 @@
+package cpu_partitioning
+
+import (
+	"context"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var _ = g.Describe("[sig-node] CPU Partitioned cluster platform pods", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc  = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		ctx = context.Background()
+	)
+
+	g.BeforeEach(func() {
+		skipNonCPUPartitionedCluster(oc)
+	})
+
+	g.It("should be annotated correctly", func() {
+
+		g.By("checking deployments and pods", func() {
+			deployments, err := oc.KubeClient().AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			for _, deployment := range deployments.Items {
+				if _, ok := deployment.Spec.Template.Annotations[workloadAnnotations]; ok {
+
+					pods, err := oc.KubeClient().CoreV1().Pods(deployment.Namespace).List(ctx, metav1.ListOptions{
+						LabelSelector: labels.SelectorFromSet(deployment.Spec.Template.Labels).String(),
+					})
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					for _, pod := range pods.Items {
+						o.Expect(pod.Annotations).To(
+							o.And(
+								o.HaveKey(workloadAnnotations),
+								o.HaveKey(o.MatchRegexp(workloadAnnotationsRegex)),
+							), "pod (%s/%s) does not contain correct annotations", pod.Namespace, pod.Name)
+
+						for _, container := range pod.Spec.Containers {
+							_, ok := container.Resources.Limits[resourceLabel]
+							o.Expect(ok).To(o.BeTrue(),
+								"limits resources not present for container %s in pod %s/%s", container.Name, pod.Name, pod.Namespace)
+							_, ok = container.Resources.Requests[resourceLabel]
+							o.Expect(ok).To(o.BeTrue(),
+								"requests resources not present for container %s in pod %s/%s", container.Name, pod.Name, pod.Namespace)
+						}
+					}
+				} else if strings.HasPrefix(deployment.Namespace, "openshift-") {
+					o.Expect(ok).To(o.BeTrue(), "deployments in openshift namespace must have pod templates annotated with %s", deploymentPodAnnotation)
+				}
+			}
+		})
+	})
+})

--- a/test/extended/cpu_partitioning/pods.go
+++ b/test/extended/cpu_partitioning/pods.go
@@ -2,62 +2,116 @@ package cpu_partitioning
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
+	ocpv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-var _ = g.Describe("[sig-node] CPU Partitioned cluster platform pods", func() {
+var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster platform workloads", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc  = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
-		ctx = context.Background()
+		oc                      = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		ctx                     = context.Background()
+		isClusterCPUPartitioned = false
+
+		messageFormat = expectedMessage
+		matcher       = o.And(
+			o.HaveKey(workloadAnnotations),
+			o.HaveKey(o.MatchRegexp(workloadAnnotationsRegex)),
+		)
 	)
 
 	g.BeforeEach(func() {
+		// TODO: Remove to run on all cluster configs after resolving missing deployments/daemonsets.
 		skipNonCPUPartitionedCluster(oc)
+		isClusterCPUPartitioned = getCpuPartitionedStatus(oc) == ocpv1.CPUPartitioningAllNodes
+		matcher, messageFormat = adjustMatcherAndMessageForCluster(isClusterCPUPartitioned, matcher)
 	})
 
-	g.It("should be annotated correctly", func() {
+	g.It("should be annotated correctly for Deployments", func() {
 
-		g.By("checking deployments and pods", func() {
-			deployments, err := oc.KubeClient().AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
-			for _, deployment := range deployments.Items {
-				if _, ok := deployment.Spec.Template.Annotations[workloadAnnotations]; ok {
+		var (
+			deploymentErr []error
+		)
 
-					pods, err := oc.KubeClient().CoreV1().Pods(deployment.Namespace).List(ctx, metav1.ListOptions{
-						LabelSelector: labels.SelectorFromSet(deployment.Spec.Template.Labels).String(),
-					})
-					o.Expect(err).NotTo(o.HaveOccurred())
+		deployments, err := oc.KubeClient().AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-					for _, pod := range pods.Items {
-						o.Expect(pod.Annotations).To(
-							o.And(
-								o.HaveKey(workloadAnnotations),
-								o.HaveKey(o.MatchRegexp(workloadAnnotationsRegex)),
-							), "pod (%s/%s) does not contain correct annotations", pod.Namespace, pod.Name)
+		for _, deployment := range deployments.Items {
+			if _, ok := deployment.Spec.Template.Annotations[workloadAnnotations]; ok {
 
-						for _, container := range pod.Spec.Containers {
-							_, ok := container.Resources.Limits[resourceLabel]
-							o.Expect(ok).To(o.BeTrue(),
-								"limits resources not present for container %s in pod %s/%s", container.Name, pod.Name, pod.Namespace)
-							_, ok = container.Resources.Requests[resourceLabel]
-							o.Expect(ok).To(o.BeTrue(),
-								"requests resources not present for container %s in pod %s/%s", container.Name, pod.Name, pod.Namespace)
-						}
+				pods, err := oc.KubeClient().CoreV1().Pods(deployment.Namespace).List(ctx, metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(deployment.Spec.Template.Labels).String(),
+				})
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				for _, pod := range pods.Items {
+
+					o.Expect(pod.Annotations).To(
+						matcher, "pod (%s/%s) %s have workload annotations", pod.Namespace, pod.Name, messageFormat)
+
+					for _, container := range pod.Spec.Containers {
+						_, ok := container.Resources.Limits[resourceLabel]
+						o.Expect(ok).To(o.Equal(isClusterCPUPartitioned),
+							"limits resources %s be present for container %s in pod %s/%s", messageFormat, container.Name, pod.Name, pod.Namespace)
+						_, ok = container.Resources.Requests[resourceLabel]
+						o.Expect(ok).To(o.Equal(isClusterCPUPartitioned),
+							"requests resources %s be present for container %s in pod %s/%s", messageFormat, container.Name, pod.Name, pod.Namespace)
 					}
-				} else if strings.HasPrefix(deployment.Namespace, "openshift-") {
-					o.Expect(ok).To(o.BeTrue(), "deployments in openshift namespace must have pod templates annotated with %s", deploymentPodAnnotation)
 				}
+			} else if strings.HasPrefix(deployment.Namespace, "openshift-") && !strings.HasPrefix(deployment.Namespace, "openshift-e2e-") {
+				deploymentErr = append(deploymentErr, fmt.Errorf("deployment (%s) in openshift namespace (%s) must have pod templates annotated with %s",
+					deployment.Name, deployment.Namespace, deploymentPodAnnotation))
 			}
-		})
+		}
+		o.Expect(deploymentErr).To(o.BeEmpty())
+	})
+
+	g.It("should be annotated correctly for DaemonSets", func() {
+
+		var (
+			daemonsetErr []error
+		)
+
+		daemonsets, err := oc.KubeClient().AppsV1().DaemonSets("").List(ctx, metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		for _, daemonset := range daemonsets.Items {
+			if _, ok := daemonset.Spec.Template.Annotations[workloadAnnotations]; ok {
+
+				pods, err := oc.KubeClient().CoreV1().Pods(daemonset.Namespace).List(ctx, metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(daemonset.Spec.Template.Labels).String(),
+				})
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				for _, pod := range pods.Items {
+
+					o.Expect(pod.Annotations).To(
+						matcher, "pod (%s/%s) %s have workload annotations", pod.Namespace, pod.Name, messageFormat)
+
+					for _, container := range pod.Spec.Containers {
+						_, ok := container.Resources.Limits[resourceLabel]
+						o.Expect(ok).To(o.Equal(isClusterCPUPartitioned),
+							"limits resources %s be present for container %s in pod %s/%s", messageFormat, container.Name, pod.Name, pod.Namespace)
+						_, ok = container.Resources.Requests[resourceLabel]
+						o.Expect(ok).To(o.Equal(isClusterCPUPartitioned),
+							"requests resources %s be present for container %s in pod %s/%s", messageFormat, container.Name, pod.Name, pod.Namespace)
+					}
+				}
+			} else if strings.HasPrefix(daemonset.Namespace, "openshift-") && !strings.HasPrefix(daemonset.Namespace, "openshift-e2e-") {
+				daemonsetErr = append(daemonsetErr, fmt.Errorf("daemonset (%s) in openshift namespace (%s) must have pod templates annotated with %s",
+					daemonset.Name, daemonset.Namespace, deploymentPodAnnotation))
+			}
+		}
+		o.Expect(daemonsetErr).To(o.BeEmpty())
 	})
 })

--- a/test/extended/cpu_partitioning/utils.go
+++ b/test/extended/cpu_partitioning/utils.go
@@ -1,0 +1,36 @@
+package cpu_partitioning
+
+import (
+	"context"
+
+	o "github.com/onsi/gomega"
+
+	v1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+)
+
+const (
+	resourceLabel            = "management.workload.openshift.io/cores"
+	namespaceAnnotationKey   = "workload.openshift.io/allowed"
+	workloadAnnotations      = "target.workload.openshift.io/management"
+	workloadAnnotationsRegex = "resources.workload.openshift.io/.*"
+)
+
+var (
+	namespaceAnnotation     = map[string]string{namespaceAnnotationKey: "management"}
+	deploymentPodAnnotation = map[string]string{workloadAnnotations: `{"effect": "PreferredDuringScheduling"}`}
+)
+
+func skipNonCPUPartitionedCluster(oc *exutil.CLI) {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(),
+		"cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	if infra.Status.CPUPartitioning != v1.CPUPartitioningAllNodes {
+		e2eskipper.Skipf("Tests are only valid for clusters with CPUPartitioning enabled.")
+	}
+}

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/cmd"
 	_ "github.com/openshift/origin/test/extended/controller_manager"
 	_ "github.com/openshift/origin/test/extended/coreos"
+	_ "github.com/openshift/origin/test/extended/cpu_partitioning"
 	_ "github.com/openshift/origin/test/extended/crdvalidation"
 	_ "github.com/openshift/origin/test/extended/csrapprover"
 	_ "github.com/openshift/origin/test/extended/deployments"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2705,6 +2705,14 @@ var Annotations = map[string]string{
 
 	"[sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile": " [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
+	"[sig-node] CPU Partitioned cluster infrastructure should be configured correctly": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-node] CPU Partitioned cluster platform pods should be annotated correctly": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-node] CPU Partitioned cluster workloads in annotated namespaces should be modified": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-node] CPU Partitioned cluster workloads in non-annotated namespaces should not be modified": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]": " [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[sig-node] ConfigMap should be consumable via the environment [NodeConformance] [Conformance]": " [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2705,14 +2705,6 @@ var Annotations = map[string]string{
 
 	"[sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile": " [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[sig-node] CPU Partitioned cluster infrastructure should be configured correctly": " [Suite:openshift/conformance/parallel]",
-
-	"[sig-node] CPU Partitioned cluster platform pods should be annotated correctly": " [Suite:openshift/conformance/parallel]",
-
-	"[sig-node] CPU Partitioned cluster workloads in annotated namespaces should be modified": " [Suite:openshift/conformance/parallel]",
-
-	"[sig-node] CPU Partitioned cluster workloads in non-annotated namespaces should not be modified": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-node] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]": " [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[sig-node] ConfigMap should be consumable via the environment [NodeConformance] [Conformance]": " [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
@@ -3084,6 +3076,16 @@ var Annotations = map[string]string{
 	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the default algorithm": " [Serial]",
 
 	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the round robin algorithm": " [Serial]",
+
+	"[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster infrastructure should be configured correctly": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster platform workloads should be annotated correctly for DaemonSets": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster platform workloads should be annotated correctly for Deployments": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster workloads in annotated namespaces should be modified if CPUPartitioningMode = AllNodes": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster workloads in non-annotated namespaces should not be allowed if CPUPartitioningMode = AllNodes": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
Add e2e tests for validating a cluster that is setup for CPU Partitioning is configured correctly. This supports the enhancement workload partitioning enhancement. openshift/enhancements#1213