### PR TITLE
OCPBUGS-13379: machines: add a test which verifies number of node reboots

### DIFF
--- a/test/extended/machines/display_reboots_pod.yaml
+++ b/test/extended/machines/display_reboots_pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: list-boots-
+spec:
+  restartPolicy: Never
+  hostPID: true
+  containers:
+    - command:
+        - exec chroot /host-root journalctl --list-boots
+      image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+      name: list-boots
+      terminationMessagePolicy: FallbackToLogsOnError
+      securityContext:
+        runAsUser: 0
+        privileged: true
+      volumeMounts:
+        - mountPath: /host-root
+          name: host-root
+  volumes:
+    - name: host-root
+      hostPath:
+        path: /
+        type: Directory

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1387,6 +1387,8 @@ var Annotations = map[string]string{
 
 	"[sig-node] Managed cluster should report ready nodes the entire duration of the test run [Late][apigroup:monitoring.coreos.com]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-node] Managed cluster should verify that nodes have no unexpected reboots [Late]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node] should override timeoutGracePeriodSeconds when annotation is set": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Evolution of https://github.com/openshift/origin/pull/27899/ that uses the upstream helpers for waiting, generates a namespace as "normal", marks as allowed for privileged namespace, uses admin creds to pass SCC checks, uses upstream helpers to get logs, avoids recursion for looping, reports all failures for attempts, and reduces length.


/assign @vrutkovs 