### PR TITLE
`openshift-tests`: expose e2e tests flags

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -90,6 +90,7 @@ func main() {
 	pflag.CommandLine = pflag.NewFlagSet("empty", pflag.ExitOnError)
 	flag.CommandLine = flag.NewFlagSet("empty", flag.ExitOnError)
 	exutil.InitStandardFlags()
+	root.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
 	if err := func() error {
 		defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()


### PR DESCRIPTION
This is an exploratory PR not intended to be merged (yet).
Following up the design laid out in [openshift/kubernetes/pull/1560 ](https://github.com/openshift/kubernetes/pull/1560) I would like to understand the consequences of exposing some e2e tests flags.