### PR TITLE
OCPBUGS-13372: Add missing error check in sysctl allowlist test

### DIFF
--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -276,6 +276,7 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 				}
 				return false, nil
 			})
+			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
This prevents the test to pass when the pod is not running. A bug was not detected due to this missing check.