### PR TITLE
update pathological event namespace label to be unambiguous

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -139,7 +139,7 @@ func appendToFirstLine(s string, add string) string {
 func getJUnitName(testName string, namespace string) string {
 	jUnitName := testName
 	if namespace != "" {
-		jUnitName = jUnitName + " for namespace " + namespace
+		jUnitName = jUnitName + " for ns/" + namespace
 	}
 	return jUnitName
 }


### PR DESCRIPTION
To have machine categorization, we need to have the namespace label be pretty unambiguous.  This "namespace foo" has false matches for e2e tests.

To match https://github.com/openshift-eng/ci-test-mapping/pull/50, we need to use "ns/foo", which has less (no?) false matches.