### PR TITLE
Test build.spec.source.configMaps in custom builds

### DIFF
--- a/test/extended/testdata/builds/custom-configmap/Dockerfile
+++ b/test/extended/testdata/builds/custom-configmap/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.redhat.io/rhel8/buildah:latest
+# For simplicity, /var/run/configs/openshift.io/build contains the config map
+# we're using as a source for this custom builder image. Normally the custom
+# builder image would fetch this content from some location at build time.
+# (e.g. via git clone).
+ADD build.sh /usr/bin
+RUN chmod a+x /usr/bin/build.sh
+# /usr/build/build.sh contains the actual custom build logic that will be
+# executed when this custom builder image is executed.
+ENTRYPOINT ["/usr/bin/build.sh"]

--- a/test/extended/testdata/builds/custom-configmap/build.sh
+++ b/test/extended/testdata/builds/custom-configmap/build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -euo pipefail
+
+# Note that in this case we're looking for a config map as the main build
+# source. The build controller mounts config maps by name under
+# /var/run/configs/openshift.io/build, and the builder image decides how to use
+# the corresponding DestinationDir values from the Build object encoded in
+# $BUILD, if it consults them at all.
+#
+# A Docker or Source builder would clone the git repository named in the
+# $SOURCE_REPOSITORY env variable, copy the config map contents into a
+# subdirectory of the cloned source tree (or a context subdirectory of it)
+# named after the config map, and proceed from there.
+#
+# We'll just use the map contents from where the build controller put them.
+cd /var/run/configs/openshift.io/build/custom-configmap
+
+# OUTPUT_REGISTRY and OUTPUT_IMAGE are env variables provided by the custom
+# build framework
+TAG="${OUTPUT_REGISTRY}/${OUTPUT_IMAGE}"
+
+cp -R /var/run/configs/openshift.io/certs/certs.d/* /etc/containers/certs.d/
+
+# buildah requires a slight modification to the push secret provided by the service account in order to use it for pushing the image
+echo "{ \"auths\": $(cat /var/run/secrets/openshift.io/pull/.dockercfg)}" > /tmp/.pull
+echo "{ \"auths\": $(cat /var/run/secrets/openshift.io/push/.dockercfg)}" > /tmp/.push
+
+# performs the build of the new image defined by Dockerfile.sample
+buildah --authfile /tmp/.pull --storage-driver vfs bud --isolation chroot -t ${TAG} .
+# push the new image to the target for the build
+buildah --authfile /tmp/.push --storage-driver vfs push ${TAG}

--- a/test/extended/testdata/builds/test-custom-configmap.yaml
+++ b/test/extended/testdata/builds/test-custom-configmap.yaml
@@ -1,0 +1,44 @@
+kind: List
+apiVersion: v1
+items:
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    name: sample-custom-configmap
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: custom-configmap
+  data:
+    Dockerfile: |
+      FROM image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+      RUN echo config-map-Dockerfile | tee /tmp/built
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: sample-custom-configmap
+    labels:
+      name: sample-custom-configmap
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: 'true'
+  spec:
+    source:
+      type: None
+      configMaps:
+      - configMap:
+          name: custom-configmap
+        destinationDir: /tmp/input
+    strategy:
+      type: Custom
+      customStrategy:
+        env:
+          - name: "BUILD_LOGLEVEL"
+            value: "2"
+        forcePull: true
+        from:
+          kind: ImageStreamTag
+          name: custom-configmap-builder-image:latest
+    output:
+      to:
+        kind: ImageStreamTag
+        name: sample-custom-configmap:latest

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -369,6 +369,8 @@ var Annotations = map[string]string{
 
 	"[sig-builds][Feature:Builds] custom build with buildah being created from new-build should complete build with custom builder image [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-builds][Feature:Builds] custom build with buildah being created from new-build should complete build with custom configmap builder image [apigroup:build.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-builds][Feature:Builds] imagechangetriggers imagechangetriggers should trigger builds of all types [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-builds][Feature:Builds] oc new-app should fail with a --name longer than 58 characters [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Test that build.spec.source.configMaps maps are mounted for use by custom builder images.