### PR TITLE
OCPBUGS-15893: Update permission to incl. watch for helmchartrepositories for console users

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -208,7 +208,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] The default clust
 
 						// HelmChartRepository instances keep Helm chart repository configuration
 						// By default users are able to browse charts from all configured repositories through console UI
-						rbacv1helpers.NewRule("get", "list").Groups("helm.openshift.io").Resources("helmchartrepositories").RuleOrDie(),
+						rbacv1helpers.NewRule(read...).Groups("helm.openshift.io").Resources("helmchartrepositories").RuleOrDie(),
 					}...,
 				)
 


### PR DESCRIPTION
See also https://github.com/openshift/console-operator/pull/775

Change the permission check for helmchartrepositories from `get, list` to `get, list, watch`.