### PR TITLE
USHIFT-704: skip [sig-cli] whoami result with console for MicroShift

### DIFF
--- a/cmd/openshift-tests/provider.go
+++ b/cmd/openshift-tests/provider.go
@@ -78,7 +78,23 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster
 func decodeProvider(provider string, dryRun, discover bool, clusterState *exutilcluster.ClusterState) (*exutilcluster.ClusterConfiguration, error) {
 	switch provider {
 	case "none":
-		return &exutilcluster.ClusterConfiguration{ProviderName: "skeleton"}, nil
+		config := &exutilcluster.ClusterConfiguration{
+			ProviderName: "skeleton",
+		}
+		// Add NoOptionalCapabilities for MicroShift
+		coreClient, err := e2e.LoadClientset(true)
+		if err != nil {
+			return nil, err
+		}
+		isMicroShift, err := exutil.IsMicroShiftCluster(coreClient)
+		if err != nil {
+			return nil, err
+		}
+		if isMicroShift {
+			config.HasNoOptionalCapabilities = true
+		}
+
+		return config, nil
 
 	case "":
 		if _, ok := os.LookupEnv("KUBE_SSH_USER"); ok {

--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -475,7 +475,7 @@ var (
 )
 
 func getCrdTypes(oc *exutil.CLI) []schema.GroupVersionResource {
-	isMicroShift, err := exutil.IsMicroShiftCluster(oc)
+	isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
 	o.Expect(err).NotTo(o.HaveOccurred())
 	if isMicroShift {
 		return microshiftCRDTypes

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2094,9 +2094,11 @@ func DoesApiResourceExist(config *rest.Config, apiResourceName, groupVersionName
 	return false, nil
 }
 
-func IsMicroShiftCluster(oc *CLI) (bool, error) {
+// IsMicroShiftCluster returns "true" if a cluster is MicroShift,
+// "false" otherwise. It needs kube-admin client as input.
+func IsMicroShiftCluster(kubeClient k8sclient.Interface) (bool, error) {
 	// MicroShift cluster contains "microshift-version" configmap in "kube-public" namespace
-	cm, err := oc.AdminKubeClient().CoreV1().ConfigMaps("kube-public").Get(context.Background(), "microshift-version", metav1.GetOptions{})
+	cm, err := kubeClient.CoreV1().ConfigMaps("kube-public").Get(context.Background(), "microshift-version", metav1.GetOptions{})
 	if err != nil {
 		if kapierrs.IsNotFound(err) {
 			e2e.Logf("microshift-version configmap not found")


### PR DESCRIPTION
This change will skip 
`"[sig-cli] oc basics can show correct whoami result with console [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]"` 
test by adding NoOptionalCapabilities for MicroShift