### PR TITLE
OCPBUGS-5943: e2e/node/taints: Add toleration for DNS

### DIFF
--- a/deps.diff
+++ b/deps.diff
@@ -1,0 +1,45 @@
+diff --no-dereference -N -r current/vendor/k8s.io/kubernetes/test/e2e/node/taints.go updated/vendor/k8s.io/kubernetes/test/e2e/node/taints.go
+27,28d26
+< 	"k8s.io/apimachinery/pkg/runtime/schema"
+< 	"k8s.io/apimachinery/pkg/types"
+30d27
+< 	"k8s.io/client-go/dynamic"
+162,183d158
+< // dnsOperatorResource is the OpenShift DNS operator configuration resource.
+< var dnsOperatorResource = schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "dnses"}
+< 
+< // addDNSToleration adds a toleration for the "e2e-evict-taint-key" taint to the
+< // DNS operator configuration for DNS pods.
+< func addDNSToleration(ctx context.Context, dc dynamic.Interface, ns string) {
+< 	// Configure DNS pods to tolerate the taint that this
+< 	// test adds.  Evicting DNS pods causes noisy events;
+< 	// see <https://issues.redhat.com/browse/OCPBUGS-5943>.
+< 	const patch = `{"spec":{"nodePlacement":{"tolerations":[{"key":"node-role.kubernetes.io/master","operator":"Exists"},{"key":"kubernetes.io/e2e-evict-taint-key","operator":"Exists"}]}}}`
+< 	_, err := dc.Resource(dnsOperatorResource).Namespace(ns).Patch(ctx, "default", types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+< 	framework.ExpectNoError(err)
+< }
+< 
+< // removeDNSToleration removes the toleration for the "e2e-evict-taint-key"
+< // taint from the DNS operator configuration.
+< func removeDNSToleration(ctx context.Context, dc dynamic.Interface, ns string) {
+< 	const patch = `{"spec":{"nodePlacement":{"tolerations":[{"key":"node-role.kubernetes.io/master","operator":"Exists"}]}}}`
+< 	_, err := dc.Resource(dnsOperatorResource).Namespace(ns).Patch(ctx, "default", types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+< 	framework.ExpectNoError(err)
+< }
+< 
+191d165
+< 	var dc dynamic.Interface
+198d171
+< 		dc = f.DynamicClient
+201,203d173
+< 		ginkgo.DeferCleanup(removeDNSToleration, dc, ns)
+< 		addDNSToleration(ctx, dc, ns)
+< 
+405d374
+< 	var dc dynamic.Interface
+412d380
+< 		dc = f.DynamicClient
+414,416d381
+< 
+< 		ginkgo.DeferCleanup(removeDNSToleration, dc, ns)
+< 		addDNSToleration(ctx, dc, ns)

--- a/pkg/duplicateevents/duplicated_event_patterns.go
+++ b/pkg/duplicateevents/duplicated_event_patterns.go
@@ -220,10 +220,6 @@ var KnownEventsBugs = []KnownProblem{
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
 	},
 	{
-		Regexp: regexp.MustCompile("reason/TopologyAwareHintsDisabled"),
-		BZ:     "https://issues.redhat.com/browse/OCPBUGS-13366",
-	},
-	{
 		Regexp:   regexp.MustCompile("ns/.*reason/.*APICheckFailed.*503.*"),
 		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
 		Topology: TopologyPointer(v1.SingleReplicaTopologyMode),


### PR DESCRIPTION
#### UPSTREAM: <carry>: e2e/node/taints: Add toleration for DNS

In the "NoExecuteTaintManager" tests, configure DNS pods to tolerate the taint that these tests add, so that the tests don't trigger a flood of "TopologyAwareHintsDisabled" events by evicting DNS pods.

The DNS operator annotates the cluster DNS service to enable the topology-aware hints feature.  However, this feature emits pathologically repeating events when a DNS pod is evicted from a node.  These pathologically repeating events trigger a test failure.  Thus in order to allow the DNS operator to enable the topology-aware hints feature, it is necessary to prevent tests from evicting DNS pods.

* `vendor/k8s.io/kubernetes/test/e2e/node/taints.go`: Ensure DNS pods tolerate the taint that the tests add, and remove the toleration once the tests terminate.
* `deps.diff`: Regenerate.

#### Revert "OCPBUGS-13366: ignore repeated TopologyAwareHintsDisabled events"

This reverts #27916.