### PR TITLE
Unrevert websocket SCC exec test with skip for clusters reachable via HTTP proxy.

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -341,6 +341,8 @@ var Annotations = map[string]string{
 
 	"[sig-auth][Feature:SecurityContextConstraints]  TestPodUpdateSCCEnforcement with service account": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-auth][Feature:SecurityContextConstraints]  Websocket requests to pods/exec are subject to security.openshift.io/SCCExecRestrictions": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-auth][Feature:UserAPI] groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-auth][Feature:UserAPI] users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]": " [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -341,7 +341,7 @@ var Annotations = map[string]string{
 
 	"[sig-auth][Feature:SecurityContextConstraints]  TestPodUpdateSCCEnforcement with service account": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-auth][Feature:SecurityContextConstraints]  Websocket requests to pods/exec are subject to security.openshift.io/SCCExecRestrictions": " [Suite:openshift/conformance/parallel]",
+	"[sig-auth][Feature:SecurityContextConstraints]  Websocket requests to pods/exec are subject to security.openshift.io/SCCExecRestrictions": " [Skipped:Proxy] [Suite:openshift/conformance/parallel]",
 
 	"[sig-auth][Feature:UserAPI] groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -89,6 +89,8 @@ var (
 			`\[sig-builds\]\[Feature:Builds\] build can reference a cluster service with a build being created from new-build should be able to run a build that references a cluster service`,
 			`\[sig-builds\]\[Feature:Builds\] oc new-app should succeed with a --name of 58 characters`,
 			`\[sig-arch\] Only known images used by tests`,
+			// limitation of the golang.org/x/net/websocket package currently used within Kubernetes
+			`\[sig-auth\]\[Feature:SecurityContextConstraints\]  Websocket requests to pods/exec are subject to security.openshift.io/SCCExecRestrictions`,
 		},
 		"[Skipped:SingleReplicaTopology]": {},
 


### PR DESCRIPTION
Unrevert of https://github.com/openshift/origin/pull/27943.