### PR TITLE
add wait for ingress to be responsive before beginning upgrade

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -310,7 +310,8 @@ func (b *BackendSampler) GetHTTPClient() (*http.Client, error) {
 	return b.httpClient, b.httpClientErr
 }
 
-func (b *BackendSampler) checkConnection(ctx context.Context) (string, error) {
+// CheckConnnection returns the audit request UID and an error if there was one.
+func (b *BackendSampler) CheckConnection(ctx context.Context) (string, error) {
 	httpClient, err := b.GetHTTPClient()
 	if err != nil {
 		return "", err
@@ -487,7 +488,7 @@ func (b *disruptionSampler) produceSamples(ctx context.Context, interval time.Du
 		// was actually 30s before.
 		currDisruptionSample := b.newSample(ctx)
 		go func() {
-			uid, sampleErr := b.backendSampler.checkConnection(ctx)
+			uid, sampleErr := b.backendSampler.CheckConnection(ctx)
 			currDisruptionSample.setSampleError(sampleErr)
 			if sampleErr != nil {
 				// We'd like to include these UUIDs in the backend-disruption.json file but this is

--- a/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
@@ -144,8 +144,8 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 				cancel()
 			}
 
-			if _, err := backend.checkConnection(ctx); (err != nil) != tt.wantErr {
-				t.Errorf("checkConnection() error = %v, wantErr %v", err, tt.wantErr)
+			if _, err := backend.CheckConnection(ctx); (err != nil) != tt.wantErr {
+				t.Errorf("CheckConnection() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 	"k8s.io/kubernetes/test/e2e/upgrades/apps"
@@ -39,6 +40,7 @@ import (
 	"github.com/openshift/origin/test/e2e/upgrade/service"
 	"github.com/openshift/origin/test/extended/prometheus"
 	"github.com/openshift/origin/test/extended/util/disruption"
+	"github.com/openshift/origin/test/extended/util/disruption/frontends"
 	"github.com/openshift/origin/test/extended/util/disruption/imageregistry"
 	"github.com/openshift/origin/test/extended/util/operator"
 )
@@ -325,6 +327,24 @@ func GatherPreUpgradeResourceCounts() error {
 func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynamic.Interface, config *rest.Config, version upgrades.VersionContext) error {
 	fmt.Fprintf(os.Stderr, "\n\n\n")
 	defer func() { fmt.Fprintf(os.Stderr, "\n\n\n") }()
+
+	// ignore the failure here, we don't want this to fail the upgrade, we want it to fail this particular test.
+	_ = disruption.RecordJUnit(
+		f,
+		"[bz-Routing] console is not available via ingress",
+		func() (error, bool) {
+			pollErr := wait.PollImmediateWithContext(context.TODO(), 1*time.Second, 10*time.Minute, func(ctx context.Context) (bool, error) {
+				consoleSampler := frontends.CreateConsoleRouteAvailableWithNewConnections()
+				_, err := consoleSampler.CheckConnection(ctx)
+				if err == nil {
+					return true, nil
+				}
+				klog.Errorf("ingress is down: %v", err)
+				return false, nil
+			})
+			return pollErr, false
+		},
+	)
 
 	if version.NodeImage == "[pause]" {
 		framework.Logf("Running a dry-run upgrade test")

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -37,7 +37,7 @@ func NewOAuthRouteAvailableWithConnectionReuseTest() upgrades.Test {
 func NewConsoleRouteAvailableWithNewConnectionsTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
 		"[sig-network-edge] Console remains available via cluster ingress using new connections",
-		createConsoleRouteAvailableWithNewConnections(),
+		CreateConsoleRouteAvailableWithNewConnections(),
 	)
 }
 

--- a/test/extended/util/disruption/frontends/known_backends.go
+++ b/test/extended/util/disruption/frontends/known_backends.go
@@ -57,7 +57,7 @@ func StartAllIngressMonitoring(ctx context.Context, m monitor.Recorder, clusterC
 		// it has it by default. This is to catch possible future scenarios where we upgrade 4.11 no cap to 4.12 no cap.
 		if !cluster.KnowsCapability(clusterVersion, "Console") ||
 			cluster.HasCapability(clusterVersion, "Console") {
-			if err := createConsoleRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
+			if err := CreateConsoleRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
 				return err
 			}
 			if err := createConsoleRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
@@ -110,7 +110,7 @@ func createOAuthRouteAvailableWithConnectionReuse() *backenddisruption.BackendSa
 		WithExpectedBody("ok")
 }
 
-func createConsoleRouteAvailableWithNewConnections() *backenddisruption.BackendSampler {
+func CreateConsoleRouteAvailableWithNewConnections() *backenddisruption.BackendSampler {
 	restConfig, err := monitor.GetMonitorRESTConfig()
 	utilruntime.Must(err)
 	return backenddisruption.NewRouteBackend(


### PR DESCRIPTION
This adds a wait before installs start to be sure that ingress is available before beginning an upgrade so that upgrades become a cleaner signal.