### PR TITLE
OCPBUGS-15500: Avoid panic attempting to process interval logs

### DIFF
--- a/pkg/monitor/intervalcreation/podlogs.go
+++ b/pkg/monitor/intervalcreation/podlogs.go
@@ -124,7 +124,11 @@ func IntervalsFromPodLogs(kubeClient kubernetes.Interface, beginning, end time.T
 			logger.Infof("fetching logs between %s and %s", beginning.Format(time.RFC3339), end.Format(time.RFC3339))
 			reader, err := podClient.GetLogs(pod.Name, &kapiv1.PodLogOptions{Container: g.container}).Stream(context.Background())
 			if err != nil {
+
+				// If there's trouble getting logs, the intervals will be missing.  During troubleshooting,
+				// error information (including the pod name) will be in this message.
 				logger.WithError(err).Error("error reading pod logs")
+				continue
 			}
 			scan := bufio.NewScanner(reader)
 			for scan.Scan() {


### PR DESCRIPTION
This avoids a panic in `Scan.scan()` when the `io.ReadCloser()` (`reader`) is invalid (because we were unable to retrieve the logs).

Sample log where this occurred:

```
[2023-06-27 10:12:07] time="2023-06-27T10:12:07Z" level=error msg="error reading pod logs" error="container \"etcd\" in pod \"etcd-test-infra-cluster-a1729bd4-master-2\" is not available" pod=etcd-test-infra-cluster-a1729bd4-master-2
```

From a [pre-submit job](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/2212/pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted/1673615526967906304/build-log.txt) in a [PR](https://github.com/openshift/assisted-test-infra/pull/2212)