### PR TITLE
OCPBUGS-11560,OCPBUGS-11629: flake Pods Extended Pod Container lifecycle evicted pods

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2353,7 +2353,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-network] Services should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node": "should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-network] Services should be rejected for evicted pods (no endpoints exist)": "should be rejected for evicted pods (no endpoints exist) [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-network] Services should be rejected for evicted pods (no endpoints exist)": "should be rejected for evicted pods (no endpoints exist) [Flaky] [Suite:k8s]",
 
 	"[Top Level] [sig-network] Services should be rejected when no endpoints exist": "should be rejected when no endpoints exist [Skipped:ibmroks] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
@@ -2673,7 +2673,7 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-node] Pods Extended Pod Container Status should never report success for a pending container": "should never report success for a pending container [Suite:openshift/conformance/parallel] [Suite:k8s]",
 
-	"[Top Level] [sig-node] Pods Extended Pod Container lifecycle evicted pods should be terminal": "evicted pods should be terminal [Suite:openshift/conformance/parallel] [Suite:k8s]",
+	"[Top Level] [sig-node] Pods Extended Pod Container lifecycle evicted pods should be terminal": "evicted pods should be terminal [Flaky] [Suite:k8s]",
 
 	"[Top Level] [sig-node] Pods Extended Pod Container lifecycle should not create extra sandbox if all containers are done": "should not create extra sandbox if all containers are done [Suite:openshift/conformance/parallel] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -86,7 +86,9 @@ var (
 		"[Slow]": {},
 		// tests that are known flaky
 		"[Flaky]": {
-			`openshift mongodb replication creating from a template`, // flaking on deployment
+			`openshift mongodb replication creating from a template`,                              // flaking on deployment
+			`\[sig-node\] Pods Extended Pod Container lifecycle evicted pods should be terminal`,  // OCPBUGS-11560
+			`\[sig-network\] Services should be rejected for evicted pods \(no endpoints exist\)`, // OCPBUGS-11629
 		},
 		// tests that must be run without competition
 		"[Serial]": {},


### PR DESCRIPTION
Flake `Pods Extended Pod Container lifecycle evicted pods should be terminal` test.

I had a conversation with upstream about backporting https://github.com/kubernetes/kubernetes/pull/115331.  115331 depends on other changes for correctness and is also risky to backport. For now, the best we can do is flake this test and work on Clayton's upstream redesign to fix these subsystems. 