### PR TITLE
push intervals to loki

### DIFF
--- a/cmd/openshift-tests/dev.go
+++ b/cmd/openshift-tests/dev.go
@@ -236,7 +236,8 @@ func newUploadIntervalsCommand() *cobra.Command {
 				logrus.WithError(err).Fatal("error loading intervals file")
 			}
 			logrus.Infof("loaded %d intervals", len(intervals))
-			err = monitor.UploadIntervalsToLoki(os.Getenv("LOKI_SSO_CLIENT_ID"), os.Getenv("LOKI_SSO_CLIENT_SECRET"), intervals)
+
+			err = monitor.UploadIntervalsToLoki(intervals)
 			if err != nil {
 				logrus.WithError(err).Fatal("error uploading intervals to loki")
 			}

--- a/cmd/openshift-tests/dev.go
+++ b/cmd/openshift-tests/dev.go
@@ -7,6 +7,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/pkg/alerts"
+	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 	"github.com/openshift/origin/pkg/synthetictests"
@@ -27,6 +28,7 @@ func newDevCommand() *cobra.Command {
 	cmd.AddCommand(
 		newRunAlertInvariantsCommand(),
 		newRunDisruptionInvariantsCommand(),
+		newUploadIntervalsCommand(),
 	)
 	return cmd
 }
@@ -213,5 +215,36 @@ a running cluster.
 		&opts.topology,
 		"topology", "ha",
 		"Topology for simulated cluster under test when intervals were gathered (ha, single)")
+	return cmd
+}
+
+type uploadIntervalsOpts struct {
+	intervalsFile string
+}
+
+func newUploadIntervalsCommand() *cobra.Command {
+	opts := uploadIntervalsOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "upload-intervals",
+		Short: "Upload an intervals file from a CI run to loki",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.WithField("intervalsFile", opts.intervalsFile).Info("loading e2e intervals")
+			intervals, err := readIntervalsFromFile(opts.intervalsFile)
+			if err != nil {
+				logrus.WithError(err).Fatal("error loading intervals file")
+			}
+			logrus.Infof("loaded %d intervals", len(intervals))
+			err = monitor.UploadIntervalsToLoki(os.Getenv("LOKI_SSO_CLIENT_ID"), os.Getenv("LOKI_SSO_CLIENT_SECRET"), intervals)
+			if err != nil {
+				logrus.WithError(err).Fatal("error uploading intervals to loki")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.intervalsFile,
+		"intervals-file", "e2e-events.json",
+		"Path to an intervals file (i.e. e2e-events_20230214-203340.json). Can be obtained from a CI run in openshift-tests junit artifacts.")
 	return cmd
 }

--- a/pkg/cmd/monitor_command/run_monitor_command.go
+++ b/pkg/cmd/monitor_command/run_monitor_command.go
@@ -149,6 +149,7 @@ func (opt *RunMonitorOptions) Run() error {
 			fmt.Printf("Failed to write event data, err: %v\n", err)
 			return err
 		}
+		// TODO: upload events to loki
 		if err := monitor.WriteTrackedResourcesForJobRun(eventDir, recordedResources, recordedEvents, timeSuffix); err != nil {
 			fmt.Printf("Failed to write resource data, err: %v\n", err)
 			return err

--- a/pkg/cmd/monitor_command/run_monitor_command.go
+++ b/pkg/cmd/monitor_command/run_monitor_command.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 	"github.com/openshift/origin/test/extended/util/disruption/externalservice"
 	"github.com/openshift/origin/test/extended/util/disruption/frontends"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -135,7 +136,7 @@ func (opt *RunMonitorOptions) Run() error {
 
 	// Store events to artifact directory
 	if len(opt.ArtifactDir) != 0 {
-		recordedEvents := m.Intervals(time.Time{}, time.Time{})
+		intervals := m.Intervals(time.Time{}, time.Time{})
 		recordedResources := m.CurrentResourceState()
 		timeSuffix := fmt.Sprintf("_%s", time.Now().UTC().Format("20060102-150405"))
 
@@ -145,12 +146,18 @@ func (opt *RunMonitorOptions) Run() error {
 			return err
 		}
 
-		if err := monitor.WriteEventsForJobRun(eventDir, recordedResources, recordedEvents, timeSuffix); err != nil {
+		if err := monitor.WriteEventsForJobRun(eventDir, recordedResources, intervals, timeSuffix); err != nil {
 			fmt.Printf("Failed to write event data, err: %v\n", err)
 			return err
 		}
-		// TODO: upload events to loki
-		if err := monitor.WriteTrackedResourcesForJobRun(eventDir, recordedResources, recordedEvents, timeSuffix); err != nil {
+
+		err = monitor.UploadIntervalsToLoki(intervals)
+		if err != nil {
+			// Best effort, we do not want to error out here:
+			logrus.WithError(err).Warn("unable to upload intervals to loki")
+		}
+
+		if err := monitor.WriteTrackedResourcesForJobRun(eventDir, recordedResources, intervals, timeSuffix); err != nil {
 			fmt.Printf("Failed to write resource data, err: %v\n", err)
 			return err
 		}

--- a/pkg/monitor/intervalcreation/e2etest.go
+++ b/pkg/monitor/intervalcreation/e2etest.go
@@ -65,7 +65,7 @@ func IntervalsFromEvents_E2ETests(events monitorapi.Intervals, _ monitorapi.Reso
 		ret = append(ret, monitorapi.EventInterval{
 			Condition: monitorapi.Condition{
 				Level:   monitorapi.Warning,
-				Locator: monitorapi.OperatorLocator(testName),
+				Locator: monitorapi.E2ETestLocator(testName),
 				Message: fmt.Sprintf("e2e test did not finish %q", "DidNotFinish"),
 			},
 			From: testStart,

--- a/pkg/monitor/loki_upload.go
+++ b/pkg/monitor/loki_upload.go
@@ -1,0 +1,62 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/sirupsen/logrus"
+)
+
+func UploadIntervalsToLoki(clientID, clientSecret string, intervals monitorapi.Intervals) error {
+	_, err := obtainSSOBearerToken(clientID, clientSecret, intervals)
+	if err != nil {
+		return err
+	}
+	logrus.Info("bearer token obtained")
+	return nil
+}
+
+func obtainSSOBearerToken(clientID, clientSecret string, intervals monitorapi.Intervals) (string, error) {
+	logrus.Info("requesting bearer token from RH SSO")
+	// Obtain a bearer token for pushing intervals to loki using RH SSO:
+	client := &http.Client{}
+	requestBody := url.Values{}
+	requestBody.Set("grant_type", "client_credentials")
+	requestBody.Set("client_id", clientID)
+	requestBody.Set("client_secret", clientSecret)
+
+	req, err := http.NewRequest("POST", "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token", strings.NewReader(requestBody.Encode()))
+	if err != nil {
+		logrus.WithError(err).Error("error creating bearer token HTTP request")
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := client.Do(req)
+	if err != nil {
+		logrus.WithError(err).Error("error making bearer token HTTP request")
+		return "", err
+	}
+	defer response.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		logrus.WithError(err).Error("error reading bearer token HTTP request body for bearer token")
+		return "", err
+	}
+
+	var responseJSON map[string]interface{}
+	if err := json.Unmarshal(responseBody, &responseJSON); err != nil {
+		logrus.WithError(err).Error("error parsing bearer token HTTP request body as json")
+		fmt.Println("Error decoding response JSON:", err)
+		return "", err
+	}
+	bearerToken := responseJSON["access_token"].(string)
+	return bearerToken, nil
+}

--- a/pkg/monitor/loki_upload.go
+++ b/pkg/monitor/loki_upload.go
@@ -28,6 +28,7 @@ func pushBatch(client *http.Client, bearerToken string, lokiData LokiData) error
 	}
 	jsonData, err := json.Marshal(lokiData)
 	if err != nil {
+
 		logrus.WithError(err).Error("error marshalling loki data")
 		return err
 	}
@@ -115,6 +116,12 @@ func UploadIntervalsToLoki(clientID, clientSecret string, intervals monitorapi.I
 		for _, lp := range locatorParts {
 			parts := strings.Split(lp, "/")
 			tag, val := parts[0], parts[1]
+			if strings.TrimSpace(tag) == "" {
+				// Have seen this fail on: WARN[0002] unable to process locator tag: May 12 11:10:00.000 I /machine-config reason/OperatorVersionChanged clusteroperator/machine-config-operator version changed from [{operator 4.14.0-0.nightly-2023-05-03-163151}] to [{operator 4.14.0-0.nightly-2023-05-12-121801}]
+				// Would be interesting to track down where this is coming from
+				logrus.Warnf("unable to process locator tag: %+v", i)
+				continue
+			}
 
 			// TODO: Unclear if we should massage data here to match existing loki entries and open the door
 			// to efficient searches by namespace/node (which will require the intervals processing code

--- a/pkg/monitor/loki_upload.go
+++ b/pkg/monitor/loki_upload.go
@@ -118,7 +118,7 @@ func UploadIntervalsToLoki(intervals monitorapi.Intervals) error {
 		return fmt.Errorf("BUILD_ID env var is not defined")
 	}
 
-	bearerToken, err := obtainSSOBearerToken(clientID, clientSecret, intervals)
+	bearerToken, err := obtainSSOBearerToken(clientID, clientSecret)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func UploadIntervalsToLoki(intervals monitorapi.Intervals) error {
 	labels := map[string]string{
 		"invoker": invoker,
 		"type":    "origin-interval",
-		// TODO: in future, may group intrvals in origin rather than in the js itself, if we do,
+		// TODO: in future, may group intervals in origin rather than in the js itself, if we do,
 		// ensure this group gets carried over to this series.
 	}
 
@@ -168,7 +168,7 @@ func UploadIntervalsToLoki(intervals monitorapi.Intervals) error {
 				continue
 			}
 
-			// WAARNING: opting for a potentially risky change here, I want namespace filtering to be available as a
+			// WARNING: opting for a potentially risky change here, I want namespace filtering to be available as a
 			// label in loki soon,	and thus I am translating some labels we used historically in origin intervals to
 			// match those we pull from pod logs in the cluster itself. This will require our intervals charts in sippy
 			// be able to parse this new name instead of the other. Ideally, we would go rename these fully in origin wherever used.
@@ -187,7 +187,8 @@ func UploadIntervalsToLoki(intervals monitorapi.Intervals) error {
 		// directives in logQL.
 		logLineJson, err := json.Marshal(logLine)
 		if err != nil {
-			logrus.WithError(err).Errorf("unable to unmashall log line: %s", logLine)
+			logrus.WithError(err).Errorf("unable to mashall log line to json: %s", logLine)
+			continue
 		}
 
 		values = append(values, []interface{}{
@@ -240,7 +241,7 @@ type LokiData struct {
 	Streams []Streams `json:"streams"`
 }
 
-func obtainSSOBearerToken(clientID, clientSecret string, intervals monitorapi.Intervals) (string, error) {
+func obtainSSOBearerToken(clientID, clientSecret string) (string, error) {
 	logrus.Info("requesting bearer token from RH SSO")
 	// Obtain a bearer token for pushing intervals to loki using RH SSO:
 	client := &http.Client{}

--- a/pkg/monitor/loki_upload.go
+++ b/pkg/monitor/loki_upload.go
@@ -55,10 +55,17 @@ func pushBatch(client *http.Client, bearerToken string, lokiData LokiData) error
 		return err
 	}
 
-	logrus.WithField("status", response.Status).
-		Infof("%d log entries pushed to loki\n", len(lokiData.Streams[0].Values))
+	status := response.StatusCode
 	if len(body) > 0 {
 		logrus.Infof("request body: %s", body)
+	}
+	if status >= 200 && status < 300 {
+		logrus.WithField("status", status).
+			Infof("%d log entries pushed to loki", len(lokiData.Streams[0].Values))
+	} else {
+		logrus.WithField("status", status).
+			Errorf("%d log entries failed to push to loki", len(lokiData.Streams[0].Values))
+		return fmt.Errorf("logs push to loki failed with http status %d", status)
 	}
 
 	// TODO: error handling and retries based on status code?

--- a/pkg/monitor/loki_upload.go
+++ b/pkg/monitor/loki_upload.go
@@ -1,24 +1,187 @@
 package monitor
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	batchSize = 500
+)
+
+func pushBatch(client *http.Client, bearerToken string, lokiData LokiData) error {
+	logrus.Infof("pushing batch of %d intervals", len(lokiData.Streams[0].Values))
+	url := "https://logging-loki-openshift-operators-redhat.apps.cr.j7t7.p1.openshiftapps.com/api/logs/v1/openshift-trt/loki/api/v1/push"
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer " + bearerToken,
+	}
+	jsonData, err := json.Marshal(lokiData)
+	if err != nil {
+		logrus.WithError(err).Error("error marshalling loki data")
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		logrus.WithError(err).Error("error creating HTTP request")
+		return err
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	response, err := client.Do(req)
+	if err != nil {
+		logrus.WithError(err).Error("error making HTTP request")
+		return err
+	}
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		logrus.WithError(err).Error("error reading response body")
+		return err
+	}
+
+	logrus.WithField("status", response.Status).
+		Infof("%d log entries pushed to loki\n", len(lokiData.Streams[0].Values))
+	if len(body) > 0 {
+		logrus.Infof("request body: %s", body)
+	}
+
+	// TODO: error handling and retries based on status code?
+
+	return nil
+}
+
 func UploadIntervalsToLoki(clientID, clientSecret string, intervals monitorapi.Intervals) error {
-	_, err := obtainSSOBearerToken(clientID, clientSecret, intervals)
+	bearerToken, err := obtainSSOBearerToken(clientID, clientSecret, intervals)
 	if err != nil {
 		return err
 	}
+
 	logrus.Info("bearer token obtained")
+	client := &http.Client{}
+
+	// NOTE: there is a promtail go client available at https://github.com/grafana/loki/blob/main/clients/pkg/promtail/client/client.go,
+	// however it appears near impossible to vendor. For now, we roll our own with http requests, the worst
+	// part of which is we lose out on resilient retries in the event the ingesters are overloaded.
+
+	values := make([][]interface{}, 0)
+	// TODO: Replace, this is exported in scripts not globally defined: export OPENSHIFT_INSTALL_INVOKER="openshift-internal-ci/${JOB_NAME}/${BUILD_ID}"
+	invoker := os.Getenv("OPENSHIFT_INSTALL_INVOKER")
+	if invoker == "" {
+		return fmt.Errorf("OPENSHIFT_INSTALL_INVOKER is needed for the invoker loki label")
+	}
+	labels := map[string]string{
+		"invoker": invoker,
+		"src":     "origin-interval",
+	}
+
+	for _, i := range intervals {
+		//logLine := LogEntry{Entry: i.Message}
+		logLine := map[string]string{
+			"_entry": i.Message,
+		}
+
+		if strings.HasPrefix(i.Locator, "e2e-test/\"") {
+			startIndex := strings.Index(i.Locator, "\"") + 1
+			endIndex := strings.LastIndex(i.Locator, "\"")
+			logLine["e2e-test"] = i.Locator[startIndex:endIndex]
+			continue
+		}
+
+		locatorParts := strings.Split(i.Locator, " ")
+
+		for _, lp := range locatorParts {
+			parts := strings.Split(lp, "/")
+			tag, val := parts[0], parts[1]
+
+			// TODO: Unclear if we should massage data here to match existing loki entries and open the door
+			// to efficient searches by namespace/node (which will require the intervals processing code
+			// in sippy to change a little and no longer work with plain intervals files from gcs)...
+			/*
+				if tag == "ns" {
+					tag = "namespace"
+				}
+				if tag == "node" {
+					tag = "host"
+				}
+
+			*/
+
+			logLine[tag] = val
+		}
+
+		// Convert the log data to a packed json log line, where the message is in '_entry'.
+		// This allows us to search additional fields we didn't index as labels using the unpack/json
+		// directives in logQL.
+		logLineJson, err := json.Marshal(logLine)
+		if err != nil {
+			logrus.WithError(err).Errorf("unable to unmashall log line: %s", logLine)
+		}
+
+		values = append(values, []interface{}{
+			strconv.FormatInt(i.From.UnixNano(), 10),
+			string(logLineJson),
+		})
+		//fmt.Printf("Added value: %v\n", values[len(values)-1])
+
+		if len(values) == batchSize {
+			ld := LokiData{
+				Streams: []Streams{
+					{
+						Stream: labels,
+						Values: values,
+					},
+				},
+			}
+			err := pushBatch(client, bearerToken, ld)
+			if err != nil {
+				return err
+			}
+			values = make([][]interface{}, 0)
+		}
+	}
+
+	// Push the final batch:
+	if len(values) > 0 {
+		ld := LokiData{
+			Streams: []Streams{
+				{
+					Stream: labels,
+					Values: values,
+				},
+			},
+		}
+		err := pushBatch(client, bearerToken, ld)
+		if err != nil {
+			return err
+		}
+		values = make([][]interface{}, 0)
+	}
 	return nil
+}
+
+type Streams struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]interface{}   `json:"values"` // array of arrays of [ts, jsonStr]
+}
+
+type LokiData struct {
+	Streams []Streams `json:"streams"`
 }
 
 func obtainSSOBearerToken(clientID, clientSecret string, intervals monitorapi.Intervals) (string, error) {

--- a/pkg/monitor/loki_upload.go
+++ b/pkg/monitor/loki_upload.go
@@ -268,12 +268,17 @@ func obtainSSOBearerToken(clientID, clientSecret string, intervals monitorapi.In
 		logrus.WithError(err).Error("error reading bearer token HTTP request body for bearer token")
 		return "", err
 	}
+	logrus.WithField("status", response.StatusCode).Info("obtained response to bearer token request")
 
 	var responseJSON map[string]interface{}
 	if err := json.Unmarshal(responseBody, &responseJSON); err != nil {
 		logrus.WithError(err).Error("error parsing bearer token HTTP request body as json")
-		fmt.Println("Error decoding response JSON:", err)
 		return "", err
+	}
+	if _, ok := responseJSON["access_token"]; !ok {
+		// TODO: careful we're not logging anything sensitive here
+		logrus.Errorf("no access token in response: %s", responseBody)
+		return "", fmt.Errorf("no access token in response")
 	}
 	bearerToken := responseJSON["access_token"].(string)
 	return bearerToken, nil

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -60,13 +60,8 @@ func NodeFromLocator(locator string) (string, bool) {
 	return parts[0], true
 }
 
-func OperatorLocator(testName string) string {
-	return fmt.Sprintf("clusteroperator/%v", testName)
-}
-
-func IsOperator(locator string) bool {
-	_, ret := OperatorFromLocator(locator)
-	return ret
+func OperatorLocator(operatorName string) string {
+	return fmt.Sprintf("clusteroperator/%v", operatorName)
 }
 
 func OperatorFromLocator(locator string) (string, bool) {

--- a/pkg/test/ginkgo/options_monitor_events.go
+++ b/pkg/test/ginkgo/options_monitor_events.go
@@ -253,6 +253,16 @@ func (o *MonitorEventsOptions) WriteRunDataToArtifactsDir(artifactDir string, ti
 			errs = append(errs, currErr)
 		}
 	}
+
+	// TODO: Re-sort for loki, where we need these to go    in chronologically, and based on the
+	// above comments that would not be the case otherwise.
+	sort.Sort(monitorapi.Intervals(events))
+	err := monitor.UploadIntervalsToLoki(events)
+	if err != nil {
+		// Best effort, we do not want to error out here:
+		logrus.WithError(err).Warn("unable to upload intervals to loki")
+	}
+
 	if o.auditLogSummary != nil {
 		if currErr := nodedetails.WriteAuditLogSummary(artifactDir, timeSuffix, o.auditLogSummary); currErr != nil {
 			errs = append(errs, currErr)


### PR DESCRIPTION
This change is part of a process to get intervals charts, a key debugging tool, more robust and powerful. Once live, sippy will be able to pull intervals from loki instead of gcs buckets, which gives us more powerful searching, but also the ability to intermingle actual logs from the cluster. We will also be able to search intervals across all CI jobs.

Pushing intervals to loki is best effort. If we fail, we log and continue.

- Obtain bearer token for loki upload
- Push intervals to loki in batches
- Detect bad http codes
- Fix an edge case where locators parse badly for loki unpack
- Add retries for batches of intervals going to loki
- Fix discrepancies with interval creation funcs
- Final hookup to run after we write intervals to disk

[TRT-994](https://issues.redhat.com//browse/TRT-994)