### PR TITLE
add anonymous cert detection test case

### DIFF
--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -74,6 +74,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testNodeHasSufficientPID(events)...)
 
 	tests = append(tests, testFailedToDeleteCGroupsPath(events)...)
+	tests = append(tests, testAnonymousCertConnectionFailure(events)...)
 	tests = append(tests, testHttpConnectionLost(events)...)
 	tests = append(tests, testMarketplaceStartupProbeFailure(events)...)
 	tests = append(tests, testErrImagePullUnrecognizedSignatureFormat(events)...)
@@ -144,6 +145,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testNodeHasSufficientMemory(events)...)
 	tests = append(tests, testNodeHasSufficientPID(events)...)
 
+	tests = append(tests, testAnonymousCertConnectionFailure(events)...)
 	tests = append(tests, testFailedToDeleteCGroupsPath(events)...)
 	tests = append(tests, testHttpConnectionLost(events)...)
 	tests = append(tests, testMarketplaceStartupProbeFailure(events)...)


### PR DESCRIPTION
Detects a kubelet using only an anonymous user. Kubelet certificates rotate negotiate an OpenShift user instead of using anonymous users.