### PR TITLE
OCPBUGS-13366: ignore repeated TopologyAwareHintsDisabled events

### DIFF
--- a/pkg/duplicateevents/duplicated_event_patterns.go
+++ b/pkg/duplicateevents/duplicated_event_patterns.go
@@ -220,6 +220,10 @@ var KnownEventsBugs = []KnownProblem{
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
 	},
 	{
+		Regexp: regexp.MustCompile("reason/TopologyAwareHintsDisabled"),
+		BZ:     "https://issues.redhat.com/browse/OCPBUGS-13366",
+	},
+	{
 		Regexp:   regexp.MustCompile("ns/.*reason/.*APICheckFailed.*503.*"),
 		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
 		Topology: TopologyPointer(v1.SingleReplicaTopologyMode),


### PR DESCRIPTION
This reverts commit 1af057b15c718510b728a645ae5929b79e8a8b83 from https://github.com/openshift/origin/pull/27815 which unfortunately we're still seeing after landing k8s 1.27. 

/assign @Miciah @dgoodwin 