### PR TITLE
Change oc annotate cli test output check string

### DIFF
--- a/test/extended/cli/annotation.go
+++ b/test/extended/cli/annotation.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-cli] oc annotate", func() {
 		g.By("setting a new annotation")
 		out, err := oc.Run("annotate").Args("pod", "hello-openshift", "new-anno=hello").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("pod/hello-openshift annotated"))
+		o.Expect(out).To(o.ContainSubstring("pod/hello-openshift annotate"))
 
 		g.By("validating new annotation")
 		out, err = oc.Run("get").Args("pod", "hello-openshift", "--template", podAnnotationTemplate).Output()
@@ -42,7 +42,7 @@ var _ = g.Describe("[sig-cli] oc annotate", func() {
 		g.By("removing the annotation")
 		out, err = oc.Run("annotate").Args("pod", "hello-openshift", "new-anno-").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("pod/hello-openshift annotated"))
+		o.Expect(out).To(o.ContainSubstring("pod/hello-openshift annotate"))
 
 		g.By("validating missing annotation")
 		out, err = oc.Run("get").Args("pod", "hello-openshift", "--template", podAnnotationTemplate).Output()
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-cli] oc annotate", func() {
 		g.By("setting empty annotation")
 		out, err = oc.Run("annotate").Args("pod", "hello-openshift", `new-anno=`).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("pod/hello-openshift annotated"))
+		o.Expect(out).To(o.ContainSubstring("pod/hello-openshift annotate"))
 
 		g.By("validating empty annotation")
 		out, err = oc.Run("get").Args("pod", "hello-openshift", "--template", podAnnotationTemplate).Output()


### PR DESCRIPTION
Output of kubectl annotate command was incorrectly changed in https://github.com/kubernetes/kubernetes/pull/112817. Although it was reverted back by https://github.com/kubernetes/kubernetes/pull/118045, rebase v1.27.1 already landed and `oc annotate` test is failing in oc rebase PR https://github.com/openshift/oc/pull/1420 (see https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_oc/1420/pull-ci-openshift-oc-master-e2e-aws-ovn/1660630230638792704)

This PR mitigates the output check to let test passes in oc rebase.