### PR TITLE
add apiserver availability timeline events

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -13,24 +13,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
-
-	"github.com/openshift/origin/pkg/monitor/nodedetails"
-	"github.com/sirupsen/logrus"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	utilflag "k8s.io/component-base/cli/flag"
-	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/library-go/pkg/serviceability"
 	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
 	"github.com/openshift/origin/pkg/monitor/monitor_cmd"
+	"github.com/openshift/origin/pkg/monitor/nodedetails"
 	"github.com/openshift/origin/pkg/monitor/resourcewatch/cmd"
 	"github.com/openshift/origin/pkg/riskanalysis"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
@@ -40,6 +28,14 @@ import (
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 	"github.com/openshift/origin/test/extended/util/disruption/externalservice"
 	"github.com/openshift/origin/test/extended/util/disruption/frontends"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	utilflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/util/templates"
 )
 
 func main() {

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
+
 	"github.com/openshift/origin/pkg/monitor/nodedetails"
 	"github.com/sirupsen/logrus"
 
@@ -147,6 +149,7 @@ func newMonitorCommand() *cobra.Command {
 	}
 	cmd.AddCommand(
 		nodedetails.AuditLogSummaryCommand(),
+		apiserveravailability.LogSummaryCommand(),
 	)
 	return cmd
 }

--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -7,10 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
-	"k8s.io/klog/v2"
-
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 )
 
 func GetMonitorRESTConfig() (*rest.Config, error) {

--- a/pkg/monitor/apiserveravailability/cmd.go
+++ b/pkg/monitor/apiserveravailability/cmd.go
@@ -1,0 +1,81 @@
+package apiserveravailability
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/kubernetes"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/spf13/cobra"
+)
+
+type auditLogSummaryOptions struct {
+	ArtifactDir string
+
+	ConfigFlags *genericclioptions.ConfigFlags
+	IOStreams   genericclioptions.IOStreams
+}
+
+func LogSummaryCommand() *cobra.Command {
+	o := &auditLogSummaryOptions{
+		ConfigFlags: genericclioptions.NewConfigFlags(true),
+		IOStreams: genericclioptions.IOStreams{
+			In:     os.Stdin,
+			Out:    os.Stdout,
+			ErrOut: os.Stderr,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "summarize-cluster-logs",
+		Short: "Download and inspect some logs for interesting things.",
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Run(context.Background())
+		},
+	}
+
+	cmd.Flags().StringVar(&o.ArtifactDir, "artifact-dir", o.ArtifactDir, "The directory where monitor events will be stored.")
+	o.ConfigFlags.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (o auditLogSummaryOptions) Run(ctx context.Context) error {
+	restConfig, err := o.ConfigFlags.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	summary, err := SummarizeInterestingPodLogs(ctx, kubeClient)
+	if err != nil {
+		return err
+	}
+
+	if err := WriteAPIServerAccessClientFailureSummary(o.ArtifactDir, "", summary); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func WriteAPIServerAccessClientFailureSummary(artifactDir, timeSuffix string, summary *APIServerClientAccessFailureSummary) error {
+	summaryBytes, err := json.MarshalIndent(summary, "", "    ")
+	if err != nil {
+		return err
+	}
+	summaryPath := filepath.Join(artifactDir, fmt.Sprintf("apiserver-client-access-failure-summary_%s.json", timeSuffix))
+	if err := os.WriteFile(summaryPath, summaryBytes, 0644); err != nil {
+		return fmt.Errorf("failed to write %v: %w", summaryPath, err)
+	}
+	return nil
+}

--- a/pkg/monitor/apiserveravailability/cmd.go
+++ b/pkg/monitor/apiserveravailability/cmd.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/client-go/kubernetes"
-
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 )
 
 type auditLogSummaryOptions struct {

--- a/pkg/monitor/apiserveravailability/pod_log.go
+++ b/pkg/monitor/apiserveravailability/pod_log.go
@@ -1,0 +1,148 @@
+package apiserveravailability
+
+import (
+	"bufio"
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+func APIServerAvailabilityIntervalsFromCluster(kubeClient kubernetes.Interface, beginning, end time.Time) (monitorapi.Intervals, error) {
+	summary, err := SummarizeInterestingPodLogs(context.TODO(), kubeClient)
+	if err != nil {
+		return nil, err
+	}
+
+	allIntervals := monitorapi.Intervals{}
+	// as more are added, append
+	allIntervals = append(allIntervals, summary.WriteOperationFailures...)
+
+	if beginning.IsZero() || end.IsZero() {
+		return allIntervals, nil
+	}
+
+	timeFiltered := monitorapi.Intervals{}
+	for i := range allIntervals {
+		interval := allIntervals[i]
+		if interval.From.After(end) || interval.To.Before(beginning) {
+			continue
+		}
+		timeFiltered = append(timeFiltered, interval)
+	}
+
+	sort.Sort(timeFiltered)
+	return timeFiltered, nil
+}
+
+var interestingNamespaces = []string{"openshift-cluster-version"}
+
+func SummarizeInterestingPodLogs(ctx context.Context, client kubernetes.Interface) (*APIServerClientAccessFailureSummary, error) {
+	summary := &APIServerClientAccessFailureSummary{}
+	wg := sync.WaitGroup{}
+	for _, namespace := range interestingNamespaces {
+		wg.Add(1)
+		go func(ctx context.Context, namespace string) {
+			defer wg.Done()
+
+			currSummary, err := summarizeLogsForNamespace(ctx, client, namespace)
+			if err != nil {
+				// ignore error and continue
+				klog.Warningf("error summarizing pod logs: %v", err)
+			}
+			summary.AddSummary(currSummary)
+		}(ctx, namespace)
+	}
+	wg.Wait()
+
+	return summary, nil
+}
+
+func summarizeLogsForNamespace(ctx context.Context, client kubernetes.Interface, namespaceName string) (*APIServerClientAccessFailureSummary, error) {
+	podList, err := client.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &APIServerClientAccessFailureSummary{}
+	wg := sync.WaitGroup{}
+	for i := range podList.Items {
+		pod := podList.Items[i]
+
+		wg.Add(1)
+		go func(ctx context.Context, pod *corev1.Pod) {
+			defer wg.Done()
+
+			currSummary, err := summarizeLogsForPod(ctx, client, pod)
+			if err != nil {
+				// ignore error and continue
+				klog.Warningf("error summarizing pod logs: %v", err)
+			}
+			summary.AddSummary(currSummary)
+		}(ctx, &pod)
+	}
+	wg.Wait()
+
+	return summary, nil
+}
+
+func summarizeLogsForPod(ctx context.Context, client kubernetes.Interface, pod *corev1.Pod) (*APIServerClientAccessFailureSummary, error) {
+	pod, err := client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	containerNames := []string{}
+	for _, container := range pod.Spec.InitContainers {
+		containerNames = append(containerNames, container.Name)
+	}
+	for _, container := range pod.Spec.Containers {
+		containerNames = append(containerNames, container.Name)
+	}
+
+	summary := &APIServerClientAccessFailureSummary{}
+	wg := sync.WaitGroup{}
+	for _, previousContainer := range []bool{true, false} {
+		for _, containerName := range containerNames {
+			wg.Add(1)
+			go func(ctx context.Context, previousContainer bool, containerName string) {
+				defer wg.Done()
+
+				locator := monitorapi.LocatePodContainer(pod, containerName)
+				currSummary := &APIServerClientAccessFailureSummary{}
+				logOptions := &corev1.PodLogOptions{
+					Container:                    containerName,
+					Follow:                       false,
+					Previous:                     previousContainer,
+					Timestamps:                   true,
+					InsecureSkipTLSVerifyBackend: true, // set in case the kubelet doesn't have valid serving certs
+				}
+				req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
+				logStream, err := req.Stream(ctx)
+				if err != nil {
+					// ignore error and continue
+					klog.Warningf("error summarizing pod logs: %v", err)
+					return
+				}
+
+				scanner := bufio.NewScanner(logStream)
+				for scanner.Scan() {
+					line := scanner.Bytes()
+					if len(line) == 0 {
+						continue
+					}
+					currSummary.SummarizeLine(locator, string(line))
+				}
+				summary.AddSummary(currSummary)
+			}(ctx, previousContainer, containerName)
+		}
+	}
+	wg.Wait()
+
+	return summary, nil
+}

--- a/pkg/monitor/apiserveravailability/summarizer.go
+++ b/pkg/monitor/apiserveravailability/summarizer.go
@@ -1,0 +1,60 @@
+package apiserveravailability
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"k8s.io/klog/v2"
+)
+
+type SummarizationFunc func(locator, line string)
+
+type APIServerClientAccessFailureSummary struct {
+	lock                   sync.Mutex
+	WriteOperationFailures []monitorapi.EventInterval
+}
+
+func timeFromPodLogTime(line string) time.Time {
+	tokens := strings.Split(line, " ")
+	timeString := tokens[0]
+	t, err := time.Parse(time.RFC3339Nano, timeString)
+	if err != nil {
+		klog.Error(err)
+		return t
+	}
+
+	return time.Now()
+}
+
+func (s *APIServerClientAccessFailureSummary) SummarizeLine(locator, line string) {
+	if strings.Contains(line, "write: operation not permitted") {
+		timeOfLog := timeFromPodLogTime(line)
+		// TODO collapse all in the same second into a single interval
+		event := monitorapi.EventInterval{
+			Condition: monitorapi.Condition{
+				Level:   monitorapi.Warning,
+				Locator: locator,
+				Message: fmt.Sprintf("reason/iptables-operation-not-permitted %v", line),
+			},
+			From: timeOfLog,
+			To:   timeOfLog.Add(1 * time.Second),
+		}
+		s.WriteOperationFailures = append(s.WriteOperationFailures, event)
+	}
+}
+
+func (s *APIServerClientAccessFailureSummary) AddSummary(rhs *APIServerClientAccessFailureSummary) {
+	if rhs == nil {
+		return
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	rhs.lock.Lock()
+	defer rhs.lock.Unlock()
+
+	s.WriteOperationFailures = append(s.WriteOperationFailures, rhs.WriteOperationFailures...)
+}

--- a/pkg/monitor/intervalcreation/types.go
+++ b/pkg/monitor/intervalcreation/types.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
+
 	"github.com/openshift/origin/pkg/monitor/nodedetails"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -65,6 +67,12 @@ func InsertIntervalsFromCluster(ctx context.Context, kubeConfig *rest.Config, st
 		allErrors = append(allErrors, err)
 	}
 	ret = append(ret, podLogIntervals...)
+
+	apiserverAvailabilityIntervals, err := apiserveravailability.APIServerAvailabilityIntervalsFromCluster(kubeClient, from, to)
+	if err != nil {
+		allErrors = append(allErrors, err)
+	}
+	ret = append(ret, apiserverAvailabilityIntervals...)
 
 	auditLogSummary, auditEvents, err := IntervalsFromAuditLogs(ctx, kubeClient, from, to)
 	if err != nil {

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -187,6 +187,13 @@ func (m *Monitor) Record(conditions ...monitorapi.Condition) {
 	}
 }
 
+// AddIntervals provides a mechanism to directly inject eventIntervals
+func (m *Monitor) AddIntervals(eventIntervals ...monitorapi.EventInterval) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.events = append(m.events, eventIntervals...)
+}
+
 // StartInterval inserts a record at time t with the provided condition and returns an opaque
 // locator to the interval. The caller may close the sample at any point by invoking EndInterval().
 func (m *Monitor) StartInterval(t time.Time, condition monitorapi.Condition) int {

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -38,6 +38,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, TestAllAPIBackendsForDisruption(events, duration, jobType)...)
 	tests = append(tests, TestAllIngressBackendsForDisruption(events, duration, jobType)...)
 	tests = append(tests, TestExternalBackendsForDisruption(events, duration, jobType)...)
+	tests = append(tests, TestAPIServerIPTablesAccessDisruption(events)...)
 
 	tests = append(tests, testMultipleSingleSecondDisruptions(events)...)
 	tests = append(tests, testStableSystemOperatorStateTransitions(events)...)
@@ -128,6 +129,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, TestExternalBackendsForDisruption(events, duration, jobType)...)
 	tests = append(tests, testMultipleSingleSecondDisruptions(events)...)
 	tests = append(tests, testNoDNSLookupErrorsInDisruptionSamplers(events)...)
+	tests = append(tests, TestAPIServerIPTablesAccessDisruption(events)...)
 
 	tests = append(tests, testNoExcessiveSecretGrowthDuringUpgrade()...)
 	tests = append(tests, testNoExcessiveConfigMapGrowthDuringUpgrade()...)


### PR DESCRIPTION
example PR of how to scan pod logs for particular failures.  apiserver availability probably also wants to scan node logs.