### PR TITLE
OCPBUGS-11304: Increasing limits for Nodes OSUpdateStaged time test

### DIFF
--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -90,8 +90,8 @@ type startedStaged struct {
 func testOperatorOSUpdateStaged(events monitorapi.Intervals, clientConfig *rest.Config) []*junitapi.JUnitTestCase {
 	testName := "[bz-Machine Config Operator] Nodes should reach OSUpdateStaged in a timely fashion"
 	success := &junitapi.JUnitTestCase{Name: testName}
-	flakeThreshold := 5 * time.Minute
-	failThreshold := 10 * time.Minute
+	flakeThreshold := 7 * time.Minute
+	failThreshold := 14 * time.Minute
 
 	// Scan all OSUpdateStarted and OSUpdateStaged events, sort by node.
 	nodeNameToOSUpdateTimes := map[string]*startedStaged{}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-11304

For 4.14 it is only affecting `periodic-ci-openshift-multiarch-master-nightly-4.14-ocp-e2e-aws-ovn-heterogeneous-upgrade` job

/cc @sdodson @dgoodwin 