### PR TITLE
ODC-7333: Add consolesamples to the exception list of CRDs without a status

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -411,18 +411,23 @@ var (
 				pattern: `DESCRIPTION\:.*`,
 			},
 			{
-				gv:      schema.GroupVersion{Group: "console.openshift.io", Version: "v1alpha1"},
+				gv:      schema.GroupVersion{Group: "console.openshift.io", Version: "v1"},
 				field:   "consoleplugins.spec",
 				pattern: `DESCRIPTION\:.*`,
 			},
 			{
 				gv:      schema.GroupVersion{Group: "console.openshift.io", Version: "v1"},
-				field:   "consoleyamlsamples.spec",
+				field:   "consolequickstarts.spec",
 				pattern: `DESCRIPTION\:.*`,
 			},
 			{
 				gv:      schema.GroupVersion{Group: "console.openshift.io", Version: "v1"},
-				field:   "consolequickstarts.spec",
+				field:   "consolesamples.spec",
+				pattern: `DESCRIPTION\:.*`,
+			},
+			{
+				gv:      schema.GroupVersion{Group: "console.openshift.io", Version: "v1"},
+				field:   "consoleyamlsamples.spec",
 				pattern: `DESCRIPTION\:.*`,
 			},
 		},

--- a/test/extended/operators/check_crd_status.go
+++ b/test/extended/operators/check_crd_status.go
@@ -90,6 +90,7 @@ func checkStatusInSchema(crdItemList []apiextensionsv1.CustomResourceDefinition)
 		"consolenotifications.console.openshift.io",
 		"consoleplugins.console.openshift.io",
 		"consolequickstarts.console.openshift.io",
+		"consolesamples.console.openshift.io",
 		"consoleyamlsamples.console.openshift.io",
 		"egressnetworkpolicies.network.openshift.io",
 		"hostsubnets.network.openshift.io",


### PR DESCRIPTION
This is a follow-up on #28045:

This PR adds the new `ConsoleSample` CRD to an `exceptionsList` in `check_crd_status.go` because the openshift/api version bump in console-operator PR https://github.com/openshift/console-operator/pull/771 always fails because this new CRD has no `status` field.

**e2e-aws-ovn-single-node** fails with ([example job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console-operator/771/pull-ci-openshift-console-operator-master-e2e-aws-ovn-single-node/1680186512810971136)):

```
[sig-arch][Early] CRDs for openshift.io should have a status in the CRD schema [Suite:openshift/conformance/parallel]

Writing JUnit report to /logs/artifacts/junit/junit_e2e__20230715-124231.xml

Suite run returned error: 1 fail, 1342 pass, 1843 skip (1h2m52s)
error: 1 fail, 1342 pass, 1843 skip (1h2m52s)
```

**e2e-gcp-ovn** fails with ([example job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console-operator/771/pull-ci-openshift-console-operator-master-e2e-gcp-ovn/1680186512840331264)):

```
  Jul 15 12:41:11.689: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-schema-status-check-s26h6-user}, err: <nil>
  Jul 15 12:41:11.733: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-schema-status-check-s26h6}, err: <nil>
  Jul 15 12:41:11.777: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~1hMic_8pAxOE3tzjdyZltH0VK9aeItHyvE3Z0Z2yWyc}, err: <nil>
fail [github.com/openshift/origin/test/extended/operators/check_crd_status.go:187]: CRD consolesamples.console.openshift.io has no 'status' element in its schema
Ginkgo exit error 1: exit with code 1
```

