### PR TITLE
OCPVE-378: feat: remove skip, allow check on all platforms regardless

### DIFF
--- a/test/extended/cpu_partitioning/pods.go
+++ b/test/extended/cpu_partitioning/pods.go
@@ -31,8 +31,6 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 	)
 
 	g.BeforeEach(func() {
-		// TODO: Remove to run on all cluster configs after resolving missing deployments/daemonsets.
-		skipNonCPUPartitionedCluster(oc)
 		isClusterCPUPartitioned = getCpuPartitionedStatus(oc) == ocpv1.CPUPartitioningAllNodes
 		matcher, messageFormat = adjustMatcherAndMessageForCluster(isClusterCPUPartitioned, matcher)
 	})

--- a/test/extended/cpu_partitioning/utils.go
+++ b/test/extended/cpu_partitioning/utils.go
@@ -10,8 +10,6 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
 const (
@@ -28,12 +26,6 @@ var (
 	namespaceAnnotation     = map[string]string{namespaceAnnotationKey: "management"}
 	deploymentPodAnnotation = map[string]string{workloadAnnotations: `{"effect": "PreferredDuringScheduling"}`}
 )
-
-func skipNonCPUPartitionedCluster(oc *exutil.CLI) {
-	if getCpuPartitionedStatus(oc) != v1.CPUPartitioningAllNodes {
-		e2eskipper.Skipf("Tests are only valid for clusters with CPUPartitioning enabled.")
-	}
-}
 
 func getCpuPartitionedStatus(oc *exutil.CLI) v1.CPUPartitioningMode {
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(),


### PR DESCRIPTION
This skip should be safe now because all identified workloads that were missing the workload annotation have been fixed.

We did run the payload jobs to validate that other platforms were not missing any annotations. Currently these tests are passing on all relevant payload runs, this does not include payloads that did not execute the test suite with these tests, but that.