### PR TITLE
Scan etcd logs for dropped internal raft messages

### DIFF
--- a/pkg/monitor/intervalcreation/podlogs.go
+++ b/pkg/monitor/intervalcreation/podlogs.go
@@ -94,6 +94,15 @@ func buildLogGatherers() []PodLogIntervalGenerator {
 			},
 			lineParser: etcdLogParser,
 		},
+		{
+			namespace: "openshift-etcd",
+			selector:  "app=etcd",
+			container: "etcd",
+			subStrings: []SubStringLevel{
+				{"dropped internal Raft message since sending buffer is full", monitorapi.Warning},
+			},
+			lineParser: etcdLogParser,
+		},
 	}
 }
 

--- a/pkg/synthetictests/etcd.go
+++ b/pkg/synthetictests/etcd.go
@@ -34,3 +34,30 @@ func testEtcdShouldNotLogSlowFdataSyncs(events monitorapi.Intervals) []*junitapi
 	// TODO: marked flaky until we have monitored it for consistency
 	return []*junitapi.JUnitTestCase{failure, success}
 }
+
+func testEtcdShouldNotLogDroppedRaftMessages(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-etcd] etcd pod logs do not log dropped internal Raft messages"
+	success := &junitapi.JUnitTestCase{Name: testName}
+
+	var failures []string
+	for _, event := range events {
+		if strings.Contains(event.Message, "dropped internal Raft message since sending buffer is full") {
+			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
+		}
+	}
+
+	if len(failures) == 0 {
+		return []*junitapi.JUnitTestCase{success}
+	}
+
+	failure := &junitapi.JUnitTestCase{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &junitapi.FailureOutput{
+			Output: fmt.Sprintf("etcd pod logs indicated dropped internal Raft messages"+
+				"%d times.\n\n%v", len(failures), strings.Join(failures, "\n")),
+		},
+	}
+	// TODO: marked flaky until we have monitored it for consistency
+	return []*junitapi.JUnitTestCase{failure, success}
+}

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -76,6 +76,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testMarketplaceStartupProbeFailure(events)...)
 	tests = append(tests, testErrImagePullUnrecognizedSignatureFormat(events)...)
 	tests = append(tests, testEtcdShouldNotLogSlowFdataSyncs(events)...)
+	tests = append(tests, testEtcdShouldNotLogDroppedRaftMessages(events)...)
 	return tests
 }
 
@@ -144,6 +145,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testMarketplaceStartupProbeFailure(events)...)
 	tests = append(tests, testErrImagePullUnrecognizedSignatureFormat(events)...)
 	tests = append(tests, testEtcdShouldNotLogSlowFdataSyncs(events)...)
+	tests = append(tests, testEtcdShouldNotLogDroppedRaftMessages(events)...)
 	return tests
 }
 


### PR DESCRIPTION
If found, intervals will be created, charted in spyglass, and a test
will flake giving us insight into how often this is happening across the
fleet.
