### PR TITLE
OCPBUGS-5943: Revert "ignore repeated TopologyAwareHintsDisabled events"

### DIFF
--- a/pkg/duplicateevents/duplicated_event_patterns.go
+++ b/pkg/duplicateevents/duplicated_event_patterns.go
@@ -220,10 +220,6 @@ var KnownEventsBugs = []KnownProblem{
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
 	},
 	{
-		Regexp: regexp.MustCompile("reason/TopologyAwareHintsDisabled"),
-		BZ:     "https://issues.redhat.com/browse/OCPBUGS-5943",
-	},
-	{
 		Regexp:   regexp.MustCompile("ns/.*reason/.*APICheckFailed.*503.*"),
 		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
 		Topology: TopologyPointer(v1.SingleReplicaTopologyMode),


### PR DESCRIPTION
This reverts #27666.  The purpose of this PR is to determine whether https://issues.redhat.com/browse/OCPBUGS-5943 is still present.  

