### PR TITLE
Revert "disruption refinement for availability, not latency."

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ vendor/github.com/prometheus/procfs/fixtures/26231/exe
 
 # Ignore generated binary
 /openshift-tests
-/disruption

--- a/pkg/disruption/backend/disruption/handler.go
+++ b/pkg/disruption/backend/disruption/handler.go
@@ -67,7 +67,7 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 		info = fmt.Sprintf("range=[%d-%d] %s", fs.ID, ts.ID, info)
 	}
 	message, eventReason, level := backenddisruption.DisruptionBegan(h.descriptor.DisruptionLocator(),
-		h.descriptor.GetConnectionType(), fmt.Errorf("%w - %s", from.AggregateErr(), info), "no-audit-id")
+		h.descriptor.GetConnectionType(), fmt.Errorf("%w - %s", from.AggregateErr(), info))
 
 	framework.Logf(message)
 	h.eventRecorder.Eventf(

--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -211,7 +211,7 @@ func (b *BackendSampler) GetConnectionType() monitorapi.BackendConnectionType {
 
 func (b *BackendSampler) getTimeout() time.Duration {
 	if b.timeout == nil {
-		return 20 * time.Second
+		return 10 * time.Second
 	}
 	return *b.timeout
 }
@@ -249,7 +249,7 @@ func (b *BackendSampler) wrapWithAuth(rt http.RoundTripper) (http.RoundTripper, 
 
 func (b *BackendSampler) GetHTTPClient() (*http.Client, error) {
 	timeoutForEntireRequest := b.getTimeout()
-	timeoutForPartOfRequest := timeoutForEntireRequest * 4 / 5 // this is less so that we can see failures for individual portions of the request
+	timeoutForPartOfRequest := timeoutForEntireRequest / 2 // this is less so that we can see failures for individual portions of the request
 
 	b.initHTTPClient.Do(func() {
 		var httpTransport *http.Transport
@@ -489,12 +489,7 @@ func (b *disruptionSampler) produceSamples(ctx context.Context, interval time.Du
 		currDisruptionSample := b.newSample(ctx)
 		go func() {
 			uid, sampleErr := b.backendSampler.CheckConnection(ctx)
-			if sampleErr != nil {
-				// add the audit ID to the error so we can track backwards to the audit log to chase a request.
-				sampleErr = fmt.Errorf("%w -- RequestAuditID=%v", sampleErr, uid)
-			}
 			currDisruptionSample.setSampleError(sampleErr)
-			currDisruptionSample.setRequestAuditID(uid)
 			if sampleErr != nil {
 				// We'd like to include these UUIDs in the backend-disruption.json file but this is
 				// not possible without some work as we're basing everything off intervals today. There is
@@ -581,7 +576,7 @@ func (b *disruptionSampler) consumeSamples(ctx context.Context, interval time.Du
 			}
 
 			// start a new interval with the new error
-			message, eventReason, level := DisruptionBegan(b.backendSampler.GetLocator(), b.backendSampler.GetConnectionType(), currentError, currSample.getRequestAuditID())
+			message, eventReason, level := DisruptionBegan(b.backendSampler.GetLocator(), b.backendSampler.GetConnectionType(), currentError)
 			framework.Logf(message)
 			eventRecorder.Eventf(
 				&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: b.backendSampler.GetDisruptionBackendName()}, nil,
@@ -617,7 +612,7 @@ func (b *disruptionSampler) consumeSamples(ctx context.Context, interval time.Du
 				monitorRecorder.EndInterval(previousIntervalID, currSample.startTime)
 			}
 
-			message, eventReason, level := DisruptionBegan(b.backendSampler.GetLocator(), b.backendSampler.GetConnectionType(), currentError, currSample.getRequestAuditID())
+			message, eventReason, level := DisruptionBegan(b.backendSampler.GetLocator(), b.backendSampler.GetConnectionType(), currentError)
 			framework.Logf(message)
 			eventRecorder.Eventf(
 				&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: b.backendSampler.GetDisruptionBackendName()}, nil,
@@ -668,10 +663,9 @@ func (b *disruptionSampler) numberOfSamples(ctx context.Context) int {
 }
 
 type disruptionSample struct {
-	lock           sync.Mutex
-	startTime      time.Time
-	sampleErr      error
-	requestAuditID string
+	lock      sync.Mutex
+	startTime time.Time
+	sampleErr error
 
 	finished chan struct{}
 }
@@ -688,21 +682,8 @@ func (s *disruptionSample) setSampleError(sampleErr error) {
 	defer s.lock.Unlock()
 	s.sampleErr = sampleErr
 }
-
 func (s *disruptionSample) getSampleError() error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.sampleErr
-}
-
-func (s *disruptionSample) setRequestAuditID(auditID string) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	s.requestAuditID = auditID
-}
-
-func (s *disruptionSample) getRequestAuditID() string {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	return s.requestAuditID
 }

--- a/pkg/monitor/backenddisruption/disruption_locator.go
+++ b/pkg/monitor/backenddisruption/disruption_locator.go
@@ -30,25 +30,22 @@ var DnsLookupRegex = regexp.MustCompile(`dial tcp: lookup.*: i/o timeout`)
 
 // DisruptionBegan examines the error received, attempts to determine if it looks like real disruption to the cluster under test,
 // or other problems possibly on the system running the tests/monitor, and returns an appropriate user message, event reason, and monitoring level.
-func DisruptionBegan(locator string, connectionType monitorapi.BackendConnectionType, err error, auditID string) (string, monitorapi.IntervalReason, monitorapi.EventLevel) {
+func DisruptionBegan(locator string, connectionType monitorapi.BackendConnectionType, err error) (string, monitorapi.IntervalReason, monitorapi.EventLevel) {
 	if DnsLookupRegex.MatchString(err.Error()) {
 		switch connectionType {
 		case monitorapi.NewConnectionType:
 			return monitorapi.Message().
 					Reason(monitorapi.DisruptionSamplerOutageBeganEventReason).
-					WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
 					Messagef("DNS lookup timeouts began for %s GET requests over new connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, err),
 				monitorapi.DisruptionSamplerOutageBeganEventReason, monitorapi.Warning
 		case monitorapi.ReusedConnectionType:
 			return monitorapi.Message().
 					Reason(monitorapi.DisruptionSamplerOutageBeganEventReason).
-					WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
 					Messagef("DNS lookup timeouts began for %s GET requests over reused connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, err),
 				monitorapi.DisruptionSamplerOutageBeganEventReason, monitorapi.Warning
 		default:
 			return monitorapi.Message().
 					Reason(monitorapi.DisruptionSamplerOutageBeganEventReason).
-					WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
 					Messagef("DNS lookup timeouts began for %s GET requests over %v connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, "Unknown", err),
 				monitorapi.DisruptionSamplerOutageBeganEventReason, monitorapi.Warning
 		}
@@ -57,19 +54,16 @@ func DisruptionBegan(locator string, connectionType monitorapi.BackendConnection
 	case monitorapi.NewConnectionType:
 		return monitorapi.Message().
 				Reason(monitorapi.DisruptionBeganEventReason).
-				WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
 				Messagef("%s stopped responding to GET requests over new connections: %v", locator, err),
 			monitorapi.DisruptionBeganEventReason, monitorapi.Error
 	case monitorapi.ReusedConnectionType:
 		return monitorapi.Message().
 				Reason(monitorapi.DisruptionBeganEventReason).
-				WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
 				Messagef("%s stopped responding to GET requests over reused connections: %v", locator, err),
 			monitorapi.DisruptionBeganEventReason, monitorapi.Error
 	default:
 		return monitorapi.Message().
 				Reason(monitorapi.DisruptionBeganEventReason).
-				WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
 				Messagef("%s stopped responding to GET requests over %v connections: %v", locator, "Unknown", err),
 			monitorapi.DisruptionBeganEventReason, monitorapi.Error
 	}

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -147,8 +147,7 @@ const (
 	AnnotationPodPhase          AnnotationKey = "phase"
 	AnnotationIsStaticPod       AnnotationKey = "mirrored"
 	// TODO this looks wrong. seems like it ought to be set in the to/from
-	AnnotationDuration       AnnotationKey = "duration"
-	AnnotationRequestAuditID AnnotationKey = "request-audit-id"
+	AnnotationDuration AnnotationKey = "duration"
 )
 
 type MessageBuilder struct {


### PR DESCRIPTION
Reverts openshift/origin#28003

This is a test, our disruption seemed to drop to near 0 and we can't see why. This PR doesn't line up perfectly, but we want to check and make sure.