### PR TITLE
OCPBUGS-14667:  Revert "MON-3213: Changing the severity of "missing runbook_url annotation for critical alerts" test case from flaky to failure"

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -35,6 +35,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/openshift/origin/pkg/synthetictests/allowedalerts"
+	testresult "github.com/openshift/origin/pkg/test/ginkgo/result"
 	"github.com/openshift/origin/test/extended/networking"
 	exutil "github.com/openshift/origin/test/extended/util"
 	helper "github.com/openshift/origin/test/extended/util/prometheus"
@@ -64,44 +65,6 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		"MCDPivotError",
 		"MCDRebootError",
 		"SystemMemoryExceedsReservation",
-	)
-
-	criticalAlertsMissingRunbookURLExceptions := sets.NewString(
-		// Repository: https://github.com/openshift/cluster-network-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14062
-		"OVNKubernetesNorthboundDatabaseClusterIDError",
-		"OVNKubernetesSouthboundDatabaseClusterIDError",
-		"OVNKubernetesNorthboundDatabaseLeaderError",
-		"OVNKubernetesSouthboundDatabaseLeaderError",
-		"OVNKubernetesNorthboundDatabaseMultipleLeadersError",
-		"OVNKubernetesSouthboundDatabaseMultipleLeadersError",
-		"OVNKubernetesNorthdInactive",
-
-		// Repository: https://github.com/openshift/cluster-kube-scheduler-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14052
-		"KubeSchedulerDown",
-
-		// Repository; https://github.com/openshift/cluster-storage-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14053
-		"MultipleDefaultStorageClasses",
-
-		// Repository: https://github.com/openshift/machine-api-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14055
-		"MachineAPIOperatorMetricsCollectionFailing",
-
-		// Repository: https://github.com/openshift/machine-config-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14056
-		"MCDRebootError",
-		"ExtremelyHighIndividualControlPlaneMemory",
-
-		// Repository: https://github.com/openshift/cluster-ingress-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14057
-		"HAProxyDown",
-
-		// Repository: https://github.com/openshift/cluster-version-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14246
-		"ClusterOperatorDown",
-		"ClusterVersionOperatorDown",
 	)
 
 	var alertingRules map[string][]promv1.AlertingRule
@@ -188,10 +151,6 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 
 	g.It("should have a runbook_url annotation if the alert is critical", func() {
 		err := helper.ForEachAlertingRule(alertingRules, func(alert promv1.AlertingRule) sets.String {
-			if criticalAlertsMissingRunbookURLExceptions.Has(alert.Name) {
-				framework.Logf("Critical alerting rule %q is known to have missing runbook_url.", alert.Name)
-				return nil
-			}
 			violations := sets.NewString()
 			severity := string(alert.Labels["severity"])
 			runbook := string(alert.Annotations["runbook_url"])
@@ -215,7 +174,9 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		})
 
 		if err != nil {
-			e2e.Failf(err.Error())
+			// We are still gathering data on how many alerts need to
+			// be fixed, so this is marked as a flake for now.
+			testresult.Flakef(err.Error())
 		}
 	})
 })


### PR DESCRIPTION
This test is permafailing in 4.14
Example logs https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ironic-image/379/pull-ci-openshift-ironic-image-master-prevalidation-e2e-metal-ipi-virtualmedia-prevalidation/1666311316056313856

Reverts openshift/origin#27933