### PR TITLE
fix: add missing namespaces to exclude list

### DIFF
--- a/test/extended/cpu_partitioning/pods.go
+++ b/test/extended/cpu_partitioning/pods.go
@@ -29,10 +29,10 @@ import (
 // Any pod resource that matches the name in the map and the substring of the namespace in the array is skipped.
 var (
 	excludedBestEffortDeployments = map[string][]string{
-		"egress-router-cni-deployment": {"openshift-multus"},
+		"egress-router-cni-deployment": {"openshift-multus", "egress-router-cni-e2e"},
 	}
 	excludedBestEffortDaemonSets = map[string][]string{
-		"cni-sysctl-allowlist-ds": {"egress-router-cni-e2e"},
+		"cni-sysctl-allowlist-ds": {"openshift-multus", "egress-router-cni-e2e"},
 	}
 )
 


### PR DESCRIPTION
Originally these namespaces were thought to not be needed for the test, recent flakes show that these pods do get deployed in these namespaces. Updated to include the namespaces.