### PR TITLE
Add selfsubjectreviews RBAC rules

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -248,6 +248,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] The default clust
 			testAllGroupRules(ruleResolver, "system:authenticated:oauth", []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("create").Groups(projectGroup, legacyProjectGroup).Resources("projectrequests").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch", "delete").Groups(oauthGroup).Resources("useroauthaccesstokens").RuleOrDie(),
+				rbacv1helpers.NewRule("create").Groups(kAuthnGroup).Resources("selfsubjectreviews").RuleOrDie(),
 			}, namespaces.Items)
 		})
 


### PR DESCRIPTION
This PR addresses the following test failure happening in several jobs of openshift/kubernetes/pull/1524

```
{  fail [github.com/openshift/origin/test/extended/authorization/rbac/groups_default_rules.go:274]: Apr 10 17:57:34.909: system:authenticated has extra permissions in namespace "":
{APIGroups:["authentication.k8s.io"], Resources:["selfsubjectreviews"], Verbs:["create"]}
Ginkgo exit error 1: exit with code 1}
```

CC @stlaz @soltysh 