### PR TITLE
verifies number of node reboots even for HA

### DIFF
--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -8,8 +8,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/prometheus"
@@ -117,15 +115,6 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 
 	g.It("should verify that nodes have no unexpected reboots [Late]", func() {
 		ctx := context.Background()
-
-		// This test is applicable for SNO installations only
-		configClient, err := configv1client.NewForConfig(oc.AdminConfig())
-		o.Expect(err).NotTo(o.HaveOccurred())
-		infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if infrastructure.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
-			return
-		}
 
 		// List all nodes
 		nodes, err := oc.KubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})

--- a/test/extended/machines/display_reboots_pod.yaml
+++ b/test/extended/machines/display_reboots_pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: list-boots-
+spec:
+  restartPolicy: Never
+  hostPID: true
+  containers:
+    - command:
+        - exec chroot /host-root journalctl --list-boots
+      image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+      name: list-boots
+      terminationMessagePolicy: FallbackToLogsOnError
+      securityContext:
+        runAsUser: 0
+        privileged: true
+      volumeMounts:
+        - mountPath: /host-root
+          name: host-root
+  volumes:
+    - name: host-root
+      hostPath:
+        path: /
+        type: Directory

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1387,6 +1387,8 @@ var Annotations = map[string]string{
 
 	"[sig-node] Managed cluster should report ready nodes the entire duration of the test run [Late][apigroup:monitoring.coreos.com]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-node] Managed cluster should verify that nodes have no unexpected reboots [Late]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node] should override timeoutGracePeriodSeconds when annotation is set": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
enable https://github.com/openshift/origin/pull/27993 everywhere

What if arm64 (or something else) is consistently restarting and on HA we simply recover fast enough to not notice?

/assign @vrutkovs 

This one will require a payload test first to ensure we don't straight out fail.