### PR TITLE
OCPBUGS-11072: Add test for Egress Firewall node selector

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -39744,6 +39744,11 @@ spec:
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32
+  - type: Allow
+    to:
+      nodeSelector:
+        matchLabels:
+          node-role.kubernetes.io/control-plane: ''
   - type: Deny
     to:
       cidrSelector: 0.0.0.0/0

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -16,6 +16,11 @@ spec:
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32
+  - type: Allow
+    to:
+      nodeSelector:
+        matchLabels:
+          node-role.kubernetes.io/control-plane: ''
   - type: Deny
     to:
       cidrSelector: 0.0.0.0/0


### PR DESCRIPTION
Adds an allow rule for EF with node selector to k8s control plane nodes then tests traffic towards kapi server.