### PR TITLE
add interface for future invariant tests

### DIFF
--- a/pkg/defaultinvariants/types.go
+++ b/pkg/defaultinvariants/types.go
@@ -1,0 +1,11 @@
+package defaultinvariants
+
+import "github.com/openshift/origin/pkg/invariants"
+
+func NewDefaultInvariants() invariants.InvariantRegistry {
+	invariantTests := invariants.NewInvariantRegistry()
+
+	// TODO add invariantTests here
+
+	return invariantTests
+}

--- a/pkg/invariants/impl.go
+++ b/pkg/invariants/impl.go
@@ -1,0 +1,230 @@
+package invariants
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+type invariantRegistry struct {
+	invariantTests map[string]*invariantItem
+
+	collectData sync.Once
+}
+
+type invariantItem struct {
+	name          string
+	jiraComponent string
+
+	invariantTest InvariantTest
+}
+
+func NewInvariantRegistry() InvariantRegistry {
+	return &invariantRegistry{
+		invariantTests: map[string]*invariantItem{},
+	}
+}
+
+func (r *invariantRegistry) AddInvariant(name, jiraComponent string, invariantTest InvariantTest) error {
+	if _, ok := r.invariantTests[name]; ok {
+		return fmt.Errorf("%q is already registered", name)
+	}
+	r.invariantTests[name] = &invariantItem{
+		name:          name,
+		jiraComponent: jiraComponent,
+		invariantTest: invariantTest,
+	}
+
+	return nil
+}
+
+func (r *invariantRegistry) AddInvariantOrDie(name, jiraComponent string, invariantTest InvariantTest) {
+	err := r.AddInvariant(name, jiraComponent, invariantTest)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (r *invariantRegistry) StartCollection(ctx context.Context, adminRESTConfig *rest.Config) ([]*junitapi.JUnitTestCase, error) {
+	junits := []*junitapi.JUnitTestCase{}
+	errs := []error{}
+
+	for _, invariant := range r.invariantTests {
+		testName := fmt.Sprintf("jira/%q invariant test %v setup", invariant.jiraComponent, invariant.name)
+
+		start := time.Now()
+		err := invariant.invariantTest.StartCollection(ctx, adminRESTConfig)
+		end := time.Now()
+		duration := end.Sub(start)
+		if err != nil {
+			errs = append(errs, err)
+			junits = append(junits, &junitapi.JUnitTestCase{
+				Name:     testName,
+				Duration: duration.Seconds(),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: fmt.Sprintf("failed during setup\n%v", err),
+				},
+				SystemOut: fmt.Sprintf("failed during setup\n%v", err),
+			})
+			continue
+		}
+
+		junits = append(junits, &junitapi.JUnitTestCase{
+			Name:     testName,
+			Duration: duration.Seconds(),
+		})
+	}
+
+	return junits, utilerrors.NewAggregate(errs)
+}
+
+func (r *invariantRegistry) CollectData(ctx context.Context) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	intervals := monitorapi.Intervals{}
+	junits := []*junitapi.JUnitTestCase{}
+	errs := []error{}
+
+	r.collectData.Do(func() {
+		for _, invariant := range r.invariantTests {
+			testName := fmt.Sprintf("jira/%q invariant test %v collection", invariant.jiraComponent, invariant.name)
+
+			start := time.Now()
+			localIntervals, localJunits, err := invariant.invariantTest.CollectData(ctx)
+			junits = append(junits, localJunits...)
+			intervals = append(intervals, localIntervals...)
+			end := time.Now()
+			duration := end.Sub(start)
+			if err != nil {
+				errs = append(errs, err)
+				junits = append(junits, &junitapi.JUnitTestCase{
+					Name:     testName,
+					Duration: duration.Seconds(),
+					FailureOutput: &junitapi.FailureOutput{
+						Output: fmt.Sprintf("failed during collection\n%v", err),
+					},
+					SystemOut: fmt.Sprintf("failed during collection\n%v", err),
+				})
+				continue
+			}
+
+			junits = append(junits, &junitapi.JUnitTestCase{
+				Name:     testName,
+				Duration: duration.Seconds(),
+			})
+		}
+	})
+
+	return intervals, junits, utilerrors.NewAggregate(errs)
+}
+
+func (r *invariantRegistry) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	intervals := monitorapi.Intervals{}
+	junits := []*junitapi.JUnitTestCase{}
+	errs := []error{}
+
+	r.collectData.Do(func() {
+		for _, invariant := range r.invariantTests {
+			testName := fmt.Sprintf("jira/%q invariant test %v interval construction", invariant.jiraComponent, invariant.name)
+
+			start := time.Now()
+			localIntervals, err := invariant.invariantTest.ConstructComputedIntervals(ctx, startingIntervals)
+			intervals = append(intervals, localIntervals...)
+			end := time.Now()
+			duration := end.Sub(start)
+			if err != nil {
+				errs = append(errs, err)
+				junits = append(junits, &junitapi.JUnitTestCase{
+					Name:     testName,
+					Duration: duration.Seconds(),
+					FailureOutput: &junitapi.FailureOutput{
+						Output: fmt.Sprintf("failed during interval construction\n%v", err),
+					},
+					SystemOut: fmt.Sprintf("failed during interval construction\n%v", err),
+				})
+				continue
+			}
+
+			junits = append(junits, &junitapi.JUnitTestCase{
+				Name:     testName,
+				Duration: duration.Seconds(),
+			})
+		}
+	})
+
+	return intervals, junits, utilerrors.NewAggregate(errs)
+}
+
+func (r *invariantRegistry) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	junits := []*junitapi.JUnitTestCase{}
+	errs := []error{}
+
+	r.collectData.Do(func() {
+		for _, invariant := range r.invariantTests {
+			testName := fmt.Sprintf("jira/%q invariant test %v test evaluation", invariant.jiraComponent, invariant.name)
+
+			start := time.Now()
+			localJunits, err := invariant.invariantTest.EvaluateTestsFromConstructedIntervals(ctx, finalIntervals)
+			junits = append(junits, localJunits...)
+			end := time.Now()
+			duration := end.Sub(start)
+			if err != nil {
+				errs = append(errs, err)
+				junits = append(junits, &junitapi.JUnitTestCase{
+					Name:     testName,
+					Duration: duration.Seconds(),
+					FailureOutput: &junitapi.FailureOutput{
+						Output: fmt.Sprintf("failed during test evaluation\n%v", err),
+					},
+					SystemOut: fmt.Sprintf("failed during test evaluation\n%v", err),
+				})
+				continue
+			}
+
+			junits = append(junits, &junitapi.JUnitTestCase{
+				Name:     testName,
+				Duration: duration.Seconds(),
+			})
+		}
+	})
+
+	return junits, utilerrors.NewAggregate(errs)
+}
+
+func (r *invariantRegistry) Cleanup(ctx context.Context) ([]*junitapi.JUnitTestCase, error) {
+	junits := []*junitapi.JUnitTestCase{}
+	errs := []error{}
+
+	for _, invariant := range r.invariantTests {
+		testName := fmt.Sprintf("jira/%q invariant test %v cleanup", invariant.jiraComponent, invariant.name)
+
+		start := time.Now()
+		err := invariant.invariantTest.Cleanup(ctx)
+		end := time.Now()
+		duration := end.Sub(start)
+		if err != nil {
+			errs = append(errs, err)
+			junits = append(junits, &junitapi.JUnitTestCase{
+				Name:     testName,
+				Duration: duration.Seconds(),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: fmt.Sprintf("failed during cleanup\n%v", err),
+				},
+				SystemOut: fmt.Sprintf("failed during cleanup\n%v", err),
+			})
+			continue
+		}
+
+		junits = append(junits, &junitapi.JUnitTestCase{
+			Name:     testName,
+			Duration: duration.Seconds(),
+		})
+	}
+
+	return junits, utilerrors.NewAggregate(errs)
+}

--- a/pkg/invariants/types.go
+++ b/pkg/invariants/types.go
@@ -1,0 +1,70 @@
+package invariants
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+type InvariantTest interface {
+	// StartCollection is responsible for setting up all resources required for collection of data on the cluster.
+	// An error will not stop execution, but will cause a junit failure that will cause the job run to fail.
+	// This allows us to know when setups fail.
+	StartCollection(ctx context.Context, adminRESTConfig *rest.Config) error
+
+	// CollectData will only be called once near the end of execution, before all Intervals are inspected.
+	// Errors reported will be indicated as junit test failure and will cause job runs to fail.
+	CollectData(ctx context.Context) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error)
+
+	// ConstructComputedIntervals is called after all InvariantTests have produced raw Intervals.
+	// Order of ConstructComputedIntervals across different InvariantTests is not guaranteed.
+	// Return *only* the constructed intervals.
+	// Errors reported will be indicated as junit test failure and will cause job runs to fail.
+	ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals) (constructedIntervals monitorapi.Intervals, err error)
+
+	// EvaluateTestsFromConstructedIntervals is called after all Intervals are known and can produce
+	// junit tests for reporting purposes.
+	// Errors reported will be indicated as junit test failure and will cause job runs to fail.
+	EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error)
+
+	// Cleanup must be idempotent and it may be called multiple times in any scenario.  Multiple defers, multi-registered
+	// abort handlers, abort handler running concurrent to planned shutdown.  Make your cleanup callable multiple times.
+	// Errors reported will cause job runs to fail to ensure cleanup functions work reliably.
+	Cleanup(ctx context.Context) error
+}
+
+type InvariantRegistry interface {
+	// AddInvariant adds an invariant test with a particular name, the name will be used to create a testsuite.
+	// The jira component will be forced into every JunitTestCase.
+	AddInvariant(name, jiraComponent string, invariantTest InvariantTest) error
+
+	AddInvariantOrDie(name, jiraComponent string, invariantTest InvariantTest)
+
+	// StartCollection is responsible for setting up all resources required for collection of data on the cluster.
+	// An error will not stop execution, but will cause a junit failure that will cause the job run to fail.
+	// This allows us to know when setups fail.
+	StartCollection(ctx context.Context, adminRESTConfig *rest.Config) ([]*junitapi.JUnitTestCase, error)
+
+	// CollectData will only be called once near the end of execution, before all Intervals are inspected.
+	// Errors reported will be indicated as junit test failure and will cause job runs to fail.
+	CollectData(ctx context.Context) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error)
+
+	// ConstructComputedIntervals is called after all InvariantTests have produced raw Intervals.
+	// Order of ConstructComputedIntervals across different InvariantTests is not guaranteed.
+	// Return *only* the constructed intervals.
+	// Errors reported will be indicated as junit test failure and will cause job runs to fail.
+	ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error)
+
+	// EvaluateTestsFromConstructedIntervals is called after all Intervals are known and can produce
+	// junit tests for reporting purposes.
+	// Errors reported will be indicated as junit test failure and will cause job runs to fail.
+	EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error)
+
+	// Cleanup must be idempotent and it may be called multiple times in any scenario.  Multiple defers, multi-registered
+	// abort handlers, abort handler running concurrent to planned shutdown.  Make your cleanup callable multiple times.
+	// Errors reported will cause job runs to fail to ensure cleanup functions work reliably.
+	Cleanup(ctx context.Context) ([]*junitapi.JUnitTestCase, error)
+}


### PR DESCRIPTION
Adds an interface to use for tests like kube-apiserver disruption inside the cluster, pod to pod communciation failure inside the cluster, and DNS connectivity inside the cluster.

I'm going to continue wiring in the handling for these changes, but I think this interface will remain. The steps for measuring podnetwork-to-podnetwork, podnetwork-to-service, and podnetwork-to-hostnetwork will probably look something like this.

1. create generated namespace with openshift-ci-network-check-xxx (cleanup will destroy this namespace).  
2. create required permissions
3. create deployment with antiaffinity with an http server (not secured, possibly a simple on in this repo) that honors readyz.  Need a target server for pod network and host network, plus services.  
4. create a binary in this repo that takes a target service and uses its endpoint slices to run disruption checks with dynamic endpoints that log errors for connectivity failures that can be parsed out of a log.  The data needs to be stored in local volumes so it survives restarts.  This can probably start as a deployment (honors eviction) to start, but may need to extend to a daemonset (doesn't evict) at some later date.  APIServer team can provide reference of how to use the disruption checker.  Contact @tkashem 
5. add collection to the invarianttest to read the probing pods from each node and summarize results into eventintervals.  TRT can provide reference for how to shape locators and messages to get properly aggregated into the disruption report that is uploaded.  Contact @dgoodwin 

In parallel, @deads2k will wire up the invariantTests in the defaultRegistry (this PR) to be run durign e2e tests and have their methods called. 

/assign @dgoodwin 
/cc @trozet @vrutkovs 