### PR TITLE
Add (optional) dual-stack tests to the CNI certification test suite

### DIFF
--- a/cmd/openshift-tests/cni.go
+++ b/cmd/openshift-tests/cni.go
@@ -11,10 +11,17 @@ func inCNISuite(name string) bool {
 		if strings.Contains(name, "[Conformance]") {
 			return true
 		}
+
 		// Run all upstream NetworkPolicy tests except named port tests. (Neither
 		// openshift-sdn nor ovn-kubernetes supports named ports in NetworkPolicy,
 		// so we don't require third party tests to support them either.)
 		if strings.Contains(name, "NetworkPolicy") && !strings.Contains(name, "named port") {
+			return true
+		}
+
+		// Include dual-stack tests in the test suite; they will automatically get
+		// filtered out if the cluster is single-stack.
+		if strings.Contains(name, "[Feature:IPv6DualStack]") {
 			return true
 		}
 	}


### PR DESCRIPTION
Some third-party CNI vendors want to be certified as working in OpenShift with dual-stack, so add those tests to the suite.
