### PR TITLE
Update expected name for OVN acl logging test

### DIFF
--- a/test/extended/networking/acl_audit_log.go
+++ b/test/extended/networking/acl_audit_log.go
@@ -200,17 +200,16 @@ func verifyAuditLogs(out string, ns []string, ips []string, ipv6 bool) (bool, bo
 		ipMatchDst = "ipv6_dst="
 	}
 
-	e2e.Logf("Ensuring the audit log contains: '%s_allow-from-same-ns_0\", verdict=allow' AND '%s' AND '%s'", ns[0], ipMatchSrc+ips[1], ipMatchDst+ips[0])
-	e2e.Logf("Ensuring the audit log contains: '%s_allow-from-same-ns\", verdict=drop' AND '%s' AND '%s'", ns[0], ipMatchSrc+ips[2], ipMatchDst+ips[0])
+	e2e.Logf("Ensuring the audit log contains: '%s:allow-from-same-ns:Ingress:0\", verdict=allow' AND '%s' AND '%s'", ns[0], ipMatchSrc+ips[1], ipMatchDst+ips[0])
+	e2e.Logf("Ensuring the audit log contains: '%s:Ingress\", verdict=drop' AND '%s' AND '%s'", ns[0], ipMatchSrc+ips[2], ipMatchDst+ips[0])
 	// Ensure the ACL audit logs are correct
 	for _, logLine := range strings.Split(out, "\n") {
-		if strings.Contains(logLine, ns[0]+"_allow-from-same-ns_0\", verdict=allow") && strings.Contains(logLine, ipMatchSrc+ips[1]) &&
+		if strings.Contains(logLine, ns[0]+":allow-from-same-ns:Ingress:0\", verdict=allow") && strings.Contains(logLine, ipMatchSrc+ips[1]) &&
 			strings.Contains(logLine, ipMatchDst+ips[0]) {
 			allowLogFound = true
 			continue
 		}
-		if (strings.Contains(logLine, ns[0]+"_allow-from-same-ns\", verdict=drop") && strings.Contains(logLine, ipMatchSrc+ips[2]) ||
-			strings.Contains(logLine, ns[0]+"_ingressDefaultDeny\", verdict=drop") && strings.Contains(logLine, ipMatchSrc+ips[2])) &&
+		if strings.Contains(logLine, ns[0]+":Ingress\", verdict=drop") && strings.Contains(logLine, ipMatchSrc+ips[2]) &&
 			strings.Contains(logLine, ipMatchDst+ips[0]) {
 			denyLogFound = true
 			continue


### PR DESCRIPTION
The name in the OVN acl log was updated by
https://github.com/ovn-org/ovn-kubernetes/pull/3521. The matching string needs be updated accordingly.