### PR TITLE
OCPBUGS-11560: flake Pods Extended Pod Container lifecycle evicted pods

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2673,7 +2673,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] Pods Extended Pod Container Status should never report success for a pending container": "should never report success for a pending container [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-node] Pods Extended Pod Container lifecycle evicted pods should be terminal": "evicted pods should be terminal [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-node] Pods Extended Pod Container lifecycle evicted pods should be terminal": "evicted pods should be terminal [Flaky] [Suite:k8s]",
 
 	"[Top Level] [sig-node] Pods Extended Pod Container lifecycle should not create extra sandbox if all containers are done": "should not create extra sandbox if all containers are done [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -87,6 +87,7 @@ var (
 		// tests that are known flaky
 		"[Flaky]": {
 			`openshift mongodb replication creating from a template`, // flaking on deployment
+			`\[sig-node\] Pods Extended Pod Container lifecycle evicted pods should be terminal`,
 		},
 		// tests that must be run without competition
 		"[Serial]": {},


### PR DESCRIPTION
Flake `Pods Extended Pod Container lifecycle evicted pods should be terminal` test.

I had a conversation with upstream about backporting https://github.com/kubernetes/kubernetes/pull/115331.  115331 depends on other changes for correctness and is also risky to backport. For now, the best we can do is flake this test and work on Clayton's upstream redesign to fix these subsystems. 