### PR TITLE
bump timeout

### DIFF
--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -248,7 +248,7 @@ func IsCPMSActive(ctx context.Context, t TestingT, cpmsClient machinev1client.Co
 // this effectively counts the number of control-plane machines with the provider state as running
 func EnsureReadyReplicasOnCPMS(ctx context.Context, t TestingT, expectedReplicaCount int, cpmsClient machinev1client.ControlPlaneMachineSetInterface) error {
 	waitPollInterval := 5 * time.Second
-	waitPollTimeout := 18 * time.Minute
+	waitPollTimeout := 30 * time.Minute
 	t.Logf("Waiting up to %s for the CPMS to have status.readyReplicas = %v", waitPollTimeout.String(), expectedReplicaCount)
 
 	return wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {


### PR DESCRIPTION
This PR increased the timeout of etcd vertical scaling e2e test. 

The test scenario attempts to add a new master machine, and delete another master machine. Machine provisioning requires time from the provider side, also draining and deleting a machine. CI results shows a lot of timeout during machine deletion and provisioning. 

This PR attempts to increase the timeout according to observing the time required from the `machine-controller` logs.

see https://github.com/openshift/origin/pull/27695 

cc @hasbro17 @damdo 