### PR TITLE
Specify Audit-ID to identify disruption requests in api audit logs

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
@@ -144,7 +144,7 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 				cancel()
 			}
 
-			if err := backend.checkConnection(ctx); (err != nil) != tt.wantErr {
+			if _, err := backend.checkConnection(ctx); (err != nil) != tt.wantErr {
 				t.Errorf("checkConnection() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/monitor/write_job_run_data.go
+++ b/pkg/monitor/write_job_run_data.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-
 	"path/filepath"
 	"strings"
 
@@ -91,7 +90,8 @@ func computeDisruptionData(eventIntervals monitorapi.Intervals) *BackendDisrupti
 		connectionType := monitorapi.DisruptionConnectionTypeFrom(locatorParts)
 		aggregatedDisruptionName := strings.ToLower(fmt.Sprintf("%s-%s-connections", disruptionBackend, connectionType))
 
-		disruptionDuration, disruptionMessages, connectionType := monitorapi.BackendDisruptionSeconds(locator, allDisruptionEventsIntervals)
+		disruptionDuration, disruptionMessages, connectionType :=
+			monitorapi.BackendDisruptionSeconds(locator, allDisruptionEventsIntervals)
 		ret.BackendDisruptions[aggregatedDisruptionName] = &BackendDisruption{
 			Name:               aggregatedDisruptionName,
 			BackendName:        disruptionBackend,

--- a/test/extended/util/disruption/controlplane/known_backends.go
+++ b/test/extended/util/disruption/controlplane/known_backends.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
@@ -215,7 +216,7 @@ func createAPIServerBackendSampler(clusterConfig *rest.Config, disruptionBackend
 	if err != nil {
 		return nil, err
 	}
-	backendSampler.WithUserAgent("openshift-origin-external-backend-sampler")
+	backendSampler = backendSampler.WithUserAgent(fmt.Sprintf("openshift-external-backend-sampler-%s-%s", connectionType, disruptionBackendName))
 
 	return backendSampler, nil
 }


### PR DESCRIPTION
[TRT-888](https://issues.redhat.com//browse/TRT-888)