### PR TITLE
STOR-1272: DisableSC test should ignore in-tree storage classes

### DIFF
--- a/test/extended/storage/storageclass.go
+++ b/test/extended/storage/storageclass.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -22,6 +23,7 @@ import (
 
 const (
 	defaultScAnnotationKey = "storageclass.kubernetes.io/is-default-class"
+	inTreeScPrefix         = "kubernetes.io/"
 	sleepInterval          = 10
 	maxRetries             = 10
 )
@@ -114,6 +116,10 @@ func FindDefaultStorageClass(oc *exutil.CLI) *storagev1.StorageClass {
 		e2e.Failf("could not list storage classes: %v", err)
 	}
 	for _, sc := range scList.Items {
+		if strings.HasPrefix(sc.Provisioner, inTreeScPrefix) {
+			e2e.Logf("ignoring in-tree storage class %s", sc.Name)
+			continue
+		}
 		if sc.Annotations[defaultScAnnotationKey] == "true" {
 			return &sc
 		}


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-1272
This is only needed if we are going to merge https://github.com/openshift/cluster-storage-operator/pull/351 because it re-introduces the in-tree storage class and this test is only valid for CSI.
/cc @openshift/storage
