### PR TITLE
WIP pkg/test/ginkgo: allow test to expose a metric

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -547,4 +547,5 @@ func bindTestOptions(opt *testginkgo.Options, flags *pflag.FlagSet) {
 	flags.DurationVar(&opt.Timeout, "timeout", opt.Timeout, "Set the maximum time a test can run before being aborted. This is read from the suite by default, but will be 10 minutes otherwise.")
 	flags.BoolVar(&opt.IncludeSuccessOutput, "include-success", opt.IncludeSuccessOutput, "Print output from successful tests.")
 	flags.IntVar(&opt.Parallelism, "max-parallel-tests", opt.Parallelism, "Maximum number of tests running in parallel. 0 defaults to test suite recommended value, which is different in each suite.")
+	flags.StringVar(&opt.TestMetricFile, "test-metric-file", opt.TestMetricFile, "The file to save test metrics to.")
 }

--- a/pkg/synthetictests/disruption.go
+++ b/pkg/synthetictests/disruption.go
@@ -2,6 +2,7 @@ package synthetictests
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -92,6 +93,9 @@ func testServerAvailability(
 	successTest := &junitapi.JUnitTestCase{
 		Name:     testName,
 		Duration: jobRunDuration.Seconds(),
+		TestMetrics: map[string]string{
+			backendName: strconv.FormatFloat(observedDisruption.Seconds(), 'f', -1, 64),
+		},
 	}
 	if observedDisruption > roundedAllowedDisruption {
 		test := &junitapi.JUnitTestCase{
@@ -101,6 +105,9 @@ func testServerAvailability(
 				Output: resultsStr,
 			},
 			SystemOut: strings.Join(disruptionMsgs, "\n"),
+			TestMetrics: map[string]string{
+				backendName: strconv.FormatFloat(observedDisruption.Seconds(), 'f', -1, 64),
+			},
 		}
 		return []*junitapi.JUnitTestCase{test}
 	} else {

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -62,6 +62,8 @@ type Options struct {
 	Out, ErrOut   io.Writer
 
 	StartTime time.Time
+
+	TestMetricFile string
 }
 
 func NewOptions(out io.Writer, errOut io.Writer) *Options {
@@ -549,10 +551,17 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 		fmt.Fprintf(opt.Out, "%d flakes detected, suite allows passing with only flakes\n\n", fail)
 	}
 
+	if len(opt.TestMetricFile) > 0 {
+		if err := WriteTestMetrics(opt.TestMetricFile, tests); err != nil {
+			return fmt.Errorf("failed to write tests metrics file: %v", err)
+		}
+	}
+
 	if syntheticFailure {
 		return fmt.Errorf("failed because an invariant was violated, %d pass, %d skip (%s)\n", pass, skip, duration)
 	}
 
 	fmt.Fprintf(opt.Out, "%d pass, %d skip (%s)\n", pass, skip, duration)
+
 	return ctx.Err()
 }

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -551,10 +551,11 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string) error {
 		fmt.Fprintf(opt.Out, "%d flakes detected, suite allows passing with only flakes\n\n", fail)
 	}
 
-	if len(opt.TestMetricFile) > 0 {
-		if err := WriteTestMetrics(opt.TestMetricFile, tests); err != nil {
-			return fmt.Errorf("failed to write tests metrics file: %v", err)
-		}
+	if err := WriteTestMetrics(opt.TestMetricFile, tests); err != nil {
+		return fmt.Errorf("failed to write tests metrics file: %v", err)
+	}
+	if err := WriteSyntheticTestMetrics(opt.TestMetricFile, syntheticTestResults); err != nil {
+		return fmt.Errorf("failed to write synthetic tests metrics file: %v", err)
 	}
 
 	if syntheticFailure {

--- a/pkg/test/ginkgo/cmd_runtest.go
+++ b/pkg/test/ginkgo/cmd_runtest.go
@@ -148,6 +148,9 @@ func (opt *TestOptions) Run(args []string) error {
 	default:
 		return fmt.Errorf("unrecognized test case outcome: %#v", summary)
 	}
+	for _, reportEntry := range summary.ReportEntries {
+		fmt.Fprintf(opt.ErrOut, "metric %s %s\n", reportEntry.Name, reportEntry.Value.AsJSON)
+	}
 	return nil
 }
 

--- a/pkg/test/ginkgo/junitapi/types.go
+++ b/pkg/test/ginkgo/junitapi/types.go
@@ -77,6 +77,9 @@ type JUnitTestCase struct {
 
 	// SystemErr is output written to stderr during the execution of this test case
 	SystemErr string `xml:"system-err,omitempty"`
+
+	// TestMetrics allows storing custom metrics exposed during the execution of this test case
+	TestMetrics map[string]string `xml:"-"`
 }
 
 // SkipMessage holds a message explaining why a test was skipped

--- a/pkg/test/ginkgo/metrics.go
+++ b/pkg/test/ginkgo/metrics.go
@@ -4,17 +4,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 )
 
 type TestMetrics map[string]string
 
-func WriteTestMetrics(outputFile string, tests []*testCase) error {
-	testMetrics := make(TestMetrics)
-	for _, test := range tests {
-		for k, v := range test.testMetrics {
-			testMetrics[k] = v
-		}
-	}
+func writeTestMetrics(outputFile string, testMetrics TestMetrics) error {
 	lines := make([]string, 0)
 	for k, v := range testMetrics {
 		lines = append(lines, fmt.Sprintf("%s %s", k, v))
@@ -27,4 +23,24 @@ func WriteTestMetrics(outputFile string, tests []*testCase) error {
 	defer f.Close()
 	fmt.Fprint(f, strings.Join(lines, "\n")+"\n")
 	return nil
+}
+
+func WriteTestMetrics(outputFile string, tests []*testCase) error {
+	testMetrics := make(TestMetrics)
+	for _, test := range tests {
+		for k, v := range test.testMetrics {
+			testMetrics[k] = v
+		}
+	}
+	return writeTestMetrics(outputFile, testMetrics)
+}
+
+func WriteSyntheticTestMetrics(outputFile string, tests []*junitapi.JUnitTestCase) error {
+	testMetrics := make(TestMetrics)
+	for _, test := range tests {
+		for k, v := range test.TestMetrics {
+			testMetrics[k] = v
+		}
+	}
+	return writeTestMetrics(outputFile, testMetrics)
 }

--- a/pkg/test/ginkgo/metrics.go
+++ b/pkg/test/ginkgo/metrics.go
@@ -1,0 +1,30 @@
+package ginkgo
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type TestMetrics map[string]string
+
+func WriteTestMetrics(outputFile string, tests []*testCase) error {
+	testMetrics := make(TestMetrics)
+	for _, test := range tests {
+		for k, v := range test.testMetrics {
+			testMetrics[k] = v
+		}
+	}
+	lines := make([]string, 0)
+	for k, v := range testMetrics {
+		lines = append(lines, fmt.Sprintf("%s %s", k, v))
+	}
+	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open metrics file for writing: %v", err)
+	}
+
+	defer f.Close()
+	fmt.Fprint(f, strings.Join(lines, "\n")+"\n")
+	return nil
+}

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -27,6 +27,7 @@ type testCase struct {
 	end             time.Time
 	duration        time.Duration
 	testOutputBytes []byte
+	testMetrics     TestMetrics
 
 	flake    bool
 	failed   bool

--- a/pkg/test/ginkgo/test_runner.go
+++ b/pkg/test/ginkgo/test_runner.go
@@ -309,9 +309,11 @@ func (c *commandContext) RunTestInNewProcess(ctx context.Context, test *testCase
 		// Extract metrics if last line starts with "metric "
 		testOutputLines := strings.Split(strings.Trim(string((ret.testOutputBytes)), "/n"), "/n")
 		lastTestOutputLine := testOutputLines[len(testOutputLines)-1]
-		if metricString, found := strings.CutPrefix(lastTestOutputLine, "metric "); found {
-			tokens := strings.SplitN(metricString, " ", 3)
-			ret.testMetrics[tokens[1]] = tokens[2]
+		if strings.HasPrefix(lastTestOutputLine, "metric ") {
+			if _, metricString, found := strings.Cut(lastTestOutputLine, " "); found {
+				tokens := strings.SplitN(metricString, " ", 3)
+				ret.testMetrics[tokens[1]] = tokens[2]
+			}
 		}
 		return ret
 	}


### PR DESCRIPTION
Disruption tests show amount of time the service was disrupted, but this value is not saved as a cluster metric and cannot be aggregated across several releases.

This PR allows tests to expose custom metrics (via ginkgo's `ReportEntries`) custom metrics. Synthetic tests save disruption duration in seconds. Later this file will be parsed in `gather-extra` step, mixed in collected metrics and rendered on https://search.ci.openshift.org/graph/metrics

Open questions:
* Should we add a prefix test metrics so that it would not overwrite in cluster metrics?
* Maybe we should write JSON directly so that we could easily merge those in `gather-extras` [job metrics](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/27879/pull-ci-openshift-origin-master-e2e-aws-ovn-etcd-scaling/1648642018034847744/artifacts/e2e-aws-ovn-etcd-scaling/gather-extra/artifacts/metrics/job_metrics.json)?