### PR TITLE
deploy: Change imagestreams importMode to work with multi-arch compute clusters

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -428,7 +428,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForSyncedConfig(oc, dcName, deploymentRunTimeout)).NotTo(o.HaveOccurred())
 
 			g.By("tagging the initial test:v1 image")
-			_, err = oc.Run("tag").Args("image-registry.openshift-image-registry.svc:5000/openshift/cli:latest", "test:v1").Output()
+			_, err = oc.Run("tag").Args("--import-mode=PreserveOriginal", "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest", "test:v1").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			expectLatestVersion := func(version int) {
@@ -459,7 +459,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForSyncedConfig(oc, dcName, deploymentRunTimeout)).NotTo(o.HaveOccurred())
 
 			g.By("tagging a different image as test:v2")
-			_, err = oc.Run("tag").Args("image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "test:v2").Output()
+			_, err = oc.Run("tag").Args("--import-mode=PreserveOriginal", "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "test:v2").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("ensuring the deployment config latest version is 2 and rollout completed")
@@ -548,10 +548,10 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 		g.It("should run a successful deployment with multiple triggers [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
 			g.By("creating DC")
 
-			_, err := oc.Run("import-image").Args("registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
+			_, err := oc.Run("import-image").Args("--import-mode=PreserveOriginal", "registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			_, err = oc.Run("import-image").Args("registry.redhat.io/rhel8/postgresql-13:latest", "--confirm", "--reference-policy=local").Output()
+			_, err = oc.Run("import-image").Args("--import-mode=PreserveOriginal", "registry.redhat.io/rhel8/postgresql-13:latest", "--confirm", "--reference-policy=local").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			dc, err := createDeploymentConfig(oc, multipleICTFixture)
@@ -563,7 +563,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 
 		g.It("should run a successful deployment with a trigger used by different containers [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
 
-			_, err := oc.Run("import-image").Args("registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
+			_, err := oc.Run("import-image").Args("--import-mode=PreserveOriginal", "registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			dc, err := createDeploymentConfig(oc, anotherMultiICTFixture)
@@ -1535,7 +1535,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("tagging the tools image as test:v1 to create ImageStream")
-			out, err := oc.Run("tag").Args("image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "test:v1").Output()
+			out, err := oc.Run("tag").Args("--import-mode=PreserveOriginal", "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "test:v1").Output()
 			e2e.Logf("%s", out)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -93,6 +93,9 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageAppend] Image append", func
 		pod := cli.Create(context.TODO(), cliPodWithPullSecret(oc, heredoc.Docf(`
 			set -x
 
+			# create a copy of the single manifest image from the original image for layer count
+			oc image append --insecure --from %[3]s --to %[2]s/%[1]s/tools:singlemanifest
+
 			# create a scratch image with fixed date
 			oc image append --insecure --to %[2]s/%[1]s/test:scratch1 --image='{"Cmd":["/bin/sleep"]}' --created-at=0
 
@@ -115,9 +118,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageAppend] Image append", func
 		`, ns, registry, image.ShellImage())))
 		cli.WaitForSuccess(context.TODO(), pod.Name, podStartupTimeout)
 
-		// verify that the shell image matches our check - if the shell image changes, we'll need to look up a different image
-		o.Expect(image.ShellImage()).To(o.HaveSuffix("/openshift/tools:latest"))
-		baseTools, err := oc.ImageClient().ImageV1().ImageStreamTags("openshift").Get(context.Background(), "tools:latest", metav1.GetOptions{})
+		baseTools, err := oc.ImageClient().ImageV1().ImageStreamTags(ns).Get(context.Background(), "tools:singlemanifest", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// subsequent operations are expected to append to this image
 		baseLayerCount := len(baseTools.Image.DockerImageLayers)

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -23,7 +23,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	cloudnetwork "github.com/openshift/client-go/cloudnetwork/clientset/versioned"
 	networkclient "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
-	"github.com/openshift/origin/test/extended/util"
 	exutil "github.com/openshift/origin/test/extended/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -334,7 +333,7 @@ func createPacketSnifferDaemonSet(oc *exutil.CLI, namespace string, scheduleOnHo
 	f := oc.KubeFramework()
 	clientset := f.ClientSet
 
-	tcpdumpImage, err := util.DetermineImageFromRelease(oc, "network-tools")
+	tcpdumpImage, err := exutil.GetDockerImageReference(oc.ImageClient().ImageV1().ImageStreams("openshift"), "network-tools", "latest")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On multi-arch compute clusters, the pods can land on any arch type of worker node. Making sure that the imagstreams import the manifestlist will help make sure the deployment succeeds on any node that it lands on.