### PR TITLE
USHIFT-1484: skip prometheus alerts for MicroShift

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -265,6 +266,16 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 	var (
 		oc = exutil.NewCLIWithoutNamespace("prometheus")
 	)
+
+	g.BeforeEach(func() {
+		kubeClient, err := kubernetes.NewForConfig(oc.AdminConfig())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		nsExist, err := exutil.IsNamespaceExist(kubeClient, "openshift-monitoring")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if !nsExist {
+			g.Skip("openshift-monitoring namespace does not exist, skipping")
+		}
+	})
 
 	g.It("shouldn't report any unexpected alerts in firing or pending state", func() {
 		// we only consider samples since the beginning of the test

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2102,6 +2102,19 @@ func DoesApiResourceExist(config *rest.Config, apiResourceName, group string) (b
 	return false, nil
 }
 
+func IsNamespaceExist(kubeClient *kubernetes.Clientset, namespace string) (bool, error) {
+	_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil {
+		if kapierrs.IsNotFound(err) {
+			e2e.Logf("%s namespace not found", namespace)
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
 // IsMicroShiftCluster returns "true" if a cluster is MicroShift,
 // "false" otherwise. It needs kube-admin client as input.
 func IsMicroShiftCluster(kubeClient k8sclient.Interface) (bool, error) {


### PR DESCRIPTION
This change will first look for `"openshift-monitoring"` namespace before creating prometheus client.

If the namespace doesn't exist, it will skip the following tests
```
"[sig-instrumentation][Late] Alerts shouldn't exceed the series limit of total series sent via telemetry from each cluster": " [Suite:openshift/conformance/parallel]",
"[sig-instrumentation][Late] Alerts shouldn't report any unexpected alerts in firing or pending state": " [Suite:openshift/conformance/parallel]", 
```

[USHIFT-1484](https://issues.redhat.com/browse/USHIFT-1484)
