### PR TITLE
upkeep: updated query results

### DIFF
--- a/pkg/synthetictests/allowedbackenddisruption/query_results.json
+++ b/pkg/synthetictests/allowedbackenddisruption/query_results.json
@@ -2,12 +2,12 @@
   {
     "BackendName": "cache-kube-api-new-connections",
     "Release": "4.14",
-    "FromRelease": "4.13",
+    "FromRelease": "4.12",
     "Platform": "aws",
     "Architecture": "amd64",
-    "Network": "ovn",
+    "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 758,
+    "JobRuns": 1,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -18,10 +18,22 @@
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "17.0",
+    "P99": "22.069999999999993"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "179.7",
-    "P99": "183.94"
+    "JobRuns": 3,
+    "P95": "141.6",
+    "P99": "143.52"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -31,9 +43,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "0.79999999999999893"
+    "JobRuns": 178,
+    "P95": "18.0",
+    "P99": "25.789999999999996"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -44,8 +56,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "7.1999999999999993",
-    "P99": "7.84"
+    "P95": "15.7",
+    "P99": "15.94"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -55,9 +67,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "3.0",
-    "P99": "7.0"
+    "JobRuns": 786,
+    "P95": "16.0",
+    "P99": "25.149999999999991"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -67,9 +79,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "4.0",
-    "P99": "7.0"
+    "JobRuns": 487,
+    "P95": "18.0",
+    "P99": "24.139999999999997"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -80,8 +92,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "2.6999999999999997",
-    "P99": "2.94"
+    "P95": "15.7",
+    "P99": "15.94"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -91,21 +103,21 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "7.0499999999999989",
-    "P99": "7.81"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "12.0",
+    "JobRuns": 50,
+    "P95": "10.549999999999997",
     "P99": "12.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "11.6",
+    "P99": "11.92"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -115,9 +127,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "13.0",
+    "P99": "13.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -127,9 +139,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "14.1",
-    "P99": "14.82"
+    "JobRuns": 4,
+    "P95": "15.399999999999999",
+    "P99": "15.879999999999999"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -139,9 +151,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "0.79999999999999893"
+    "JobRuns": 30,
+    "P95": "18.0",
+    "P99": "25.789999999999996"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -151,9 +163,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "720.69999999999959",
-    "P99": "917.9"
+    "JobRuns": 11,
+    "P95": "762.69999999999993",
+    "P99": "796.54"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -164,8 +176,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "720.69999999999959",
-    "P99": "917.9"
+    "P95": "762.69999999999993",
+    "P99": "796.54"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -175,9 +187,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "12.0",
-    "P99": "17.089999999999993"
+    "JobRuns": 844,
+    "P95": "17.0",
+    "P99": "20.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -188,8 +200,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "214.65",
-    "P99": "215.73"
+    "P95": "183.25",
+    "P99": "183.85"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -199,9 +211,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "17.0",
-    "P99": "21.0"
+    "JobRuns": 447,
+    "P95": "16.699999999999982",
+    "P99": "22.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -211,9 +223,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
+    "JobRuns": 458,
     "P95": "21.0",
-    "P99": "31.859999999999996"
+    "P99": "31.859999999999992"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -223,9 +235,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "17.099999999999998",
+    "P99": "18.62"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -235,9 +247,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "5.6999999999999993",
-    "P99": "5.9399999999999995"
+    "JobRuns": 3,
+    "P95": "14.499999999999998",
+    "P99": "15.7"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -248,8 +260,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 5,
-    "P95": "2.3999999999999995",
-    "P99": "2.88"
+    "P95": "10.599999999999998",
+    "P99": "11.719999999999999"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -259,9 +271,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "8.2",
-    "P99": "8.84"
+    "JobRuns": 45,
+    "P95": "11.799999999999997",
+    "P99": "12.559999999999999"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -271,7 +283,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 7,
     "P95": "9.0",
     "P99": "9.0"
   },
@@ -283,21 +295,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "12.0",
-    "P99": "17.089999999999993"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 49,
+    "P95": "17.0",
+    "P99": "20.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -319,19 +319,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -343,7 +331,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -355,9 +343,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "1.8199999999999963"
+    "P99": "4.7999999999999954"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -367,9 +355,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "167.1999999999999",
-    "P99": "195.88"
+    "JobRuns": 97,
+    "P95": "203.79999999999998",
+    "P99": "267.24"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -379,9 +367,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "2.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -391,9 +379,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "1.0",
-    "P99": "5.2699999999999978"
+    "JobRuns": 55,
+    "P95": "2.0",
+    "P99": "8.5099999999999856"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -403,9 +391,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "1.0",
-    "P99": "5.0599999999999987"
+    "JobRuns": 204,
+    "P95": "2.0",
+    "P99": "6.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -415,9 +403,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
+    "JobRuns": 142,
     "P95": "2.0",
-    "P99": "3.4299999999999997"
+    "P99": "4.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -427,9 +415,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "2.0",
-    "P99": "4.4599999999999991"
+    "JobRuns": 245,
+    "P95": "3.0",
+    "P99": "8.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -451,9 +439,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 236,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.64999999999999791"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -463,9 +451,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "42.179999999999971"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -475,7 +463,43 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.6499999999999988",
+    "P99": "1021.5399999999996"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "618.09999999999991",
+    "P99": "1144.5199999999998"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -483,47 +507,11 @@
     "BackendName": "cache-kube-api-new-connections",
     "Release": "4.14",
     "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1755.3999999999996",
-    "P99": "2103.88"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "964.99999999999955",
-    "P99": "2330.4399999999996"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "0.0",
-    "P99": "1.1899999999999984"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
     "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -535,9 +523,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "1.8199999999999963"
+    "P99": "4.7999999999999954"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -547,9 +535,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "167.1999999999999",
-    "P99": "195.88"
+    "JobRuns": 48,
+    "P95": "203.79999999999998",
+    "P99": "267.24"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -559,9 +547,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "2.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -571,9 +559,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "1.0",
-    "P99": "5.2699999999999978"
+    "JobRuns": 43,
+    "P95": "2.0",
+    "P99": "8.5099999999999856"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -583,9 +571,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 44,
+    "P95": "2.8499999999999979",
+    "P99": "14.829999999999993"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -595,9 +583,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "279.24999999999977",
-    "P99": "492.87999999999994"
+    "JobRuns": 56,
+    "P95": "436.99999999999989",
+    "P99": "1046.9999999999995"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -607,9 +595,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "279.24999999999977",
-    "P99": "492.87999999999994"
+    "JobRuns": 45,
+    "P95": "436.99999999999989",
+    "P99": "1046.9999999999995"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -619,9 +619,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 758,
+    "JobRuns": 794,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -631,9 +631,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "179.7",
-    "P99": "183.94"
+    "JobRuns": 3,
+    "P95": "141.6",
+    "P99": "143.52"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -643,7 +643,19 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
+    "JobRuns": 178,
+    "P95": "1.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -653,7 +665,31 @@
     "FromRelease": "4.13",
     "Platform": "azure",
     "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "2.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
     "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "1.0",
+    "P99": "1.1399999999999957"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 3,
     "P95": "0.89999999999999991",
@@ -663,49 +699,13 @@
     "BackendName": "cache-kube-api-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "1.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "9.0499999999999989",
-    "P99": "9.81"
+    "JobRuns": 50,
+    "P95": "9.5499999999999972",
+    "P99": "11.53"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -715,7 +715,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 9,
     "P95": "14.0",
     "P99": "14.0"
   },
@@ -727,9 +727,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "7.2999999999999989",
+    "P99": "7.8599999999999994"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -739,9 +739,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "12.299999999999999",
-    "P99": "12.86"
+    "JobRuns": 4,
+    "P95": "8.85",
+    "P99": "8.97"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -751,9 +751,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 30,
+    "P95": "1.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -763,9 +763,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "605.69999999999959",
-    "P99": "790.52"
+    "JobRuns": 11,
+    "P95": "601.09999999999991",
+    "P99": "637.81999999999994"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -776,8 +776,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "605.69999999999959",
-    "P99": "790.52"
+    "P95": "601.09999999999991",
+    "P99": "637.81999999999994"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -787,8 +787,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "0.0",
+    "JobRuns": 844,
+    "P95": "1.0",
     "P99": "1.0"
   },
   {
@@ -800,8 +800,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "214.65",
-    "P99": "215.73"
+    "P95": "183.25",
+    "P99": "183.85"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -811,9 +811,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
+    "JobRuns": 447,
     "P95": "1.0",
-    "P99": "1.0899999999999983"
+    "P99": "1.539999999999996"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -823,9 +823,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
+    "JobRuns": 458,
     "P95": "2.0",
-    "P99": "2.0"
+    "P99": "3.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -835,9 +835,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.9",
-    "P99": "1.98"
+    "JobRuns": 3,
+    "P95": "3.8",
+    "P99": "3.96"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -847,7 +847,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -871,9 +871,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "6.3999999999999986",
-    "P99": "7.68"
+    "JobRuns": 45,
+    "P95": "10.799999999999997",
+    "P99": "12.559999999999999"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -883,7 +883,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 7,
     "P95": "8.0",
     "P99": "8.0"
   },
@@ -895,21 +895,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "0.0",
+    "JobRuns": 49,
+    "P95": "1.0",
     "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -931,19 +919,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -955,7 +931,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -967,7 +943,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -979,9 +955,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "165.7999999999999",
-    "P99": "194.88"
+    "JobRuns": 97,
+    "P95": "203.79999999999998",
+    "P99": "267.8"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -991,7 +967,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1003,9 +979,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
+    "JobRuns": 55,
     "P95": "0.0",
-    "P99": "0.60999999999999965"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1015,7 +991,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 204,
     "P95": "0.0",
     "P99": "1.0"
   },
@@ -1027,7 +1003,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
+    "JobRuns": 142,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1039,7 +1015,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
+    "JobRuns": 245,
     "P95": "0.0",
     "P99": "1.0"
   },
@@ -1063,7 +1039,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 236,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1075,9 +1051,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "42.179999999999971"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1087,9 +1063,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1099,9 +1075,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1023.4599999999997"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1111,9 +1087,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "962.19999999999948",
-    "P99": "2321.9599999999996"
+    "JobRuns": 119,
+    "P95": "608.19999999999982",
+    "P99": "1143.6999999999998"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1123,9 +1099,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
-    "P99": "0.18999999999999839"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1135,7 +1111,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1147,7 +1123,7 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1159,9 +1135,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "165.7999999999999",
-    "P99": "194.88"
+    "JobRuns": 48,
+    "P95": "203.79999999999998",
+    "P99": "267.8"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1171,7 +1147,7 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1183,9 +1159,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "0.60999999999999965"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1195,9 +1171,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "0.56999999999999962"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1207,9 +1183,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "237.0999999999998",
-    "P99": "385.23999999999995"
+    "JobRuns": 56,
+    "P95": "341.0",
+    "P99": "800.99999999999977"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1219,9 +1195,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "237.0999999999998",
-    "P99": "385.23999999999995"
+    "JobRuns": 45,
+    "P95": "341.0",
+    "P99": "800.99999999999977"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1231,9 +1219,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 794,
+    "P95": "18.0",
+    "P99": "55.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1243,9 +1231,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "435.5",
-    "P99": "447.1"
+    "JobRuns": 3,
+    "P95": "414.7",
+    "P99": "415.74"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1255,9 +1243,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "4.9999999999999947"
+    "JobRuns": 178,
+    "P95": "17.0",
+    "P99": "34.159999999999975"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1268,8 +1256,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "12.299999999999999",
-    "P99": "12.86"
+    "P95": "16.7",
+    "P99": "16.94"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1279,9 +1267,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "4.0",
-    "P99": "9.2399999999999878"
+    "JobRuns": 786,
+    "P95": "20.749999999999964",
+    "P99": "36.749999999999964"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1291,9 +1279,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "10.0",
-    "P99": "18.799999999999997"
+    "JobRuns": 487,
+    "P95": "25.0",
+    "P99": "44.839999999999975"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1304,8 +1292,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "0.89999999999999991",
-    "P99": "0.98"
+    "P95": "18.9",
+    "P99": "18.98"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1315,9 +1303,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "7.0499999999999989",
-    "P99": "7.81"
+    "JobRuns": 50,
+    "P95": "10.549999999999997",
+    "P99": "15.53"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1327,9 +1315,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "12.0",
-    "P99": "12.0"
+    "JobRuns": 9,
+    "P95": "11.6",
+    "P99": "11.92"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1339,9 +1327,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "14.0",
+    "P99": "14.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1351,9 +1339,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "17.7",
-    "P99": "18.74"
+    "JobRuns": 4,
+    "P95": "13.0",
+    "P99": "13.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1363,9 +1351,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "4.9999999999999947"
+    "JobRuns": 30,
+    "P95": "17.0",
+    "P99": "34.159999999999975"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1375,9 +1363,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "881.69999999999959",
-    "P99": "1094.48"
+    "JobRuns": 11,
+    "P95": "852.19999999999993",
+    "P99": "911.24"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1388,8 +1376,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "881.69999999999959",
-    "P99": "1094.48"
+    "P95": "852.19999999999993",
+    "P99": "911.24"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1399,9 +1387,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "12.449999999999966",
-    "P99": "17.0"
+    "JobRuns": 844,
+    "P95": "18.0",
+    "P99": "26.079999999999991"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1412,8 +1400,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "492.3",
-    "P99": "494.46"
+    "P95": "470.7",
+    "P99": "473.34"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1423,9 +1411,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "17.0",
-    "P99": "22.09"
+    "JobRuns": 447,
+    "P95": "18.699999999999982",
+    "P99": "26.779999999999973"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1435,9 +1423,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "23.149999999999988",
-    "P99": "30.859999999999996"
+    "JobRuns": 458,
+    "P95": "25.149999999999981",
+    "P99": "67.429999999999993"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1447,9 +1435,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "7.3999999999999995",
+    "P99": "7.88"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1459,9 +1447,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "7.95",
-    "P99": "7.99"
+    "JobRuns": 3,
+    "P95": "14.2",
+    "P99": "14.84"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1472,8 +1460,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 5,
-    "P95": "1.0",
-    "P99": "1.0"
+    "P95": "14.999999999999998",
+    "P99": "16.6"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1483,9 +1471,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "7.0",
-    "P99": "7.0"
+    "JobRuns": 45,
+    "P95": "12.399999999999995",
+    "P99": "13.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1495,9 +1483,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "8.35",
-    "P99": "8.87"
+    "JobRuns": 7,
+    "P95": "8.7",
+    "P99": "8.94"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1507,21 +1495,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "12.449999999999966",
-    "P99": "17.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "11.0",
-    "P99": "11.0"
+    "JobRuns": 49,
+    "P95": "18.0",
+    "P99": "26.079999999999991"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1543,19 +1519,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1567,7 +1531,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1579,9 +1543,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "2.9099999999999984"
+    "P99": "19.399999999999984"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1591,9 +1555,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "530.1999999999997",
-    "P99": "693.12"
+    "JobRuns": 97,
+    "P95": "707.19999999999982",
+    "P99": "927.07999999999993"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1603,9 +1567,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
-    "P99": "0.28999999999999759"
+    "P99": "12.499999999999991"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1615,9 +1579,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "2.1999999999999931",
-    "P99": "16.979999999999993"
+    "JobRuns": 55,
+    "P95": "13.649999999999952",
+    "P99": "39.15"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1627,9 +1591,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "1.0",
-    "P99": "6.2999999999999954"
+    "JobRuns": 204,
+    "P95": "2.8499999999999908",
+    "P99": "54.919999999999938"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1639,8 +1603,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "2.2999999999999949",
+    "JobRuns": 142,
+    "P95": "2.0",
     "P99": "5.0"
   },
   {
@@ -1651,9 +1615,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
+    "JobRuns": 245,
     "P95": "3.0",
-    "P99": "5.4599999999999991"
+    "P99": "24.56"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1675,7 +1639,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 236,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1687,9 +1651,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "42.179999999999971"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1699,9 +1663,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "3.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1711,9 +1675,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
+    "JobRuns": 28,
+    "P95": "0.6499999999999988",
+    "P99": "1023.7299999999997"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1723,9 +1687,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "968.7999999999995",
-    "P99": "2332.4399999999996"
+    "JobRuns": 119,
+    "P95": "619.89999999999986",
+    "P99": "1146.1599999999999"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1735,9 +1699,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
-    "P99": "0.18999999999999839"
+    "P99": "0.44999999999999685"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1747,7 +1711,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -1759,9 +1723,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "2.9099999999999984"
+    "P99": "19.399999999999984"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1771,9 +1735,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "530.1999999999997",
-    "P99": "693.12"
+    "JobRuns": 48,
+    "P95": "707.19999999999982",
+    "P99": "927.07999999999993"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1783,9 +1747,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
-    "P99": "0.28999999999999759"
+    "P99": "12.499999999999991"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1795,9 +1759,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "2.1999999999999931",
-    "P99": "16.979999999999993"
+    "JobRuns": 43,
+    "P95": "13.649999999999952",
+    "P99": "39.15"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1807,9 +1771,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "11.0",
-    "P99": "11.0"
+    "JobRuns": 44,
+    "P95": "12.849999999999998",
+    "P99": "21.979999999999993"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1819,9 +1783,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "281.94999999999976",
-    "P99": "494.87999999999994"
+    "JobRuns": 56,
+    "P95": "435.99999999999989",
+    "P99": "1044.9999999999995"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1831,9 +1795,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "281.94999999999976",
-    "P99": "494.87999999999994"
+    "JobRuns": 45,
+    "P95": "435.99999999999989",
+    "P99": "1044.9999999999995"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1843,9 +1819,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 758,
+    "JobRuns": 794,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1855,9 +1831,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "437.5",
-    "P99": "449.1"
+    "JobRuns": 3,
+    "P95": "414.7",
+    "P99": "415.74"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1867,45 +1843,45 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "5.6999999999999993",
-    "P99": "5.9399999999999995"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "3.0",
-    "P99": "6.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
+    "JobRuns": 178,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "11.649999999999991"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "1.7999999999999998",
+    "P99": "1.96"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "6.0",
+    "P99": "15.749999999999964"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "1.0",
+    "P99": "3.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1927,9 +1903,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "9.0499999999999989",
-    "P99": "9.81"
+    "JobRuns": 50,
+    "P95": "9.5499999999999972",
+    "P99": "11.53"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1939,7 +1915,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 9,
     "P95": "14.0",
     "P99": "14.0"
   },
@@ -1951,9 +1927,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "8.2",
+    "P99": "8.84"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1963,9 +1939,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "15.899999999999999",
-    "P99": "16.78"
+    "JobRuns": 4,
+    "P95": "8.85",
+    "P99": "8.97"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1975,9 +1951,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 30,
+    "P95": "1.0",
+    "P99": "11.649999999999991"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -1987,9 +1963,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "709.89999999999952",
-    "P99": "874.33999999999992"
+    "JobRuns": 11,
+    "P95": "645.19999999999993",
+    "P99": "733.04"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2000,8 +1976,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "709.89999999999952",
-    "P99": "874.33999999999992"
+    "P95": "645.19999999999993",
+    "P99": "733.04"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2011,8 +1987,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "0.0",
+    "JobRuns": 844,
+    "P95": "1.0",
     "P99": "1.0"
   },
   {
@@ -2024,8 +2000,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "493.3",
-    "P99": "495.46"
+    "P95": "470.7",
+    "P99": "473.34"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2035,7 +2011,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
+    "JobRuns": 447,
     "P95": "1.0",
     "P99": "1.0"
   },
@@ -2047,9 +2023,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "5.0",
-    "P99": "15.289999999999994"
+    "JobRuns": 458,
+    "P95": "7.0",
+    "P99": "19.289999999999988"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2059,9 +2035,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
+    "JobRuns": 3,
+    "P95": "3.0",
+    "P99": "3.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2071,9 +2047,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
+    "JobRuns": 3,
+    "P95": "0.89999999999999991",
+    "P99": "0.98"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2095,9 +2071,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "6.3999999999999986",
-    "P99": "7.68"
+    "JobRuns": 45,
+    "P95": "10.799999999999997",
+    "P99": "12.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2107,7 +2083,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 7,
     "P95": "8.0",
     "P99": "8.0"
   },
@@ -2119,21 +2095,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "0.0",
+    "JobRuns": 49,
+    "P95": "1.0",
     "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2155,19 +2119,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2179,7 +2131,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2191,9 +2143,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "3.9099999999999984"
+    "P99": "11.199999999999958"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2203,9 +2155,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "529.79999999999973",
-    "P99": "692.12"
+    "JobRuns": 97,
+    "P95": "706.39999999999975",
+    "P99": "926.96"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2215,7 +2167,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2227,9 +2179,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "0.1499999999999948",
-    "P99": "18.859999999999992"
+    "JobRuns": 55,
+    "P95": "1.2999999999999914",
+    "P99": "29.119999999999997"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2239,9 +2191,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "1.0",
-    "P99": "2.4799999999999933"
+    "JobRuns": 204,
+    "P95": "0.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2251,9 +2203,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
+    "JobRuns": 142,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.58999999999999875"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2263,9 +2215,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
+    "JobRuns": 245,
     "P95": "0.0",
-    "P99": "0.45999999999999863"
+    "P99": "0.55999999999999783"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2287,7 +2239,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 236,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2299,9 +2251,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "42.179999999999971"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2311,7 +2263,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
     "P99": "1.0"
   },
@@ -2323,9 +2275,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1023.4599999999997"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2335,9 +2287,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "968.59999999999957",
-    "P99": "2332.7599999999993"
+    "JobRuns": 119,
+    "P95": "618.09999999999991",
+    "P99": "1146.9799999999998"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2347,9 +2299,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
-    "P99": "0.18999999999999839"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2359,7 +2311,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2371,9 +2323,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "3.9099999999999984"
+    "P99": "11.199999999999958"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2383,9 +2335,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "529.79999999999973",
-    "P99": "692.12"
+    "JobRuns": 48,
+    "P95": "706.39999999999975",
+    "P99": "926.96"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2395,7 +2347,7 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2407,9 +2359,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "0.1499999999999948",
-    "P99": "18.859999999999992"
+    "JobRuns": 43,
+    "P95": "1.2999999999999914",
+    "P99": "29.119999999999997"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2419,9 +2371,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
+    "JobRuns": 44,
+    "P95": "0.84999999999999809",
+    "P99": "11.829999999999993"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2431,9 +2383,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "233.39999999999981",
-    "P99": "389.10999999999996"
+    "JobRuns": 56,
+    "P95": "370.99999999999989",
+    "P99": "806.99999999999977"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2443,9 +2395,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "233.39999999999981",
-    "P99": "389.10999999999996"
+    "JobRuns": 45,
+    "P95": "370.99999999999989",
+    "P99": "806.99999999999977"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2455,9 +2419,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 794,
+    "P95": "17.349999999999966",
+    "P99": "25.069999999999993"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2467,9 +2431,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "444.55",
-    "P99": "456.11"
+    "JobRuns": 3,
+    "P95": "425.9",
+    "P99": "427.58"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2479,9 +2443,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 178,
+    "P95": "18.0",
+    "P99": "35.369999999999983"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2492,8 +2456,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "10.1",
-    "P99": "10.82"
+    "P95": "19.6",
+    "P99": "19.92"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2503,9 +2467,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "5.0",
-    "P99": "8.6199999999999939"
+    "JobRuns": 786,
+    "P95": "22.0",
+    "P99": "39.149999999999991"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2515,9 +2479,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "13.0",
-    "P99": "20.0"
+    "JobRuns": 487,
+    "P95": "24.0",
+    "P99": "40.139999999999993"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2528,8 +2492,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "3.9",
-    "P99": "3.98"
+    "P95": "19.9",
+    "P99": "19.98"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2539,9 +2503,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "7.0499999999999989",
-    "P99": "7.81"
+    "JobRuns": 50,
+    "P95": "11.549999999999997",
+    "P99": "13.53"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2551,9 +2515,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "12.0",
-    "P99": "12.0"
+    "JobRuns": 9,
+    "P95": "11.6",
+    "P99": "11.92"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2563,9 +2527,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "14.8",
+    "P99": "14.96"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2575,9 +2539,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "18.599999999999998",
-    "P99": "19.72"
+    "JobRuns": 4,
+    "P95": "14.0",
+    "P99": "14.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2587,9 +2551,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 30,
+    "P95": "18.0",
+    "P99": "35.369999999999983"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2599,9 +2563,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "905.09999999999957",
-    "P99": "1097.08"
+    "JobRuns": 11,
+    "P95": "855.69999999999993",
+    "P99": "932.74"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2612,8 +2576,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "905.09999999999957",
-    "P99": "1097.08"
+    "P95": "855.69999999999993",
+    "P99": "932.74"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2623,9 +2587,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "12.0",
-    "P99": "18.089999999999993"
+    "JobRuns": 844,
+    "P95": "18.0",
+    "P99": "21.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2636,8 +2600,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "498.7",
-    "P99": "498.94"
+    "P95": "489.1",
+    "P99": "492.22"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2647,9 +2611,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
+    "JobRuns": 447,
     "P95": "18.0",
-    "P99": "20.09"
+    "P99": "21.539999999999996"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2659,9 +2623,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "26.0",
-    "P99": "33.0"
+    "JobRuns": 458,
+    "P95": "28.0",
+    "P99": "34.429999999999993"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2671,9 +2635,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
+    "JobRuns": 3,
+    "P95": "12.7",
+    "P99": "13.74"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2683,9 +2647,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "4.85",
-    "P99": "4.97"
+    "JobRuns": 3,
+    "P95": "19.4",
+    "P99": "20.68"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2696,8 +2660,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 5,
-    "P95": "3.9999999999999991",
-    "P99": "4.8"
+    "P95": "17.4",
+    "P99": "19.48"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2707,9 +2671,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "8.0",
-    "P99": "8.0"
+    "JobRuns": 45,
+    "P95": "11.599999999999996",
+    "P99": "13.559999999999999"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2719,9 +2683,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "10.049999999999999",
-    "P99": "11.61"
+    "JobRuns": 7,
+    "P95": "9.0",
+    "P99": "9.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2731,21 +2695,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "12.0",
-    "P99": "18.089999999999993"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "10.2",
-    "P99": "11.64"
+    "JobRuns": 49,
+    "P95": "18.0",
+    "P99": "21.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2767,19 +2719,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2791,7 +2731,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2803,9 +2743,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "14.799999999999995"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2815,9 +2755,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "531.99999999999977",
-    "P99": "670.4799999999999"
+    "JobRuns": 97,
+    "P95": "727.0",
+    "P99": "917.75999999999988"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2827,9 +2767,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "4.7499999999999956"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2839,9 +2779,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "1.1499999999999948",
-    "P99": "22.909999999999989"
+    "JobRuns": 55,
+    "P95": "6.4499999999999869",
+    "P99": "35.539999999999985"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2851,9 +2791,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "1.0",
-    "P99": "2.1199999999999983"
+    "JobRuns": 204,
+    "P95": "2.0",
+    "P99": "10.969999999999999"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2863,9 +2803,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "1.1499999999999975",
-    "P99": "3.2899999999999983"
+    "JobRuns": 142,
+    "P95": "2.0",
+    "P99": "4.589999999999999"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2875,9 +2815,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "2.2999999999999932",
-    "P99": "4.4599999999999991"
+    "JobRuns": 245,
+    "P95": "3.0",
+    "P99": "8.5599999999999987"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2899,7 +2839,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 237,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2911,9 +2851,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.78999999999999981"
+    "P99": "42.609999999999971"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2923,9 +2863,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "2.5799999999999987"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2935,9 +2875,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1756.4999999999995",
-    "P99": "2104.1"
+    "JobRuns": 28,
+    "P95": "0.6499999999999988",
+    "P99": "1022.9999999999997"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2947,9 +2887,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "969.39999999999952",
-    "P99": "2332.4399999999996"
+    "JobRuns": 119,
+    "P95": "620.8",
+    "P99": "1146.1599999999999"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2959,9 +2899,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.44999999999999685"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2971,7 +2911,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -2983,9 +2923,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "14.799999999999995"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2995,9 +2935,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "531.99999999999977",
-    "P99": "670.4799999999999"
+    "JobRuns": 48,
+    "P95": "727.0",
+    "P99": "917.75999999999988"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3007,9 +2947,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "4.7499999999999956"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3019,9 +2959,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "1.1499999999999948",
-    "P99": "22.909999999999989"
+    "JobRuns": 43,
+    "P95": "6.4499999999999869",
+    "P99": "35.539999999999985"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3031,9 +2971,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "10.2",
-    "P99": "11.64"
+    "JobRuns": 44,
+    "P95": "14.849999999999998",
+    "P99": "25.119999999999994"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3043,9 +2983,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "284.34999999999974",
-    "P99": "495.44999999999993"
+    "JobRuns": 56,
+    "P95": "436.99999999999989",
+    "P99": "1044.9999999999995"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3055,9 +2995,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "284.34999999999974",
-    "P99": "495.44999999999993"
+    "JobRuns": 45,
+    "P95": "436.99999999999989",
+    "P99": "1044.9999999999995"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3067,9 +3019,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 758,
+    "JobRuns": 794,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3079,9 +3031,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "445.55",
-    "P99": "457.11"
+    "JobRuns": 3,
+    "P95": "425.8",
+    "P99": "427.56"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3091,9 +3043,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 178,
+    "P95": "1.0",
+    "P99": "11.299999999999981"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3104,8 +3056,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "0.89999999999999991",
-    "P99": "0.98"
+    "P95": "8.2",
+    "P99": "8.84"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3115,9 +3067,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "3.0",
-    "P99": "7.0"
+    "JobRuns": 786,
+    "P95": "8.0",
+    "P99": "22.299999999999986"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3127,7 +3079,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 221,
+    "JobRuns": 487,
     "P95": "1.0",
     "P99": "2.0"
   },
@@ -3151,9 +3103,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "9.0999999999999979",
-    "P99": "10.62"
+    "JobRuns": 50,
+    "P95": "9.5499999999999972",
+    "P99": "12.02"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3163,9 +3115,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "13.35",
-    "P99": "13.87"
+    "JobRuns": 9,
+    "P95": "13.6",
+    "P99": "13.92"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3175,9 +3127,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "9.1",
+    "P99": "9.82"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3187,9 +3139,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "15.899999999999999",
-    "P99": "16.78"
+    "JobRuns": 4,
+    "P95": "8.0",
+    "P99": "8.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3199,9 +3151,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 30,
+    "P95": "1.0",
+    "P99": "11.299999999999981"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3211,9 +3163,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "699.79999999999973",
-    "P99": "879.31999999999994"
+    "JobRuns": 11,
+    "P95": "610.99999999999989",
+    "P99": "704.6"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3224,8 +3176,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "699.79999999999973",
-    "P99": "879.31999999999994"
+    "P95": "610.99999999999989",
+    "P99": "704.6"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3235,8 +3187,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "0.0",
+    "JobRuns": 844,
+    "P95": "1.0",
     "P99": "1.0"
   },
   {
@@ -3248,8 +3200,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "499.7",
-    "P99": "499.94"
+    "P95": "489.25",
+    "P99": "492.25"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3259,9 +3211,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
+    "JobRuns": 447,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "2.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3271,8 +3223,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "6.0",
+    "JobRuns": 458,
+    "P95": "7.0",
     "P99": "20.429999999999996"
   },
   {
@@ -3283,9 +3235,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.9",
-    "P99": "1.98"
+    "JobRuns": 3,
+    "P95": "2.9",
+    "P99": "2.98"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3295,7 +3247,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "1.0",
     "P99": "1.0"
   },
@@ -3319,9 +3271,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "6.3999999999999986",
-    "P99": "7.68"
+    "JobRuns": 45,
+    "P95": "10.799999999999997",
+    "P99": "12.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3331,7 +3283,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 7,
     "P95": "8.0",
     "P99": "8.0"
   },
@@ -3343,21 +3295,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "0.0",
+    "JobRuns": 49,
+    "P95": "1.0",
     "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3379,19 +3319,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3403,7 +3331,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3415,9 +3343,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "7.5999999999999677"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3427,9 +3355,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "531.5999999999998",
-    "P99": "670.0"
+    "JobRuns": 97,
+    "P95": "726.8",
+    "P99": "917.87999999999988"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3439,7 +3367,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3451,9 +3379,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "0.24999999999999134",
-    "P99": "16.589999999999993"
+    "JobRuns": 55,
+    "P95": "4.1499999999999959",
+    "P99": "24.119999999999997"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3463,8 +3391,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "0.0",
+    "JobRuns": 204,
+    "P95": "1.0",
     "P99": "1.0"
   },
   {
@@ -3475,7 +3403,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
+    "JobRuns": 142,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3487,9 +3415,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
+    "JobRuns": 245,
     "P95": "0.0",
-    "P99": "1.4599999999999986"
+    "P99": "1.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3511,7 +3439,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 236,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3523,9 +3451,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.78999999999999981"
+    "P99": "42.609999999999971"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3535,9 +3463,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.57999999999999874"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3547,9 +3475,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1755.9499999999996",
-    "P99": "2103.99"
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1021.9999999999997"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3559,9 +3487,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "969.99999999999955",
-    "P99": "2333.1199999999994"
+    "JobRuns": 119,
+    "P95": "619.89999999999986",
+    "P99": "1146.1599999999999"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3571,9 +3499,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
-    "P99": "0.18999999999999839"
+    "P99": "0.44999999999999685"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3583,7 +3511,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3595,9 +3523,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "7.5999999999999677"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3607,9 +3535,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "531.5999999999998",
-    "P99": "670.0"
+    "JobRuns": 48,
+    "P95": "726.8",
+    "P99": "917.87999999999988"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3619,7 +3547,7 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3631,9 +3559,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "0.24999999999999134",
-    "P99": "16.589999999999993"
+    "JobRuns": 43,
+    "P95": "4.1499999999999959",
+    "P99": "24.119999999999997"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3643,9 +3571,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "9.5499999999999936"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3655,9 +3583,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "233.69999999999982",
-    "P99": "389.38999999999993"
+    "JobRuns": 56,
+    "P95": "359.0",
+    "P99": "802.99999999999977"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3667,123 +3595,15 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "233.69999999999982",
-    "P99": "389.38999999999993"
+    "JobRuns": 45,
+    "P95": "359.0",
+    "P99": "802.99999999999977"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
     "Release": "4.14",
-    "FromRelease": "4.13",
+    "FromRelease": "4.12",
     "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "3.1499999999999666",
-    "P99": "9.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "3.8",
-    "P99": "3.96"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "4.0",
-    "P99": "8.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "2.6999999999999997",
-    "P99": "2.94"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "3.0",
-    "P99": "11.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "5.99999999999999",
-    "P99": "17.79999999999999"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "3.5999999999999996",
-    "P99": "3.92"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "24.999999999999982",
-    "P99": "40.199999999999996"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "17.949999999999978",
-    "P99": "37.19"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -3795,13 +3615,133 @@
     "BackendName": "ci-cluster-network-liveness-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
-    "Platform": "vsphere",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "5.0",
+    "P99": "50.349999999999966"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "4.0",
+    "P99": "9.8599999999999959"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "0.89999999999999991",
-    "P99": "0.98"
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "4.0",
+    "P99": "20.749999999999964"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "5.0",
+    "P99": "28.499999999999893"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "4.0",
+    "P99": "14.689999999999992"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "2.9999999999999982",
+    "P99": "4.6"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3811,9 +3751,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
+    "JobRuns": 30,
     "P95": "4.0",
-    "P99": "8.0"
+    "P99": "9.8599999999999959"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3823,9 +3763,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "1.799999999999998",
-    "P99": "3.5599999999999996"
+    "JobRuns": 11,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3836,8 +3776,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "1.799999999999998",
-    "P99": "3.5599999999999996"
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3847,9 +3787,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
+    "JobRuns": 844,
     "P95": "4.0",
-    "P99": "13.809999999999937"
+    "P99": "55.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3860,8 +3800,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "4.2499999999999991",
-    "P99": "4.85"
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3871,9 +3811,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "4.0",
-    "P99": "7.0899999999999981"
+    "JobRuns": 447,
+    "P95": "5.69999999999998",
+    "P99": "50.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3883,9 +3823,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "4.0",
-    "P99": "24.179999999999939"
+    "JobRuns": 458,
+    "P95": "7.0",
+    "P99": "28.579999999999977"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3895,7 +3835,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -3907,9 +3847,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.7999999999999998",
+    "P99": "1.96"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3920,8 +3860,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 5,
-    "P95": "3.1999999999999993",
-    "P99": "3.84"
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3931,9 +3871,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "14.599999999999952",
-    "P99": "58.11999999999999"
+    "JobRuns": 45,
+    "P95": "1.0",
+    "P99": "4.6799999999999988"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3943,9 +3883,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "17.499999999999972",
-    "P99": "43.499999999999993"
+    "JobRuns": 7,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3955,21 +3895,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
+    "JobRuns": 49,
     "P95": "4.0",
-    "P99": "13.809999999999937"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
+    "P99": "55.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3980,8 +3908,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "2.6999999999999997",
-    "P99": "2.94"
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -3991,21 +3919,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 12,
+    "P95": "0.44999999999999951",
+    "P99": "0.8899999999999999"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4015,9 +3931,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
-    "P95": "0.49999999999999689",
-    "P99": "2.6499999999999995"
+    "JobRuns": 10,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4027,9 +3943,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
-    "P95": "2.0",
-    "P99": "6.8199999999999967"
+    "JobRuns": 316,
+    "P95": "1.0",
+    "P99": "7.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4039,9 +3955,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "3.7999999999999954",
-    "P99": "20.879999999999985"
+    "JobRuns": 97,
+    "P95": "0.79999999999999361",
+    "P99": "24.719999999999985"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4051,9 +3967,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
-    "P95": "2.0",
-    "P99": "6.2899999999999974"
+    "JobRuns": 407,
+    "P95": "2.7499999999999769",
+    "P99": "18.499999999999972"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4063,9 +3979,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "1.0499999999999983",
-    "P99": "3.8299999999999992"
+    "JobRuns": 55,
+    "P95": "0.14999999999999569",
+    "P99": "16.499999999999957"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4075,9 +3991,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "4.2999999999999954",
-    "P99": "7.1199999999999983"
+    "JobRuns": 204,
+    "P95": "6.8499999999999908",
+    "P99": "39.579999999999977"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4087,9 +4003,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "1.2999999999999949",
-    "P99": "5.0"
+    "JobRuns": 142,
+    "P95": "0.0",
+    "P99": "6.1799999999999979"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4099,9 +4015,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "1.0",
-    "P99": "2.4599999999999986"
+    "JobRuns": 245,
+    "P95": "2.7999999999999892",
+    "P99": "14.559999999999999"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4123,9 +4039,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 94,
+    "JobRuns": 234,
     "P95": "0.0",
-    "P99": "1.2799999999999967"
+    "P99": "5.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4135,7 +4051,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4147,69 +4063,69 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
-    "P95": "3.2999999999999976",
+    "JobRuns": 143,
+    "P95": "3.0",
+    "P99": "4.5799999999999983"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "0.0",
+    "P99": "7.9199999999999937"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
+    "P95": "1.0",
+    "P99": "10.449999999999998"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 109,
+    "P95": "0.0",
     "P99": "7.919999999999999"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
     "Release": "4.14",
     "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "0.0",
-    "P99": "1.3599999999999994"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "2.9499999999999922",
-    "P99": "52.99999999999968"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "5.0999999999999961"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
-    "P95": "2.0",
-    "P99": "6.8199999999999967"
+    "JobRuns": 205,
+    "P95": "1.0",
+    "P99": "7.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4219,9 +4135,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "3.7999999999999954",
-    "P99": "20.879999999999985"
+    "JobRuns": 48,
+    "P95": "0.79999999999999361",
+    "P99": "24.719999999999985"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4231,9 +4147,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
-    "P95": "2.0",
-    "P99": "6.2899999999999974"
+    "JobRuns": 119,
+    "P95": "2.7499999999999769",
+    "P99": "18.499999999999972"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4243,9 +4159,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "1.0499999999999983",
-    "P99": "3.8299999999999992"
+    "JobRuns": 43,
+    "P95": "0.14999999999999569",
+    "P99": "16.499999999999957"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4255,9 +4171,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 44,
+    "P95": "1.6999999999999962",
+    "P99": "5.5699999999999994"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4267,9 +4183,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
+    "JobRuns": 56,
     "P95": "0.0",
-    "P99": "1.5699999999999996"
+    "P99": "6.9999999999999973"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4279,123 +4195,15 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
+    "JobRuns": 45,
     "P95": "0.0",
-    "P99": "1.5699999999999996"
+    "P99": "6.9999999999999973"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.14",
-    "FromRelease": "4.13",
+    "FromRelease": "4.12",
     "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "1.7999999999999998",
-    "P99": "1.96"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "1.7999999999999998",
-    "P99": "1.96"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "0.049999999999999156",
-    "P99": "0.80999999999999983"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "1.3999999999999977",
-    "P99": "3.4799999999999995"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -4407,13 +4215,133 @@
     "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
-    "Platform": "vsphere",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "0.89999999999999991",
-    "P99": "0.98"
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "0.0",
+    "P99": "1.1399999999999957"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4423,7 +4351,7 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
+    "JobRuns": 30,
     "P95": "0.0",
     "P99": "1.0"
   },
@@ -4435,7 +4363,7 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
+    "JobRuns": 11,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4459,7 +4387,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
+    "JobRuns": 844,
     "P95": "0.0",
     "P99": "1.0"
   },
@@ -4483,7 +4411,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
+    "JobRuns": 447,
     "P95": "0.0",
     "P99": "1.0"
   },
@@ -4495,9 +4423,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
+    "JobRuns": 458,
     "P95": "0.0",
-    "P99": "1.4299999999999977"
+    "P99": "1.4299999999999959"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4507,7 +4435,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4519,7 +4447,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4543,9 +4471,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "0.19999999999999929",
-    "P99": "0.83999999999999986"
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4555,9 +4483,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "1.0499999999999983",
-    "P99": "2.6099999999999994"
+    "JobRuns": 7,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4567,21 +4495,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
+    "JobRuns": 49,
     "P95": "0.0",
     "P99": "1.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4603,19 +4519,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4627,9 +4531,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
-    "P99": "0.64999999999999969"
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4639,7 +4543,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4651,9 +4555,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
+    "JobRuns": 97,
     "P95": "0.0",
-    "P99": "13.919999999999987"
+    "P99": "3.7999999999999936"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4663,19 +4567,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 25,
+    "JobRuns": 407,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4685,11 +4577,23 @@
     "FromRelease": "",
     "Platform": "azure",
     "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "0.029999999999999138"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 204,
     "P95": "0.0",
-    "P99": "1.0599999999999992"
+    "P99": "1.9399999999999964"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4699,7 +4603,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
+    "JobRuns": 142,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4711,9 +4615,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
+    "JobRuns": 245,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "2.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4735,7 +4639,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 93,
+    "JobRuns": 233,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4747,7 +4651,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4759,93 +4663,93 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
-    "P95": "0.2999999999999976",
-    "P99": "1.4599999999999995"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "0.0",
-    "P99": "0.18999999999999839"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 77,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 12,
-    "P95": "0.0",
-    "P99": "13.919999999999987"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 143,
     "P95": "0.0",
     "P99": "1.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "0.0",
+    "P99": "0.819999999999999"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 109,
+    "P95": "0.0",
+    "P99": "0.919999999999999"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 205,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 48,
+    "P95": "0.0",
+    "P99": "3.7999999999999936"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4855,9 +4759,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.029999999999999138"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4867,9 +4771,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.56999999999999962"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4879,7 +4783,7 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
+    "JobRuns": 56,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -4891,624 +4795,60 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
+    "JobRuns": 45,
     "P95": "0.0",
     "P99": "0.0"
   },
   {
     "BackendName": "image-registry-new-connections",
     "Release": "4.14",
-    "FromRelease": "4.13",
+    "FromRelease": "4.12",
     "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 756,
-    "P95": "6.0",
-    "P99": "9.449999999999994"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "362.9",
-    "P99": "378.18"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 113,
-    "P95": "4.149999999999995",
-    "P99": "6.8299999999999992"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "15.0",
-    "P99": "15.8"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 715,
-    "P95": "4.2999999999999687",
-    "P99": "10.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 219,
-    "P95": "30.199999999999982",
-    "P99": "49.279999999999994"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.89999999999999991",
-    "P99": "0.98"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "37.449999999999996",
-    "P99": "44.29"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "37.699999999999996",
-    "P99": "38.74"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 1,
-    "P95": "149.0",
-    "P99": "149.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "40.0",
-    "P99": "40.8"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "4.149999999999995",
-    "P99": "6.8299999999999992"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "814.59999999999991",
-    "P99": "964.86"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 8,
-    "P95": "814.59999999999991",
-    "P99": "964.86"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 732,
-    "P95": "5.0",
-    "P99": "10.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 4,
-    "P95": "377.7",
-    "P99": "377.94"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 191,
-    "P95": "3.9999999999999831",
-    "P99": "11.399999999999993"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 250,
-    "P95": "12.099999999999978",
-    "P99": "26.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "2.9",
-    "P99": "2.98"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "7.8",
-    "P99": "7.96"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
     "P95": "0.0",
     "P99": "0.0"
   },
   {
     "BackendName": "image-registry-new-connections",
     "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "95.799999999999969",
-    "P99": "120.75999999999999"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "67.199999999999989",
-    "P99": "73.44"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "5.0",
-    "P99": "10.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 756,
+    "JobRuns": 792,
     "P95": "3.0",
-    "P99": "5.0"
+    "P99": "6.0899999999999928"
   },
   {
-    "BackendName": "image-registry-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "336.3",
-    "P99": "350.46"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 113,
-    "P95": "3.149999999999995",
-    "P99": "6.8299999999999992"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
     "JobRuns": 3,
-    "P95": "0.89999999999999991",
-    "P99": "0.98"
+    "P95": "283.5",
+    "P99": "284.7"
   },
   {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 715,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 219,
-    "P95": "5.0",
-    "P99": "10.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "18.199999999999996",
-    "P99": "21.24"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "30.099999999999998",
-    "P99": "33.22"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "124.0",
-    "P99": "124.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "8.2",
-    "P99": "8.84"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "3.149999999999995",
-    "P99": "6.8299999999999992"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "701.9",
-    "P99": "818.31999999999994"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 8,
-    "P95": "701.9",
-    "P99": "818.31999999999994"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 732,
-    "P95": "3.0",
-    "P99": "6.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 4,
-    "P95": "373.4",
-    "P99": "376.28"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 191,
-    "P95": "2.9999999999999831",
-    "P99": "10.099999999999998"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 250,
+    "JobRuns": 174,
     "P95": "6.0",
-    "P99": "6.0"
+    "P99": "10.939999999999994"
   },
   {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "1.5999999999999996",
-    "P99": "1.92"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "75.399999999999977",
-    "P99": "99.08"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "39.35",
-    "P99": "39.87"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "3.0",
-    "P99": "6.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "31.0",
-    "P99": "38.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "360.84999999999997",
-    "P99": "374.57"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "6.9999999999999947",
-    "P99": "57.19999999999996"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "azure",
@@ -5516,647 +4856,35 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "13.1",
-    "P99": "13.82"
+    "P95": "5.9",
+    "P99": "5.98"
   },
   {
-    "BackendName": "ingress-to-console-new-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "azure",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "4.0999999999999677",
-    "P99": "11.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "26.999999999999961",
-    "P99": "51.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "0.049999999999999156",
-    "P99": "0.80999999999999983"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "9.0",
-    "P99": "9.8"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "6.9999999999999947",
-    "P99": "57.19999999999996"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "720.39999999999964",
-    "P99": "906.42"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 8,
-    "P95": "720.39999999999964",
-    "P99": "906.42"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "32.0",
-    "P99": "52.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 4,
-    "P95": "398.2",
-    "P99": "399.64"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "6.0",
-    "P99": "9.1799999999999962"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "20.149999999999988",
-    "P99": "118.82999999999959"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.9",
-    "P99": "1.98"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "12.6",
-    "P99": "12.92"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "1.5999999999999979",
-    "P99": "3.5199999999999996"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "1.6999999999999988",
-    "P99": "2.7399999999999998"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "32.0",
-    "P99": "52.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "87.5",
-    "P99": "91.1"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "external",
-    "JobRuns": 36,
-    "P95": "2.9999999999999938",
-    "P99": "8.5999999999999979"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 130,
-    "P95": "61.0",
-    "P99": "111.19999999999995"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 41,
-    "P95": "582.59999999999968",
-    "P99": "763.24"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 236,
-    "P95": "1.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "458.39999999999986",
-    "P99": "1331.3399999999995"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "156.89999999999802",
-    "P99": "1451.9799999999998"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "0.14999999999999747",
-    "P99": "2.4299999999999997"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "2.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ibmcloud",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 93,
-    "P95": "0.0",
-    "P99": "1.0799999999999992"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 22,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 55,
-    "P95": "0.2999999999999976",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1756.9499999999996",
-    "P99": "2104.99"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "976.19999999999959",
-    "P99": "2335.7999999999997"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "1.949999999999992",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "1278.0599999999988"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 77,
-    "P95": "61.0",
-    "P99": "111.19999999999995"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 12,
-    "P95": "582.59999999999968",
-    "P99": "763.24"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 36,
-    "P95": "1.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "458.39999999999986",
-    "P99": "1331.3399999999995"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "87.5",
-    "P99": "91.1"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "370.44999999999982",
-    "P99": "554.96"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "370.44999999999982",
-    "P99": "554.96"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "30.0",
-    "P99": "37.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "359.9",
-    "P99": "373.58"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "6.0",
-    "P99": "29.199999999999982"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "8.3999999999999986",
-    "P99": "8.879999999999999"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "9.0",
+    "JobRuns": 759,
+    "P95": "8.0",
     "P99": "13.0"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 477,
+    "P95": "39.0",
+    "P99": "45.239999999999995"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "gcp",
@@ -6164,83 +4892,83 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "1.0",
-    "P99": "1.0"
+    "P95": "0.89999999999999991",
+    "P99": "0.98"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "3.0",
-    "P99": "3.0"
+    "JobRuns": 50,
+    "P95": "85.299999999999855",
+    "P99": "134.29999999999998"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "4.0",
-    "P99": "4.0"
+    "JobRuns": 9,
+    "P95": "36.2",
+    "P99": "36.84"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "ovirt",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "248.89999999999998",
+    "P99": "257.78"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "vsphere",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "7.1999999999999993",
-    "P99": "7.84"
+    "JobRuns": 4,
+    "P95": "149.79999999999998",
+    "P99": "165.16"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "aws",
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
+    "JobRuns": 29,
     "P95": "6.0",
-    "P99": "29.199999999999982"
+    "P99": "10.939999999999994"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "libvirt",
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "626.79999999999961",
-    "P99": "786.0"
+    "JobRuns": 11,
+    "P95": "792.0",
+    "P99": "813.6"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "libvirt",
@@ -6248,23 +4976,23 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "626.79999999999961",
-    "P99": "786.0"
+    "P95": "792.0",
+    "P99": "813.6"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "33.0",
-    "P99": "52.0"
+    "JobRuns": 793,
+    "P95": "2.0",
+    "P99": "6.2399999999999851"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "aws",
@@ -6272,1706 +5000,38 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "397.35",
-    "P99": "398.67"
+    "P95": "404.7",
+    "P99": "409.74"
   },
   {
-    "BackendName": "ingress-to-console-reused-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "1.0",
-    "P99": "7.3599999999999932"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "6.0",
-    "P99": "102.57999999999953"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.95",
-    "P99": "1.99"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "1.7999999999999998",
-    "P99": "1.96"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "6.0",
-    "P99": "6.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "4.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "33.0",
-    "P99": "52.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "84.399999999999991",
-    "P99": "87.28"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "external",
-    "JobRuns": 36,
-    "P95": "1.4999999999999907",
-    "P99": "8.5999999999999979"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 130,
-    "P95": "60.399999999999984",
-    "P99": "112.95999999999994"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 41,
-    "P95": "582.1999999999997",
-    "P99": "762.24"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 236,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "447.89999999999981",
-    "P99": "1326.0699999999995"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "146.79999999999797",
-    "P99": "1451.9799999999998"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "0.29999999999999316",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ibmcloud",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 93,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 22,
-    "P95": "0.0",
-    "P99": "0.78999999999999981"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 55,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1756.9499999999996",
-    "P99": "2104.99"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "976.19999999999959",
-    "P99": "2335.7999999999997"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "1.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "1278.0599999999988"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 77,
-    "P95": "60.399999999999984",
-    "P99": "112.95999999999994"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 12,
-    "P95": "582.1999999999997",
-    "P99": "762.24"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 36,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "447.89999999999981",
-    "P99": "1326.0699999999995"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "84.399999999999991",
-    "P99": "87.28"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "312.94999999999982",
-    "P99": "503.9"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "312.94999999999982",
-    "P99": "503.9"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "6.1499999999999666",
+    "JobRuns": 445,
+    "P95": "5.0",
     "P99": "11.0"
   },
   {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "380.34999999999997",
-    "P99": "395.27"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "4.0",
-    "P99": "51.399999999999942"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "19.5",
-    "P99": "20.7"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "4.0",
-    "P99": "10.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "28.999999999999961",
-    "P99": "49.399999999999991"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "8.1",
-    "P99": "8.82"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "4.0",
-    "P99": "51.399999999999942"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "723.59999999999968",
-    "P99": "917.56"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 8,
-    "P95": "723.59999999999968",
-    "P99": "917.56"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "5.0",
-    "P99": "9.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 4,
-    "P95": "408.65",
-    "P99": "412.13"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "5.4499999999999913",
-    "P99": "8.2699999999999942"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "azure",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "17.149999999999988",
-    "P99": "117.82999999999959"
+    "JobRuns": 448,
+    "P95": "10.649999999999981",
+    "P99": "29.589999999999989"
   },
   {
-    "BackendName": "ingress-to-oauth-server-new-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "3.8",
-    "P99": "3.96"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "11.5",
-    "P99": "11.9"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "0.19999999999999929",
-    "P99": "0.83999999999999986"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "5.0",
-    "P99": "9.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "87.5",
-    "P99": "91.1"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.69999999999999973",
-    "P99": "0.94"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 133,
-    "P95": "1.0",
-    "P99": "3.8199999999999963"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 41,
-    "P95": "558.5999999999998",
-    "P99": "733.43999999999994"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 236,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "454.59999999999985",
-    "P99": "1330.7299999999996"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "158.29999999999802",
-    "P99": "1451.9799999999998"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "0.0",
-    "P99": "2.4299999999999997"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "2.0",
-    "P99": "3.9199999999999973"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ibmcloud",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "0.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 22,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 55,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.4999999999995",
-    "P99": "2105.1"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "975.59999999999957",
-    "P99": "2336.4799999999996"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "0.949999999999992",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "1278.0599999999988"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 77,
-    "P95": "1.0",
-    "P99": "3.8199999999999963"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 12,
-    "P95": "558.5999999999998",
-    "P99": "733.43999999999994"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 36,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "454.59999999999985",
-    "P99": "1330.7299999999996"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "87.5",
-    "P99": "91.1"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "376.44999999999982",
-    "P99": "550.8"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "376.44999999999982",
-    "P99": "550.8"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "3.0",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "329.9",
-    "P99": "343.58"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "2.0",
-    "P99": "7.3999999999999968"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "4.6999999999999993",
-    "P99": "4.9399999999999995"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "5.0",
-    "P99": "7.5999999999999961"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "2.8",
-    "P99": "2.96"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "4.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "7.1999999999999993",
-    "P99": "7.84"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "2.0",
-    "P99": "7.3999999999999968"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "614.09999999999957",
-    "P99": "802.42"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 8,
-    "P95": "614.09999999999957",
-    "P99": "802.42"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "2.0",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 4,
-    "P95": "356.85",
-    "P99": "356.97"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "2.0",
-    "P99": "6.4499999999999913"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "3.0",
-    "P99": "99.729999999999521"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "2.8",
-    "P99": "2.96"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "4.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "4.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "2.0",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "21.499999999999964",
-    "P99": "53.899999999999991"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 133,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 41,
-    "P95": "557.99999999999977",
-    "P99": "732.43999999999994"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 236,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "445.99999999999983",
-    "P99": "1326.6799999999996"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "146.09999999999798",
-    "P99": "1451.9799999999998"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ibmcloud",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 22,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 55,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.4999999999995",
-    "P99": "2105.1"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "975.59999999999957",
-    "P99": "2336.4799999999996"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "0.0",
-    "P99": "0.18999999999999839"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "1278.0599999999988"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 77,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 12,
-    "P95": "557.99999999999977",
-    "P99": "732.43999999999994"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 36,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "445.99999999999983",
-    "P99": "1326.6799999999996"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "21.499999999999964",
-    "P99": "53.899999999999991"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "303.5499999999999",
-    "P99": "487.86999999999995"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "303.5499999999999",
-    "P99": "487.86999999999995"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "235.25",
-    "P99": "239.85"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "17.5",
-    "P99": "18.7"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "12.0",
-    "P99": "16.619999999999994"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "4.0",
-    "P99": "7.799999999999998"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -7980,1387 +5040,19 @@
     "P99": "2.94"
   },
   {
-    "BackendName": "kube-api-new-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "7.0499999999999989",
-    "P99": "7.81"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "12.0",
-    "P99": "12.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "15.899999999999999",
-    "P99": "16.78"
+    "P95": "6.6999999999999993",
+    "P99": "6.9399999999999995"
   },
   {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "715.09999999999968",
-    "P99": "919.69999999999993"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 8,
-    "P95": "715.09999999999968",
-    "P99": "919.69999999999993"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "13.0",
-    "P99": "19.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 4,
-    "P95": "270.9",
-    "P99": "272.58"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "17.0",
-    "P99": "20.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "31.149999999999988",
-    "P99": "42.719999999999992"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "10.5",
-    "P99": "10.9"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "6.6499999999999995",
-    "P99": "6.93"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "1.7999999999999998",
-    "P99": "1.96"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "7.1999999999999993",
-    "P99": "7.84"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "9.0",
-    "P99": "9.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "13.0",
-    "P99": "19.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "external",
-    "JobRuns": 36,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 133,
-    "P95": "0.0",
-    "P99": "1.8199999999999963"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 41,
-    "P95": "167.7999999999999",
-    "P99": "195.88"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 236,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "4.0",
-    "P99": "9.4899999999999967"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "1.0",
-    "P99": "6.539999999999992"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "2.1499999999999977",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "2.0",
-    "P99": "5.4599999999999991"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ibmcloud",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 22,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 55,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "969.7999999999995",
-    "P99": "2332.0799999999995"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "0.0",
-    "P99": "0.18999999999999839"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 77,
-    "P95": "0.0",
-    "P99": "1.8199999999999963"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 12,
-    "P95": "167.7999999999999",
-    "P99": "195.88"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 36,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "4.0",
-    "P99": "9.4899999999999967"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "275.54999999999978",
-    "P99": "492.30999999999995"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "275.54999999999978",
-    "P99": "492.30999999999995"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "235.25",
-    "P99": "239.85"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "6.5",
-    "P99": "6.9"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "7.0",
-    "P99": "10.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "1.0",
-    "P99": "5.3999999999999941"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "9.0499999999999989",
-    "P99": "9.81"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "14.0",
-    "P99": "14.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "12.299999999999999",
-    "P99": "12.86"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "611.49999999999966",
-    "P99": "783.81999999999994"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 8,
-    "P95": "611.49999999999966",
-    "P99": "783.81999999999994"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 4,
-    "P95": "271.75",
-    "P99": "273.55"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "16.0",
-    "P99": "20.429999999999996"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "6.3999999999999986",
-    "P99": "7.68"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "8.0",
-    "P99": "8.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "external",
-    "JobRuns": 36,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 133,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 41,
-    "P95": "165.7999999999999",
-    "P99": "194.88"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 236,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "0.049999999999998268",
-    "P99": "6.4899999999999967"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "0.0",
-    "P99": "2.359999999999995"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "0.0",
-    "P99": "0.42999999999999949"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ibmcloud",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 22,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 55,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "969.19999999999948",
-    "P99": "2332.7599999999993"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 182,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 77,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 12,
-    "P95": "165.7999999999999",
-    "P99": "194.88"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 36,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "azure",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "0.049999999999998268",
-    "P99": "6.4899999999999967"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "237.64999999999978",
-    "P99": "384.81999999999994"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "237.64999999999978",
-    "P99": "384.81999999999994"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 2,
-    "P95": "491.15",
-    "P99": "503.03"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "8.19999999999999"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "24.5",
-    "P99": "25.7"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "12.0",
-    "P99": "16.619999999999994"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "11.0",
-    "P99": "15.799999999999997"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "0.89999999999999991",
-    "P99": "0.98"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "7.0499999999999989",
-    "P99": "7.81"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "12.0",
-    "P99": "12.0"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "19.5",
-    "P99": "20.7"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "8.19999999999999"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "895.89999999999952",
-    "P99": "1092.76"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 8,
-    "P95": "895.89999999999952",
-    "P99": "1092.76"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "12.0",
-    "P99": "18.0"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "JobRuns": 4,
-    "P95": "533.7",
-    "P99": "533.94"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "18.899999999999984",
-    "P99": "23.0"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "35.149999999999991",
-    "P99": "58.009999999999984"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "2.95",
-    "P99": "2.99"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "12.65",
-    "P99": "12.93"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
+    "BackendName": "image-registry-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
@@ -9372,6 +5064,4182 @@
     "P99": "2.88"
   },
   {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "119.39999999999992",
+    "P99": "135.92"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 7,
+    "P95": "71.399999999999991",
+    "P99": "74.28"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 46,
+    "P95": "2.0",
+    "P99": "6.2399999999999851"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 792,
+    "P95": "0.0",
+    "P99": "2.0899999999999928"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "281.7",
+    "P99": "282.74"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 174,
+    "P95": "3.899999999999991",
+    "P99": "6.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 759,
+    "P95": "0.0",
+    "P99": "0.41999999999999327"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 477,
+    "P95": "4.1999999999999789",
+    "P99": "7.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "1.9",
+    "P99": "1.98"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "66.749999999999858",
+    "P99": "122.57"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "25.199999999999996",
+    "P99": "27.439999999999998"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "178.9",
+    "P99": "183.78"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "128.2",
+    "P99": "144.04"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 29,
+    "P95": "3.899999999999991",
+    "P99": "6.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 11,
+    "P95": "617.8",
+    "P99": "688.36"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 8,
+    "P95": "617.8",
+    "P99": "688.36"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 793,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 4,
+    "P95": "375.55",
+    "P99": "380.71"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 445,
+    "P95": "2.0",
+    "P99": "8.6799999999999891"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 448,
+    "P95": "2.0",
+    "P99": "6.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.89999999999999991",
+    "P99": "0.98"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 5,
+    "P95": "0.79999999999999982",
+    "P99": "0.96"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "101.59999999999997",
+    "P99": "135.72"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 7,
+    "P95": "39.1",
+    "P99": "39.82"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 46,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "30.349999999999966",
+    "P99": "37.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "310.6",
+    "P99": "310.92"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "7.6499999999999906",
+    "P99": "65.86"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "4.6",
+    "P99": "4.92"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "8.0",
+    "P99": "12.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "38.0",
+    "P99": "45.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "1.5499999999999978",
+    "P99": "3.5299999999999985"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "0.59999999999999964",
+    "P99": "0.91999999999999993"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 30,
+    "P95": "7.6499999999999906",
+    "P99": "65.86"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 11,
+    "P95": "761.5",
+    "P99": "779.5"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 8,
+    "P95": "761.5",
+    "P99": "779.5"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 844,
+    "P95": "31.0",
+    "P99": "51.079999999999991"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 4,
+    "P95": "384.25",
+    "P99": "387.25"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 447,
+    "P95": "3.0",
+    "P99": "9.5399999999999956"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 458,
+    "P95": "229.0",
+    "P99": "236.43"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "7.6999999999999993",
+    "P99": "7.9399999999999995"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 5,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "3.5999999999999961",
+    "P99": "5.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 7,
+    "P95": "0.69999999999999973",
+    "P99": "0.94"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 49,
+    "P95": "31.0",
+    "P99": "51.079999999999991"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 12,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "JobRuns": 10,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 314,
+    "P95": "40.0",
+    "P99": "71.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 97,
+    "P95": "808.8",
+    "P99": "1028.32"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 407,
+    "P95": "1.0",
+    "P99": "4.4999999999999911"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 55,
+    "P95": "464.9499999999997",
+    "P99": "654.53999999999894"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 204,
+    "P95": "1545.5499999999995",
+    "P99": "3555.65"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 142,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 245,
+    "P95": "2.0",
+    "P99": "5.1199999999999957"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 234,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "45.599999999999966"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 143,
+    "P95": "0.0",
+    "P99": "2.5799999999999987"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1022.7299999999997"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "623.69999999999993",
+    "P99": "1148.6999999999998"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
+    "P95": "4.0",
+    "P99": "5.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 109,
+    "P95": "0.0",
+    "P99": "2467.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 205,
+    "P95": "40.0",
+    "P99": "71.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 48,
+    "P95": "808.8",
+    "P99": "1028.32"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "1.0",
+    "P99": "4.4999999999999911"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 43,
+    "P95": "464.9499999999997",
+    "P99": "654.53999999999894"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 44,
+    "P95": "84.999999999999957",
+    "P99": "213.14999999999992"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 56,
+    "P95": "556.99999999999989",
+    "P99": "2692.9999999999986"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "556.99999999999989",
+    "P99": "2692.9999999999986"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "30.0",
+    "P99": "36.069999999999993"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "310.5",
+    "P99": "310.9"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "6.0",
+    "P99": "63.689999999999941"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "1.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "8.0",
+    "P99": "14.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "1.9",
+    "P99": "1.98"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "4.0",
+    "P99": "7.0399999999999983"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "4.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 30,
+    "P95": "6.0",
+    "P99": "63.689999999999941"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 11,
+    "P95": "628.5",
+    "P99": "660.9"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 8,
+    "P95": "628.5",
+    "P99": "660.9"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 844,
+    "P95": "30.0",
+    "P99": "49.239999999999974"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 4,
+    "P95": "384.25",
+    "P99": "387.25"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 447,
+    "P95": "1.0",
+    "P99": "7.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 458,
+    "P95": "225.0",
+    "P99": "230.85999999999999"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.89999999999999991",
+    "P99": "0.98"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "2.8",
+    "P99": "2.96"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 5,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "4.799999999999998",
+    "P99": "5.56"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 7,
+    "P95": "4.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 49,
+    "P95": "30.0",
+    "P99": "49.239999999999974"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 12,
+    "P95": "1.4499999999999995",
+    "P99": "1.89"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "JobRuns": 10,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 314,
+    "P95": "36.09999999999998",
+    "P99": "67.639999999999986"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 97,
+    "P95": "808.59999999999991",
+    "P99": "1028.32"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 407,
+    "P95": "0.0",
+    "P99": "2.4999999999999907"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 55,
+    "P95": "459.9499999999997",
+    "P99": "652.359999999999"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 204,
+    "P95": "1545.5499999999995",
+    "P99": "3552.68"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 142,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 245,
+    "P95": "1.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 233,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "46.029999999999973"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 143,
+    "P95": "1.0",
+    "P99": "1.5799999999999987"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1022.7299999999997"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "622.69999999999993",
+    "P99": "1148.6999999999998"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
+    "P95": "2.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 109,
+    "P95": "0.0",
+    "P99": "2467.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 205,
+    "P95": "36.09999999999998",
+    "P99": "67.639999999999986"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 48,
+    "P95": "808.59999999999991",
+    "P99": "1028.32"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "0.0",
+    "P99": "2.4999999999999907"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 43,
+    "P95": "459.9499999999997",
+    "P99": "652.359999999999"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 44,
+    "P95": "69.249999999999986",
+    "P99": "189.89999999999995"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 56,
+    "P95": "533.99999999999943",
+    "P99": "2682.9999999999986"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "533.99999999999943",
+    "P99": "2682.9999999999986"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "4.0",
+    "P99": "14.069999999999993"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "326.0",
+    "P99": "328.4"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "6.6499999999999906",
+    "P99": "241.48999999999964"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "5.5",
+    "P99": "5.9"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "7.0",
+    "P99": "12.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "38.699999999999982",
+    "P99": "47.139999999999993"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "1.0",
+    "P99": "1.5099999999999996"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "0.59999999999999964",
+    "P99": "0.91999999999999993"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 30,
+    "P95": "6.6499999999999906",
+    "P99": "241.48999999999964"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 11,
+    "P95": "763.6",
+    "P99": "789.52"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 8,
+    "P95": "763.6",
+    "P99": "789.52"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 844,
+    "P95": "2.0",
+    "P99": "7.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 4,
+    "P95": "383.8",
+    "P99": "389.56"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 447,
+    "P95": "3.0",
+    "P99": "7.5399999999999956"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 458,
+    "P95": "227.14999999999998",
+    "P99": "237.29"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "3.5999999999999996",
+    "P99": "3.92"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "8.2999999999999989",
+    "P99": "8.86"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 5,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 7,
+    "P95": "0.69999999999999973",
+    "P99": "0.94"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 49,
+    "P95": "2.0",
+    "P99": "7.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 12,
+    "P95": "0.44999999999999951",
+    "P99": "0.8899999999999999"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 316,
+    "P95": "1.0",
+    "P99": "10.599999999999968"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 97,
+    "P95": "773.8",
+    "P99": "984.43999999999994"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 407,
+    "P95": "1.0",
+    "P99": "4.7499999999999956"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 55,
+    "P95": "462.69999999999965",
+    "P99": "654.509999999999"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 204,
+    "P95": "1545.5499999999995",
+    "P99": "3554.68"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 142,
+    "P95": "0.0",
+    "P99": "2.589999999999999"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 245,
+    "P95": "2.0",
+    "P99": "3.5599999999999978"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 236,
+    "P95": "0.0",
+    "P99": "1.6499999999999979"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "42.179999999999971"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 143,
+    "P95": "0.0",
+    "P99": "1.5799999999999987"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1023.4599999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "622.69999999999993",
+    "P99": "1148.5199999999998"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
+    "P95": "4.0",
+    "P99": "6.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 109,
+    "P95": "0.0",
+    "P99": "2467.08"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 205,
+    "P95": "1.0",
+    "P99": "10.599999999999968"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 48,
+    "P95": "773.8",
+    "P99": "984.43999999999994"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "1.0",
+    "P99": "4.7499999999999956"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 43,
+    "P95": "462.69999999999965",
+    "P99": "654.509999999999"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 44,
+    "P95": "61.699999999999996",
+    "P99": "67.14"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 56,
+    "P95": "570.99999999999977",
+    "P99": "2685.9999999999986"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "570.99999999999977",
+    "P99": "2685.9999999999986"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "1.0",
+    "P99": "2.0699999999999932"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "281.4",
+    "P99": "281.88"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "5.6499999999999906",
+    "P99": "7.9299999999999979"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "4.5",
+    "P99": "4.9"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "4.0",
+    "P99": "6.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "3.549999999999998",
+    "P99": "4.51"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "4.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 30,
+    "P95": "5.6499999999999906",
+    "P99": "7.9299999999999979"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 11,
+    "P95": "610.0",
+    "P99": "646.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 8,
+    "P95": "610.0",
+    "P99": "646.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 844,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 4,
+    "P95": "357.8",
+    "P99": "363.56"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 447,
+    "P95": "0.0",
+    "P99": "6.5399999999999956"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 458,
+    "P95": "225.0",
+    "P99": "230.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "1.9",
+    "P99": "1.98"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 5,
+    "P95": "2.8",
+    "P99": "2.96"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "3.799999999999998",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 7,
+    "P95": "4.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 49,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 12,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 316,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 97,
+    "P95": "771.99999999999989",
+    "P99": "983.31999999999994"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 407,
+    "P95": "0.0",
+    "P99": "0.74999999999999534"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 55,
+    "P95": "460.04999999999973",
+    "P99": "651.41999999999894"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 204,
+    "P95": "1545.5499999999995",
+    "P99": "3553.68"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 142,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 245,
+    "P95": "1.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 236,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "39.89999999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 143,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1023.4599999999997"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "622.69999999999993",
+    "P99": "1148.5199999999998"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
+    "P95": "0.0",
+    "P99": "0.44999999999999685"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 109,
+    "P95": "0.0",
+    "P99": "2467.08"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 205,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 48,
+    "P95": "771.99999999999989",
+    "P99": "983.31999999999994"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "0.0",
+    "P99": "0.74999999999999534"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 43,
+    "P95": "460.04999999999973",
+    "P99": "651.41999999999894"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 44,
+    "P95": "14.849999999999998",
+    "P99": "60.28"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 56,
+    "P95": "526.99999999999943",
+    "P99": "2682.9999999999986"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "526.99999999999943",
+    "P99": "2682.9999999999986"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "16.0",
+    "P99": "19.069999999999993"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "180.7",
+    "P99": "181.74"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "18.0",
+    "P99": "32.439999999999984"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "21.7",
+    "P99": "21.94"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "31.0",
+    "P99": "39.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "18.0",
+    "P99": "22.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "18.6",
+    "P99": "18.92"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "10.549999999999997",
+    "P99": "13.53"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "11.6",
+    "P99": "11.92"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "17.6",
+    "P99": "17.92"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "13.7",
+    "P99": "13.94"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 30,
+    "P95": "18.0",
+    "P99": "32.439999999999984"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 11,
+    "P95": "756.59999999999991",
+    "P99": "789.72"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 8,
+    "P95": "756.59999999999991",
+    "P99": "789.72"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 844,
+    "P95": "18.0",
+    "P99": "21.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 4,
+    "P95": "240.7",
+    "P99": "240.94"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 447,
+    "P95": "17.0",
+    "P99": "20.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 458,
+    "P95": "35.149999999999977",
+    "P99": "49.579999999999977"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "38.0",
+    "P99": "40.4"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "8.1",
+    "P99": "8.82"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 5,
+    "P95": "11.399999999999999",
+    "P99": "13.48"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "12.399999999999995",
+    "P99": "15.559999999999999"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 7,
+    "P95": "8.7",
+    "P99": "8.94"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 49,
+    "P95": "18.0",
+    "P99": "21.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 12,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "JobRuns": 10,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 316,
+    "P95": "0.0",
+    "P99": "5.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 97,
+    "P95": "203.79999999999998",
+    "P99": "267.24"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 407,
+    "P95": "0.0",
+    "P99": "2.7499999999999956"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 55,
+    "P95": "4.0",
+    "P99": "16.3899999999999"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 204,
+    "P95": "1.0",
+    "P99": "7.9399999999999959"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 142,
+    "P95": "3.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 245,
+    "P95": "3.0",
+    "P99": "6.5599999999999978"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 237,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "43.319999999999972"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 143,
+    "P95": "0.0",
+    "P99": "1.5799999999999987"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.6499999999999988",
+    "P99": "1023.7299999999997"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "621.69999999999993",
+    "P99": "1146.9799999999998"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 109,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 205,
+    "P95": "0.0",
+    "P99": "5.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 48,
+    "P95": "203.79999999999998",
+    "P99": "267.24"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "0.0",
+    "P99": "2.7499999999999956"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 43,
+    "P95": "4.0",
+    "P99": "16.3899999999999"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 44,
+    "P95": "2.0",
+    "P99": "16.679999999999993"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 56,
+    "P95": "435.99999999999989",
+    "P99": "1047.9999999999995"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "435.99999999999989",
+    "P99": "1047.9999999999995"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "180.7",
+    "P99": "181.74"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "1.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "7.0",
+    "P99": "7.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "17.0",
+    "P99": "22.149999999999991"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "1.0",
+    "P99": "3.1399999999999957"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.89999999999999991",
+    "P99": "0.98"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "9.5499999999999972",
+    "P99": "11.53"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "14.0",
+    "P99": "14.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "9.8",
+    "P99": "9.96"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "8.85",
+    "P99": "8.97"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 30,
+    "P95": "1.0",
+    "P99": "3.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 11,
+    "P95": "602.5",
+    "P99": "642.1"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 8,
+    "P95": "602.5",
+    "P99": "642.1"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 844,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 4,
+    "P95": "240.7",
+    "P99": "240.94"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 447,
+    "P95": "1.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 458,
+    "P95": "19.149999999999981",
+    "P99": "26.429999999999996"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "11.299999999999999",
+    "P99": "11.86"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 5,
+    "P95": "0.79999999999999982",
+    "P99": "0.96"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "11.599999999999996",
+    "P99": "12.559999999999999"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 7,
+    "P95": "8.0",
+    "P99": "8.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 49,
+    "P95": "1.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 12,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "JobRuns": 10,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 316,
+    "P95": "0.0",
+    "P99": "1.7999999999999954"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 97,
+    "P95": "204.0",
+    "P99": "267.24"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 407,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 55,
+    "P95": "1.1499999999999957",
+    "P99": "12.369999999999932"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 204,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 142,
+    "P95": "0.0",
+    "P99": "0.58999999999999875"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 245,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 237,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "42.179999999999971"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 143,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1023.4599999999997"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "619.89999999999986",
+    "P99": "1146.9799999999998"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 356,
+    "P95": "0.0",
+    "P99": "1.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 109,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 205,
+    "P95": "0.0",
+    "P99": "1.7999999999999954"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 48,
+    "P95": "204.0",
+    "P99": "267.24"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 119,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 43,
+    "P95": "1.1499999999999957",
+    "P99": "12.369999999999932"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 44,
+    "P95": "0.84999999999999809",
+    "P99": "2.7099999999999991"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 56,
+    "P95": "353.99999999999994",
+    "P99": "789.99999999999977"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 45,
+    "P95": "353.99999999999994",
+    "P99": "789.99999999999977"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 794,
+    "P95": "17.349999999999966",
+    "P99": "37.20999999999998"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 3,
+    "P95": "453.7",
+    "P99": "453.94"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 178,
+    "P95": "19.0",
+    "P99": "28.859999999999996"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "26.9",
+    "P99": "26.98"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "33.0",
+    "P99": "51.149999999999991"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "25.0",
+    "P99": "44.67999999999995"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "17.8",
+    "P99": "17.96"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
+    "P95": "9.0",
+    "P99": "12.04"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 9,
+    "P95": "11.6",
+    "P99": "11.92"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "17.7",
+    "P99": "17.94"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 4,
+    "P95": "14.7",
+    "P99": "14.94"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 30,
+    "P95": "19.0",
+    "P99": "28.859999999999996"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 11,
+    "P95": "850.3",
+    "P99": "924.46"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 8,
+    "P95": "850.3",
+    "P99": "924.46"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 844,
+    "P95": "17.0",
+    "P99": "26.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "JobRuns": 4,
+    "P95": "530.25",
+    "P99": "533.25"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 447,
+    "P95": "18.0",
+    "P99": "23.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 458,
+    "P95": "43.149999999999977",
+    "P99": "65.719999999999985"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "30.199999999999996",
+    "P99": "32.44"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "16.6",
+    "P99": "16.92"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 5,
+    "P95": "11.6",
+    "P99": "11.92"
+  },
+  {
     "BackendName": "oauth-api-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
@@ -9379,9 +9247,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "7.7999999999999972",
-    "P99": "10.36"
+    "JobRuns": 45,
+    "P95": "11.799999999999997",
+    "P99": "14.68"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9391,9 +9259,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "8.35",
-    "P99": "8.87"
+    "JobRuns": 7,
+    "P95": "8.7",
+    "P99": "8.94"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9403,21 +9271,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "12.0",
-    "P99": "18.0"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "12.2",
-    "P99": "13.64"
+    "JobRuns": 49,
+    "P95": "17.0",
+    "P99": "26.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9439,19 +9295,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -9463,7 +9307,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -9475,9 +9319,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "2.9099999999999984"
+    "P99": "19.599999999999966"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9487,9 +9331,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "530.1999999999997",
-    "P99": "693.12"
+    "JobRuns": 97,
+    "P95": "707.19999999999982",
+    "P99": "927.07999999999993"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9499,9 +9343,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "5.4999999999999911"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9511,9 +9355,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "1.2499999999999913",
-    "P99": "28.569999999999986"
+    "JobRuns": 55,
+    "P95": "9.1999999999999655",
+    "P99": "45.969999999999914"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9523,9 +9367,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 204,
     "P95": "2.0",
-    "P99": "2.9599999999999866"
+    "P99": "29.579999999999973"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9535,9 +9379,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "1.0",
-    "P99": "2.859999999999999"
+    "JobRuns": 142,
+    "P95": "2.0",
+    "P99": "5.589999999999999"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9547,9 +9391,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "2.0",
-    "P99": "5.0"
+    "JobRuns": 245,
+    "P95": "3.0",
+    "P99": "13.119999999999996"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9571,9 +9415,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 237,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.6399999999999979"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9583,9 +9427,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "42.179999999999971"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9595,7 +9439,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -9607,9 +9451,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
+    "JobRuns": 28,
+    "P95": "0.6499999999999988",
+    "P99": "1023.7299999999997"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9619,9 +9463,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "970.39999999999952",
-    "P99": "2332.7599999999993"
+    "JobRuns": 119,
+    "P95": "621.69999999999993",
+    "P99": "1146.9799999999998"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9631,9 +9475,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
-    "P99": "1.3799999999999968"
+    "P99": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9643,7 +9487,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -9655,9 +9499,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "2.9099999999999984"
+    "P99": "19.599999999999966"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9667,9 +9511,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "530.1999999999997",
-    "P99": "693.12"
+    "JobRuns": 48,
+    "P95": "707.19999999999982",
+    "P99": "927.07999999999993"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9679,9 +9523,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "5.4999999999999911"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9691,9 +9535,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "1.2499999999999913",
-    "P99": "28.569999999999986"
+    "JobRuns": 43,
+    "P95": "9.1999999999999655",
+    "P99": "45.969999999999914"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9703,9 +9547,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "12.2",
-    "P99": "13.64"
+    "JobRuns": 44,
+    "P95": "12.849999999999998",
+    "P99": "25.539999999999992"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9715,9 +9559,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "281.24999999999977",
-    "P99": "494.87999999999994"
+    "JobRuns": 56,
+    "P95": "435.99999999999989",
+    "P99": "1045.9999999999995"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -9727,9 +9571,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "281.24999999999977",
-    "P99": "494.87999999999994"
+    "JobRuns": 45,
+    "P95": "435.99999999999989",
+    "P99": "1045.9999999999995"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9739,9 +9595,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 794,
+    "P95": "1.0",
+    "P99": "2.0699999999999932"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9751,9 +9607,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "493.05",
-    "P99": "505.01"
+    "JobRuns": 3,
+    "P95": "453.8",
+    "P99": "453.96"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9763,9 +9619,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 178,
+    "P95": "1.0",
+    "P99": "15.579999999999989"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9776,8 +9632,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "9.0",
-    "P99": "9.0"
+    "P95": "14.399999999999999",
+    "P99": "14.879999999999999"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9787,9 +9643,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "10.0",
-    "P99": "15.619999999999994"
+    "JobRuns": 786,
+    "P95": "21.0",
+    "P99": "33.149999999999991"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9799,9 +9655,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "1.0",
-    "P99": "3.0"
+    "JobRuns": 487,
+    "P95": "2.0",
+    "P99": "4.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9823,9 +9679,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "9.0499999999999989",
-    "P99": "9.81"
+    "JobRuns": 50,
+    "P95": "9.5499999999999972",
+    "P99": "11.53"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9835,7 +9691,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 9,
     "P95": "14.0",
     "P99": "14.0"
   },
@@ -9847,9 +9703,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "14.5",
+    "P99": "14.9"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9859,9 +9715,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "16.799999999999997",
-    "P99": "17.759999999999998"
+    "JobRuns": 4,
+    "P95": "8.85",
+    "P99": "8.97"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9871,9 +9727,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 30,
+    "P95": "1.0",
+    "P99": "15.579999999999989"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9883,9 +9739,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "695.89999999999952",
-    "P99": "884.07999999999993"
+    "JobRuns": 11,
+    "P95": "616.59999999999991",
+    "P99": "714.52"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9896,8 +9752,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "695.89999999999952",
-    "P99": "884.07999999999993"
+    "P95": "616.59999999999991",
+    "P99": "714.52"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9907,9 +9763,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "0.0",
-    "P99": "1.089999999999993"
+    "JobRuns": 844,
+    "P95": "1.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9920,8 +9776,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "534.7",
-    "P99": "534.94"
+    "P95": "530.25",
+    "P99": "533.25"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9931,7 +9787,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
+    "JobRuns": 447,
     "P95": "1.0",
     "P99": "2.0"
   },
@@ -9943,9 +9799,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "19.0",
-    "P99": "29.0"
+    "JobRuns": 458,
+    "P95": "26.149999999999981",
+    "P99": "37.859999999999992"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9955,9 +9811,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "7.6499999999999995",
-    "P99": "7.93"
+    "JobRuns": 3,
+    "P95": "17.9",
+    "P99": "18.78"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9967,9 +9823,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -9991,9 +9847,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "6.3999999999999986",
-    "P99": "7.68"
+    "JobRuns": 45,
+    "P95": "11.599999999999996",
+    "P99": "12.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10003,7 +9859,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 7,
     "P95": "8.0",
     "P99": "8.0"
   },
@@ -10015,21 +9871,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "0.0",
-    "P99": "1.089999999999993"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
+    "JobRuns": 49,
+    "P95": "1.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10051,19 +9895,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -10075,7 +9907,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -10087,9 +9919,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "3.8199999999999963"
+    "P99": "13.199999999999958"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10099,9 +9931,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "530.1999999999997",
-    "P99": "692.12"
+    "JobRuns": 97,
+    "P95": "706.39999999999975",
+    "P99": "926.52"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10111,7 +9943,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -10123,9 +9955,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "0.099999999999996536",
-    "P99": "15.419999999999993"
+    "JobRuns": 55,
+    "P95": "2.0",
+    "P99": "34.849999999999916"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10135,9 +9967,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "0.0",
-    "P99": "1.9599999999999866"
+    "JobRuns": 204,
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10147,9 +9979,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
+    "JobRuns": 142,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.58999999999999875"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10159,7 +9991,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
+    "JobRuns": 245,
     "P95": "0.0",
     "P99": "1.0"
   },
@@ -10183,7 +10015,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 236,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -10195,9 +10027,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "42.179999999999971"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10207,9 +10039,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
-    "P99": "0.45999999999999952"
+    "P99": "1.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10219,9 +10051,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1023.4599999999997"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10231,9 +10063,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "969.7999999999995",
-    "P99": "2332.7599999999993"
+    "JobRuns": 119,
+    "P95": "620.8",
+    "P99": "1146.9799999999998"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10243,9 +10075,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "1.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10255,9 +10087,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.919999999999999"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10267,9 +10099,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "3.8199999999999963"
+    "P99": "13.199999999999958"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10279,9 +10111,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "530.1999999999997",
-    "P99": "692.12"
+    "JobRuns": 48,
+    "P95": "706.39999999999975",
+    "P99": "926.52"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10291,7 +10123,7 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -10303,9 +10135,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "0.099999999999996536",
-    "P99": "15.419999999999993"
+    "JobRuns": 43,
+    "P95": "2.0",
+    "P99": "34.849999999999916"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10315,9 +10147,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
+    "JobRuns": 44,
+    "P95": "0.84999999999999809",
+    "P99": "14.109999999999991"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10327,9 +10159,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "235.0999999999998",
-    "P99": "391.67999999999995"
+    "JobRuns": 56,
+    "P95": "369.99999999999989",
+    "P99": "792.99999999999977"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -10339,9 +10171,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "235.0999999999998",
-    "P99": "391.67999999999995"
+    "JobRuns": 45,
+    "P95": "369.99999999999989",
+    "P99": "792.99999999999977"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10351,9 +10195,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 794,
+    "P95": "17.0",
+    "P99": "23.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10363,9 +10207,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "507.7",
-    "P99": "519.93999999999994"
+    "JobRuns": 3,
+    "P95": "465.0",
+    "P99": "465.8"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10375,9 +10219,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 178,
+    "P95": "18.0",
+    "P99": "23.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10388,8 +10232,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "19.5",
-    "P99": "20.7"
+    "P95": "29.6",
+    "P99": "29.92"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10399,45 +10243,45 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 739,
+    "JobRuns": 786,
+    "P95": "33.0",
+    "P99": "50.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "24.0",
+    "P99": "33.139999999999993"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "17.9",
+    "P99": "17.98"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 50,
     "P95": "10.0",
-    "P99": "17.0"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
-    "P95": "12.999999999999989",
-    "P99": "19.399999999999995"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "8.3999999999999986",
-    "P99": "8.879999999999999"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "7.0499999999999989",
-    "P99": "7.81"
+    "P99": "13.059999999999997"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10447,9 +10291,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
-    "P95": "12.0",
-    "P99": "12.0"
+    "JobRuns": 9,
+    "P95": "11.6",
+    "P99": "11.92"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10459,9 +10303,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "17.7",
+    "P99": "17.94"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10471,9 +10315,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "20.4",
-    "P99": "21.68"
+    "JobRuns": 4,
+    "P95": "19.099999999999998",
+    "P99": "19.82"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10483,9 +10327,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 30,
+    "P95": "18.0",
+    "P99": "23.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10495,9 +10339,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "892.49999999999955",
-    "P99": "1105.7"
+    "JobRuns": 11,
+    "P95": "852.49999999999989",
+    "P99": "920.9"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10508,8 +10352,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "892.49999999999955",
-    "P99": "1105.7"
+    "P95": "852.49999999999989",
+    "P99": "920.9"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10519,9 +10363,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "12.0",
-    "P99": "19.089999999999993"
+    "JobRuns": 844,
+    "P95": "17.0",
+    "P99": "22.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10532,8 +10376,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "559.2",
-    "P99": "560.64"
+    "P95": "548.65",
+    "P99": "552.13"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10543,8 +10387,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
-    "P95": "17.449999999999992",
+    "JobRuns": 447,
+    "P95": "17.0",
     "P99": "21.0"
   },
   {
@@ -10555,9 +10399,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "40.0",
-    "P99": "51.719999999999992"
+    "JobRuns": 458,
+    "P95": "44.149999999999977",
+    "P99": "59.859999999999992"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10567,9 +10411,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.9",
-    "P99": "1.98"
+    "JobRuns": 3,
+    "P95": "31.099999999999998",
+    "P99": "33.42"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10579,9 +10423,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "7.0",
-    "P99": "7.0"
+    "JobRuns": 3,
+    "P95": "16.0",
+    "P99": "16.8"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10592,8 +10436,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 5,
-    "P95": "4.7999999999999989",
-    "P99": "5.76"
+    "P95": "18.2",
+    "P99": "19.64"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10603,9 +10447,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "8.0",
-    "P99": "8.0"
+    "JobRuns": 45,
+    "P95": "13.599999999999996",
+    "P99": "14.559999999999999"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10615,7 +10459,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 7,
     "P95": "9.0",
     "P99": "9.0"
   },
@@ -10627,21 +10471,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "12.0",
-    "P99": "19.089999999999993"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "10.1",
-    "P99": "10.82"
+    "JobRuns": 49,
+    "P95": "17.0",
+    "P99": "22.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10663,19 +10495,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -10687,7 +10507,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -10699,9 +10519,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "1.8199999999999963"
+    "P99": "17.799999999999947"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10711,9 +10531,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "531.99999999999977",
-    "P99": "670.4799999999999"
+    "JobRuns": 97,
+    "P95": "727.0",
+    "P99": "917.75999999999988"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10723,9 +10543,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "2.4999999999999907"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10735,9 +10555,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "2.149999999999995",
-    "P99": "32.449999999999982"
+    "JobRuns": 55,
+    "P95": "5.4499999999999869",
+    "P99": "52.549999999999926"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10747,8 +10567,8 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "2.0",
+    "JobRuns": 204,
+    "P95": "1.849999999999991",
     "P99": "5.0"
   },
   {
@@ -10759,9 +10579,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
-    "P95": "2.1499999999999977",
-    "P99": "4.0"
+    "JobRuns": 142,
+    "P95": "3.0",
+    "P99": "5.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10771,9 +10591,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
-    "P95": "3.0",
-    "P99": "4.9199999999999973"
+    "JobRuns": 245,
+    "P95": "3.7999999999999892",
+    "P99": "6.6799999999999935"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10795,9 +10615,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 236,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.64999999999999791"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10807,9 +10627,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.78999999999999981"
+    "P99": "42.609999999999971"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10819,9 +10639,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "1.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10831,9 +10651,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
+    "JobRuns": 28,
+    "P95": "0.6499999999999988",
+    "P99": "1023.7299999999997"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10843,9 +10663,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "970.39999999999952",
-    "P99": "2332.7599999999993"
+    "JobRuns": 119,
+    "P95": "620.8",
+    "P99": "1146.9799999999998"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10855,9 +10675,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
-    "P99": "1.1899999999999984"
+    "P99": "0.44999999999999685"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10867,9 +10687,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.919999999999999"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10879,9 +10699,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "1.8199999999999963"
+    "P99": "17.799999999999947"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10891,9 +10711,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "531.99999999999977",
-    "P99": "670.4799999999999"
+    "JobRuns": 48,
+    "P95": "727.0",
+    "P99": "917.75999999999988"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10903,9 +10723,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "2.4999999999999907"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10915,9 +10735,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "2.149999999999995",
-    "P99": "32.449999999999982"
+    "JobRuns": 43,
+    "P95": "5.4499999999999869",
+    "P99": "52.549999999999926"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10927,9 +10747,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "10.1",
-    "P99": "10.82"
+    "JobRuns": 44,
+    "P95": "13.849999999999998",
+    "P99": "26.259999999999994"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10939,9 +10759,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "279.09999999999974",
-    "P99": "493.44999999999993"
+    "JobRuns": 56,
+    "P95": "435.99999999999989",
+    "P99": "1046.9999999999995"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -10951,9 +10771,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "279.09999999999974",
-    "P99": "493.44999999999993"
+    "JobRuns": 45,
+    "P95": "435.99999999999989",
+    "P99": "1046.9999999999995"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -10963,8 +10795,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 758,
-    "P95": "0.0",
+    "JobRuns": 794,
+    "P95": "1.0",
     "P99": "1.0"
   },
   {
@@ -10975,9 +10807,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 2,
-    "P95": "509.65",
-    "P99": "521.93"
+    "JobRuns": 3,
+    "P95": "464.1",
+    "P99": "464.82"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -10987,45 +10819,45 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 115,
-    "P95": "0.0",
-    "P99": "0.79999999999999893"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "12.1",
-    "P99": "12.82"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 739,
-    "P95": "10.0",
-    "P99": "15.619999999999994"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 221,
+    "JobRuns": 178,
     "P95": "1.0",
-    "P99": "5.99999999999999"
+    "P99": "12.299999999999981"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "17.5",
+    "P99": "17.9"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 786,
+    "P95": "21.749999999999964",
+    "P99": "37.299999999999983"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 487,
+    "P95": "1.0",
+    "P99": "3.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11036,8 +10868,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "0.0",
-    "P99": "0.0"
+    "P95": "0.89999999999999991",
+    "P99": "0.98"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11047,9 +10879,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 20,
-    "P95": "9.0999999999999979",
-    "P99": "10.62"
+    "JobRuns": 50,
+    "P95": "9.5499999999999972",
+    "P99": "12.02"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11059,7 +10891,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 9,
     "P95": "14.0",
     "P99": "14.0"
   },
@@ -11071,9 +10903,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "14.399999999999999",
+    "P99": "14.879999999999999"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11083,9 +10915,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 3,
-    "P95": "16.799999999999997",
-    "P99": "17.759999999999998"
+    "JobRuns": 4,
+    "P95": "9.7",
+    "P99": "9.94"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11095,9 +10927,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "0.79999999999999893"
+    "JobRuns": 30,
+    "P95": "1.0",
+    "P99": "12.299999999999981"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11107,9 +10939,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "703.59999999999968",
-    "P99": "907.81999999999994"
+    "JobRuns": 11,
+    "P95": "611.89999999999986",
+    "P99": "711.98"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11120,8 +10952,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 8,
-    "P95": "703.59999999999968",
-    "P99": "907.81999999999994"
+    "P95": "611.89999999999986",
+    "P99": "711.98"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11131,8 +10963,8 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 776,
-    "P95": "0.0",
+    "JobRuns": 844,
+    "P95": "1.0",
     "P99": "1.0"
   },
   {
@@ -11144,8 +10976,8 @@
     "Network": "ovn",
     "Topology": "single",
     "JobRuns": 4,
-    "P95": "560.2",
-    "P99": "561.64"
+    "P95": "548.8",
+    "P99": "552.16"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11155,7 +10987,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 192,
+    "JobRuns": 447,
     "P95": "1.0",
     "P99": "2.0"
   },
@@ -11167,9 +10999,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 258,
-    "P95": "19.0",
-    "P99": "31.0"
+    "JobRuns": 458,
+    "P95": "25.0",
+    "P99": "40.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11179,9 +11011,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.9",
-    "P99": "1.98"
+    "JobRuns": 3,
+    "P95": "23.9",
+    "P99": "25.58"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11191,9 +11023,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11215,9 +11047,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 17,
-    "P95": "6.3999999999999986",
-    "P99": "7.68"
+    "JobRuns": 45,
+    "P95": "10.799999999999997",
+    "P99": "12.559999999999999"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11227,7 +11059,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 14,
+    "JobRuns": 7,
     "P95": "8.0",
     "P99": "8.0"
   },
@@ -11239,21 +11071,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 16,
-    "P95": "0.0",
+    "JobRuns": 49,
+    "P95": "1.0",
     "P99": "1.0"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 1,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11275,19 +11095,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 7,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "alibaba",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 1,
+    "JobRuns": 12,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -11299,7 +11107,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "JobRuns": 36,
+    "JobRuns": 10,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -11311,9 +11119,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 133,
+    "JobRuns": 316,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "10.599999999999945"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11323,9 +11131,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 41,
-    "P95": "531.5999999999998",
-    "P99": "670.0"
+    "JobRuns": 97,
+    "P95": "726.8",
+    "P99": "918.31999999999994"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11335,9 +11143,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 236,
+    "JobRuns": 407,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.74999999999999534"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11347,9 +11155,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 25,
-    "P95": "0.1499999999999948",
-    "P99": "21.29999999999999"
+    "JobRuns": 55,
+    "P95": "3.1499999999999959",
+    "P99": "43.729999999999919"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11359,9 +11167,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 95,
-    "P95": "0.0",
-    "P99": "1.4799999999999933"
+    "JobRuns": 204,
+    "P95": "1.0",
+    "P99": "1.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11371,7 +11179,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 58,
+    "JobRuns": 142,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -11383,9 +11191,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 155,
+    "JobRuns": 245,
     "P95": "0.0",
-    "P99": "0.45999999999999863"
+    "P99": "1.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11407,7 +11215,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 95,
+    "JobRuns": 236,
     "P95": "0.0",
     "P99": "0.0"
   },
@@ -11419,9 +11227,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 22,
+    "JobRuns": 44,
     "P95": "0.0",
-    "P99": "0.78999999999999981"
+    "P99": "42.609999999999971"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11431,9 +11239,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 55,
+    "JobRuns": 143,
     "P95": "0.0",
-    "P99": "0.45999999999999952"
+    "P99": "1.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11443,9 +11251,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 12,
-    "P95": "1757.0499999999997",
-    "P99": "2104.21"
+    "JobRuns": 28,
+    "P95": "0.0",
+    "P99": "1023.4599999999997"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11455,9 +11263,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 33,
-    "P95": "969.19999999999948",
-    "P99": "2333.4399999999996"
+    "JobRuns": 119,
+    "P95": "620.8",
+    "P99": "1146.9799999999998"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11467,7 +11275,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 182,
+    "JobRuns": 356,
     "P95": "0.0",
     "P99": "1.0"
   },
@@ -11479,9 +11287,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 50,
+    "JobRuns": 109,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.919999999999999"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11491,9 +11299,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 77,
+    "JobRuns": 205,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "10.599999999999945"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11503,9 +11311,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "single",
-    "JobRuns": 12,
-    "P95": "531.5999999999998",
-    "P99": "670.0"
+    "JobRuns": 48,
+    "P95": "726.8",
+    "P99": "918.31999999999994"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11515,9 +11323,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 36,
+    "JobRuns": 119,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.74999999999999534"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11527,9 +11335,9 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 15,
-    "P95": "0.1499999999999948",
-    "P99": "21.29999999999999"
+    "JobRuns": 43,
+    "P95": "3.1499999999999959",
+    "P99": "43.729999999999919"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11539,9 +11347,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 18,
-    "P95": "0.0999999999999992",
-    "P99": "0.81999999999999984"
+    "JobRuns": 44,
+    "P95": "0.0",
+    "P99": "11.259999999999993"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11551,9 +11359,9 @@
     "Architecture": "ppc64le",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "240.19999999999979",
-    "P99": "390.82999999999993"
+    "JobRuns": 56,
+    "P95": "365.99999999999989",
+    "P99": "787.99999999999977"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -11563,9 +11371,21 @@
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 22,
-    "P95": "240.19999999999979",
-    "P99": "390.82999999999993"
+    "JobRuns": 45,
+    "P95": "365.99999999999989",
+    "P99": "787.99999999999977"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11575,9 +11395,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 756,
-    "P95": "13.0",
-    "P99": "15.0"
+    "JobRuns": 784,
+    "P95": "25.0",
+    "P99": "35.339999999999989"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11587,9 +11407,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 112,
-    "P95": "9.0",
-    "P99": "11.84"
+    "JobRuns": 173,
+    "P95": "22.0",
+    "P99": "27.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11600,8 +11420,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "7.3999999999999995",
-    "P99": "7.88"
+    "P95": "23.7",
+    "P99": "24.74"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11611,9 +11431,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 715,
-    "P95": "7.0",
-    "P99": "10.0"
+    "JobRuns": 759,
+    "P95": "15.0",
+    "P99": "20.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11623,9 +11443,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 219,
-    "P95": "69.1",
-    "P99": "77.82"
+    "JobRuns": 477,
+    "P95": "60.0",
+    "P99": "71.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11636,8 +11456,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "3.0",
-    "P99": "3.0"
+    "P95": "31.7",
+    "P99": "31.94"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11647,9 +11467,9 @@
     "Architecture": "arm64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "9.0",
-    "P99": "11.84"
+    "JobRuns": 29,
+    "P95": "22.0",
+    "P99": "27.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11659,9 +11479,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 731,
-    "P95": "18.849999999999966",
-    "P99": "26.139999999999986"
+    "JobRuns": 782,
+    "P95": "27.0",
+    "P99": "36.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11671,9 +11491,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 189,
-    "P95": "21.0",
-    "P99": "29.0"
+    "JobRuns": 437,
+    "P95": "22.0",
+    "P99": "28.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11683,9 +11503,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 250,
+    "JobRuns": 448,
     "P95": "18.0",
-    "P99": "29.509999999999998"
+    "P99": "30.529999999999998"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11695,9 +11515,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.9",
-    "P99": "1.98"
+    "JobRuns": 3,
+    "P95": "15.0",
+    "P99": "15.8"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11707,9 +11527,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "58.0",
-    "P99": "58.0"
+    "JobRuns": 3,
+    "P95": "55.199999999999996",
+    "P99": "57.44"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11720,8 +11540,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 5,
-    "P95": "4.6",
-    "P99": "4.92"
+    "P95": "18.199999999999996",
+    "P99": "21.24"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -11731,9 +11551,21 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 13,
-    "P95": "18.849999999999966",
-    "P99": "26.139999999999986"
+    "JobRuns": 45,
+    "P95": "27.0",
+    "P99": "36.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -11743,9 +11575,9 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 756,
-    "P95": "2.0",
-    "P99": "3.0"
+    "JobRuns": 784,
+    "P95": "4.0",
+    "P99": "23.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -11755,9 +11587,9 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 112,
-    "P95": "2.0",
-    "P99": "3.839999999999999"
+    "JobRuns": 173,
+    "P95": "4.0",
+    "P99": "18.99"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -11768,8 +11600,8 @@
     "Network": "ovn",
     "Topology": "ha",
     "JobRuns": 3,
-    "P95": "1.9",
-    "P99": "1.98"
+    "P95": "2.0",
+    "P99": "2.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -11779,7 +11611,7 @@
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
-    "JobRuns": 715,
+    "JobRuns": 758,
     "P95": "3.0",
     "P99": "4.0"
   },
@@ -11791,7 +11623,7 @@
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 219,
+    "JobRuns": 477,
     "P95": "3.0",
     "P99": "4.0"
   },
@@ -11800,6 +11632,66 @@
     "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 3,
+    "P95": "2.0",
+    "P99": "2.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 29,
+    "P95": "4.0",
+    "P99": "18.99"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 781,
+    "P95": "8.0",
+    "P99": "23.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "JobRuns": 438,
+    "P95": "10.599999999999923",
+    "P99": "21.629999999999995"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "JobRuns": 448,
+    "P95": "3.0",
+    "P99": "4.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
@@ -11810,74 +11702,14 @@
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
     "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 5,
-    "P95": "2.0",
-    "P99": "3.839999999999999"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 731,
-    "P95": "3.0",
-    "P99": "18.139999999999986"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 190,
-    "P95": "11.049999999999908",
-    "P99": "21.11"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "JobRuns": 250,
-    "P95": "3.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-reused-connections",
-    "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 2,
-    "P95": "1.95",
-    "P99": "1.99"
+    "JobRuns": 3,
+    "P95": "0.89999999999999991",
+    "P99": "0.98"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -11888,8 +11720,8 @@
     "Network": "sdn",
     "Topology": "ha",
     "JobRuns": 5,
-    "P95": "3.5999999999999996",
-    "P99": "3.92"
+    "P95": "2.8",
+    "P99": "2.96"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -11899,8 +11731,8 @@
     "Architecture": "arm64",
     "Network": "ovn",
     "Topology": "ha",
-    "JobRuns": 13,
-    "P95": "3.0",
-    "P99": "18.139999999999986"
+    "JobRuns": 45,
+    "P95": "8.0",
+    "P99": "23.0"
   }
 ]


### PR DESCRIPTION
## alerts Information

There were (`1223`) added jobs and (`1764`) were removed.

### Comparisons were above allowed leeway of `30.00%`

Note: For P99, alerts had `60` jobs increased and `224` jobs decreased.

<details>
  <summary>Click To Show Table</summary>

| Name | Release | From | Arch | Network | Platform | Topology | Job Results | P95 | P95 % Increase | P99 | P99 % Increase |
| ---- | ------- | ---- | ---- | ------- | -------- |--------- | ----------- | --- | -------------- | --- | -------------- |
| TargetDown openshift-e2e-loki Warning | 4.13 | 4.13 | amd64 | ovn | aws | ha | 208 | 0s| 0.00% | 1h59m37.76s | 331.46% 
| HighOverallControlPlaneCPU openshift-kube-apiserver Warning | 4.13 | 4.12 | amd64 | ovn | gcp | ha | 109 | 5m16s| 0.00% | 12m34.96s | 33.03% 
| KubePodNotReady openshift-multus Warning | 4.13 | 4.12 | amd64 | sdn | azure | ha | 201 | 0s| 0.00% | 20s | 1539.34% 
| OVNKubernetesResourceRetryFailure openshift-ovn-kubernetes Warning | 4.13 | 4.13 | amd64 | ovn | aws | ha | 208 | 0s| 0.00% | 9m28s | 38.78% 
| TargetDown openshift-e2e-loki Warning | 4.13 |  | amd64 | sdn | aws | ha | 110 | 0s| 0.00% | 1h38m6.14s | 1891.25% 
| KubePodNotReady openshift-e2e-loki Warning | 4.13 | 4.12 | amd64 | ovn | aws | ha | 206 | 0s| 0.00% | 13h6m12.3s | 4240.40% 
| OVNKubernetesNorthboundDatabaseOutboundConnectionMissing openshift-ovn-kubernetes Warning | 4.13 | 4.13 | amd64 | ovn | aws | ha | 208 | 0s| 0.00% | 26.04s | 144.74% 
| ClusterOperatorDown openshift-cluster-version Critical | 4.13 | 4.12 | amd64 | sdn | azure | ha | 201 | 0s| 0.00% | 5m58s | 72.12% 
| PrometheusErrorSendingAlertsToSomeAlertmanagers openshift-monitoring Warning | 4.13 |  | amd64 | ovn | vsphere | ha | 107 | 0s| 0.00% | 14m35.6s | 125.04% 
| OVNKubernetesSouthboundDatabaseOutboundConnectionMissing openshift-ovn-kubernetes Warning | 4.13 | 4.13 | amd64 | ovn | aws | ha | 208 | 0s| 0.00% | 26.04s | 144.74% 
| TargetDown openshift-machine-config-operator Warning | 4.13 |  | amd64 | ovn | vsphere | ha | 107 | 0s| 0.00% | 1m57.88s | 88.67% 
| KubeContainerWaiting openshift-e2e-loki Warning | 4.13 | 4.13 | amd64 | ovn | aws | ha | 208 | 0s| 0.00% | 7h15m13.92s | 18446.82% 
| OVNKubernetesSouthboundDatabaseInboundConnectionMissing openshift-ovn-kubernetes Warning | 4.13 | 4.13 | amd64 | ovn | aws | ha | 208 | 0s| 0.00% | 26.04s | 144.74% 
| TargetDown openshift-e2e-loki Warning | 4.13 | 4.12 | amd64 | ovn | aws | ha | 206 | 0s| 0.00% | 2h11m28.7s | 927.44% 
| TargetDown openshift-e2e-loki Warning | 4.13 | 4.12 | amd64 | sdn | azure | ha | 201 | 28s| 0.00% | 2h10m18s | 13379.31% 
| TelemeterClientFailures openshift-monitoring Warning | 4.13 | 4.12 | amd64 | sdn | azure | ha | 201 | 0s| 0.00% | 42m50s | 3470.44% 
| TargetDown openshift-e2e-loki Warning | 4.13 |  | amd64 | ovn | vsphere | ha | 107 | 0s| 0.00% | 2m26.2s | 133.99% 
| TelemeterClientFailures openshift-monitoring Warning | 4.13 | 4.12 | amd64 | ovn | gcp | ha | 109 | 0s| 0.00% | 21m54.4s | 38.29% 
| OVNKubernetesNorthboundDatabaseInboundConnectionMissing openshift-ovn-kubernetes Warning | 4.13 | 4.13 | amd64 | ovn | aws | ha | 208 | 0s| 0.00% | 26.04s | 144.74% 
| KubeContainerWaiting openshift-e2e-loki Warning | 4.13 | 4.12 | amd64 | ovn | aws | ha | 206 | 0s| 0.00% | 8h24m12.3s | 52221.52% 
| KubePodNotReady openshift-e2e-loki Warning | 4.13 | 4.12 | amd64 | sdn | azure | ha | 201 | 28s| 0.00% | 12h40m24s | 2932.30% 
| KubePodNotReady openshift-e2e-loki Warning | 4.13 | 4.13 | amd64 | ovn | aws | ha | 208 | 0s| 0.00% | 11h57m1.32s | 1397.94% 


</details>

### Missing Data

Note: Jobs that are missing from the new data set but were present in the previous dataset.

### ⚠️ Dataset is too large since we're in a transition between 4.13 -> 4.14

## disruptions Information

There were (`22`) added jobs and (`36`) were removed.

### Comparisons were above allowed leeway of `30.00%`

Note: For P99, disruptions had `338` jobs increased and `249` jobs decreased.

<details>
  <summary>Click To Show Table</summary>

| Name | Release | From | Arch | Network | Platform | Topology | Job Results | P95 | P95 % Increase | P99 | P99 % Increase |
| ---- | ------- | ---- | ---- | ------- | -------- |--------- | ----------- | --- | -------------- | --- | -------------- |
| ingress-to-oauth-server-reused-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 25m45.55s| 957.87% | 59m13.68s | 144.75% 
| ingress-to-console-reused-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 25m45.55s| 952.83% | 59m12.68s | 144.68% 
| ingress-to-console-new-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 25m45.55s| 885.05% | 59m15.65s | 144.88% 
| ingress-to-oauth-server-new-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 25m45.55s| 876.34% | 59m14.68s | 144.82% 
| ingress-to-oauth-server-reused-connections | 4.14 | 4.14 | amd64 | ovn | azure | ha | 458 | 3m45s| 7400.00% | 3m50s | 130.62% 
| ingress-to-console-reused-connections | 4.14 | 4.14 | amd64 | ovn | azure | ha | 458 | 3m45s| 3650.00% | 3m50.86s | 125.05% 
| ingress-to-oauth-server-new-connections | 4.14 | 4.14 | amd64 | ovn | azure | ha | 458 | 3m47.15s| 1224.49% | 3m57.29s | 101.38% 
| ingress-to-console-new-connections | 4.14 | 4.14 | amd64 | ovn | azure | ha | 458 | 3m49s| 1036.48% | 3m56.43s | 98.96% 
| openshift-api-new-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 33s| 230.00% | 50s | 194.12% 
| oauth-api-new-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 33s| 175.00% | 51.15s | 207.76% 
| kube-api-new-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 31s| 158.33% | 39s | 134.66% 
| cache-openshift-api-new-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 22s| 340.00% | 39.15s | 354.18% 
| cache-oauth-api-new-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 20.75s| 418.75% | 36.75s | 297.73% 
| cache-oauth-api-new-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 25s| 150.00% | 44.84s | 138.51% 
| cache-kube-api-new-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 18s| 350.00% | 24.14s | 244.86% 
| oauth-api-new-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 25s| 127.27% | 44.68s | 182.78% 
| kube-api-new-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 18s| 350.00% | 22s | 182.05% 
| service-load-balancer-with-pdb-new-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 173 | 22s| 144.44% | 27s | 128.04% 
| cache-kube-api-new-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 16s| 433.33% | 25.15s | 259.29% 
| service-load-balancer-with-pdb-new-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 784 | 25s| 92.31% | 35.34s | 135.60% 
| openshift-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 21.75s| 117.50% | 37.3s | 138.80% 
| openshift-api-new-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 24s| 84.62% | 33.14s | 70.82% 
| oauth-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 21s| 110.00% | 33.15s | 112.23% 
| cache-openshift-api-new-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 24s| 84.62% | 40.14s | 100.70% 
| kube-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 17s| 142.86% | 22.15s | 121.50% 
| service-load-balancer-with-pdb-new-connections | 4.14 | 4.14 | amd64 | ovn | aws | ha | 782 | 27s| 43.24% | 36s | 37.72% 
| service-load-balancer-with-pdb-new-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 759 | 15s| 114.29% | 20s | 100.00% 
| oauth-api-reused-connections | 4.14 | 4.14 | amd64 | ovn | azure | ha | 458 | 26.15s| 37.63% | 37.86s | 30.55% 
| cache-oauth-api-new-connections | 4.14 | 4.14 | amd64 | ovn | aws | ha | 844 | 18s| 44.58% | 26.08s | 53.41% 
| oauth-api-new-connections | 4.14 | 4.14 | amd64 | ovn | aws | ha | 844 | 17s| 41.67% | 26s | 44.44% 
| cache-openshift-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 8s| 166.67% | 22.3s | 218.57% 
| cache-oauth-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 6s| 100.00% | 15.75s | 162.50% 
| ingress-to-oauth-server-new-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 6.65s| 66.25% | 4m1.49s | 369.82% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 6.85s| 59.30% | 39.58s | 455.90% 
| service-load-balancer-with-pdb-reused-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 173 | 4s| 100.00% | 18.99s | 394.53% 
| service-load-balancer-with-pdb-reused-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 784 | 4s| 100.00% | 23s | 666.67% 
| image-registry-new-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 174 | 6s| 44.58% | 10.94s | 60.18% 
| ci-cluster-network-liveness-new-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 794 | 5s| 58.73% | 50.35s | 459.44% 
| cache-oauth-api-new-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 2.85s| 185.00% | 54.92s | 771.75% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 2.8s| 180.00% | 14.56s | 491.87% 
| ci-cluster-network-liveness-new-connections | 4.14 | 4.14 | amd64 | sdn | aws | ha | 447 | 5.7s| 42.50% | 50s | 605.22% 
| cache-kube-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 2s| 100.00% | 4s | 100.00% 
| oauth-api-new-connections | 4.14 |  | amd64 | ovn | gcp | ha | 142 | 2s| 100.00% | 5.59s | 95.45% 
| ci-cluster-network-liveness-new-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 4s| 33.33% | 20.75s | 88.64% 
| oauth-api-reused-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 2s| 100.00% | 4s | 33.33% 
| oauth-api-new-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 3s| 50.00% | 13.12s | 162.40% 
| cache-kube-api-new-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 3s| 50.00% | 8s | 79.37% 
| cache-openshift-api-new-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 2s| 100.00% | 10.97s | 417.45% 
| cache-openshift-api-new-connections | 4.14 |  | amd64 | ovn | gcp | ha | 142 | 2s| 73.91% | 4.59s | 39.51% 
| kube-api-new-connections | 4.14 |  | amd64 | ovn | gcp | ha | 142 | 3s| 39.53% | 4s | 33.33% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | amd64 | sdn | aws | ha | 407 | 2.75s| 37.50% | 18.5s | 194.12% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | arm64 | sdn | aws | ha | 119 | 2.75s| 37.50% | 18.5s | 194.12% 
| ingress-to-console-reused-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 1s| 233.33% | 2s | 100.00% 
| cache-openshift-api-new-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 3s| 30.43% | 8.56s | 91.93% 
| ingress-to-oauth-server-new-connections | 4.14 |  | amd64 | sdn | metal | ha | 143 | 0s| 0.00% | 1.58s | 58.00% 
| kube-api-reused-connections | 4.14 | 4.14 | amd64 | sdn | aws | ha | 447 | 1s| 0.00% | 2s | 100.00% 
| cache-kube-api-reused-connections | 4.14 | 4.14 | amd64 | sdn | aws | ha | 447 | 1s| 0.00% | 1.54s | 41.28% 
| cache-oauth-api-new-connections | 4.14 |  | arm64 | ovn | aws | ha | 205 | 0s| 0.00% | 19.4s | 566.67% 
| oauth-api-new-connections | 4.14 |  | arm64 | ovn | aws | ha | 205 | 0s| 0.00% | 19.6s | 573.54% 
| kube-api-new-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 794 | 16s| 0.00% | 19.07s | 1807.00% 
| openshift-api-reused-connections | 4.14 |  | amd64 | sdn | metal | ha | 143 | 0s| 0.00% | 1s | 117.39% 
| cache-openshift-api-reused-connections | 4.14 | 4.14 | amd64 | sdn | aws | ha | 447 | 1s| 0.00% | 2s | 100.00% 
| cache-kube-api-new-connections | 4.14 |  | arm64 | ovn | aws | ha | 205 | 0s| 0.00% | 4.8s | 163.74% 
| ingress-to-console-reused-connections | 4.14 | 4.13 | amd64 | sdn | azure | ha | 786 | 1s| 0.00% | 3s | 200.00% 
| openshift-api-reused-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 0s| 0.00% | 1s | 117.39% 
| oauth-api-reused-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 794 | 1s| 0.00% | 2.07s | 107.00% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | amd64 | sdn | vsphere | ha | 109 | 0s| 0.00% | 7.92s | 55.29% 
| cache-oauth-api-new-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 17s| 0.00% | 34.16s | 583.20% 
| openshift-api-new-connections | 4.14 |  | amd64 | ovn | aws | ha | 316 | 0s| 0.00% | 17.8s | 878.02% 
| ingress-to-console-reused-connections | 4.14 |  | amd64 | sdn | vsphere | ha | 109 | 0s| 0.00% | 41m7s | 93.03% 
| ingress-to-console-new-connections | 4.14 |  | amd64 | sdn | metal | ha | 143 | 0s| 0.00% | 2.58s | 158.00% 
| cache-oauth-api-new-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 794 | 18s| 0.00% | 55s | 5400.00% 
| ci-cluster-network-liveness-new-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 5s| 0.00% | 28.5s | 60.11% 
| ci-cluster-network-liveness-reused-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 0s| 0.00% | 1.94s | 83.02% 
| ingress-to-oauth-server-reused-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 1s| 0.00% | 2s | 100.00% 
| cache-oauth-api-reused-connections | 4.14 |  | amd64 | ovn | aws | ha | 316 | 0s| 0.00% | 11.2s | 186.45% 
| cache-oauth-api-new-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 3s| 0.00% | 24.56s | 349.82% 
| openshift-api-new-connections | 4.14 |  | arm64 | ovn | aws | ha | 205 | 0s| 0.00% | 17.8s | 878.02% 
| openshift-api-new-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 18s| 0.00% | 23s | 2200.00% 
| ingress-to-console-new-connections | 4.14 |  | amd64 | sdn | aws | ha | 407 | 1s| 0.00% | 4.5s | 125.00% 
| kube-api-new-connections | 4.14 |  | amd64 | ovn | aws | ha | 316 | 0s| 0.00% | 5s | 174.73% 
| cache-oauth-api-new-connections | 4.14 |  | arm64 | sdn | aws | ha | 119 | 0s| 0.00% | 12.5s | 4210.34% 
| ingress-to-console-new-connections | 4.14 |  | amd64 | sdn | vsphere | ha | 109 | 0s| 0.00% | 41m7s | 93.03% 
| cache-openshift-api-new-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 794 | 17.35s| 0.00% | 25.07s | 2407.00% 
| ingress-to-console-new-connections | 4.14 |  | arm64 | sdn | aws | ha | 119 | 1s| 0.00% | 4.5s | 125.00% 
| openshift-api-new-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 794 | 17s| 0.00% | 23s | 2200.00% 
| ci-cluster-network-liveness-new-connections | 4.14 | 4.14 | amd64 | ovn | aws | ha | 844 | 4s| 0.00% | 55s | 298.26% 
| ingress-to-oauth-server-new-connections | 4.14 |  | amd64 | ovn | aws | ha | 316 | 1s| 0.00% | 10.6s | 177.49% 
| oauth-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 1s| 0.00% | 15.58s | 1458.00% 
| cache-kube-api-reused-connections | 4.14 | 4.14 | amd64 | ovn | azure | ha | 458 | 2s| 0.00% | 3s | 50.00% 
| cache-kube-api-reused-connections | 4.14 |  | amd64 | ovn | vsphere | ha | 356 | 0s| 0.00% | 1s | 426.32% 
| oauth-api-new-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 19s| 0.00% | 28.86s | 251.95% 
| cache-oauth-api-new-connections | 4.14 |  | amd64 | sdn | aws | ha | 407 | 0s| 0.00% | 12.5s | 4210.34% 
| kube-api-new-connections | 4.14 |  | arm64 | ovn | aws | ha | 205 | 0s| 0.00% | 5s | 174.73% 
| oauth-api-reused-connections | 4.14 |  | amd64 | ovn | aws | ha | 316 | 0s| 0.00% | 13.2s | 245.55% 
| ci-cluster-network-liveness-reused-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 0s| 0.00% | 2s | 100.00% 
| kube-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 1s| 0.00% | 3s | 200.00% 
| oauth-api-reused-connections | 4.14 |  | amd64 | sdn | metal | ha | 143 | 0s| 0.00% | 1s | 117.39% 
| ingress-to-console-reused-connections | 4.14 |  | amd64 | sdn | metal | ha | 143 | 1s| 0.00% | 1.58s | 58.00% 
| ingress-to-oauth-server-new-connections | 4.14 |  | amd64 | sdn | aws | ha | 407 | 1s| 0.00% | 4.75s | 375.00% 
| openshift-api-reused-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 1s| 0.00% | 12.3s | 1437.50% 
| ingress-to-oauth-server-reused-connections | 4.14 |  | amd64 | ovn | vsphere | ha | 356 | 0s| 0.00% | 450ms | 136.84% 
| cache-oauth-api-new-connections | 4.14 |  | amd64 | ovn | vsphere | ha | 356 | 0s| 0.00% | 450ms | 136.84% 
| oauth-api-reused-connections | 4.14 |  | arm64 | ovn | aws | ha | 205 | 0s| 0.00% | 13.2s | 245.55% 
| oauth-api-reused-connections | 4.14 | 4.14 | amd64 | ovn | aws | ha | 844 | 1s| 0.00% | 2s | 83.49% 
| oauth-api-new-connections | 4.14 |  | amd64 | ovn | aws | ha | 316 | 0s| 0.00% | 19.6s | 573.54% 
| openshift-api-new-connections | 4.14 |  | amd64 | sdn | gcp | ha | 245 | 3.8s| 0.00% | 6.68s | 35.77% 
| cache-oauth-api-reused-connections | 4.14 |  | arm64 | ovn | aws | ha | 205 | 0s| 0.00% | 11.2s | 186.45% 
| ingress-to-oauth-server-new-connections | 4.14 |  | arm64 | ovn | aws | ha | 205 | 1s| 0.00% | 10.6s | 177.49% 
| ingress-to-console-reused-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 6s| 0.00% | 1m3.69s | 118.12% 
| ingress-to-oauth-server-new-connections | 4.14 |  | arm64 | sdn | aws | ha | 119 | 1s| 0.00% | 4.75s | 375.00% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | amd64 | sdn | ovirt | ha | 119 | 0s| 0.00% | 7.92s | 482.35% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | amd64 | ovn | metal | ha | 234 | 0s| 0.00% | 5s | 290.62% 
| cache-kube-api-new-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 18s| 0.00% | 25.79s | 3123.75% 
| cache-oauth-api-new-connections | 4.14 |  | amd64 | ovn | aws | ha | 316 | 0s| 0.00% | 19.4s | 566.67% 
| ingress-to-oauth-server-reused-connections | 4.14 |  | amd64 | sdn | vsphere | ha | 109 | 0s| 0.00% | 41m7.08s | 93.03% 
| kube-api-reused-connections | 4.14 |  | amd64 | ovn | gcp | ha | 142 | 0s| 0.00% | 590ms | 37.21% 
| oauth-api-new-connections | 4.14 | 4.13 | amd64 | ovn | aws | ha | 794 | 17.35s| 0.00% | 37.21s | 1760.50% 
| cache-oauth-api-new-connections | 4.14 | 4.14 | amd64 | ovn | azure | ha | 458 | 25.15s| 0.00% | 1m7.43s | 118.50% 
| oauth-api-new-connections | 4.14 |  | amd64 | sdn | azure | ha | 204 | 2s| 0.00% | 29.58s | 899.32% 
| cache-kube-api-new-connections | 4.14 |  | amd64 | ovn | aws | ha | 316 | 0s| 0.00% | 4.8s | 163.74% 
| cache-oauth-api-reused-connections | 4.14 |  | amd64 | ovn | vsphere | ha | 356 | 0s| 0.00% | 1s | 426.32% 
| ingress-to-oauth-server-new-connections | 4.14 |  | amd64 | sdn | vsphere | ha | 109 | 0s| 0.00% | 41m7.08s | 93.03% 
| cache-openshift-api-reused-connections | 4.14 |  | amd64 | ovn | vsphere | ha | 356 | 0s| 0.00% | 450ms | 136.84% 
| cache-oauth-api-reused-connections | 4.14 | 4.13 | amd64 | ovn | gcp | ha | 487 | 1s| 0.00% | 3s | 50.00% 
| kube-api-new-connections | 4.14 | 4.13 | amd64 | sdn | aws | ha | 178 | 18s| 0.00% | 32.44s | 3144.00% 


</details>


### Missing Data

Note: Jobs that are missing from the new data set but were present in the previous dataset.

<details>
  <summary>Click To Show Table</summary>

| Name | Release | From | Arch | Network | Platform | Topology | Job Results | P95 | P95 % Increase | P99 | P99 % Increase |
| ---- | ------- | ---- | ---- | ------- | -------- |--------- | ----------- | --- | -------------- | --- | -------------- |
| cache-oauth-api-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-openshift-api-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-oauth-api-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| oauth-api-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| oauth-api-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-openshift-api-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| openshift-api-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| openshift-api-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| kube-api-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ingress-to-oauth-server-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| kube-api-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| oauth-api-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ingress-to-console-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ingress-to-oauth-server-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ci-cluster-network-liveness-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-kube-api-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-kube-api-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| kube-api-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| oauth-api-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-kube-api-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-oauth-api-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| openshift-api-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-kube-api-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ci-cluster-network-liveness-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-openshift-api-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ingress-to-console-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ingress-to-oauth-server-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ingress-to-console-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ingress-to-console-reused-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| openshift-api-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-oauth-api-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| kube-api-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ingress-to-oauth-server-new-connections | 4.14 |  | amd64 | sdn | alibaba | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| cache-openshift-api-new-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 
| ci-cluster-network-liveness-reused-connections | 4.14 |  | amd64 | ovn |  | ha | 0 | 0s| 0.00% | 0s | 0.00% 


</details>

 