### PR TITLE
USHIFT-1379: skip must-gather tests for MicroShift

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -30,21 +30,13 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 
 	oc := exutil.NewCLI("oc-adm-must-gather").AsAdmin()
 
-	g.BeforeEach(func() {
-		isMicroShift, err := exutil.IsMicroShiftCluster(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if isMicroShift {
-			g.Skip("oc adm must-gather is not supported in MicroShift, skipping")
-		}
-	})
-
 	g.JustBeforeEach(func() {
 		// wait for the default service account to be avaiable
 		err := exutil.WaitForServiceAccount(oc.KubeClient().CoreV1().ServiceAccounts(oc.Namespace()), "default")
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("runs successfully", func() {
+	g.It("runs successfully [apigroup:config.openshift.io]", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
@@ -109,7 +101,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		}
 	})
 
-	g.It("runs successfully with options", func() {
+	g.It("runs successfully with options [apigroup:config.openshift.io]", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
@@ -307,7 +299,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		}
 	})
 
-	g.When("looking at the audit logs", func() {
+	g.When("looking at the audit logs [apigroup:config.openshift.io]", func() {
 		g.Describe("[sig-node] kubelet", func() {
 			g.It("runs apiserver processes strictly sequentially in order to not risk audit log corruption", func() {
 				controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)

--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -30,6 +30,14 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 
 	oc := exutil.NewCLI("oc-adm-must-gather").AsAdmin()
 
+	g.BeforeEach(func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("oc adm must-gather is not supported in MicroShift, skipping")
+		}
+	})
+
 	g.JustBeforeEach(func() {
 		// wait for the default service account to be avaiable
 		err := exutil.WaitForServiceAccount(oc.KubeClient().CoreV1().ServiceAccounts(oc.Namespace()), "default")

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -627,13 +627,13 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc adm images [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] oc adm must-gather runs successfully [apigroup:config.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli] oc adm must-gather runs successfully for audit logs [apigroup:config.openshift.io][apigroup:oauth.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-cli] oc adm must-gather runs successfully with options": " [Suite:openshift/conformance/parallel]",
+	"[sig-cli] oc adm must-gather runs successfully with options [apigroup:config.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-cli] oc adm must-gather runs successfully": " [Suite:openshift/conformance/parallel]",
-
-	"[sig-cli] oc adm must-gather when looking at the audit logs [sig-node] kubelet runs apiserver processes strictly sequentially in order to not risk audit log corruption": " [Suite:openshift/conformance/parallel]",
+	"[sig-cli] oc adm must-gather when looking at the audit logs [apigroup:config.openshift.io] [sig-node] kubelet runs apiserver processes strictly sequentially in order to not risk audit log corruption": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc adm new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io]": " [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
As `oc adm must-gather` is not supported in MicroShift, these tests can be skipped. 