### PR TITLE
OCPBUGS-14425: Skip CCM upgradable condition on AlibabaCloud

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -75,6 +75,12 @@ var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.op
 		clusterOperatorsObj, err := coc.List(context.Background(), metav1.ListOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		g.By("determining fetching the cluster platform")
+		infraC := dc.Resource(schema.GroupVersionResource{Group: "config.openshift.io", Resource: "infrastructures", Version: "v1"})
+		infraObj, err := infraC.Get(context.Background(), "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		infra := objx.Map(infraObj.UnstructuredContent())
+
 		clusterOperators := objx.Map(clusterOperatorsObj.UnstructuredContent())
 		items := objects(clusterOperators.Get("items"))
 		if len(items) == 0 {
@@ -91,6 +97,12 @@ var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.op
 				// kube-apiserver blocks upgrades when feature gates are present.
 				// Allow testing of TechPreviewNoUpgrade clusters by ignoring this condition.
 				if isNoUpgrade && name == "kube-apiserver" && isKubeAPIUpgradableNoUpgradeCondition(worstCondition) {
+					continue
+				}
+
+				// For 4.13 onwards the cloud-controller-manager is used to prevent upgrades for AlibabaCloud clusters.
+				// This will eventually go away once Alibaba is removed from the product and forced into TechPreview only.
+				if infra.Get("status.platformStatus.type").String() == "AlibabaCloud" && name == "cloud-controller-manager" && isCloudControllerManagerUpgradableNoUpgradeCondition(worstCondition) {
 					continue
 				}
 
@@ -293,6 +305,15 @@ func surprisingConditions(co objx.Map) ([]configv1.ClusterOperatorStatusConditio
 func isKubeAPIUpgradableNoUpgradeCondition(cond configv1.ClusterOperatorStatusCondition) bool {
 	return (cond.Reason == "FeatureGates_RestrictedFeatureGates_TechPreviewNoUpgrade" ||
 		cond.Reason == "FeatureGates_RestrictedFeatureGates_CustomNoUpgrade") &&
+		cond.Status == "False" &&
+		cond.Type == "Upgradeable"
+}
+
+// AlibabaCloud should always have been tech preview, and used a feature gate, but it didn't.
+// To prevent upgrades, the cloud-controller-manager operator sets the following condition and prevents upgrades.
+// Ref: https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/257
+func isCloudControllerManagerUpgradableNoUpgradeCondition(cond configv1.ClusterOperatorStatusCondition) bool {
+	return cond.Reason == "PlatformTechPreview" &&
 		cond.Status == "False" &&
 		cond.Type == "Upgradeable"
 }


### PR DESCRIPTION
To start the process of removing support for Alibaba in IPI installations, we want to set an [upgrade blocker via the CCM](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/257) to prevent users upgrading into 4.14.

This will then allow us to start moving Alibaba code and its deployment behind a feature gate.

To allow the tests to continue to function right now, need to add an exception to not fail this test when the CCM is blocking the upgrade on Alibaba.

Once we are behind a TechPreview featuregate we can remove this block and the code changes here