### PR TITLE
Revert "Make unidle test more strict"

### DIFF
--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -74,7 +74,7 @@ func tryEchoHTTP(svc *kapiv1.Service, execPod *kapiv1.Pod) error {
 	}
 
 	expected := "It is time to TCP."
-	cmd := fmt.Sprintf("curl --max-time 120 -v -g http://%s/echo?msg=%s",
+	cmd := fmt.Sprintf("curl --retry-max-time 120 --retry-connrefused --retry 20 --max-time 5 -s -g http://%s/echo?msg=%s",
 		net.JoinHostPort(rawIP, tcpPort),
 		url.QueryEscape(expected),
 	)


### PR DESCRIPTION
Reverts #27673  ; tracked by [TRT-944](https://issues.redhat.com//browse/TRT-944)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.


After https://github.com/openshift/origin/pull/27673 landed, we started failing payloads on the test: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.14.0-0.nightly/release/4.14.0-0.nightly-2023-03-30-083327

 Example run:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-metal-ipi-ovn-ipv6/1641431627710074880


To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of `/payload 4.14 nightly blocking`.

CC: @zeeke , @bparees 