### PR TITLE
test/extended/prometheus: fix test with enabled telemetry

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -210,10 +210,10 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 	})
 
 	g.It("shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster", func() {
-		if enabled, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
+		if enabledErr, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
 			e2e.Failf("could not determine if Telemetry is enabled: %v", err)
-		} else {
-			e2eskipper.Skipf("Telemetry is disabled: %v", enabled)
+		} else if enabledErr != nil {
+			e2eskipper.Skipf("Telemetry is disabled: %v", enabledErr)
 		}
 
 		// we only consider series sent since the beginning of the test
@@ -275,10 +275,10 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 
 	g.Describe("when installed on the cluster", func() {
 		g.It("should report telemetry [Late]", func() {
-			if enabled, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
+			if enabledErr, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
 				e2e.Failf("could not determine if Telemetry is enabled: %v", err)
-			} else {
-				e2eskipper.Skipf("Telemetry is disabled: %v", enabled)
+			} else if enabledErr != nil {
+				e2eskipper.Skipf("Telemetry is disabled: %v", enabledErr)
 			}
 
 			tests := map[string]bool{}


### PR DESCRIPTION
Telemetry tests were always skipped because nothing checked the first value returned by telemetryIsEnabled().

For example, the openshift/telemeter [e2e-aws-ovn](
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_telemeter/459/pull-ci-openshift-telemeter-master-e2e-aws-ovn/1648956364942217216) job skips the tests while it's [enabled](https://github.com/openshift/release/blob/c423fd934ae060a1e6db5eb7d5ae8b22671c89a4/ci-operator/config/openshift/telemeter/openshift-telemeter-master.yaml#L55-L60) in openshift/release.

ping @wking since you submitted #27422.