### PR TITLE
Revert "TRT-889: Temp flake all azure disruption"

### DIFF
--- a/pkg/synthetictests/disruption.go
+++ b/pkg/synthetictests/disruption.go
@@ -102,14 +102,6 @@ func testServerAvailability(
 			},
 			SystemOut: strings.Join(disruptionMsgs, "\n"),
 		}
-
-		// https://issues.redhat.com/browse/TRT-889 temporarily flake all disruption for azure
-		if jobType.Platform == "azure" {
-			return []*junitapi.JUnitTestCase{test, {
-				Name: testName,
-			}}
-		}
-
 		return []*junitapi.JUnitTestCase{test}
 	} else {
 		successTest.SystemOut = resultsStr


### PR DESCRIPTION
Reverts openshift/origin#27781

We are past the point of needing to allow azure disruption to pass through unchecked. Reverting.