### PR TITLE
OCPBUGS-6586: oc idle: increase wait timeouts to 60 sec

### DIFF
--- a/test/extended/cli/idle.go
+++ b/test/extended/cli/idle.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("wait until idling-echo endpoint is ready")
-		err = wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
+		err = wait.PollImmediate(time.Second, 60*time.Second, func() (done bool, err error) {
 			err = oc.Run("describe").Args("endpoints", "idling-echo").Execute()
 			if err != nil {
 				return false, nil
@@ -65,7 +65,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("wait until replicationcontroller is ready")
-		err = wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
+		err = wait.PollImmediate(time.Second, 60*time.Second, func() (done bool, err error) {
 			err = oc.Run("get").Args("replicationcontroller", fmt.Sprintf("%s-1", deploymentConfigName)).Execute()
 			if err != nil {
 				return false, nil
@@ -80,7 +80,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By(fmt.Sprintf("wait until pod is scaled to %s", scaledReplicaCount))
-		err = wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
+		err = wait.PollImmediate(time.Second, 60*time.Second, func() (done bool, err error) {
 			out, err := oc.Run("get").Args("pods", "-l", "app=idling-echo", "--template={{ len .items }}", "--output=go-template").Output()
 			if err != nil {
 				return false, err
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By(fmt.Sprintf("wait until endpoint addresses are scaled to %s", scaledReplicaCount))
-		err = wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
+		err = wait.PollImmediate(time.Second, 60*time.Second, func() (done bool, err error) {
 			out, err := oc.Run("get").Args("endpoints", "idling-echo", "--template={{ len (index .subsets 0).addresses }}", "--output=go-template").Output()
 			if err != nil || out != scaledReplicaCount {
 				return false, nil


### PR DESCRIPTION
For blocking jobs, 30 second timeout value is sufficient. However, these test fails on OpenStack by
getting timeout error. This PR increases oc idle tests timeout to 60 seconds to pass
on OpenStack as mentioned in referenced bug.