### PR TITLE
OCPVE-383: feat: added the early and late upgrade suite tests for RT kernel

### DIFF
--- a/test/extended/kernel/common.go
+++ b/test/extended/kernel/common.go
@@ -28,7 +28,7 @@ func skipIfNotRT(oc *exutil.CLI) {
 	o.Expect(err).NotTo(o.HaveOccurred(), "unable to retrieve realtime worker nodes")
 
 	if len(rtNodes) == 0 {
-		g.Skip("Skipping due to lack of Realtime Nodes")
+		g.Skip("These tests are only expected to run on nodes running a realtime kernel")
 	}
 }
 

--- a/test/extended/kernel/common.go
+++ b/test/extended/kernel/common.go
@@ -22,6 +22,16 @@ var (
 	rtPodName        = "rt-tests"
 )
 
+func skipIfNotRT(oc *exutil.CLI) {
+	g.By("checking kernel configuration")
+	rtNodes, err := getRealTimeWorkerNodes(oc)
+	o.Expect(err).NotTo(o.HaveOccurred(), "unable to retrieve realtime worker nodes")
+
+	if len(rtNodes) == 0 {
+		g.Skip("Skipping due to lack of Realtime Nodes")
+	}
+}
+
 func failIfNotRT(oc *exutil.CLI) {
 	g.By("checking kernel configuration")
 

--- a/test/extended/kernel/kernel_rt_pi_stress.go
+++ b/test/extended/kernel/kernel_rt_pi_stress.go
@@ -2,7 +2,6 @@ package kernel
 
 import (
 	g "github.com/onsi/ginkgo/v2"
-	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -21,22 +20,16 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real 
 		startRtTestPod(oc)
 	})
 
-	g.It("pi_stress to run successfully with the default algorithm", func() {
-		args := []string{rtPodName, "--", "pi_stress", "--duration=600", "--groups=1"}
-		_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the fifo algorithm")
+	g.It("pi_stress to run successfully with the fifo algorithm", func() {
+		runPiStressFifo(oc)
 	})
 
 	g.It("pi_stress to run successfully with the round robin algorithm", func() {
-		args := []string{rtPodName, "--", "pi_stress", "--duration=600", "--groups=1", "--rr"}
-		_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the round robin algorithm")
+		runPiStressRR(oc)
 	})
 
 	g.It("deadline_test to run successfully", func() {
-		args := []string{rtPodName, "--", "deadline_test"}
-		_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running deadline_test")
+		runDeadlineTest(oc)
 	})
 
 	g.AfterEach(func() {

--- a/test/extended/kernel/tools.go
+++ b/test/extended/kernel/tools.go
@@ -1,0 +1,24 @@
+package kernel
+
+import (
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+func runPiStressFifo(oc *exutil.CLI) {
+	args := []string{rtPodName, "--", "pi_stress", "--duration=600", "--groups=1"}
+	_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the fifo algorithm")
+}
+
+func runPiStressRR(oc *exutil.CLI) {
+	args := []string{rtPodName, "--", "pi_stress", "--duration=600", "--groups=1", "--rr"}
+	_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the round robin algorithm")
+}
+
+func runDeadlineTest(oc *exutil.CLI) {
+	args := []string{rtPodName, "--", "deadline_test"}
+	_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "error occured running deadline_test")
+}

--- a/test/extended/kernel/upgrade.go
+++ b/test/extended/kernel/upgrade.go
@@ -6,14 +6,14 @@ import (
 )
 
 // Early upgrade cycle tests
-var _ = g.Describe("[sig-node][Disruptive][Feature:ClusterUpgrade] Openshift running on RT Kernel", func() {
+var _ = g.Describe("[sig-node][Disruptive][Feature:ClusterUpgrade]", func() {
 	defer g.GinkgoRecover()
 
 	var (
 		oc = exutil.NewCLI(rtNamespace).AsAdmin()
 	)
 
-	g.Context("prior to upgrade", g.Ordered, func() {
+	g.Context("[Early] Openshift running on RT Kernel prior to upgrade", g.Ordered, func() {
 		g.BeforeAll(func() {
 			skipIfNotRT(oc)
 			configureRealtimeTestEnvironment(oc)
@@ -23,15 +23,15 @@ var _ = g.Describe("[sig-node][Disruptive][Feature:ClusterUpgrade] Openshift run
 			startRtTestPod(oc)
 		})
 
-		g.It("should allow pi_stress to run successfully with the fifo algorithm [Early]", func() {
+		g.It("should allow pi_stress to run successfully with the fifo algorithm", func() {
 			runPiStressFifo(oc)
 		})
 
-		g.It("should allow pi_stress to run successfully with the round robin algorithm [Early]", func() {
+		g.It("should allow pi_stress to run successfully with the round robin algorithm", func() {
 			runPiStressRR(oc)
 		})
 
-		g.It("should allow deadline_test to run successfully [Early]", func() {
+		g.It("should allow deadline_test to run successfully", func() {
 			runDeadlineTest(oc)
 		})
 
@@ -44,7 +44,7 @@ var _ = g.Describe("[sig-node][Disruptive][Feature:ClusterUpgrade] Openshift run
 		})
 	})
 
-	g.Context("after upgrade", g.Ordered, func() {
+	g.Context("[Late] Openshift running on RT Kernel after upgrade", g.Ordered, func() {
 		g.BeforeAll(func() {
 			skipIfNotRT(oc)
 			configureRealtimeTestEnvironment(oc)
@@ -54,15 +54,15 @@ var _ = g.Describe("[sig-node][Disruptive][Feature:ClusterUpgrade] Openshift run
 			startRtTestPod(oc)
 		})
 
-		g.It("should allow pi_stress to run successfully with the fifo algorithm [Late]", func() {
+		g.It("should allow pi_stress to run successfully with the fifo algorithm", func() {
 			runPiStressFifo(oc)
 		})
 
-		g.It("should allow pi_stress to run successfully with the round robin algorithm [Late]", func() {
+		g.It("should allow pi_stress to run successfully with the round robin algorithm", func() {
 			runPiStressRR(oc)
 		})
 
-		g.It("should allow deadline_test to run successfully [Late]", func() {
+		g.It("should allow deadline_test to run successfully", func() {
 			runDeadlineTest(oc)
 		})
 

--- a/test/extended/kernel/upgrade.go
+++ b/test/extended/kernel/upgrade.go
@@ -1,0 +1,77 @@
+package kernel
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// Early upgrade cycle tests
+var _ = g.Describe("[sig-node][Disruptive][Feature:ClusterUpgrade] Openshift running on RT Kernel", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = exutil.NewCLI(rtNamespace).AsAdmin()
+	)
+
+	g.Context("prior to upgrade", g.Ordered, func() {
+		g.BeforeAll(func() {
+			skipIfNotRT(oc)
+			configureRealtimeTestEnvironment(oc)
+		})
+
+		g.BeforeEach(func() {
+			startRtTestPod(oc)
+		})
+
+		g.It("should allow pi_stress to run successfully with the fifo algorithm [Early]", func() {
+			runPiStressFifo(oc)
+		})
+
+		g.It("should allow pi_stress to run successfully with the round robin algorithm [Early]", func() {
+			runPiStressRR(oc)
+		})
+
+		g.It("should allow deadline_test to run successfully [Early]", func() {
+			runDeadlineTest(oc)
+		})
+
+		g.AfterEach(func() {
+			cleanupRtTestPod(oc)
+		})
+
+		g.AfterAll(func() {
+			cleanupRealtimeTestEnvironment(oc)
+		})
+	})
+
+	g.Context("after upgrade", g.Ordered, func() {
+		g.BeforeAll(func() {
+			skipIfNotRT(oc)
+			configureRealtimeTestEnvironment(oc)
+		})
+
+		g.BeforeEach(func() {
+			startRtTestPod(oc)
+		})
+
+		g.It("should allow pi_stress to run successfully with the fifo algorithm [Late]", func() {
+			runPiStressFifo(oc)
+		})
+
+		g.It("should allow pi_stress to run successfully with the round robin algorithm [Late]", func() {
+			runPiStressRR(oc)
+		})
+
+		g.It("should allow deadline_test to run successfully [Late]", func() {
+			runDeadlineTest(oc)
+		})
+
+		g.AfterEach(func() {
+			cleanupRtTestPod(oc)
+		})
+
+		g.AfterAll(func() {
+			cleanupRealtimeTestEnvironment(oc)
+		})
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1393,13 +1393,25 @@ var Annotations = map[string]string{
 
 	"[sig-node] supplemental groups Ensure supplemental groups propagate to docker should propagate requested groups to the container [apigroup:security.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-node][Disruptive][Feature:ClusterUpgrade] [Early] Openshift running on RT Kernel prior to upgrade should allow deadline_test to run successfully": " [Serial]",
+
+	"[sig-node][Disruptive][Feature:ClusterUpgrade] [Early] Openshift running on RT Kernel prior to upgrade should allow pi_stress to run successfully with the fifo algorithm": " [Serial]",
+
+	"[sig-node][Disruptive][Feature:ClusterUpgrade] [Early] Openshift running on RT Kernel prior to upgrade should allow pi_stress to run successfully with the round robin algorithm": " [Serial]",
+
+	"[sig-node][Disruptive][Feature:ClusterUpgrade] [Late] Openshift running on RT Kernel after upgrade should allow deadline_test to run successfully": " [Serial]",
+
+	"[sig-node][Disruptive][Feature:ClusterUpgrade] [Late] Openshift running on RT Kernel after upgrade should allow pi_stress to run successfully with the fifo algorithm": " [Serial]",
+
+	"[sig-node][Disruptive][Feature:ClusterUpgrade] [Late] Openshift running on RT Kernel after upgrade should allow pi_stress to run successfully with the round robin algorithm": " [Serial]",
+
 	"[sig-node][Disruptive][Feature:KubeletGracefulShutdown] Kubelet with graceful shutdown configuration should respect pods termination grace period": " [Serial]",
 
 	"[sig-node][Late] should not have pod creation failures due to systemd timeouts": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow deadline_test to run successfully": " [Serial]",
 
-	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the default algorithm": " [Serial]",
+	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the fifo algorithm": " [Serial]",
 
 	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the round robin algorithm": " [Serial]",
 


### PR DESCRIPTION
This PR aims to add early and late tests for RT kernel testing during upgrade cycles. The goal is to validate the RT kernel is working as expected before and after upgrading Openshift.