### PR TITLE
2x Revert "Make unidle test more strict"

### DIFF
--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -74,7 +74,7 @@ func tryEchoHTTP(svc *kapiv1.Service, execPod *kapiv1.Pod) error {
 	}
 
 	expected := "It is time to TCP."
-	cmd := fmt.Sprintf("curl --retry-max-time 120 --retry-connrefused --retry 20 --max-time 5 -s -g http://%s/echo?msg=%s",
+	cmd := fmt.Sprintf("curl --max-time 120 -v -g http://%s/echo?msg=%s",
 		net.JoinHostPort(rawIP, tcpPort),
 		url.QueryEscape(expected),
 	)


### PR DESCRIPTION
This reverts 
- https://github.com/openshift/origin/pull/27833

As the 4.14.0-0.nightly CI is now consuming 4.14 HEAD:

https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4.14.0-0.nightly/release/4.14.0-0.nightly-2023-04-03-002631

> [ovn-kubernetes](https://github.com/openshift/ovn-kubernetes) git [c2e3a647](https://github.com/openshift/ovn-kubernetes/commit/c2e3a6472b7a0a6a52f85b1f905fb0dfbf95eda7) sha256:88a5686ebb164ba15631386cafc763467a29ad4f50ba491152980ffa7b39e87c

The problem was related to a bad image naming while moving to rhel9. As that problem is now fixed, it's safe to propose these changes again.

@stbenjam , @dcbw Please take a look