### PR TITLE
remove runresourcewatch git lock file on failure

### DIFF
--- a/pkg/monitor/resourcewatch/storage/git_store.go
+++ b/pkg/monitor/resourcewatch/storage/git_store.go
@@ -220,6 +220,11 @@ func (s *GitStorage) commitAdd(path, author, ocCommand string) error {
 	output, err := osCommand.CombinedOutput()
 	if err != nil {
 		klog.Errorf("Ran %v\n%v\n\n", command, string(output))
+		// sometimes git can leave behind an index.lock.  This process should be the only one working in this git repo
+		// so simply remove the lock file.
+		if deleteErr := os.Remove(filepath.Join(s.path, ".git/index.lock")); deleteErr != nil {
+			klog.Errorf("Error removing .git/index.lock: %v", deleteErr)
+		}
 		return err
 	}
 
@@ -237,6 +242,11 @@ func (s *GitStorage) commitModify(path, author, ocCommand string) error {
 	output, err := osCommand.CombinedOutput()
 	if err != nil {
 		klog.Errorf("Ran %v\n%v\n\n", command, string(output))
+		// sometimes git can leave behind an index.lock.  This process should be the only one working in this git repo
+		// so simply remove the lock file.
+		if deleteErr := os.Remove(filepath.Join(s.path, ".git/index.lock")); deleteErr != nil {
+			klog.Errorf("Error removing .git/index.lock: %v", deleteErr)
+		}
 		return err
 	}
 
@@ -254,6 +264,11 @@ func (s *GitStorage) commitRemove(path, author, ocCommand string) error {
 	output, err := osCommand.CombinedOutput()
 	if err != nil {
 		klog.Errorf("Ran %v\n%v\n\n", command, string(output))
+		// sometimes git can leave behind an index.lock.  This process should be the only one working in this git repo
+		// so simply remove the lock file.
+		if deleteErr := os.Remove(filepath.Join(s.path, ".git/index.lock")); deleteErr != nil {
+			klog.Errorf("Error removing .git/index.lock: %v", deleteErr)
+		}
 		return err
 	}
 


### PR DESCRIPTION
Some resource watch repos stop recording history due to
> fatal: Unable to create '/logs/artifacts/resource-watch-store/repo/.git/index.lock': File exists.

Seen from
> bash: line 1: 270427 Bus error               (core dumped) git add "namespaces/openshift-ingress/core/pods/router-default-65c89f6859-94ttq.yaml"

Only our process should be working with git in this area, so adding a delete to the failure path so subsequent files can have intact history.

At some point, a retry for existing files may be useful.


/assign @xueqzhan 