### PR TITLE
test/extended: cpu-partitioning: skip cluster infrastructure for Hypershift

### DIFF
--- a/test/extended/cpu_partitioning/platform.go
+++ b/test/extended/cpu_partitioning/platform.go
@@ -36,6 +36,12 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 	})
 
 	g.It("should be configured correctly", func() {
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if *controlPlaneTopology == ocpv1.ExternalTopologyMode {
+			g.Skip("Clusters with external control plane topology do not support MachineConfigs")
+		}
 
 		mcMatcher := o.And(
 			o.ContainSubstring("01-master-cpu-partitioning"),


### PR DESCRIPTION
HostedClusters i.e. Hypershift do not use MachineConfigs and do not have the CRD installed, causing `CPU Partitioning cluster infrastructure should be configured correctly` test to fail on HostedClusters.

We should skip this test for HostedClusters.