### PR TITLE
[OCPCLOUD-1988] Enable AWS platform check in external cloud provider test

### DIFF
--- a/test/extended/cloud_controller_manager/ccm.go
+++ b/test/extended/cloud_controller_manager/ccm.go
@@ -70,7 +70,8 @@ var _ = g.Describe("[sig-cloud-provider][Feature:OpenShiftCloudControllerManager
 // but the platform is expected to use the external provider.
 func isPlatformExternal(platformType configv1.PlatformType) bool {
 	switch platformType {
-	case configv1.OpenStackPlatformType,
+	case configv1.AWSPlatformType,
+		configv1.OpenStackPlatformType,
 		configv1.VSpherePlatformType:
 		return true
 	default:


### PR DESCRIPTION
This PR updates the test for checking whether an external cloud provider is deployed or not to run on both existing platforms and now AWS as well.

This will now check that an external cloud provider runs on the AWS platform.

Will not pass until this [library-go](https://github.com/openshift/library-go/pull/1485) and it's associated PRs merge