### PR TITLE
OCPBUGS-15291: [sig-cli] oc idle: get a dc name through labels instead of parsing oc create output

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -35994,6 +35994,9 @@ var _testExtendedTestdataCmdTestCmdTestdataIdlingDcYaml = []byte(`apiVersion: ap
 kind: DeploymentConfig
 metadata:
   generateName: idling-echo-
+  labels:
+    app: idling-echo
+    deploymentconfig: idling-echo
 spec:
   replicas: 2
   selector:

--- a/test/extended/testdata/cmd/test/cmd/testdata/idling-dc.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/idling-dc.yaml
@@ -2,6 +2,9 @@ apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   generateName: idling-echo-
+  labels:
+    app: idling-echo
+    deploymentconfig: idling-echo
 spec:
   replicas: 2
   selector:


### PR DESCRIPTION
Avoid parsing output of `oc create` which can return additional lines of text besides the dc name