### PR TITLE
OCPBUGS-14342: Increase timeout in sysctl allowlist test

### DIFF
--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -270,7 +270,7 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 
 			updateAllowlistConfig(updatedSysctls, f.ClientSet)
 
-			err = e2epod.WaitForPodCondition(f.ClientSet, namespace, pod.Name, "Failed", 30*time.Second, func(pod *kapiv1.Pod) (bool, error) {
+			err = e2epod.WaitForPodCondition(f.ClientSet, namespace, pod.Name, "Failed", 60*time.Second, func(pod *kapiv1.Pod) (bool, error) {
 				if pod.Status.Phase == kapiv1.PodRunning {
 					return true, nil
 				}


### PR DESCRIPTION
This test sometimes fails because the allowlist controller takes more than 30s to update the sysctl allowlist file. This controller waits up to 60s for the pods of the DS to be in ready state.

This is a cherry-pick of #27955 