### PR TITLE
OCPBUGS-14053: remove exception for MultipleDefaultStorageClasses

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -67,10 +67,6 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		"OVNKubernetesSouthboundDatabaseMultipleLeadersError",
 		"OVNKubernetesNorthdInactive",
 
-		// Repository; https://github.com/openshift/cluster-storage-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14053
-		"MultipleDefaultStorageClasses",
-
 		// Repository: https://github.com/openshift/machine-api-operator
 		// Issue: https://issues.redhat.com/browse/OCPBUGS-14055
 		"MachineAPIOperatorMetricsCollectionFailing",


### PR DESCRIPTION
Severity has been decreased to warning: https://github.com/openshift/cluster-storage-operator/pull/382

Alert no longer requires a runbook so exception can now be removed.