### PR TITLE
TRT-910: Temporarily flake ALL P99 disruption tests in 4.13

### DIFF
--- a/pkg/synthetictests/disruption.go
+++ b/pkg/synthetictests/disruption.go
@@ -104,13 +104,10 @@ func testServerAvailability(
 		}
 
 		// https://issues.redhat.com/browse/TRT-889 temporarily flake all disruption for azure
-		if jobType.Platform == "azure" {
-			return []*junitapi.JUnitTestCase{test, {
-				Name: testName,
-			}}
-		}
-
-		return []*junitapi.JUnitTestCase{test}
+		// https://issues.redhat.com/browse/TRT-910 temporarily flake ALL disruption in 4.13
+		return []*junitapi.JUnitTestCase{test, {
+			Name: testName,
+		}}
 	} else {
 		successTest.SystemOut = resultsStr
 		return []*junitapi.JUnitTestCase{successTest}


### PR DESCRIPTION
    TRT-910: Temporarily flake ALL P99 disruption tests in 4.13
    
    We do not have tooling to update the disruption tests in 4.13, on the
    assumption we keep the values at fork time. This release we merged a
    known regression after forking, and now are mass failing presubmits and
    periodics on P99 disruption tests that are using data we knew was going
    to go bad until we track down all the problems.
    
    Move to flake all P99 disruption tests for a bit. See Jira links for
    details on fixing more properly.
