### PR TITLE
add specific test for failing cgroups path

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -73,6 +73,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testNodeHasSufficientMemory(events)...)
 	tests = append(tests, testNodeHasSufficientPID(events)...)
 
+	tests = append(tests, testFailedToDeleteCGroupsPath(events)...)
 	tests = append(tests, testHttpConnectionLost(events)...)
 	tests = append(tests, testMarketplaceStartupProbeFailure(events)...)
 	tests = append(tests, testErrImagePullUnrecognizedSignatureFormat(events)...)
@@ -143,6 +144,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testNodeHasSufficientMemory(events)...)
 	tests = append(tests, testNodeHasSufficientPID(events)...)
 
+	tests = append(tests, testFailedToDeleteCGroupsPath(events)...)
 	tests = append(tests, testHttpConnectionLost(events)...)
 	tests = append(tests, testMarketplaceStartupProbeFailure(events)...)
 	tests = append(tests, testErrImagePullUnrecognizedSignatureFormat(events)...)

--- a/pkg/synthetictests/kubelet.go
+++ b/pkg/synthetictests/kubelet.go
@@ -100,6 +100,33 @@ func testHttpConnectionLost(events monitorapi.Intervals) []*junitapi.JUnitTestCa
 	return []*junitapi.JUnitTestCase{failure, success}
 }
 
+func testFailedToDeleteCGroupsPath(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-node] kubelet should be able to delete cgroups path"
+
+	var failures []string
+	for _, event := range events {
+		if strings.Contains(event.Message, "reason/FailedToDeleteCGroupsPath") {
+			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
+		}
+	}
+
+	if len(failures) == 0 {
+		success := &junitapi.JUnitTestCase{Name: testName}
+		return []*junitapi.JUnitTestCase{success}
+	}
+
+	failure := &junitapi.JUnitTestCase{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &junitapi.FailureOutput{
+			Output: fmt.Sprintf("kubelet logs contain %d failures to delete cgroups path.\n\n%v", len(failures), strings.Join(failures, "\n")),
+		},
+	}
+	// add success to flake the test because this fails very commonly.
+	success := &junitapi.JUnitTestCase{Name: testName}
+	return []*junitapi.JUnitTestCase{failure, success}
+}
+
 func testKubeAPIServerGracefulTermination(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-api-machinery] kube-apiserver terminates within graceful termination period"
 


### PR DESCRIPTION
This will only catch instances *after* the tests have started.  Many instances exist during installation: https://search.ci.openshift.org/?search=static+pod+lifecycle+failure+-+static+pod&maxAge=336h&context=1&type=junit&name=4.13.*gcp&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

This will help identify how many more we've got.  And given it means, "pods don't run right", I wouldn't expect otherwise successful runs to hit this.

@rphillips to be sure this isn't a normal error
@deepsm007 to be sure he thinks it will work