### PR TITLE
create a recorder interface that separates monitoring from recording

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -447,13 +447,13 @@ func (b *BackendSampler) Stop() {
 
 // StartEndpointMonitoring sets up a client for the given BackendSampler, starts checking the endpoint, and recording
 // success/failure edges into the monitorRecorder
-func (b *BackendSampler) StartEndpointMonitoring(ctx context.Context, monitorRecorder Recorder, eventRecorder events.EventRecorder) error {
-	if monitorRecorder == nil {
+func (b *BackendSampler) StartEndpointMonitoring(ctx context.Context, recorder Recorder, eventRecorder events.EventRecorder) error {
+	if recorder == nil {
 		return fmt.Errorf("monitor is required")
 	}
 
 	go func() {
-		err := b.RunEndpointMonitoring(ctx, monitorRecorder, eventRecorder)
+		err := b.RunEndpointMonitoring(ctx, recorder, eventRecorder)
 		if err != nil {
 			utilruntime.HandleError(err)
 		}

--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -129,13 +129,13 @@ func checkAllowedRepeatedEventOKFns(event monitorapi.EventInterval, times int32)
 
 func recordAddOrUpdateEvent(
 	ctx context.Context,
-	m Recorder,
+	recorder Recorder,
 	client kubernetes.Interface,
 	reMatchFirstQuote *regexp.Regexp,
 	significantlyBeforeNow time.Time,
 	obj *corev1.Event) {
 
-	m.RecordResource("events", obj)
+	recorder.RecordResource("events", obj)
 
 	// Temporary hack by dgoodwin, we're missing events here that show up later in
 	// gather-extra/events.json. Adding some output to see if we can isolate what we saw
@@ -262,11 +262,11 @@ func recordAddOrUpdateEvent(
 		fmt.Printf("processed event: %+v\nresulting new interval: %s from: %s to %s\n", *obj, message, pathoFrom, to)
 
 		// Add the interval.
-		inter := m.StartInterval(pathoFrom, condition)
-		m.EndInterval(inter, to)
+		inter := recorder.StartInterval(pathoFrom, condition)
+		recorder.EndInterval(inter, to)
 
 	} else {
-		m.RecordAt(t, condition)
+		recorder.RecordAt(t, condition)
 	}
 }
 

--- a/pkg/monitor/event_test.go
+++ b/pkg/monitor/event_test.go
@@ -83,7 +83,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 
 	type args struct {
 		ctx                    context.Context
-		m                      *Monitor
+		m                      Recorder
 		client                 kubernetes.Interface
 		reMatchFirstQuote      *regexp.Regexp
 		significantlyBeforeNow time.Time
@@ -102,7 +102,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 			name: "Single Event test",
 			args: args{
 				ctx:                    context.TODO(),
-				m:                      NewMonitor(nil, nil),
+				m:                      NewRecorder(),
 				client:                 nil,
 				reMatchFirstQuote:      regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`),
 				significantlyBeforeNow: now.UTC().Add(-15 * time.Minute),
@@ -115,7 +115,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 			skip: true, // skip since we use this only for interactive debugging
 			args: args{
 				ctx:               context.TODO(),
-				m:                 NewMonitor(nil, nil),
+				m:                 NewRecorder(),
 				client:            clientSet,
 				reMatchFirstQuote: regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`),
 

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -2,24 +2,17 @@ package monitor
 
 import (
 	"context"
-	"fmt"
-	"sort"
-	"strconv"
-	"sync"
 	"time"
 
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
-
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
-
 	"github.com/openshift/origin/pkg/disruption/backend"
 	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitor/shutdown"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 )
 
 // Monitor records events that have occurred in memory and can also periodically
@@ -28,11 +21,7 @@ type Monitor struct {
 	adminKubeConfig                  *rest.Config
 	additionalEventIntervalRecorders []StartEventIntervalRecorderFunc
 
-	lock   sync.Mutex
-	events monitorapi.Intervals
-
-	recordedResourceLock sync.Mutex
-	recordedResources    monitorapi.ResourcesMap
+	recorder Recorder
 }
 
 // NewMonitor creates a monitor with the default sampling interval.
@@ -40,11 +29,12 @@ func NewMonitor(adminKubeConfig *rest.Config, additionalEventIntervalRecorders [
 	return &Monitor{
 		adminKubeConfig:                  adminKubeConfig,
 		additionalEventIntervalRecorders: additionalEventIntervalRecorders,
-		recordedResources:                monitorapi.ResourcesMap{},
+		recorder:                         NewRecorder(),
 	}
 }
 
 var _ Interface = &Monitor{}
+var _ Recorder = &Monitor{}
 
 // Start begins monitoring the cluster referenced by the default kube configuration until context is finished.
 func (m *Monitor) Start(ctx context.Context) error {
@@ -81,169 +71,40 @@ func (m *Monitor) Start(ctx context.Context) error {
 }
 
 func (m *Monitor) CurrentResourceState() monitorapi.ResourcesMap {
-	m.recordedResourceLock.Lock()
-	defer m.recordedResourceLock.Unlock()
-
-	ret := monitorapi.ResourcesMap{}
-	for resourceType, instanceResourceMap := range m.recordedResources {
-		retInstance := monitorapi.InstanceMap{}
-		for instanceKey, obj := range instanceResourceMap {
-			retInstance[instanceKey] = obj.DeepCopyObject()
-		}
-		ret[resourceType] = retInstance
-	}
-
-	return ret
+	return m.recorder.CurrentResourceState()
 }
 
 func (m *Monitor) RecordResource(resourceType string, obj runtime.Object) {
-	m.recordedResourceLock.Lock()
-	defer m.recordedResourceLock.Unlock()
-
-	recordedResource, ok := m.recordedResources[resourceType]
-	if !ok {
-		recordedResource = monitorapi.InstanceMap{}
-		m.recordedResources[resourceType] = recordedResource
-	}
-
-	newMetadata, err := meta.Accessor(obj)
-	if err != nil {
-		// coding error
-		panic(err)
-	}
-	key := monitorapi.InstanceKey{
-		Namespace: newMetadata.GetNamespace(),
-		Name:      newMetadata.GetName(),
-		UID:       fmt.Sprintf("%v", newMetadata.GetUID()),
-	}
-
-	toStore := obj.DeepCopyObject()
-	// without metadata, just stomp in the new value, we can't add annotations
-	if newMetadata == nil {
-		recordedResource[key] = toStore
-		return
-	}
-
-	newAnnotations := newMetadata.GetAnnotations()
-	if newAnnotations == nil {
-		newAnnotations = map[string]string{}
-	}
-	existingResource, ok := recordedResource[key]
-	if !ok {
-		if newMetadata != nil {
-			newAnnotations[monitorapi.ObservedUpdateCountAnnotation] = "1"
-			newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = "0"
-			newMetadata.SetAnnotations(newAnnotations)
-		}
-		recordedResource[key] = toStore
-		return
-	}
-
-	existingMetadata, _ := meta.Accessor(existingResource)
-	// without metadata, just stomp in the new value, we can't add annotations
-	if existingMetadata == nil {
-		recordedResource[key] = toStore
-		return
-	}
-
-	existingAnnotations := existingMetadata.GetAnnotations()
-	if existingAnnotations == nil {
-		existingAnnotations = map[string]string{}
-	}
-	existingUpdateCountStr := existingAnnotations[monitorapi.ObservedUpdateCountAnnotation]
-	if existingUpdateCount, err := strconv.ParseInt(existingUpdateCountStr, 10, 32); err != nil {
-		newAnnotations[monitorapi.ObservedUpdateCountAnnotation] = "1"
-	} else {
-		newAnnotations[monitorapi.ObservedUpdateCountAnnotation] = fmt.Sprintf("%d", existingUpdateCount+1)
-	}
-
-	// set the recreate count. increment if the UIDs don't match
-	existingRecreateCountStr := existingAnnotations[monitorapi.ObservedUpdateCountAnnotation]
-	if existingMetadata.GetUID() != newMetadata.GetUID() {
-		if existingRecreateCount, err := strconv.ParseInt(existingRecreateCountStr, 10, 32); err != nil {
-			newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = existingRecreateCountStr
-		} else {
-			newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = fmt.Sprintf("%d", existingRecreateCount+1)
-		}
-	} else {
-		newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = existingRecreateCountStr
-	}
-
-	newMetadata.SetAnnotations(newAnnotations)
-	recordedResource[key] = toStore
-	return
+	m.recorder.RecordResource(resourceType, obj)
 }
 
 // Record captures one or more conditions at the current time. All conditions are recorded
 // in monotonic order as EventInterval objects.
 func (m *Monitor) Record(conditions ...monitorapi.Condition) {
-	if len(conditions) == 0 {
-		return
-	}
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	t := time.Now().UTC()
-	for _, condition := range conditions {
-		m.events = append(m.events, monitorapi.EventInterval{
-			Condition: condition,
-			From:      t,
-			To:        t,
-		})
-	}
+	m.recorder.Record(conditions...)
 }
 
 // AddIntervals provides a mechanism to directly inject eventIntervals
 func (m *Monitor) AddIntervals(eventIntervals ...monitorapi.EventInterval) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	m.events = append(m.events, eventIntervals...)
+	m.recorder.AddIntervals(eventIntervals...)
 }
 
 // StartInterval inserts a record at time t with the provided condition and returns an opaque
 // locator to the interval. The caller may close the sample at any point by invoking EndInterval().
 func (m *Monitor) StartInterval(t time.Time, condition monitorapi.Condition) int {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	m.events = append(m.events, monitorapi.EventInterval{
-		Condition: condition,
-		From:      t,
-	})
-	return len(m.events) - 1
+	return m.recorder.StartInterval(t, condition)
 }
 
 // EndInterval updates the To of the interval started by StartInterval if it is greater than
 // the from.
 func (m *Monitor) EndInterval(startedInterval int, t time.Time) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	if startedInterval < len(m.events) {
-		if m.events[startedInterval].From.Before(t) {
-			m.events[startedInterval].To = t
-		}
-	}
+	m.recorder.EndInterval(startedInterval, t)
 }
 
 // RecordAt captures one or more conditions at the provided time. All conditions are recorded
 // as EventInterval objects.
 func (m *Monitor) RecordAt(t time.Time, conditions ...monitorapi.Condition) {
-	if len(conditions) == 0 {
-		return
-	}
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	for _, condition := range conditions {
-		m.events = append(m.events, monitorapi.EventInterval{
-			Condition: condition,
-			From:      t,
-			To:        t,
-		})
-	}
-}
-
-func (m *Monitor) snapshot() monitorapi.Intervals {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	return m.events
+	m.recorder.RecordAt(t, conditions...)
 }
 
 // Intervals returns all events that occur between from and to, including
@@ -251,25 +112,5 @@ func (m *Monitor) snapshot() monitorapi.Intervals {
 // Intervals are returned in order of their occurrence. The returned slice
 // is a copy of the monitor's state and is safe to update.
 func (m *Monitor) Intervals(from, to time.Time) monitorapi.Intervals {
-	events := m.snapshot()
-
-	intervals := mergeIntervals(events.Slice(from, to))
-
-	return intervals
-}
-
-// mergeEvents returns a sorted list of all events provided as sources. This could be
-// more efficient by requiring all sources to be sorted and then performing a zipper
-// merge.
-func mergeIntervals(sets ...monitorapi.Intervals) monitorapi.Intervals {
-	total := 0
-	for _, set := range sets {
-		total += len(set)
-	}
-	merged := make(monitorapi.Intervals, 0, total)
-	for _, set := range sets {
-		merged = append(merged, set...)
-	}
-	sort.Sort(merged)
-	return merged
+	return m.recorder.Intervals(from, to)
 }

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -72,8 +72,10 @@ func TestMonitor_Events(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &Monitor{
-				events:            tt.events,
-				recordedResources: monitorapi.ResourcesMap{},
+				recorder: &recorder{
+					events:            tt.events,
+					recordedResources: monitorapi.ResourcesMap{},
+				},
 			}
 			if got := m.Intervals(tt.from, tt.to); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%s", diff.ObjectReflectDiff(tt.want, got))

--- a/pkg/monitor/recorder.go
+++ b/pkg/monitor/recorder.go
@@ -1,0 +1,224 @@
+package monitor
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type recorder struct {
+	lock   sync.Mutex
+	events monitorapi.Intervals
+
+	recordedResourceLock sync.Mutex
+	recordedResources    monitorapi.ResourcesMap
+}
+
+// NewRecorder creates a recorder that can  be used to store events
+func NewRecorder() *recorder {
+	return &recorder{
+		recordedResources: monitorapi.ResourcesMap{},
+	}
+}
+
+var _ Recorder = &recorder{}
+
+func (m *recorder) CurrentResourceState() monitorapi.ResourcesMap {
+	m.recordedResourceLock.Lock()
+	defer m.recordedResourceLock.Unlock()
+
+	ret := monitorapi.ResourcesMap{}
+	for resourceType, instanceResourceMap := range m.recordedResources {
+		retInstance := monitorapi.InstanceMap{}
+		for instanceKey, obj := range instanceResourceMap {
+			retInstance[instanceKey] = obj.DeepCopyObject()
+		}
+		ret[resourceType] = retInstance
+	}
+
+	return ret
+}
+
+func (m *recorder) RecordResource(resourceType string, obj runtime.Object) {
+	m.recordedResourceLock.Lock()
+	defer m.recordedResourceLock.Unlock()
+
+	recordedResource, ok := m.recordedResources[resourceType]
+	if !ok {
+		recordedResource = monitorapi.InstanceMap{}
+		m.recordedResources[resourceType] = recordedResource
+	}
+
+	newMetadata, err := meta.Accessor(obj)
+	if err != nil {
+		// coding error
+		panic(err)
+	}
+	key := monitorapi.InstanceKey{
+		Namespace: newMetadata.GetNamespace(),
+		Name:      newMetadata.GetName(),
+		UID:       fmt.Sprintf("%v", newMetadata.GetUID()),
+	}
+
+	toStore := obj.DeepCopyObject()
+	// without metadata, just stomp in the new value, we can't add annotations
+	if newMetadata == nil {
+		recordedResource[key] = toStore
+		return
+	}
+
+	newAnnotations := newMetadata.GetAnnotations()
+	if newAnnotations == nil {
+		newAnnotations = map[string]string{}
+	}
+	existingResource, ok := recordedResource[key]
+	if !ok {
+		if newMetadata != nil {
+			newAnnotations[monitorapi.ObservedUpdateCountAnnotation] = "1"
+			newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = "0"
+			newMetadata.SetAnnotations(newAnnotations)
+		}
+		recordedResource[key] = toStore
+		return
+	}
+
+	existingMetadata, _ := meta.Accessor(existingResource)
+	// without metadata, just stomp in the new value, we can't add annotations
+	if existingMetadata == nil {
+		recordedResource[key] = toStore
+		return
+	}
+
+	existingAnnotations := existingMetadata.GetAnnotations()
+	if existingAnnotations == nil {
+		existingAnnotations = map[string]string{}
+	}
+	existingUpdateCountStr := existingAnnotations[monitorapi.ObservedUpdateCountAnnotation]
+	if existingUpdateCount, err := strconv.ParseInt(existingUpdateCountStr, 10, 32); err != nil {
+		newAnnotations[monitorapi.ObservedUpdateCountAnnotation] = "1"
+	} else {
+		newAnnotations[monitorapi.ObservedUpdateCountAnnotation] = fmt.Sprintf("%d", existingUpdateCount+1)
+	}
+
+	// set the recreate count. increment if the UIDs don't match
+	existingRecreateCountStr := existingAnnotations[monitorapi.ObservedUpdateCountAnnotation]
+	if existingMetadata.GetUID() != newMetadata.GetUID() {
+		if existingRecreateCount, err := strconv.ParseInt(existingRecreateCountStr, 10, 32); err != nil {
+			newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = existingRecreateCountStr
+		} else {
+			newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = fmt.Sprintf("%d", existingRecreateCount+1)
+		}
+	} else {
+		newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = existingRecreateCountStr
+	}
+
+	newMetadata.SetAnnotations(newAnnotations)
+	recordedResource[key] = toStore
+	return
+}
+
+// Record captures one or more conditions at the current time. All conditions are recorded
+// in monotonic order as EventInterval objects.
+func (m *recorder) Record(conditions ...monitorapi.Condition) {
+	if len(conditions) == 0 {
+		return
+	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	t := time.Now().UTC()
+	for _, condition := range conditions {
+		m.events = append(m.events, monitorapi.EventInterval{
+			Condition: condition,
+			From:      t,
+			To:        t,
+		})
+	}
+}
+
+// AddIntervals provides a mechanism to directly inject eventIntervals
+func (m *recorder) AddIntervals(eventIntervals ...monitorapi.EventInterval) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.events = append(m.events, eventIntervals...)
+}
+
+// StartInterval inserts a record at time t with the provided condition and returns an opaque
+// locator to the interval. The caller may close the sample at any point by invoking EndInterval().
+func (m *recorder) StartInterval(t time.Time, condition monitorapi.Condition) int {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.events = append(m.events, monitorapi.EventInterval{
+		Condition: condition,
+		From:      t,
+	})
+	return len(m.events) - 1
+}
+
+// EndInterval updates the To of the interval started by StartInterval if it is greater than
+// the from.
+func (m *recorder) EndInterval(startedInterval int, t time.Time) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if startedInterval < len(m.events) {
+		if m.events[startedInterval].From.Before(t) {
+			m.events[startedInterval].To = t
+		}
+	}
+}
+
+// RecordAt captures one or more conditions at the provided time. All conditions are recorded
+// as EventInterval objects.
+func (m *recorder) RecordAt(t time.Time, conditions ...monitorapi.Condition) {
+	if len(conditions) == 0 {
+		return
+	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	for _, condition := range conditions {
+		m.events = append(m.events, monitorapi.EventInterval{
+			Condition: condition,
+			From:      t,
+			To:        t,
+		})
+	}
+}
+
+func (m *recorder) snapshot() monitorapi.Intervals {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.events
+}
+
+// Intervals returns all events that occur between from and to, including
+// any sampled conditions that were encountered during that period.
+// Intervals are returned in order of their occurrence. The returned slice
+// is a copy of the monitor's state and is safe to update.
+func (m *recorder) Intervals(from, to time.Time) monitorapi.Intervals {
+	events := m.snapshot()
+
+	intervals := mergeIntervals(events.Slice(from, to))
+
+	return intervals
+}
+
+// mergeEvents returns a sorted list of all events provided as sources. This could be
+// more efficient by requiring all sources to be sorted and then performing a zipper
+// merge.
+func mergeIntervals(sets ...monitorapi.Intervals) monitorapi.Intervals {
+	total := 0
+	for _, set := range sets {
+		total += len(set)
+	}
+	merged := make(monitorapi.Intervals, 0, total)
+	for _, set := range sets {
+		merged = append(merged, set...)
+	}
+	sort.Sort(merged)
+	return merged
+}

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -18,6 +18,11 @@ type Interface interface {
 }
 
 type Recorder interface {
+	// Intervals returns a sorted snapshot of intervals in the selected timeframe
+	Intervals(from, to time.Time) monitorapi.Intervals
+	// CurrentResourceState returns a list of all known resources of a given type at the instant called.
+	CurrentResourceState() monitorapi.ResourcesMap
+
 	// RecordResource stores a resource for later serialization.  Deletion is not tracked, so this can be used
 	// to determine the final state of resource that are deleted in a namespace.
 	// Annotations are added to indicate number of updates and the number of recreates.
@@ -26,6 +31,7 @@ type Recorder interface {
 	Record(conditions ...monitorapi.Condition)
 	RecordAt(t time.Time, conditions ...monitorapi.Condition)
 
+	AddIntervals(eventIntervals ...monitorapi.EventInterval)
 	StartInterval(t time.Time, condition monitorapi.Condition) int
 	EndInterval(startedInterval int, t time.Time)
 }

--- a/test/extended/util/disruption/backend_sampler_tester.go
+++ b/test/extended/util/disruption/backend_sampler_tester.go
@@ -22,7 +22,7 @@ type BackendSampler interface {
 	GetDisruptionBackendName() string
 	GetLocator() string
 	GetURL() (string, error)
-	RunEndpointMonitoring(ctx context.Context, m backenddisruption.Recorder, eventRecorder events.EventRecorder) error
+	RunEndpointMonitoring(ctx context.Context, monitorRecorder backenddisruption.Recorder, eventRecorder events.EventRecorder) error
 	Stop()
 }
 
@@ -144,10 +144,10 @@ func (t *backendDisruptionTest) Test(ctx context.Context, f *framework.Framework
 
 	endpointMonitoringContext, endpointMonitoringCancel := context.WithCancel(ctx)
 	defer endpointMonitoringCancel() // final backstop on closure
-	m := monitor.NewMonitor(f.ClientConfig(), nil)
+	recorder := monitor.NewRecorder()
 	disruptionErrCh := make(chan error, 1)
 	go func() {
-		err := t.backend.RunEndpointMonitoring(endpointMonitoringContext, m, eventRecorder)
+		err := t.backend.RunEndpointMonitoring(endpointMonitoringContext, recorder, eventRecorder)
 		disruptionErrCh <- err
 	}()
 	time.Sleep(1 * time.Second) // wait for some initial errors so we can fail early if it happens
@@ -180,7 +180,7 @@ func (t *backendDisruptionTest) Test(ctx context.Context, f *framework.Framework
 	end := time.Now()
 
 	fromTime, endTime := time.Time{}, time.Time{}
-	events := m.Intervals(fromTime, endTime)
+	events := recorder.Intervals(fromTime, endTime)
 	ginkgo.By(fmt.Sprintf("writing results: %s", t.backend.GetLocator()))
 	ExpectNoDisruptionForDuration(
 		f,

--- a/test/extended/util/disruption/controlplane/known_backends.go
+++ b/test/extended/util/disruption/controlplane/known_backends.go
@@ -15,68 +15,68 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func StartAllAPIMonitoring(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config, lb backend.LoadBalancerType) error {
-	if err := startKubeAPIMonitoringWithNewConnections(ctx, m, clusterConfig); err != nil {
+func StartAllAPIMonitoring(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config, lb backend.LoadBalancerType) error {
+	if err := startKubeAPIMonitoringWithNewConnections(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startKubeAPIMonitoringWithNewConnectionsAgainstAPICache(ctx, m, clusterConfig); err != nil {
+	if err := startKubeAPIMonitoringWithNewConnectionsAgainstAPICache(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startOpenShiftAPIMonitoringWithNewConnections(ctx, m, clusterConfig); err != nil {
+	if err := startOpenShiftAPIMonitoringWithNewConnections(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startOpenShiftAPIMonitoringWithNewConnectionsAgainstAPICache(ctx, m, clusterConfig); err != nil {
+	if err := startOpenShiftAPIMonitoringWithNewConnectionsAgainstAPICache(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startOAuthAPIMonitoringWithNewConnections(ctx, m, clusterConfig); err != nil {
+	if err := startOAuthAPIMonitoringWithNewConnections(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startOAuthAPIMonitoringWithNewConnectionsAgainstAPICache(ctx, m, clusterConfig); err != nil {
+	if err := startOAuthAPIMonitoringWithNewConnectionsAgainstAPICache(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startKubeAPIMonitoringWithConnectionReuse(ctx, m, clusterConfig); err != nil {
+	if err := startKubeAPIMonitoringWithConnectionReuse(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startKubeAPIMonitoringWithConnectionReuseAgainstAPICache(ctx, m, clusterConfig); err != nil {
+	if err := startKubeAPIMonitoringWithConnectionReuseAgainstAPICache(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startOpenShiftAPIMonitoringWithConnectionReuse(ctx, m, clusterConfig); err != nil {
+	if err := startOpenShiftAPIMonitoringWithConnectionReuse(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startOpenShiftAPIMonitoringWithConnectionReuseAgainstAPICache(ctx, m, clusterConfig); err != nil {
+	if err := startOpenShiftAPIMonitoringWithConnectionReuseAgainstAPICache(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startOAuthAPIMonitoringWithConnectionReuse(ctx, m, clusterConfig); err != nil {
+	if err := startOAuthAPIMonitoringWithConnectionReuse(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := startOAuthAPIMonitoringWithConnectionReuseAgainstAPICache(ctx, m, clusterConfig); err != nil {
+	if err := startOAuthAPIMonitoringWithConnectionReuseAgainstAPICache(ctx, recorder, clusterConfig); err != nil {
 		return err
 	}
-	if err := StartAPIMonitoringUsingNewBackend(ctx, m, clusterConfig, lb); err != nil {
+	if err := StartAPIMonitoringUsingNewBackend(ctx, recorder, clusterConfig, lb); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func StartAPIMonitoringUsingNewBackend(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config, lb backend.LoadBalancerType) error {
+func StartAPIMonitoringUsingNewBackend(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config, lb backend.LoadBalancerType) error {
 	factory := disruptionci.NewDisruptionTestFactory(clusterConfig)
-	if err := startKubeAPIMonitoringWithNewConnectionsHTTP2(ctx, m, factory, lb); err != nil {
+	if err := startKubeAPIMonitoringWithNewConnectionsHTTP2(ctx, recorder, factory, lb); err != nil {
 		return err
 	}
-	if err := startKubeAPIMonitoringWithConnectionReuseHTTP2(ctx, m, factory, lb); err != nil {
+	if err := startKubeAPIMonitoringWithConnectionReuseHTTP2(ctx, recorder, factory, lb); err != nil {
 		return err
 	}
-	if err := startKubeAPIMonitoringWithNewConnectionsHTTP1(ctx, m, factory, lb); err != nil {
+	if err := startKubeAPIMonitoringWithNewConnectionsHTTP1(ctx, recorder, factory, lb); err != nil {
 		return err
 	}
-	if err := startKubeAPIMonitoringWithConnectionReuseHTTP1(ctx, m, factory, lb); err != nil {
+	if err := startKubeAPIMonitoringWithConnectionReuseHTTP1(ctx, recorder, factory, lb); err != nil {
 		return err
 	}
-	if err := startOpenShiftAPIMonitoringWithNewConnectionsHTTP2(ctx, m, factory, lb); err != nil {
+	if err := startOpenShiftAPIMonitoringWithNewConnectionsHTTP2(ctx, recorder, factory, lb); err != nil {
 		return err
 	}
-	if err := startOpenShiftAPIMonitoringWithConnectionReuseHTTP2(ctx, m, factory, lb); err != nil {
+	if err := startOpenShiftAPIMonitoringWithConnectionReuseHTTP2(ctx, recorder, factory, lb); err != nil {
 		return err
 	}
 	return nil
@@ -90,148 +90,148 @@ func StartRemoteAPIMonitoring(ctx context.Context, m monitor.Recorder, clusterCo
 	return nil
 }
 
-func startKubeAPIMonitoringWithNewConnectionsHTTP2(ctx context.Context, m monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
+func startKubeAPIMonitoringWithNewConnectionsHTTP2(ctx context.Context, recorder monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
 	backendSampler, err := createKubeAPIMonitoringWithNewConnectionsHTTP2(factory, lb)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startKubeAPIMonitoringWithConnectionReuseHTTP2(ctx context.Context, m monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
+func startKubeAPIMonitoringWithConnectionReuseHTTP2(ctx context.Context, recorder monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
 	backendSampler, err := createKubeAPIMonitoringWithConnectionReuseHTTP2(factory, lb)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startKubeAPIMonitoringWithNewConnectionsHTTP1(ctx context.Context, m monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
+func startKubeAPIMonitoringWithNewConnectionsHTTP1(ctx context.Context, recorder monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
 	backendSampler, err := createKubeAPIMonitoringWithNewConnectionsHTTP1(factory, lb)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startKubeAPIMonitoringWithConnectionReuseHTTP1(ctx context.Context, m monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
+func startKubeAPIMonitoringWithConnectionReuseHTTP1(ctx context.Context, recorder monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
 	backendSampler, err := createKubeAPIMonitoringWithConnectionReuseHTTP1(factory, lb)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOpenShiftAPIMonitoringWithNewConnectionsHTTP2(ctx context.Context, m monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
+func startOpenShiftAPIMonitoringWithNewConnectionsHTTP2(ctx context.Context, recorder monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
 	backendSampler, err := createOpenShiftAPIMonitoringWithNewConnectionsHTTP2(factory, lb)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOpenShiftAPIMonitoringWithConnectionReuseHTTP2(ctx context.Context, m monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
+func startOpenShiftAPIMonitoringWithConnectionReuseHTTP2(ctx context.Context, recorder monitor.Recorder, factory disruptionci.Factory, lb backend.LoadBalancerType) error {
 	backendSampler, err := createOpenShiftAPIMonitoringWithConnectionReuseHTTP2(factory, lb)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startKubeAPIMonitoringWithNewConnections(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startKubeAPIMonitoringWithNewConnections(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createKubeAPIMonitoringWithNewConnections(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startKubeAPIMonitoringWithNewConnectionsAgainstAPICache(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startKubeAPIMonitoringWithNewConnectionsAgainstAPICache(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createKubeAPIMonitoringWithNewConnectionsAgainstAPICache(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOpenShiftAPIMonitoringWithNewConnections(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startOpenShiftAPIMonitoringWithNewConnections(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createOpenShiftAPIMonitoringWithNewConnections(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOpenShiftAPIMonitoringWithNewConnectionsAgainstAPICache(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startOpenShiftAPIMonitoringWithNewConnectionsAgainstAPICache(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createOpenShiftAPIMonitoringWithNewConnectionsAgainstAPICache(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOAuthAPIMonitoringWithNewConnections(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startOAuthAPIMonitoringWithNewConnections(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createOAuthAPIMonitoringWithNewConnections(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOAuthAPIMonitoringWithNewConnectionsAgainstAPICache(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startOAuthAPIMonitoringWithNewConnectionsAgainstAPICache(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createOAuthAPIMonitoringWithNewConnectionsAgainstAPICache(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startKubeAPIMonitoringWithConnectionReuse(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startKubeAPIMonitoringWithConnectionReuse(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createKubeAPIMonitoringWithConnectionReuse(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startKubeAPIMonitoringWithConnectionReuseAgainstAPICache(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startKubeAPIMonitoringWithConnectionReuseAgainstAPICache(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createKubeAPIMonitoringWithConnectionReuseAgainstAPICache(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOpenShiftAPIMonitoringWithConnectionReuse(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startOpenShiftAPIMonitoringWithConnectionReuse(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createOpenShiftAPIMonitoringWithConnectionReuse(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOpenShiftAPIMonitoringWithConnectionReuseAgainstAPICache(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startOpenShiftAPIMonitoringWithConnectionReuseAgainstAPICache(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createOpenShiftAPIMonitoringWithConnectionReuseAgainstAPICache(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOAuthAPIMonitoringWithConnectionReuse(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startOAuthAPIMonitoringWithConnectionReuse(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createOAuthAPIMonitoringWithConnectionReuse(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
-func startOAuthAPIMonitoringWithConnectionReuseAgainstAPICache(ctx context.Context, m monitor.Recorder, clusterConfig *rest.Config) error {
+func startOAuthAPIMonitoringWithConnectionReuseAgainstAPICache(ctx context.Context, recorder monitor.Recorder, clusterConfig *rest.Config) error {
 	backendSampler, err := createOAuthAPIMonitoringWithConnectionReuseAgainstAPICache(clusterConfig)
 	if err != nil {
 		return err
 	}
-	return backendSampler.StartEndpointMonitoring(ctx, m, nil)
+	return backendSampler.StartEndpointMonitoring(ctx, recorder, nil)
 }
 
 func createKubeAPIMonitoringWithNewConnections(clusterConfig *rest.Config) (*backenddisruption.BackendSampler, error) {


### PR DESCRIPTION
This will let us split controller duties from recording duties.  Only controllers need to have pre- and post-hooks for disruption checking.

This would potentially allow us to establish completely separate "monitors" with pre-post, but I think I'll leave those aspects combined.