### PR TITLE
Revert "add wait for ingress to be responsive before beginning upgrade"

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -310,8 +310,7 @@ func (b *BackendSampler) GetHTTPClient() (*http.Client, error) {
 	return b.httpClient, b.httpClientErr
 }
 
-// CheckConnnection returns the audit request UID and an error if there was one.
-func (b *BackendSampler) CheckConnection(ctx context.Context) (string, error) {
+func (b *BackendSampler) checkConnection(ctx context.Context) (string, error) {
 	httpClient, err := b.GetHTTPClient()
 	if err != nil {
 		return "", err
@@ -488,7 +487,7 @@ func (b *disruptionSampler) produceSamples(ctx context.Context, interval time.Du
 		// was actually 30s before.
 		currDisruptionSample := b.newSample(ctx)
 		go func() {
-			uid, sampleErr := b.backendSampler.CheckConnection(ctx)
+			uid, sampleErr := b.backendSampler.checkConnection(ctx)
 			currDisruptionSample.setSampleError(sampleErr)
 			if sampleErr != nil {
 				// We'd like to include these UUIDs in the backend-disruption.json file but this is

--- a/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
@@ -144,8 +144,8 @@ func TestBackendSampler_checkConnection(t *testing.T) {
 				cancel()
 			}
 
-			if _, err := backend.CheckConnection(ctx); (err != nil) != tt.wantErr {
-				t.Errorf("CheckConnection() error = %v, wantErr %v", err, tt.wantErr)
+			if _, err := backend.checkConnection(ctx); (err != nil) != tt.wantErr {
+				t.Errorf("checkConnection() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/test/extended/util/disruption/frontends/frontends.go
+++ b/test/extended/util/disruption/frontends/frontends.go
@@ -37,7 +37,7 @@ func NewOAuthRouteAvailableWithConnectionReuseTest() upgrades.Test {
 func NewConsoleRouteAvailableWithNewConnectionsTest() upgrades.Test {
 	return disruption.NewBackendDisruptionTest(
 		"[sig-network-edge] Console remains available via cluster ingress using new connections",
-		CreateConsoleRouteAvailableWithNewConnections(),
+		createConsoleRouteAvailableWithNewConnections(),
 	)
 }
 

--- a/test/extended/util/disruption/frontends/known_backends.go
+++ b/test/extended/util/disruption/frontends/known_backends.go
@@ -57,7 +57,7 @@ func StartAllIngressMonitoring(ctx context.Context, m monitor.Recorder, clusterC
 		// it has it by default. This is to catch possible future scenarios where we upgrade 4.11 no cap to 4.12 no cap.
 		if !cluster.KnowsCapability(clusterVersion, "Console") ||
 			cluster.HasCapability(clusterVersion, "Console") {
-			if err := CreateConsoleRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
+			if err := createConsoleRouteAvailableWithNewConnections().StartEndpointMonitoring(ctx, m, nil); err != nil {
 				return err
 			}
 			if err := createConsoleRouteAvailableWithConnectionReuse().StartEndpointMonitoring(ctx, m, nil); err != nil {
@@ -110,7 +110,7 @@ func createOAuthRouteAvailableWithConnectionReuse() *backenddisruption.BackendSa
 		WithExpectedBody("ok")
 }
 
-func CreateConsoleRouteAvailableWithNewConnections() *backenddisruption.BackendSampler {
+func createConsoleRouteAvailableWithNewConnections() *backenddisruption.BackendSampler {
 	restConfig, err := monitor.GetMonitorRESTConfig()
 	utilruntime.Must(err)
 	return backenddisruption.NewRouteBackend(


### PR DESCRIPTION
Reverts openshift/origin#27857

We are observing upgrade failures for GCP, AWS and Azure.