### PR TITLE
add debugging info for cluster not ready to upgrade

### DIFF
--- a/test/e2e/upgrade/clusteroperator.go
+++ b/test/e2e/upgrade/clusteroperator.go
@@ -1,0 +1,24 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+)
+
+func clusterOperatorsForRendering(ctx context.Context, c configv1client.Interface) string {
+	clusterOperators, err := c.ConfigV1().ClusterOperators().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err.Error()
+	}
+
+	retBytes, err := json.Marshal(clusterOperators)
+	if err != nil {
+		return err.Error()
+	}
+
+	return string(retBytes)
+}


### PR DESCRIPTION
this will provide a view of exactly which operator is failing when we get errors like: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade/1674247080836599808

