### PR TITLE
Bug OCPBUGS-11467: [release-4.9] Silence loki-promtail readiness probe errors

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -74,6 +74,9 @@ var allowedRepeatedEventPatterns = []*regexp.Regexp{
 	// If image pulls in e2e namespaces fail catastrophically we'd expect them to lead to test failures
 	// We are deliberately not ignoring image pull failures for core component namespaces
 	regexp.MustCompile(`ns/e2e-.* reason/BackOff Back-off pulling image`),
+
+	// promtail crashlooping as its being started by sideloading manifests.  per @vrutkovs
+	regexp.MustCompile("ns/openshift-e2e-loki pod/loki-promtail.*Readiness probe"),
 }
 
 var allowedRepeatedEventFns = []isRepeatedEventOKFunc{


### PR DESCRIPTION
Brings the same rule that is already in 4.10 to 4.9, now that loki is enabled by default for all clusters in CI.