### PR TITLE
OCPBUGS-13379: machines: add a test which verifies number of node reboots

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1387,6 +1387,8 @@ var Annotations = map[string]string{
 
 	"[sig-node] Managed cluster should report ready nodes the entire duration of the test run [Late][apigroup:monitoring.coreos.com]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-node] Managed cluster should verify that nodes have no unexpected reboots [Late]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node] should override timeoutGracePeriodSeconds when annotation is set": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This adds a new tests which checks `journalctl --list-boots` to ensure no unexpected reboots occurred on the nodes.

Its similar to `should report ready nodes the entire duration of the test run` except that its applicable to SNO - when the only node reboots it won't be recorded as a change in prometheus metric.

TODO:
* [x] Calculate number of expected boots based on rendered-* MC
* [x] Make it run on SNO(+workers) clusters only