### PR TITLE
Mitigate explain output assertion regex

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -621,7 +621,7 @@ var _ = g.Describe("[sig-cli] oc explain networking types", func() {
 
 func verifySpecStatusExplain(oc *exutil.CLI, crdClient apiextensionsclientset.Interface, gvr schema.GroupVersionResource) error {
 	return verifyExplain(oc, crdClient, gvr,
-		`(?s)DESCRIPTION:.*FIELDS:.*spec.*<Object>.*[Ss]pec(ification)?.*status.*<Object>.*[Ss]tatus.*`,
+		`(?s)DESCRIPTION:.*FIELDS:.*spec.*<.*>.*[Ss]pec(ification)?.*status.*<.*>.*[Ss]tatus.*`,
 		gvr.Resource, fmt.Sprintf("--api-version=%s", gvr.GroupVersion()))
 }
 


### PR DESCRIPTION
explain command's output was changed slightly in upstream. For example, `spec	<DeploymentSpec>` is printed instead of `spec	<Object>` (even though passing `--output=plaintext-openapiv2` still preserves the current behavior). However, our `oc explain` tests in origin have a regex expression compatible with the old behavior and they are failing in rebase 1.27 PR.

This PR mitigates regex expression to make it compatible with both versions simulateneously.