### PR TITLE
Fix up the chart so the "Not" column is lined up

### DIFF
--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -174,7 +174,7 @@
         <form>
             <div class="form-row" id="positive-selection-header-row">
                 <div class="form-group col-md-2" id="not-column">
-                    <label for="not_1">Not</label>
+                    <label for="not_1" style="display: flex; justify-content: center; align-items: center; margin-bottom:10px;">Not</label>
                 </div>
                 <div class="form-group col-md-2" id="regex-column">
                     <label for="filterInput">General RegExp</label>
@@ -228,7 +228,7 @@
 
 
     notInputTemplate = `
-                    <input class="positive-selection-fields form-control form-control-sm" type="checkbox" id="not_INPUT_NUMBER">
+                    <input class="positive-selection-fields form-control form-control-sm" type="checkbox" id="not_INPUT_NUMBER" style="margin-top: 16px; margin-bottom: 18px;">
 `
     regexInputTemplate = `
                     <input class="positive-selection-fields form-control form-control-sm" type="text" id="filterInput_INPUT_NUMBER">

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53189,7 +53189,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         <form>
             <div class="form-row" id="positive-selection-header-row">
                 <div class="form-group col-md-2" id="not-column">
-                    <label for="not_1">Not</label>
+                    <label for="not_1" style="display: flex; justify-content: center; align-items: center; margin-bottom:10px;">Not</label>
                 </div>
                 <div class="form-group col-md-2" id="regex-column">
                     <label for="filterInput">General RegExp</label>
@@ -53243,7 +53243,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
 
 
     notInputTemplate = ` + "`" + `
-                    <input class="positive-selection-fields form-control form-control-sm" type="checkbox" id="not_INPUT_NUMBER">
+                    <input class="positive-selection-fields form-control form-control-sm" type="checkbox" id="not_INPUT_NUMBER" style="margin-top: 16px; margin-bottom: 18px;">
 ` + "`" + `
     regexInputTemplate = ` + "`" + `
                     <input class="positive-selection-fields form-control form-control-sm" type="text" id="filterInput_INPUT_NUMBER">


### PR DESCRIPTION
This PR makes the html on the left image, look like the right image (without going too deep on learning html styling):

<div style="display: flex; flex-direction: row; align-items: center;">
  <img width="258" alt="Screen Shot 2023-04-21 at 8 44 01 AM" src="https://user-images.githubusercontent.com/93946516/233639286-33a6755a-e7ed-4161-9373-3543017f9c2e.png" style="margin-right: 10px;">
  <img width="218" alt="Screen Shot 2023-04-21 at 8 43 42 AM" src="https://user-images.githubusercontent.com/93946516/233639333-7eee4463-e8bb-41b5-be0a-75e69b80256b.png">
</div>
