### PR TITLE
USHIFT-647: skip sig-cli explain for CRDs in MicroShift

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -193,6 +193,13 @@ var (
 		{Group: "performance.openshift.io", Version: "v2", Resource: "performanceprofiles"},
 	}
 
+	microshiftCRDTypes = []schema.GroupVersionResource{
+		{Group: "route.openshift.io", Version: "v1", Resource: "routes"},
+		{Group: "topolvm.io", Version: "v1", Resource: "logicalvolumes"},
+		//{Group: "security.internal.openshift.io", Version: "v1", Resource: "rangeallocations"},
+		//{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"},
+	}
+
 	specialTypes = map[string][]explainExceptions{
 		"apps.openshift.io": {
 			{
@@ -473,6 +480,11 @@ var (
 )
 
 func getCrdTypes(oc *exutil.CLI) []schema.GroupVersionResource {
+	isMicroShift, err := exutil.IsMicroShiftCluster(oc)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if isMicroShift {
+		return microshiftCRDTypes
+	}
 	crdTypes := append(baseCRDTypes, mcoTypes...)
 	crdTypes = append(crdTypes, autoscalingTypes...)
 	crdTypes = append(crdTypes, machineTypes...)

--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -196,6 +196,9 @@ var (
 	microshiftCRDTypes = []schema.GroupVersionResource{
 		{Group: "route.openshift.io", Version: "v1", Resource: "routes"},
 		{Group: "topolvm.io", Version: "v1", Resource: "logicalvolumes"},
+
+		// exclude resources not having "spec" and "status" in "oc explain".
+		// they are included in specialTypes list and tested separately.
 		//{Group: "security.internal.openshift.io", Version: "v1", Resource: "rangeallocations"},
 		//{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"},
 	}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2094,6 +2094,25 @@ func DoesApiResourceExist(config *rest.Config, apiResourceName, groupVersionName
 	return false, nil
 }
 
+func IsMicroShiftCluster(oc *CLI) (bool, error) {
+	// MicroShift cluster contains "microshift-version" configmap in "kube-public" namespace
+	cm, err := oc.AdminKubeClient().CoreV1().ConfigMaps("kube-public").Get(context.Background(), "microshift-version", metav1.GetOptions{})
+	if err != nil {
+		if kapierrs.IsNotFound(err) {
+			e2e.Logf("microshift-version configmap not found")
+			return false, nil
+		}
+		e2e.Logf("error accessing microshift-version configmap: %v", err)
+		return false, err
+	}
+	if cm == nil {
+		e2e.Logf("microshift-version configmap is nil")
+		return false, nil
+	}
+	e2e.Logf("MicroShift cluster with version: %s", cm.Data["version"])
+	return true, nil
+}
+
 func groupName(groupVersionName string) string {
 	return strings.Split(groupVersionName, "/")[0]
 }


### PR DESCRIPTION
This change will check if a cluster is MicroShift and make changes accordingly for `[sig-cli] oc explain should contain proper spec+status for CRDs` test. 