### PR TITLE
trt-1150: Set explicit filemode for resource watch 

### DIFF
--- a/pkg/monitor/resourcewatch/operator/starter.go
+++ b/pkg/monitor/resourcewatch/operator/starter.go
@@ -59,6 +59,12 @@ func RunResourceWatch() error {
 		return err
 	}
 
+	// prevent git showing files as modified
+	// after tar extraction
+	// setting core.filemode false in git config works as well
+	// git config core.filemode false
+	gitStorage.SetFileMode(os.FileMode(0644))
+
 	dynamicInformer := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
 
 	resourcesToWatch := []schema.GroupVersionResource{


### PR DESCRIPTION
Extracting the resource watch git repo leads to all of the files showing modified status

`diff --git a/cluster-scoped-resources/config.openshift.io/clusteroperators/config-operator.yaml b/cluster-scoped-resources/config.openshift.io/clusteroperators/config-operator.yaml
old mode 100755
new mode 100644`

Due to a change in permissions while extracting

Git can be configured to ignore these changes:
git config core.filemode false

Or we can set the file permissions during the create / modify process.