### PR TITLE
Revert "test/extended/prometheus: fix test with enabled telemetry"

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -195,10 +195,10 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 	})
 
 	g.It("shouldn't exceed the 650 series limit of total series sent via telemetry from each cluster", func() {
-		if enabledErr, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
+		if enabled, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
 			e2e.Failf("could not determine if Telemetry is enabled: %v", err)
-		} else if enabledErr != nil {
-			e2eskipper.Skipf("Telemetry is disabled: %v", enabledErr)
+		} else {
+			e2eskipper.Skipf("Telemetry is disabled: %v", enabled)
 		}
 
 		// we only consider series sent since the beginning of the test
@@ -260,10 +260,10 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 
 	g.Describe("when installed on the cluster", func() {
 		g.It("should report telemetry [Late]", func() {
-			if enabledErr, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
+			if enabled, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
 				e2e.Failf("could not determine if Telemetry is enabled: %v", err)
-			} else if enabledErr != nil {
-				e2eskipper.Skipf("Telemetry is disabled: %v", enabledErr)
+			} else {
+				e2eskipper.Skipf("Telemetry is disabled: %v", enabled)
 			}
 
 			tests := map[string]bool{}


### PR DESCRIPTION
Reverts openshift/origin#27915


Per [TRT policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get ci and/or nightly payloads flowing again.

* This test is permafailing  [techpreview jobs](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.14/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22failed_test_names%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-instrumentation%5D%5BLate%5D%20Alerts%20shouldn%27t%20exceed%20the%20650%20series%20limit%20of%20total%20series%20sent%20via%20telemetry%20from%20each%20cluster%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aggregated%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22vsphere-ipi%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22amd64%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ovn%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22ha%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22serial%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22techpreview%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&pageSize=50&sort=desc&sortField=timestamp)

To unrevert this revert, revert this PR, and layer an additional separate commit on top that addresses the problem.

Before merging the unrevert, please run these jobs on the  PR and check the result of `periodic-ci-openshift-release-master-nightly-4.14-e2e-vsphere-ovn-techpreview-serial` to confirm the fix has corrected the problem.
