### PR TITLE
OCPBUGS-32484: chart template: limit tooltip width to first word

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -510,6 +510,9 @@
         createTimelineData(pathologicalEvents, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isInterestingOrPathological, regex)
 
         var segmentFunc = function (segment) {
+            // Copy label to clipboard
+            navigator.clipboard.writeText(segment.labelVal);
+
             // for (var i in data) {
             //     if (data[i].group == segment.group) {
             //         var groupdata = data[i].data

--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -371,6 +371,13 @@
         return keys;
     }
 
+    function segmentTooltipFunc(d) {
+        return '<span style="max-inline-size: min-content; display: inline-block;">'
+        + '<strong>' + d.labelVal + '</strong><br/>'
+        + '<strong>From: </strong>' + new Date(d.timeRange[0]).toUTCString() + '<br>'
+        + '<strong>To: </strong>' + new Date(d.timeRange[1]).toUTCString() + '</span>';
+    }
+
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc, regex) {
         const data = {}
         var now = new Date();
@@ -560,7 +567,8 @@
         maxHeight(10000).
         zColorScale(ordinalScale).
         zoomX([new Date(eventIntervals.items[0].from), new Date(eventIntervals.items[eventIntervals.items.length - 1].to)]).
-        onSegmentClick(segmentFunc)
+        onSegmentClick(segmentFunc).
+        segmentTooltipContent(segmentTooltipFunc)
         (el);
 
 

--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -598,6 +598,13 @@
         return tt
     }
 
+    function segmentTooltipFunc(d) {
+        return '<span style="max-inline-size: min-content; display: inline-block;">'
+        + '<strong>' + d.labelVal + '</strong><br/>'
+        + '<strong>From: </strong>' + new Date(d.timeRange[0]).toUTCString() + '<br>'
+        + '<strong>To: </strong>' + new Date(d.timeRange[1]).toUTCString() + '</span>';
+    }
+
     function createTimelineData(timelineVal, timelineData, filteredEventIntervals, category) {
         const data = {}
         var now = new Date();
@@ -870,7 +877,8 @@
         maxHeight(10000).
         zColorScale(ordinalScale).
         zoomX([new Date(eventIntervals.items[0].from), new Date(eventIntervals.items[eventIntervals.items.length - 1].to)]).
-        onSegmentClick(segmentFunc)
+        onSegmentClick(segmentFunc).
+        segmentTooltipContent(segmentTooltipFunc)
         (el);
 
 

--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -822,6 +822,8 @@
         createTimelineData(interestingEvents, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "interesting_events");
 
         var segmentFunc = function (segment) {
+            // Copy label to clipboard
+            navigator.clipboard.writeText(segment.labelVal);
             // for (var i in data) {
             //     if (data[i].group == segment.group) {
             //         var groupdata = data[i].data

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53067,6 +53067,9 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         createTimelineData(pathologicalEvents, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isInterestingOrPathological, regex)
 
         var segmentFunc = function (segment) {
+            // Copy label to clipboard
+            navigator.clipboard.writeText(segment.labelVal);
+
             // for (var i in data) {
             //     if (data[i].group == segment.group) {
             //         var groupdata = data[i].data
@@ -53978,6 +53981,8 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         createTimelineData(interestingEvents, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "interesting_events");
 
         var segmentFunc = function (segment) {
+            // Copy label to clipboard
+            navigator.clipboard.writeText(segment.labelVal);
             // for (var i in data) {
             //     if (data[i].group == segment.group) {
             //         var groupdata = data[i].data

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52928,6 +52928,13 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return keys;
     }
 
+    function segmentTooltipFunc(d) {
+        return '<span style="max-inline-size: min-content; display: inline-block;">'
+        + '<strong>' + d.labelVal + '</strong><br/>'
+        + '<strong>From: </strong>' + new Date(d.timeRange[0]).toUTCString() + '<br>'
+        + '<strong>To: </strong>' + new Date(d.timeRange[1]).toUTCString() + '</span>';
+    }
+
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc, regex) {
         const data = {}
         var now = new Date();
@@ -53117,7 +53124,8 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         maxHeight(10000).
         zColorScale(ordinalScale).
         zoomX([new Date(eventIntervals.items[0].from), new Date(eventIntervals.items[eventIntervals.items.length - 1].to)]).
-        onSegmentClick(segmentFunc)
+        onSegmentClick(segmentFunc).
+        segmentTooltipContent(segmentTooltipFunc)
         (el);
 
 
@@ -53746,6 +53754,13 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         return tt
     }
 
+    function segmentTooltipFunc(d) {
+        return '<span style="max-inline-size: min-content; display: inline-block;">'
+        + '<strong>' + d.labelVal + '</strong><br/>'
+        + '<strong>From: </strong>' + new Date(d.timeRange[0]).toUTCString() + '<br>'
+        + '<strong>To: </strong>' + new Date(d.timeRange[1]).toUTCString() + '</span>';
+    }
+
     function createTimelineData(timelineVal, timelineData, filteredEventIntervals, category) {
         const data = {}
         var now = new Date();
@@ -54018,7 +54033,8 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         maxHeight(10000).
         zColorScale(ordinalScale).
         zoomX([new Date(eventIntervals.items[0].from), new Date(eventIntervals.items[eventIntervals.items.length - 1].to)]).
-        onSegmentClick(segmentFunc)
+        onSegmentClick(segmentFunc).
+        segmentTooltipContent(segmentTooltipFunc)
         (el);
 
 


### PR DESCRIPTION
Two quality-of-life improvements for e2e charts:

* wrap tooltips in e2e chart to make sure that tooltips don't overflow X when a long label is used.
![image](https://github.com/openshift/origin/assets/114501/ac9ce3d2-7791-4e6d-b9ce-b6e96227e445)
* copy segment label contents to clipboard when its clicked