### PR TITLE
Trt-945 detect master node updates

### DIFF
--- a/pkg/monitor/write_job_run_data.go
+++ b/pkg/monitor/write_job_run_data.go
@@ -108,7 +108,12 @@ func WasMasterNodeUpdated(events monitorapi.Intervals) string {
 	nodeUpdates := events.Filter(monitorapi.NodeUpdate)
 
 	for _, i := range nodeUpdates {
-		if strings.Contains(i.Locator, "master") {
+		// "locator": "node/ip-10-0-240-32.us-west-1.compute.internal",
+		//            "message": "reason/NodeUpdate phase/Update config/rendered-master-757d729d8565a6f9f4e59913d4731db1 roles/control-plane,master reached desired config roles/control-plane,master",
+		// vs
+		// "locator": "node/ip-10-0-228-209.us-west-1.compute.internal",
+		//            "message": "reason/NodeUpdate phase/Update config/rendered-worker-722803a00bad408ee94572ab244ad3bc roles/worker reached desired config roles/worker",
+		if strings.Contains(i.Message, "master") {
 			return "Y"
 		}
 	}

--- a/pkg/riskanalysis/write_test_failure_summary.go
+++ b/pkg/riskanalysis/write_test_failure_summary.go
@@ -16,7 +16,7 @@ import (
 // job run, and what tests flaked and failed. (successful tests are omitted)
 // This is intended to be later submitted to sippy for a risk analysis of how unusual the
 // test failures were, but that final step is handled elsewhere.
-func WriteJobRunTestFailureSummary(artifactDir, timeSuffix string, finalSuiteResults *junitapi.JUnitTestSuite) error {
+func WriteJobRunTestFailureSummary(artifactDir, timeSuffix string, finalSuiteResults *junitapi.JUnitTestSuite, wasMasterNodeUpdated string) error {
 
 	tests := map[string]*passFail{}
 
@@ -41,7 +41,7 @@ func WriteJobRunTestFailureSummary(artifactDir, timeSuffix string, finalSuiteRes
 	jr := ProwJobRun{
 		ID:          jobRunID,
 		ProwJob:     ProwJob{Name: os.Getenv("JOB_NAME")},
-		ClusterData: monitor.CollectClusterData(),
+		ClusterData: monitor.CollectClusterData(wasMasterNodeUpdated),
 		Tests:       []ProwJobRunTest{},
 		TestCount:   len(tests),
 	}

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -150,6 +150,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testErrImagePullUnrecognizedSignatureFormat(events)...)
 	tests = append(tests, testEtcdShouldNotLogSlowFdataSyncs(events)...)
 	tests = append(tests, testEtcdShouldNotLogDroppedRaftMessages(events)...)
+	tests = append(tests, testMasterNodesUpdated(events)...)
 	return tests
 }
 

--- a/pkg/synthetictests/platformidentification/types.go
+++ b/pkg/synthetictests/platformidentification/types.go
@@ -35,6 +35,7 @@ type ClusterData struct {
 	CloudRegion           string
 	CloudZone             string
 	ClusterVersionHistory []string
+	MasterNodesUpdated    string
 }
 
 const (

--- a/pkg/synthetictests/updates.go
+++ b/pkg/synthetictests/updates.go
@@ -7,7 +7,7 @@ import (
 )
 
 func testMasterNodesUpdated(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
-	const testName = "[sig-sippy] master nodes updated"
+	const testName = "[sig-coreos] master nodes updated"
 
 	// Only return a Junit if we detect that the master nodes were updated
 	// Used in sippy to differentiate between jobs where the master nodes update and do not (no junit in that case)

--- a/pkg/synthetictests/updates.go
+++ b/pkg/synthetictests/updates.go
@@ -1,0 +1,20 @@
+package synthetictests
+
+import (
+	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+func testMasterNodesUpdated(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-sippy] master nodes updated"
+
+	// Only return a Junit if we detect that the master nodes were updated
+	// Used in sippy to differentiate between jobs where the master nodes update and do not (no junit in that case)
+	if "Y" == monitor.WasMasterNodeUpdated(events) {
+		return []*junitapi.JUnitTestCase{{
+			Name: testName,
+		}}
+	}
+	return nil
+}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -478,6 +478,8 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 		}
 	}
 
+	// default is empty string as that is what entries prior to adding this will have
+	wasMasterNodeUpdated := ""
 	if events := opt.MonitorEventsOptions.GetEvents(); len(events) > 0 {
 		var buf *bytes.Buffer
 		syntheticTestResults, buf, _ = createSyntheticTestsFromMonitor(events, duration)
@@ -519,6 +521,8 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 				fmt.Fprintf(opt.ErrOut, "error: Failed to write monitor data: %v\n", err)
 			}
 		}
+
+		wasMasterNodeUpdated = monitor.WasMasterNodeUpdated(events)
 	}
 
 	// report the outcome of the test
@@ -533,7 +537,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 			fmt.Fprintf(opt.Out, "error: Unable to write e2e JUnit xml results: %v", err)
 		}
 
-		if err := riskanalysis.WriteJobRunTestFailureSummary(opt.JUnitDir, timeSuffix, finalSuiteResults); err != nil {
+		if err := riskanalysis.WriteJobRunTestFailureSummary(opt.JUnitDir, timeSuffix, finalSuiteResults, wasMasterNodeUpdated); err != nil {
 			fmt.Fprintf(opt.Out, "error: Unable to write e2e job run failures summary: %v", err)
 		}
 	}

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -167,7 +167,11 @@ func runChaosmonkey(
 				fmt.Fprintf(os.Stderr, "error: Failed to write file %v: %v\n", fname, err)
 			}
 
-			if err := riskanalysis.WriteJobRunTestFailureSummary(framework.TestContext.ReportDir, timeSuffix, testSuite); err != nil {
+			// default for wasMasterNodeUpdated is empty string as that is what entries prior to adding this will have
+			// we don't currently need this field set for RiskAnalysis.  We could change this logic to either
+			// parse the events for the NodeUpdated interval or read the ClusterData.json from storage
+			// and pass it in if needed.
+			if err := riskanalysis.WriteJobRunTestFailureSummary(framework.TestContext.ReportDir, timeSuffix, testSuite, ""); err != nil {
 				fmt.Fprintf(os.Stderr, "error: Failed to write file %v: %v\n", fname, err)
 				return
 			}


### PR DESCRIPTION
Looks for NodeUpdate event intervals with 'master' in the locator to determine if nodes were updated.  Adds a flag to the ClusterData json Y/N (or empty string) to indicate yes, no, unknown.  If considered viable we should be able to extract the flag in ci-tools when uploading disruption to indicate if the upgrade did in fact update the master nodes.