### PR TITLE
Trt 1030 service lb lifecycle delay

### DIFF
--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -172,8 +172,8 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 		rc.Spec.Template.Spec.Containers[0].Args = append(rc.Spec.Template.Spec.Containers[0].Args, "--delay-shutdown=80")
 
 		// ensure the pod is not forcibly deleted at 30s, but waits longer than the graceful sleep
-		minute := int64(60)
-		rc.Spec.Template.Spec.TerminationGracePeriodSeconds = &minute
+		minuteAndAHalf := int64(90)
+		rc.Spec.Template.Spec.TerminationGracePeriodSeconds = &minuteAndAHalf
 
 		jig.AddRCAntiAffinity(rc)
 	})

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -167,9 +167,21 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 		// the probe will go false when the sig-term is sent.
 		rc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path = "/readyz"
 
+		rc.Spec.Template.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
+			PreStop: &v1.LifecycleHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						"sleep 80",
+					},
+				},
+			},
+		}
+
 		// delay shutdown long enough to go readyz=false before the process exits when the pod is deleted.
 		// 80 second delay was found to not show disruption in testing
-		rc.Spec.Template.Spec.Containers[0].Args = append(rc.Spec.Template.Spec.Containers[0].Args, "--delay-shutdown=80")
+		// rc.Spec.Template.Spec.Containers[0].Args = append(rc.Spec.Template.Spec.Containers[0].Args, "--delay-shutdown=80")
 
 		// ensure the pod is not forcibly deleted at 30s, but waits longer than the graceful sleep
 		minuteAndAHalf := int64(90)

--- a/test/e2e/upgrade/service/service.go
+++ b/test/e2e/upgrade/service/service.go
@@ -168,7 +168,8 @@ func (t *serviceLoadBalancerUpgradeTest) loadBalancerSetup(f *framework.Framewor
 		rc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path = "/readyz"
 
 		// delay shutdown long enough to go readyz=false before the process exits when the pod is deleted.
-		rc.Spec.Template.Spec.Containers[0].Args = append(rc.Spec.Template.Spec.Containers[0].Args, "--delay-shutdown=45")
+		// 80 second delay was found to not show disruption in testing
+		rc.Spec.Template.Spec.Containers[0].Args = append(rc.Spec.Template.Spec.Containers[0].Args, "--delay-shutdown=80")
 
 		// ensure the pod is not forcibly deleted at 30s, but waits longer than the graceful sleep
 		minute := int64(60)


### PR DESCRIPTION
Separate PR for using lifecycle delay to delay the shutdown based on analysis in [TRT-1030](https://issues.redhat.com//browse/TRT-1030) that showed disruption at 0 with 80 second and greater delay.