### PR TITLE
trt-1030: 80s for service lb under test

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -168,11 +168,12 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 		rc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path = "/readyz"
 
 		// delay shutdown long enough to go readyz=false before the process exits when the pod is deleted.
-		rc.Spec.Template.Spec.Containers[0].Args = append(rc.Spec.Template.Spec.Containers[0].Args, "--delay-shutdown=45")
+		// 80 second delay was found to not show disruption in testing
+		rc.Spec.Template.Spec.Containers[0].Args = append(rc.Spec.Template.Spec.Containers[0].Args, "--delay-shutdown=80")
 
 		// ensure the pod is not forcibly deleted at 30s, but waits longer than the graceful sleep
-		minute := int64(60)
-		rc.Spec.Template.Spec.TerminationGracePeriodSeconds = &minute
+		minuteAndAHalf := int64(90)
+		rc.Spec.Template.Spec.TerminationGracePeriodSeconds = &minuteAndAHalf
 
 		jig.AddRCAntiAffinity(rc)
 	})


### PR DESCRIPTION
Increases --delay-shutdown to 80 seconds based on analysis in [TRT-1030](https://issues.redhat.com//browse/TRT-1030) that showed disruption at 0 with 80 second and greater delay.