### PR TITLE
add event interval from rest client metric broken down by source

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -200,6 +200,38 @@
         return false
     }
 
+    function isClientInternalLBEvent(eventInterval) {
+        if (eventInterval.locator.includes("client/APIError source/internal-lb")) {
+            return true
+        }
+
+        return false
+    }
+
+    function isClientExternalLBEvent(eventInterval) {
+        if (eventInterval.locator.includes("client/APIError source/external-lb")) {
+            return true
+        }
+
+        return false
+    }
+
+    function isClientServiceNetworkEvent(eventInterval) {
+        if (eventInterval.locator.includes("client/APIError source/service-network")) {
+            return true
+        }
+
+        return false
+    }
+
+    function isClientLocalhostEvent(eventInterval) {
+        if (eventInterval.locator.includes("client/APIError source/localhost")) {
+            return true
+        }
+
+        return false
+    }
+
     function isEndpointConnectivity(eventInterval) {
         if (!eventInterval.message.includes("reason/DisruptionBegan") && !eventInterval.message.includes("reason/DisruptionSamplerOutageBegan")){
             return false
@@ -373,6 +405,10 @@
         return [item.locator, "", "GracefulShutdownWindow"]
     }
 
+    function clientErrorEventsValue(item) {
+        return [item.locator, "", "ClientError"]
+    }
+
     function getDurationString(durationSeconds) {
         const seconds = durationSeconds % 60;
         const minutes = Math.floor(durationSeconds/60);
@@ -500,6 +536,18 @@
 
         timelineGroups.push({group: "shutdown-events", data: []})
         createTimelineData(apiserverShutdownEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerShutdownEventActivity, regex)
+
+        timelineGroups.push({group: "client-internal-lb", data: []})
+        createTimelineData(clientErrorEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isClientInternalLBEvent, regex)
+
+        timelineGroups.push({group: "client-external-lb", data: []})
+        createTimelineData(clientErrorEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isClientExternalLBEvent, regex)
+
+        timelineGroups.push({group: "client-service-network", data: []})
+        createTimelineData(clientErrorEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isClientServiceNetworkEvent, regex)
+
+        timelineGroups.push({group: "client-localhost", data: []})
+        createTimelineData(clientErrorEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isClientLocalhostEvent, regex)
 
         timelineGroups.push({group: "e2e-test-failed", data: []})
         createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed, regex)

--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/storage/legacystoragemonitortests"
 	"github.com/openshift/origin/pkg/monitortests/testframework/additionaleventscollector"
 	"github.com/openshift/origin/pkg/monitortests/testframework/alertanalyzer"
+	"github.com/openshift/origin/pkg/monitortests/testframework/clientresterroranalyzer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/clusterinfoserializer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionserializer"
@@ -126,6 +127,7 @@ func newUniversalMonitorTests() monitortestframework.MonitorTestRegistry {
 	monitorTestRegistry.AddMonitorTestOrDie("e2e-test-analyzer", "Test Framework", e2etestanalyzer.NewAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("event-collector", "Test Framework", watchevents.NewEventWatcher())
 	monitorTestRegistry.AddMonitorTestOrDie("clusteroperator-collector", "Test Framework", watchclusteroperators.NewOperatorWatcher())
+	monitorTestRegistry.AddMonitorTestOrDie("client-rest-error-serializer", "Test Framework", clientresterroranalyzer.NewClientRestErrorSerializer())
 
 	return monitorTestRegistry
 }

--- a/pkg/monitortestframework/panic.go
+++ b/pkg/monitortestframework/panic.go
@@ -3,6 +3,7 @@ package monitortestframework
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"k8s.io/client-go/rest"
@@ -25,7 +26,7 @@ func startCollectionWithPanicProtection(ctx context.Context, monitortest Monitor
 func collectDataWithPanicProtection(ctx context.Context, monitortest MonitorTest, storageDir string, beginning, end time.Time) (intervals monitorapi.Intervals, junit []*junitapi.JUnitTestCase, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("caught panic: %v", r)
+			err = fmt.Errorf("caught panic: %v stack trace:\n%s", r, debug.Stack())
 		}
 	}()
 

--- a/pkg/monitortests/testframework/clientresterroranalyzer/gatherer.go
+++ b/pkg/monitortests/testframework/clientresterroranalyzer/gatherer.go
@@ -1,0 +1,205 @@
+package clientresterroranalyzer
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	prometheustypes "github.com/prometheus/common/model"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	routeclient "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/openshift/library-go/test/library/metrics"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+var scrapePeriod = 30 * time.Second
+
+func fetchEventIntervalsForRestClientError(ctx context.Context, config *rest.Config, startTime time.Time) ([]monitorapi.Interval, error) {
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	routeClient, err := routeclient.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	_, err = kubeClient.CoreV1().Namespaces().Get(ctx, "openshift-monitoring", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return []monitorapi.Interval{}, nil
+	}
+
+	kubeSvc, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(ctx, "kubernetes", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve cluster IP of kubernetes.default.svc - %v", err)
+	}
+
+	client, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
+	if err != nil {
+		return nil, err
+	}
+
+	framework.Logf("[client-rest-error-serializer] collecting rest metrics")
+	gatherer := &gatherer{start: startTime, client: client, serviceNetworkIP: kubeSvc.Spec.ClusterIP}
+
+	// TODO: build more robust range query - run multiple range
+	//  queries with smaller time range ex: {from - from+30m}
+	result, err := gatherer.query(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("metric query for rest client failed: %v", err)
+	}
+
+	return gatherer.parse(result)
+}
+
+type gatherer struct {
+	start            time.Time
+	client           prometheusv1.API
+	serviceNetworkIP string
+}
+
+func (g *gatherer) query(ctx context.Context) (prometheustypes.Value, error) {
+	// TODO: should we include 5xx? "429|5..|<error>"
+	query := `rest_client_requests_total{code =~ "429|5..|<error>"}`
+	result, warnings, err := g.client.QueryRange(ctx, query, prometheusv1.Range{
+		Start: g.start,
+		End:   time.Now(),
+		// data is scraped every 30s in OpenShift
+		Step: scrapePeriod,
+	})
+	if err != nil {
+		framework.Logf("[client-rest-error-serializer]: prometheus client returned error: %v", err)
+		return nil, err
+	}
+	if len(warnings) > 0 {
+		framework.Logf("[client-rest-error-serializer]: #### warnings \\n\\t%v\\n\", strings.Join(warningsForQuery, \"\\n\\t\"", warnings)
+	}
+
+	return result, nil
+}
+
+func (g *gatherer) batchIntervals(intervals []monitorapi.Interval, locator string, current time.Time) ([]monitorapi.Interval, bool) {
+	foundIndex := -1
+	// Find latest locator in existing intervals matching the locat
+	for index, interval := range intervals {
+		if interval.Locator == locator && interval.From == current {
+			foundIndex = index
+			break
+		}
+	}
+	// No match found
+	if foundIndex == -1 {
+		return intervals, true
+	}
+	// Extend existing interval
+	intervals[foundIndex].To = intervals[foundIndex].From.Add(scrapePeriod)
+	framework.Logf("[client-rest-error-serializer] updated existing interval %+v", intervals[foundIndex])
+	return intervals, foundIndex == -1
+}
+
+func (g *gatherer) parse(result prometheustypes.Value) ([]monitorapi.Interval, error) {
+	intervals := []monitorapi.Interval{}
+	if result.Type() != prometheustypes.ValMatrix {
+		return nil, fmt.Errorf("expected a Matrix")
+	}
+
+	matrix := result.(prometheustypes.Matrix)
+	framework.Logf("[client-rest-error-serializer]: found %v series", len(matrix))
+	for _, series := range matrix {
+		if len(series.Values) <= 1 {
+			continue
+		}
+		previous := series.Values[0].Value
+		for _, current := range series.Values[1:] {
+			if !previous.Equal(current.Value) {
+				// we have a change in the count
+				// TODO: counter can reset to zero, we need to handle it,
+				//  if we want to display the increment.
+				source := source(g.serviceNetworkIP, series.Metric)
+				component := component(series.Metric)
+				namespace := string(series.Metric["namespace"])
+				locator := fmt.Sprintf("client/APIError source/%s node/%s namespace/%s component/%s", source, instance(series.Metric), namespace, component)
+
+				if newIntervals, needsNew := g.batchIntervals(intervals, locator, current.Timestamp.Time()); !needsNew {
+					intervals = newIntervals
+					continue
+				}
+
+				// TODO: the tool tip in e2e timeline does not display
+				//  code=<error>, maybe use html.EscapeString()?
+				if series.Metric["code"] == "<error>" {
+					series.Metric["code"] = "error"
+				}
+				interval := monitorapi.Interval{
+					Condition: monitorapi.Condition{
+						Level:   monitorapi.Error,
+						Locator: locator,
+						Message: fmt.Sprintf("client observed an API error - previous=%s current=%s %s",
+							previous.String(), current.Value.String(), series.Metric.String()),
+					},
+					From: current.Timestamp.Time(),
+					// TODO: find how long did the requests took using data from rest_client_request_duration_seconds_sum?
+					To: current.Timestamp.Time().Add(time.Second),
+				}
+				framework.Logf("[client-rest-error-serializer] adding new interval %+v", interval)
+				intervals = append(intervals, interval)
+			}
+			previous = current.Value
+		}
+	}
+
+	return intervals, nil
+}
+
+func instance(metric prometheustypes.Metric) string {
+	// instance="10.128.0.16:8441"
+	hostPort := string(metric["instance"])
+	host, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return hostPort
+	}
+	return host
+}
+
+// the endpoint used to reach the apiserver
+func source(serviceNetwork string, metric prometheustypes.Metric) string {
+	host := string(metric["host"])
+	switch {
+	case strings.HasPrefix(host, "api-int."):
+		return "internal-lb"
+	case strings.HasPrefix(host, "api."):
+		return "external-lb"
+	case strings.HasPrefix(host, "[::1]:6443"):
+		return "localhost"
+	case strings.HasPrefix(host, serviceNetwork):
+		return "service-network"
+	}
+
+	return host
+}
+
+func component(metric prometheustypes.Metric) string {
+	service := string(metric["service"])
+	// TODO: this will need more tweaking, to make sure
+	//  all component names show up correctly.
+	switch {
+	case service == "kubernetes":
+		return "kube-apiserver"
+	case service == "api":
+		return "openshift-apiserver"
+	case service == "metrics":
+		// TODO: many components use 'metrics' as the default service name,
+		//  so we use the namespace as the component
+		return string(metric["namespace"])
+	default:
+		return service
+	}
+}

--- a/pkg/monitortests/testframework/clientresterroranalyzer/monitortest.go
+++ b/pkg/monitortests/testframework/clientresterroranalyzer/monitortest.go
@@ -1,0 +1,45 @@
+package clientresterroranalyzer
+
+import (
+	"context"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/rest"
+)
+
+type clientRestErrorSerializer struct {
+	adminRESTConfig *rest.Config
+}
+
+func NewClientRestErrorSerializer() monitortestframework.MonitorTest {
+	return &clientRestErrorSerializer{}
+}
+
+func (c *clientRestErrorSerializer) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	c.adminRESTConfig = adminRESTConfig
+	return nil
+}
+
+func (c *clientRestErrorSerializer) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	intervals, err := fetchEventIntervalsForRestClientError(ctx, c.adminRESTConfig, beginning)
+	return intervals, nil, err
+}
+
+func (*clientRestErrorSerializer) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+func (*clientRestErrorSerializer) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (*clientRestErrorSerializer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*clientRestErrorSerializer) Cleanup(ctx context.Context) error {
+	return nil
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52518,6 +52518,38 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return false
     }
 
+    function isClientInternalLBEvent(eventInterval) {
+        if (eventInterval.locator.includes("client/APIError source/internal-lb")) {
+            return true
+        }
+
+        return false
+    }
+
+    function isClientExternalLBEvent(eventInterval) {
+        if (eventInterval.locator.includes("client/APIError source/external-lb")) {
+            return true
+        }
+
+        return false
+    }
+
+    function isClientServiceNetworkEvent(eventInterval) {
+        if (eventInterval.locator.includes("client/APIError source/service-network")) {
+            return true
+        }
+
+        return false
+    }
+
+    function isClientLocalhostEvent(eventInterval) {
+        if (eventInterval.locator.includes("client/APIError source/localhost")) {
+            return true
+        }
+
+        return false
+    }
+
     function isEndpointConnectivity(eventInterval) {
         if (!eventInterval.message.includes("reason/DisruptionBegan") && !eventInterval.message.includes("reason/DisruptionSamplerOutageBegan")){
             return false
@@ -52691,6 +52723,10 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return [item.locator, "", "GracefulShutdownWindow"]
     }
 
+    function clientErrorEventsValue(item) {
+        return [item.locator, "", "ClientError"]
+    }
+
     function getDurationString(durationSeconds) {
         const seconds = durationSeconds % 60;
         const minutes = Math.floor(durationSeconds/60);
@@ -52818,6 +52854,18 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
         timelineGroups.push({group: "shutdown-events", data: []})
         createTimelineData(apiserverShutdownEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerShutdownEventActivity, regex)
+
+        timelineGroups.push({group: "client-internal-lb", data: []})
+        createTimelineData(clientErrorEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isClientInternalLBEvent, regex)
+
+        timelineGroups.push({group: "client-external-lb", data: []})
+        createTimelineData(clientErrorEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isClientExternalLBEvent, regex)
+
+        timelineGroups.push({group: "client-service-network", data: []})
+        createTimelineData(clientErrorEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isClientServiceNetworkEvent, regex)
+
+        timelineGroups.push({group: "client-localhost", data: []})
+        createTimelineData(clientErrorEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isClientLocalhostEvent, regex)
 
         timelineGroups.push({group: "e2e-test-failed", data: []})
         createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed, regex)


### PR DESCRIPTION
Make sure locator and message are shown as is on HTML page when `rest_` increases.

Test bed for https://github.com/openshift/origin/pull/27976 + fixes

TODO:
* [ ] Metrics are scraped every 30 sec, is there a way to find how long disruptions during that period took? Seems its possible to find that out from `rest_client_request_duration_seconds_sum`?
     Currently we'll create sequential one second intervals for each error found, but exact time and duration of the disruption cannot be properly derived