### PR TITLE
LoadBalancer network connectivity test cases for HyperShift+KubeVirt

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/images/trigger"
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/kernel"
+	_ "github.com/openshift/origin/test/extended/kubevirt"
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
 	_ "github.com/openshift/origin/test/extended/oauth"

--- a/test/extended/kubevirt/util.go
+++ b/test/extended/kubevirt/util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -24,6 +23,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	svc "k8s.io/kubernetes/test/e2e/framework/service"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
@@ -64,7 +64,7 @@ func launchWebserverNodePortService(client k8sclient.Interface, namespace, servi
 
 }
 
-func launchWebserverLoadBalancerService(client k8sclient.Interface, namespace, serviceName string, nodeName string, externalIPs []string) int32 {
+func launchWebserverLoadBalancerService(client k8sclient.Interface, namespace, serviceName string, nodeName string) (int32, []v1.LoadBalancerIngress) {
 	labelSelector := make(map[string]string)
 	labelSelector["name"] = "web"
 	createPodForService(client, namespace, serviceName, nodeName, labelSelector)
@@ -82,8 +82,7 @@ func launchWebserverLoadBalancerService(client k8sclient.Interface, namespace, s
 					Port:     int32(servicePort),
 				},
 			},
-			Selector:    labelSelector,
-			ExternalIPs: externalIPs,
+			Selector: labelSelector,
 		},
 	}
 	serviceClient := client.CoreV1().Services(namespace)
@@ -93,7 +92,11 @@ func launchWebserverLoadBalancerService(client k8sclient.Interface, namespace, s
 	service, err = serviceClient.Get(context.Background(), serviceName, metav1.GetOptions{})
 	expectNoError(err)
 
-	return int32(servicePort)
+	jig := svc.NewTestJig(client, namespace, serviceName)
+	service, err = jig.WaitForLoadBalancer(context.Background(), 1*time.Minute)
+	expectNoError(err)
+
+	return int32(servicePort), service.Status.LoadBalancer.Ingress
 
 }
 
@@ -263,16 +266,11 @@ func checkKubeVirtInfraClusterConnectivity(serverFramework, clientFramework *e2e
 		serviceAddr = net.JoinHostPort(serverGuestNodeIP, strconv.Itoa(int(serverGuestNodePort)))
 	}
 	if serviceType == v1.ServiceTypeLoadBalancer {
-		hostUrl, err := url.Parse(serverFramework.ClientConfig().Host)
-		if err != nil {
-			return err
-		}
-		externalIP := hostUrl.Host
-		serverLBPort := launchWebserverLoadBalancerService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverGuestNode.Name, []string{externalIP})
-		serviceAddr = net.JoinHostPort(externalIP, strconv.Itoa(int(serverLBPort)))
+		serverLBPort, externalIP := launchWebserverLoadBalancerService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverGuestNode.Name)
+		serviceAddr = net.JoinHostPort(externalIP[0].IP, strconv.Itoa(int(serverLBPort)))
 	}
 
-	return checkConnectivityToHostWithCLI(clientFramework, oc, infraClientNode, "service-wget", serviceAddr, 10*time.Second, false)
+	return checkConnectivityToHostWithCLI(clientFramework, oc, infraClientNode, "service-wget", serviceAddr, 30*time.Second, false)
 }
 
 func checkKubeVirtInfraClusterNodePortConnectivity(serverFramework, clientFramework *e2e.Framework, oc *exutil.CLI) error {
@@ -302,9 +300,8 @@ func checkKubeVirtGuestClusterConnectivity(serverFramework, clientFramework *e2e
 		serviceAddr = exutil.LaunchWebserverPod(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverNode.Name)
 	}
 	if serviceType == v1.ServiceTypeLoadBalancer {
-		externalIP := strings.TrimLeft(strings.Split(serverFramework.ClientConfig().Host, ":")[1], "/")
-		serverLBPort := launchWebserverLoadBalancerService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverNode.Name, []string{externalIP})
-		serviceAddr = net.JoinHostPort(externalIP, strconv.Itoa(int(serverLBPort)))
+		serverLBPort, externalIP := launchWebserverLoadBalancerService(serverFramework.ClientSet, serverFramework.Namespace.Name, podName, serverNode.Name)
+		serviceAddr = net.JoinHostPort(externalIP[0].IP, strconv.Itoa(int(serverLBPort)))
 
 	}
 	return checkConnectivityToHost(clientFramework, clientNode.Name, "service-wget", serviceAddr, 10*time.Second, hostNetwork)
@@ -317,6 +314,14 @@ func checkKubeVirtGuestClusterPodNetworkConnectivity(serverFramework, clientFram
 
 func checkKubeVirtGuestClusterHostNetworkConnectivity(serverFramework, clientFramework *e2e.Framework) error {
 	return checkKubeVirtGuestClusterConnectivity(serverFramework, clientFramework, true, v1.ServiceTypeClusterIP)
+}
+
+func checkKubeVirtInfraClusterLoadBalancerConnectivity(serverFramework, clientFramework *e2e.Framework, oc *exutil.CLI) error {
+	return checkKubeVirtInfraClusterConnectivity(serverFramework, clientFramework, oc, v1.ServiceTypeLoadBalancer)
+}
+
+func checkKubeVirtGuestClusterLoadBalancerConnectivity(serverFramework, clientFramework *e2e.Framework) error {
+	return checkKubeVirtGuestClusterConnectivity(serverFramework, clientFramework, false, v1.ServiceTypeLoadBalancer)
 }
 
 func InKubeVirtClusterContext(oc *exutil.CLI, body func()) {
@@ -333,6 +338,23 @@ func InKubeVirtClusterContext(oc *exutil.CLI, body func()) {
 			body()
 		},
 	)
+}
+
+func setMgmtFramework(mgmtFramework *e2e.Framework) *exutil.CLI {
+	_, hcpNamespace, err := exutil.GetHypershiftManagementClusterConfigAndNamespace()
+	Expect(err).NotTo(HaveOccurred())
+
+	oc := exutil.NewHypershiftManagementCLI(hcpNamespace).AsAdmin()
+
+	mgmtClientSet := oc.KubeClient()
+	mgmtFramework.Namespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hcpNamespace,
+		},
+	}
+	mgmtFramework.ClientSet = mgmtClientSet
+
+	return oc
 }
 
 func expectNoError(err error, explain ...interface{}) {

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2057,6 +2057,20 @@ var Annotations = map[string]string{
 
 	"[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from guest cluster PodNetwork pod via LoadBalancer service across different guest nodes": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from guest hostNetwork pod via NodePort across different guest nodes": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from guest podNetwork pod via NodePort across different guest nodes": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from infra cluster pod via LoadBalancer service across different guest nodes": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from infra cluster pod via NodePort across different infra nodes": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow direct connections to pods from guest cluster pod in host network across different guest nodes": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow direct connections to pods from guest cluster pod in pod network across different guest nodes": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": " [Disabled:Broken]",


### PR DESCRIPTION
The KubeVirt provider for HyperShift now supports connectivity between pods through LoadBalancer, therefore we are adding 2 new test cases to the conformance test suite to validate the following scenarios:
- Connection between pods in infra cluster to a LoadBalancer service configured on the guest cluster
- Connection between pods in guest cluster to a LoadBalancer service configured on the guest cluster

