### PR TITLE
Add a test case checking for cluster upgradeability

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -671,6 +671,10 @@ var Annotations = map[string]string{
 
 	"[sig-arch][Early] Managed cluster should [apigroup:config.openshift.io] start all core operators": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-arch][Feature:ClusterUpgrade] Cluster should be upgradeable after finishing upgrade [Late][Suite:upgrade]": "",
+
+	"[sig-arch][Feature:ClusterUpgrade] Cluster should be upgradeable before beginning upgrade [Early][Suite:upgrade]": "",
+
 	"[sig-arch][Feature:ClusterUpgrade] Cluster should remain functional during upgrade [Disruptive]": " [Serial]",
 
 	"[sig-arch][Late] clients should not use APIs that are removed in upcoming releases [apigroup:config.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
[TRT-906](https://issues.redhat.com//browse/TRT-906)

Currently if a cluster fails to upgrade because for example there's a degraded operator, the failure message isn't clear. Example run:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ovn-kubernetes/1583/pull-ci-openshift-ovn-kubernetes-master-e2e-aws-ovn-upgrade/1636065778761469952

This PR adds a test to check the cluster is upgradeable before beginning the upgrade. It also adds a test case after the upgrade to check that cluster returns to an upgradeable state (i.e. no upgrade is running anymore, and everything comes back healthy).