### PR TITLE
ETCD-399: Restore Test - Create scaffolding for platform agnostic ssh…

### DIFF
--- a/test/extended/dr/OWNERS
+++ b/test/extended/dr/OWNERS
@@ -1,10 +1,12 @@
 reviewers:
-  - hexfusion
-  - lilic
-  - marun
-  - smarterclayton
+  - dusk125
+  - hasbro17
+  - Elbehery
+  - tjungblu
 approvers:
-  - hexfusion
-  - lilic
-  - marun
-  - smarterclayton
+  - deads2k
+  - hasbro17
+  - sttts
+  - dusk125
+  - Elbehery
+  - tjungblu

--- a/test/extended/dr/recovery.go
+++ b/test/extended/dr/recovery.go
@@ -1,0 +1,22 @@
+package dr
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/recovery]", func() {
+	defer g.GinkgoRecover()
+
+	f := framework.NewDefaultFramework("recovery")
+	f.SkipNamespaceCreation = true
+
+	oc := exutil.NewCLIWithoutNamespace("recovery")
+
+	g.It("[Feature:EtcdRecovery] should install ssh keys on CP nodes", func() {
+		err := InstallSSHKeyOnControlPlaneNodes(oc)
+		o.Expect(err).ToNot(o.HaveOccurred())
+	})
+})

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -3,10 +3,9 @@ package etcd
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 	testlibraryapi "github.com/openshift/library-go/test/library/apiserver"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1835,6 +1835,8 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][Feature:DisasterRecovery][Disruptive] [Feature:EtcdRecovery] Cluster should restore itself after quorum loss [apigroup:machine.openshift.io][apigroup:operator.openshift.io]": " [Serial]",
 
+	"[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/recovery] [Feature:EtcdRecovery] should install ssh keys on CP nodes": "",
+
 	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling] etcd is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "",
 
 	"[sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
… access

This adds a DS that installs ssh keys, stored in a secret in the openshift-etcd-operator namespace.

/hold

for further review by Haseeb.