### PR TITLE
Handle new tls.CertificateVerificationError type in Go 1.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.14
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/origin
 COPY . .
 RUN make; \


### PR DESCRIPTION
In [Go 1.20](https://go-review.googlesource.com/c/go/+/449336), x509 certificates are embedded into new `tls.CertificateVerificationError` type(https://pkg.go.dev/crypto/tls#CertificateVerificationError). But currently, request_token in origin only relies onx509 certificates and when Go version is bumped to 1.20, this will no longer be a valid case. That's why, this PR also handles `tls.CertificateVerificationError` as well as other x509 certificates whose are necessary for the backwards compatibility.

But since new type only exists in Go 1.20, this PR should also bump origin images to Go 1.20.