### PR TITLE
Bug OCPBUGS-6778: Correct condition for rejecting connection

### DIFF
--- a/test/extended/csrapprover/csrapprover.go
+++ b/test/extended/csrapprover/csrapprover.go
@@ -68,9 +68,9 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 		internalAPI.Path = "/config/master"
 
 		// we should not be able to reach the endpoint
-		curlOutput, err := pod.Exec(fmt.Sprintf("curl -k %s", internalAPI.String()))
+		curlOutput, err := pod.Exec(fmt.Sprintf("curl --connect-timeout 5 -k %s", internalAPI.String()))
 		o.Expect(err).To(o.HaveOccurred())
-		o.Expect(curlOutput).To(o.ContainSubstring("Connection refused"))
+		o.Expect(curlOutput).To(o.Or(o.ContainSubstring("Connection refused"), o.ContainSubstring("Connection timed out")))
 	})
 
 	g.It("CSRs from machines that are not recognized by the cloud provider are not approved", func() {


### PR DESCRIPTION
Test 'Pods cannot access the /config/master API endpoint fails' assumes, that curl output should contain Connection refused, which is not always true, when cluster would be deployed on OpenStack with different CNI (like Kuryr), which is using Security Groups to block the traffic to the internal API. In that case rules created by SG would drop the packet, so there will be no response rather then refuse.

This patch is correcting the test case, where there is added additional response string and added timeout option for curl, just to save the time.