### PR TITLE
USHIFT-647: skip non-existing resources from security.openshift.io

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -741,11 +741,13 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc explain should contain proper fields description for project.openshift.io [apigroup:project.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] oc explain should contain proper fields description for rangeallocations of security.openshift.io, if the resource is present [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli] oc explain should contain proper fields description for route.openshift.io [apigroup:route.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc explain should contain proper fields description for security.internal.openshift.io [apigroup:security.internal.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-cli] oc explain should contain proper fields description for security.openshift.io [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",
+	"[sig-cli] oc explain should contain proper fields description for securitycontextconstraints of security.openshift.io, if the resource is present [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc explain should contain proper fields description for template.openshift.io [apigroup:template.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
@@ -759,11 +761,15 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc explain should contain spec+status for image.openshift.io [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] oc explain should contain spec+status for podsecuritypolicyreviews of security.openshift.io, if the resource is present [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-cli] oc explain should contain spec+status for podsecuritypolicyselfsubjectreviews of security.openshift.io, if the resource is present [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-cli] oc explain should contain spec+status for podsecuritypolicysubjectreviews of security.openshift.io, if the resource is present [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli] oc explain should contain spec+status for project.openshift.io [apigroup:project.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc explain should contain spec+status for route.openshift.io [apigroup:route.openshift.io]": " [Suite:openshift/conformance/parallel]",
-
-	"[sig-cli] oc explain should contain spec+status for security.openshift.io [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc explain should contain spec+status for template.openshift.io [apigroup:template.openshift.io]": " [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION

Closes: [USHIFT-647](https://issues.redhat.com/browse/USHIFT-647)

skip non-existing resources from security.openshift.io