### PR TITLE
WRKLDS-665: Enable [sig-scheduling] SchedulerPreemption [Serial] validates pod disruption condition is added to the preempted pod [Suite:openshift/conformance/serial]

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -3175,7 +3175,7 @@ var Annotations = map[string]string{
 
 	"[sig-scheduling] SchedulerPreemption [Serial] validates lower priority pod preemption by critical pod [Conformance]": " [Suite:openshift/conformance/serial/minimal] [Suite:k8s]",
 
-	"[sig-scheduling] SchedulerPreemption [Serial] validates pod disruption condition is added to the preempted pod": " [Disabled:Broken] [Suite:k8s]",
+	"[sig-scheduling] SchedulerPreemption [Serial] validates pod disruption condition is added to the preempted pod": " [Suite:openshift/conformance/serial] [Suite:k8s]",
 
 	"[sig-scheduling] SchedulerPriorities [Serial] Pod should be preferably scheduled to nodes pod can tolerate": " [Suite:openshift/conformance/serial] [Suite:k8s]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -84,9 +84,6 @@ var (
 			`\[sig-network\] LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on different nodes`,
 			`\[sig-network\] LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on the same nodes`,
 
-			// https://issues.redhat.com/browse/WRKLDS-665
-			`\[sig-scheduling\] SchedulerPreemption \[Serial\] validates pod disruption condition is added to the preempted pod`,
-
 			// https://issues.redhat.com/browse/OCPBUGS-11652
 			`\[sig-cli\] oc adm node-logs`,
 		},


### PR DESCRIPTION
From other test runs:

results 
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27832/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1642907183664336896

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27832/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1643235049660747776

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27832/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1643523246353551360

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27832/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1643573060508323840

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27832/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1643619997773205504

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27832/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1643935535271514112

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27832/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1645753651131584512


It seems the issue resolved itself. I think we can re-enable this test