### PR TITLE
OCPBUGS-11652: Enable oc adm node-logs

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -637,7 +637,7 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc adm new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-cli] oc adm node-logs": " [Disabled:Broken]",
+	"[sig-cli] oc adm node-logs": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc adm policy [apigroup:authorization.openshift.io][apigroup:user.openshift.io]": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -53,9 +53,6 @@ var (
 			// https://issues.redhat.com/browse/OCPBUGS-3339
 			`\[sig-devex\]\[Feature:ImageEcosystem\]\[mysql\]\[Slow\] openshift mysql image Creating from a template should instantiate the template`,
 			`\[sig-devex\]\[Feature:ImageEcosystem\]\[mariadb\]\[Slow\] openshift mariadb image Creating from a template should instantiate the template`,
-
-			// https://issues.redhat.com/browse/OCPBUGS-11652
-			`\[sig-cli\] oc adm node-logs`,
 		},
 		// tests that need to be temporarily disabled while the rebase is in progress.
 		"[Disabled:RebaseInProgress]": {


### PR DESCRIPTION
Now that all the required PRs for the feature to work has merged, we can enable the test. Please the bug links for the list of PRs.

Manual revert of https://github.com/openshift/origin/pull/27867