### PR TITLE
Changing the severity of "missing runbook_url annotation for critical alerts" test case from flaky to failure

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1185,6 +1185,10 @@ var Annotations = map[string]string{
 
 	"[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have description and summary annotations": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should link to a valid URL if the runbook_url annotation is defined": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should link to an HTTP(S) location if the runbook_url annotation is defined": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from guest cluster PodNetwork pod via LoadBalancer service across different guest nodes": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION


The following critical alerts do not have have runbook_url annotation added as exceptions:
  - OVNKubernetesNorthboundDatabaseClusterIDError
  - OVNKubernetesSouthboundDatabaseClusterIDError
  - OVNKubernetesNorthboundDatabaseLeaderError
  - OVNKubernetesSouthboundDatabaseLeaderError
  - OVNKubernetesNorthboundDatabaseMultipleLeadersError
  - OVNKubernetesSouthboundDatabaseMultipleLeadersError
  - OVNKubernetesNorthdInactive
  - KubeSchedulerDown
  - MultipleDefaultStorageClasses
  - MachineAPIOperatorMetricsCollectionFailing
  - MCDRebootError
  - ExtremelyHighIndividualControlPlaneMemory
  - HAProxyDown
  - ClusterOperatorDown
  - ClusterVersionOperatorDown

The check for runbook_url validity has been separated out into a new flaky test