### PR TITLE
trt-1117: Test for update lease errors

### DIFF
--- a/pkg/monitor/intervalcreation/node_test.go
+++ b/pkg/monitor/intervalcreation/node_test.go
@@ -60,6 +60,32 @@ func TestMonitorApiIntervals(t *testing.T) {
 			},
 		},
 		{
+			name:    "leaseUpdateError",
+			logLine: `May 19 19:10:03.753983 ci-op-6clh576g-0dd98-xz4pt-master-2 kubenswrapper[1516]: E0519 19:10:03.753942    1516 controller.go:189] failed to update lease, error: Put "https://api-int.ci-op-6clh576g-0dd98.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-6clh576g-0dd98-xz4pt-master-2?timeout=10s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   monitorapi.Info,
+					Locator: "node/testName",
+					Message: "reason/FailedToUpdateLease https://api-int.ci-op-6clh576g-0dd98.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-6clh576g-0dd98-xz4pt-master-2?timeout=10s - net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
+				},
+				From: systemdJournalLogTime("May 19 19:10:03.753983"),
+				To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+			},
+		},
+		{
+			name:    "leaseUpdateErr",
+			logLine: `Jun 29 05:16:54.197389 ci-op-cyqgzj4w-ed5cd-ll5md-master-0 kubenswrapper[2336]: E0629 05:16:54.195979    2336 controller.go:193] "Failed to update lease" err="Put \"https://api-int.ci-op-cyqgzj4w-ed5cd.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-cyqgzj4w-ed5cd-ll5md-master-0?timeout=10s\": http2: client connection lost"`,
+			want: monitorapi.EventInterval{
+				Condition: monitorapi.Condition{
+					Level:   monitorapi.Info,
+					Locator: "node/testName",
+					Message: "reason/FailedToUpdateLease https://api-int.ci-op-cyqgzj4w-ed5cd.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-cyqgzj4w-ed5cd-ll5md-master-0?timeout=10s - http2: client connection lost",
+				},
+				From: systemdJournalLogTime("Jun 29 05:16:54.197389"),
+				To:   systemdJournalLogTime("Jun 29 05:16:55.197389"),
+			},
+		},
+		{
 			name:    "simple failure",
 			logLine: `Jul 05 17:47:52.807876 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: I0606 17:47:52.807876    1599 prober.go:121] "Probe failed" probeType="Readiness" pod="openshift-authentication/oauth-openshift-77f7b95df5-r4xf7" podUID=1af660b3-ac3a-4182-86eb-2f74725d8415 containerName="oauth-openshift" probeResult=failure output="Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"`,
 			want: monitorapi.EventInterval{

--- a/pkg/synthetictests/event_junits.go
+++ b/pkg/synthetictests/event_junits.go
@@ -82,6 +82,7 @@ func StableSystemEventInvariants(events monitorapi.Intervals, duration time.Dura
 	tests = append(tests, testEtcdShouldNotLogSlowFdataSyncs(events)...)
 	tests = append(tests, testEtcdShouldNotLogDroppedRaftMessages(events)...)
 	tests = append(tests, testDNSOverlapDisruption(events)...)
+	tests = append(tests, testLeaseUpdateError(events)...)
 	return tests
 }
 
@@ -160,6 +161,7 @@ func SystemUpgradeEventInvariants(events monitorapi.Intervals, duration time.Dur
 	tests = append(tests, testEtcdShouldNotLogDroppedRaftMessages(events)...)
 	tests = append(tests, testMasterNodesUpdated(events)...)
 	tests = append(tests, testDNSOverlapDisruption(events)...)
+	tests = append(tests, testLeaseUpdateError(events)...)
 	return tests
 }
 


### PR DESCRIPTION
Looks for matches indicating 'Failed to update lease' in journal logs.
Creates a new flake test case.  We see update lease failures early on during the install so a grace period of 30 minutes is added from the first event time.