### PR TITLE
OCPBUGS-13788: 2x Revert "test/extended: Add MultiNetworkPolicy IPv4/IPv6 test cases" #27926

### DIFF
--- a/test/extended/networking/multinetpolicy.go
+++ b/test/extended/networking/multinetpolicy.go
@@ -136,7 +136,7 @@ func enableMultiNetworkPolicy(oc *exutil.CLI) {
 
 	o.Eventually(func() error {
 		return oc.AsAdmin().Run("get").Args("multi-networkpolicies.k8s.cni.cncf.io").Execute()
-	}, "30s", "2s").Should(o.Succeed())
+	}, "90s", "2s").Should(o.Succeed())
 
 	o.Eventually(func() error {
 		daemonset, err := oc.AdminKubeClient().AppsV1().DaemonSets("openshift-multus").Get(context.Background(), "multus-networkpolicy", metav1.GetOptions{})
@@ -166,7 +166,7 @@ func disableMultiNetworkPolicy(oc *exutil.CLI) {
 
 	o.Eventually(func() error {
 		return oc.AsAdmin().Run("get").Args("multi-networkpolicies.k8s.cni.cncf.io").Execute()
-	}, "30s", "1s").Should(o.HaveOccurred())
+	}, "90s", "1s").Should(o.HaveOccurred())
 
 	o.Eventually(func() bool {
 		_, err := oc.AdminKubeClient().AppsV1().DaemonSets("openshift-multus").Get(context.Background(), "multus-networkpolicy", metav1.GetOptions{})

--- a/test/extended/networking/multinetpolicy.go
+++ b/test/extended/networking/multinetpolicy.go
@@ -1,0 +1,224 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+type podAddressSet struct {
+	A *net.IPNet
+	B *net.IPNet
+	C *net.IPNet
+}
+
+var _ = g.Describe("[sig-network][Feature:MultiNetworkPolicy][Serial]", func() {
+
+	oc := exutil.NewCLIWithPodSecurityLevel("multinetpol-e2e", admissionapi.LevelBaseline)
+	f := oc.KubeFramework()
+
+	var previousUseMultiNetworkPolicy bool
+	g.BeforeEach(func() {
+		previousUseMultiNetworkPolicy = isMultinetNetworkPolicyEnabled(oc)
+	})
+
+	g.AfterEach(func() {
+		if !previousUseMultiNetworkPolicy {
+			disableMultiNetworkPolicy(oc)
+		}
+	})
+
+	g.DescribeTable("should enforce a network policies on secondary network", func(addrs podAddressSet) {
+		var err error
+		ns := f.Namespace.Name
+
+		g.By("creating a macvlan net-attach-def")
+		nad_yaml := exutil.FixturePath("testdata", "net-attach-defs", "macvlan-nad.yml")
+		err = oc.AsAdmin().Run("create").Args("-f", nad_yaml).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		networksTemplate := `[
+			  {
+				"name": "macvlan1-nad",		
+				"ips": ["%s"]
+			  }
+			]`
+
+		podGenerateName := "multinetpol-test-pod-"
+		podAListenAddress := formatHostAndPort(addrs.A.IP, 8889)
+		podCListenAddress := formatHostAndPort(addrs.C.IP, 8889)
+
+		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		o.Expect(err).To(o.Succeed())
+		o.Expect(len(nodes.Items)).To(o.BeNumerically(">", 0))
+		scheduledNode := nodes.Items[0]
+
+		g.By("launching pods with an annotation to use the net-attach-def on node " + scheduledNode.Name)
+
+		frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podGenerateName, func(pod *v1.Pod) {
+			pod.Spec.NodeName = scheduledNode.Name
+			pod.Spec.Containers[0].Args = []string{"net", "--serve", podAListenAddress}
+			pod.ObjectMeta.Labels = map[string]string{"pod": "a"}
+			pod.ObjectMeta.Annotations = map[string]string{
+				"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(networksTemplate, addrs.A.String())}
+		})
+
+		testPodB := frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+			pod.Spec.NodeName = scheduledNode.Name
+			pod.ObjectMeta.Labels = map[string]string{"pod": "b"}
+			pod.ObjectMeta.Annotations = map[string]string{
+				"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(networksTemplate, addrs.B.String())}
+		})
+
+		frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+			pod.Spec.NodeName = scheduledNode.Name
+			pod.Spec.Containers[0].Args = []string{"net", "--serve", podCListenAddress}
+			pod.ObjectMeta.Labels = map[string]string{"pod": "c"}
+			pod.ObjectMeta.Annotations = map[string]string{
+				"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(networksTemplate, addrs.C.String())}
+		})
+
+		g.By("checking podB can connect to podA")
+		podShouldReach(oc, testPodB.Name, podAListenAddress)
+
+		g.By("enabling MultiNetworkPolicies on cluster")
+		enableMultiNetworkPolicy(oc)
+
+		g.By("creating a deny-all-ingress traffic to pod:a MultiNetworkPolicy")
+		multinetpolicy_yaml := exutil.FixturePath("testdata", "multinetpolicy", "deny-ingress-pod-a.yml")
+		err = oc.AsAdmin().Run("create").Args("-f", multinetpolicy_yaml).Execute()
+		o.Expect(err).To(o.Succeed())
+
+		g.By("checking podB can NOT connect to podA")
+		podShouldNotReach(oc, testPodB.Name, podAListenAddress)
+
+		g.By("checking podB can still connect to podC")
+		podShouldReach(oc, testPodB.Name, podCListenAddress)
+	},
+		g.Entry("IPv4", podAddressSet{
+			A: mustParseIPAndMask("192.0.2.1/24"),
+			B: mustParseIPAndMask("192.0.2.2/24"),
+			C: mustParseIPAndMask("192.0.2.3/24"),
+		}),
+		g.Entry("IPv6", podAddressSet{
+			A: mustParseIPAndMask("2001:db8::1/32"),
+			B: mustParseIPAndMask("2001:db8::2/32"),
+			C: mustParseIPAndMask("2001:db8::3/32"),
+		}),
+	)
+
+})
+
+func enableMultiNetworkPolicy(oc *exutil.CLI) {
+	c := oc.AdminOperatorClient().OperatorV1().Networks()
+	config := getCluserNetwork(c)
+
+	b := true
+	config.Spec.UseMultiNetworkPolicy = &b
+
+	_, err := c.Update(context.Background(), config, metav1.UpdateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	o.Eventually(func() error {
+		return oc.AsAdmin().Run("get").Args("multi-networkpolicies.k8s.cni.cncf.io").Execute()
+	}, "30s", "2s").Should(o.Succeed())
+
+	o.Eventually(func() error {
+		daemonset, err := oc.AdminKubeClient().AppsV1().DaemonSets("openshift-multus").Get(context.Background(), "multus-networkpolicy", metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("can't get openshift-multus/multus-networkpolicy daemonset: %w", err)
+		}
+
+		if daemonset.Status.NumberAvailable != daemonset.Status.DesiredNumberScheduled {
+			return fmt.Errorf("openshift-multus/multus-networkpolicy daemonset is not ready [%d Available / %d Desired]",
+				daemonset.Status.NumberAvailable, daemonset.Status.DesiredNumberScheduled)
+		}
+
+		return nil
+	}, "30s", "2s").Should(o.Succeed())
+
+}
+
+func disableMultiNetworkPolicy(oc *exutil.CLI) {
+	c := oc.AdminOperatorClient().OperatorV1().Networks()
+	config := getCluserNetwork(c)
+
+	b := false
+	config.Spec.UseMultiNetworkPolicy = &b
+
+	_, err := c.Update(context.Background(), config, metav1.UpdateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	o.Eventually(func() error {
+		return oc.AsAdmin().Run("get").Args("multi-networkpolicies.k8s.cni.cncf.io").Execute()
+	}, "30s", "1s").Should(o.HaveOccurred())
+
+	o.Eventually(func() bool {
+		_, err := oc.AdminKubeClient().AppsV1().DaemonSets("openshift-multus").Get(context.Background(), "multus-networkpolicy", metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, "30s", "1s").Should(o.BeTrue())
+}
+
+func isMultinetNetworkPolicyEnabled(oc *exutil.CLI) bool {
+	c := oc.AdminOperatorClient().OperatorV1().Networks()
+	config := getCluserNetwork(c)
+	return *config.Spec.UseMultiNetworkPolicy
+}
+
+func getCluserNetwork(c operatorclientv1.NetworkInterface) *operatorv1.Network {
+	ret, err := c.Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	return ret
+}
+
+func podShouldReach(oc *exutil.CLI, podName, address string) {
+	out := ""
+	o.EventuallyWithOffset(1, func() error {
+		var err error
+		out, err = oc.AsAdmin().Run("exec").Args(podName, "--", "curl", "--connect-timeout", "1", address).Output()
+		return err
+	}, "30s", "1s").ShouldNot(o.HaveOccurred(), "cmd output: %s", out)
+}
+
+func podShouldNotReach(oc *exutil.CLI, podName, address string) {
+	out := ""
+	o.EventuallyWithOffset(1, func() error {
+		var err error
+		out, err = oc.AsAdmin().Run("exec").Args(podName, "--", "curl", "--connect-timeout", "1", address).Output()
+		return err
+	}, "30s", "1s").Should(o.HaveOccurred(), "cmd output: %s", out)
+}
+
+func mustParseIPAndMask(in string) *net.IPNet {
+	ip, addr, err := net.ParseCIDR(in)
+	if err != nil {
+		// This function is called with literal arguments only
+		return &net.IPNet{IP: net.IPv4zero}
+	}
+
+	addr.IP = ip
+	return addr
+}
+
+func formatHostAndPort(ip net.IP, port int) string {
+	if ip.To4() != nil {
+		return fmt.Sprintf("%s:%d", ip.String(), port)
+	}
+
+	return fmt.Sprintf("[%s]:%d", ip.String(), port)
+}

--- a/test/extended/networking/multinetpolicy.go
+++ b/test/extended/networking/multinetpolicy.go
@@ -177,6 +177,11 @@ func disableMultiNetworkPolicy(oc *exutil.CLI) {
 func isMultinetNetworkPolicyEnabled(oc *exutil.CLI) bool {
 	c := oc.AdminOperatorClient().OperatorV1().Networks()
 	config := getCluserNetwork(c)
+
+	if config.Spec.UseMultiNetworkPolicy == nil {
+		return false
+	}
+
 	return *config.Spec.UseMultiNetworkPolicy
 }
 

--- a/test/extended/networking/multinetpolicy.go
+++ b/test/extended/networking/multinetpolicy.go
@@ -43,7 +43,7 @@ var _ = g.Describe("[sig-network][Feature:MultiNetworkPolicy][Serial]", func() {
 		}
 	})
 
-	g.DescribeTable("should enforce a network policies on secondary network", func(addrs podAddressSet) {
+	g.DescribeTable("should enforce a network policies on secondary network", func(ctx context.Context, addrs podAddressSet) {
 		var err error
 		ns := f.Namespace.Name
 
@@ -63,14 +63,14 @@ var _ = g.Describe("[sig-network][Feature:MultiNetworkPolicy][Serial]", func() {
 		podAListenAddress := formatHostAndPort(addrs.A.IP, 8889)
 		podCListenAddress := formatHostAndPort(addrs.C.IP, 8889)
 
-		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 		o.Expect(err).To(o.Succeed())
 		o.Expect(len(nodes.Items)).To(o.BeNumerically(">", 0))
 		scheduledNode := nodes.Items[0]
 
 		g.By("launching pods with an annotation to use the net-attach-def on node " + scheduledNode.Name)
 
-		frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podGenerateName, func(pod *v1.Pod) {
+		frameworkpod.CreateExecPodOrFail(ctx, f.ClientSet, ns, podGenerateName, func(pod *v1.Pod) {
 			pod.Spec.NodeName = scheduledNode.Name
 			pod.Spec.Containers[0].Args = []string{"net", "--serve", podAListenAddress}
 			pod.ObjectMeta.Labels = map[string]string{"pod": "a"}
@@ -78,14 +78,14 @@ var _ = g.Describe("[sig-network][Feature:MultiNetworkPolicy][Serial]", func() {
 				"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(networksTemplate, addrs.A.String())}
 		})
 
-		testPodB := frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+		testPodB := frameworkpod.CreateExecPodOrFail(ctx, f.ClientSet, ns, podName, func(pod *v1.Pod) {
 			pod.Spec.NodeName = scheduledNode.Name
 			pod.ObjectMeta.Labels = map[string]string{"pod": "b"}
 			pod.ObjectMeta.Annotations = map[string]string{
 				"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(networksTemplate, addrs.B.String())}
 		})
 
-		frameworkpod.CreateExecPodOrFail(f.ClientSet, ns, podName, func(pod *v1.Pod) {
+		frameworkpod.CreateExecPodOrFail(ctx, f.ClientSet, ns, podName, func(pod *v1.Pod) {
 			pod.Spec.NodeName = scheduledNode.Name
 			pod.Spec.Containers[0].Args = []string{"net", "--serve", podCListenAddress}
 			pod.ObjectMeta.Labels = map[string]string{"pod": "c"}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -412,7 +412,9 @@
 // test/extended/testdata/mixed-api-versions.yaml
 // test/extended/testdata/multi-namespace-pipeline.yaml
 // test/extended/testdata/multi-namespace-template.yaml
+// test/extended/testdata/multinetpolicy/deny-ingress-pod-a.yml
 // test/extended/testdata/net-attach-defs/bridge-nad.yml
+// test/extended/testdata/net-attach-defs/macvlan-nad.yml
 // test/extended/testdata/net-attach-defs/whereabouts-nad.yml
 // test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml
 // test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml
@@ -48535,6 +48537,36 @@ func testExtendedTestdataMultiNamespaceTemplateYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataMultinetpolicyDenyIngressPodAYml = []byte(`apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  generateName: deny-ingress-pod-a
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: macvlan1-nad
+spec:
+  podSelector:
+    matchLabels:
+      pod: a
+  policyTypes:
+    - Ingress
+  ingress: []
+`)
+
+func testExtendedTestdataMultinetpolicyDenyIngressPodAYmlBytes() ([]byte, error) {
+	return _testExtendedTestdataMultinetpolicyDenyIngressPodAYml, nil
+}
+
+func testExtendedTestdataMultinetpolicyDenyIngressPodAYml() (*asset, error) {
+	bytes, err := testExtendedTestdataMultinetpolicyDenyIngressPodAYmlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/multinetpolicy/deny-ingress-pod-a.yml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataNetAttachDefsBridgeNadYml = []byte(`apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
@@ -48565,6 +48597,38 @@ func testExtendedTestdataNetAttachDefsBridgeNadYml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/net-attach-defs/bridge-nad.yml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataNetAttachDefsMacvlanNadYml = []byte(`apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvlan1-nad
+spec:   
+  config: '{
+            "cniVersion": "0.3.1",
+            "name": "macvlan1-nad",
+            "plugins": [
+                {
+                    "type": "macvlan",
+                    "capabilities": { "ips": true },
+                    "mode": "bridge",
+                    "ipam": { "type": "static" }
+                }]
+        }'`)
+
+func testExtendedTestdataNetAttachDefsMacvlanNadYmlBytes() ([]byte, error) {
+	return _testExtendedTestdataNetAttachDefsMacvlanNadYml, nil
+}
+
+func testExtendedTestdataNetAttachDefsMacvlanNadYml() (*asset, error) {
+	bytes, err := testExtendedTestdataNetAttachDefsMacvlanNadYmlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/net-attach-defs/macvlan-nad.yml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -54430,7 +54494,9 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/mixed-api-versions.yaml":                                                         testExtendedTestdataMixedApiVersionsYaml,
 	"test/extended/testdata/multi-namespace-pipeline.yaml":                                                   testExtendedTestdataMultiNamespacePipelineYaml,
 	"test/extended/testdata/multi-namespace-template.yaml":                                                   testExtendedTestdataMultiNamespaceTemplateYaml,
+	"test/extended/testdata/multinetpolicy/deny-ingress-pod-a.yml":                                           testExtendedTestdataMultinetpolicyDenyIngressPodAYml,
 	"test/extended/testdata/net-attach-defs/bridge-nad.yml":                                                  testExtendedTestdataNetAttachDefsBridgeNadYml,
+	"test/extended/testdata/net-attach-defs/macvlan-nad.yml":                                                 testExtendedTestdataNetAttachDefsMacvlanNadYml,
 	"test/extended/testdata/net-attach-defs/whereabouts-nad.yml":                                             testExtendedTestdataNetAttachDefsWhereaboutsNadYml,
 	"test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml":                                      testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml,
 	"test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml":                                     testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml,
@@ -55155,8 +55221,12 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"mixed-api-versions.yaml":       {testExtendedTestdataMixedApiVersionsYaml, map[string]*bintree{}},
 				"multi-namespace-pipeline.yaml": {testExtendedTestdataMultiNamespacePipelineYaml, map[string]*bintree{}},
 				"multi-namespace-template.yaml": {testExtendedTestdataMultiNamespaceTemplateYaml, map[string]*bintree{}},
+				"multinetpolicy": {nil, map[string]*bintree{
+					"deny-ingress-pod-a.yml": {testExtendedTestdataMultinetpolicyDenyIngressPodAYml, map[string]*bintree{}},
+				}},
 				"net-attach-defs": {nil, map[string]*bintree{
 					"bridge-nad.yml":              {testExtendedTestdataNetAttachDefsBridgeNadYml, map[string]*bintree{}},
+					"macvlan-nad.yml":             {testExtendedTestdataNetAttachDefsMacvlanNadYml, map[string]*bintree{}},
 					"whereabouts-nad.yml":         {testExtendedTestdataNetAttachDefsWhereaboutsNadYml, map[string]*bintree{}},
 					"whereabouts-race-awake.yml":  {testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml, map[string]*bintree{}},
 					"whereabouts-race-sleepy.yml": {testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml, map[string]*bintree{}},

--- a/test/extended/testdata/multinetpolicy/deny-ingress-pod-a.yml
+++ b/test/extended/testdata/multinetpolicy/deny-ingress-pod-a.yml
@@ -1,0 +1,13 @@
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  generateName: deny-ingress-pod-a
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: macvlan1-nad
+spec:
+  podSelector:
+    matchLabels:
+      pod: a
+  policyTypes:
+    - Ingress
+  ingress: []

--- a/test/extended/testdata/net-attach-defs/macvlan-nad.yml
+++ b/test/extended/testdata/net-attach-defs/macvlan-nad.yml
@@ -1,0 +1,16 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvlan1-nad
+spec:   
+  config: '{
+            "cniVersion": "0.3.1",
+            "name": "macvlan1-nad",
+            "plugins": [
+                {
+                    "type": "macvlan",
+                    "capabilities": { "ips": true },
+                    "mode": "bridge",
+                    "ipam": { "type": "static" }
+                }]
+        }'

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2701,6 +2701,10 @@ var Annotations = map[string]string{
 
 	"[sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-network][Feature:MultiNetworkPolicy][Serial] should enforce a network policies on secondary network IPv4": " [Suite:openshift/conformance/serial]",
+
+	"[sig-network][Feature:MultiNetworkPolicy][Serial] should enforce a network policies on secondary network IPv6": " [Suite:openshift/conformance/serial]",
+
 	"[sig-network][Feature:Multus] should use multus to create net1 device from network-attachment-definition [apigroup:k8s.cni.cncf.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:Network Policy Audit logging] when using openshift ovn-kubernetes should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Reverts
- https://github.com/openshift/origin/pull/27926

The original implementation of these tests contains a bug when the `networks.operator.openshift.io.Spec.UseMultiNetworkPolicy` is nil. This PR fix that.

CC: @s1061123 , @bparees, @deepsm007

