### PR TITLE
[sig-kubevirt] Fix retrieval of virt-launcher pod of the guest node

### DIFF
--- a/test/extended/kubevirt/util.go
+++ b/test/extended/kubevirt/util.go
@@ -204,8 +204,9 @@ func checkConnectivityToHost(f *e2e.Framework, nodeName string, podName string, 
 }
 
 func getKubeVirtPodFromGuestNode(framework *e2e.Framework, node v1.Node) (*corev1.Pod, error) {
-
-	podList, err := framework.ClientSet.CoreV1().Pods(framework.Namespace.Name).List(context.Background(), metav1.ListOptions{})
+	podList, err := framework.ClientSet.CoreV1().Pods(framework.Namespace.Name).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "kubevirt.io=virt-launcher",
+	})
 	Expect(err).NotTo(HaveOccurred())
 	for _, pod := range podList.Items {
 		if strings.Contains(pod.Name, node.Name) {


### PR DESCRIPTION
Since the console-logger as been introduced, there is one more pod in the HCP namespace that contains the node name.
This is causing the console-logger pod to be fetched instead of the virt-launcher pod, resulting in a test failure while trying to contact the guest node.
We need to fix the filtering to get only the virt-launcher pods and then find the one that contains the node name amongst them, by the `kubevirt.io=virt-launcher` label.