### PR TITLE
[OCPCLOUD-1987] Enable Azure platform check in external cloud provider test

### DIFF
--- a/test/extended/cloud_controller_manager/ccm.go
+++ b/test/extended/cloud_controller_manager/ccm.go
@@ -71,6 +71,7 @@ var _ = g.Describe("[sig-cloud-provider][Feature:OpenShiftCloudControllerManager
 func isPlatformExternal(platformType configv1.PlatformType) bool {
 	switch platformType {
 	case configv1.AWSPlatformType,
+		configv1.AzurePlatformType,
 		configv1.OpenStackPlatformType,
 		configv1.VSpherePlatformType:
 		return true


### PR DESCRIPTION
This PR updates the test for checking whether an external cloud provider is deployed or not to run on both existing platforms and now Azure as well.

This will now check that an external cloud provider runs on the Azure platform.

Will not pass until this [library-go](https://github.com/openshift/library-go/pull/1484) and it's associated PRs merge