### PR TITLE
STOR-1315: Add e2e workflow for Secrets Store CSI Driver

### DIFF
--- a/pkg/test/ginkgo/test_runner.go
+++ b/pkg/test/ginkgo/test_runner.go
@@ -365,7 +365,10 @@ func updateEnvVars(envs []string) []string {
 	clientConfig, _ := framework.LoadConfig(true)
 	clusterState, _ := clusterdiscovery.DiscoverClusterState(clientConfig)
 	if clusterState != nil {
-		config, _ = clusterdiscovery.LoadConfig(clusterState)
+		clusterConfig, _ := clusterdiscovery.LoadConfig(clusterState)
+		if clusterConfig != nil {
+			config = clusterConfig
+		}
 	}
 	if len(config.ProviderName) == 0 {
 		config.ProviderName = "skeleton"

--- a/test/extended/storage/csi-secret-store.go
+++ b/test/extended/storage/csi-secret-store.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8simage "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/openshift/library-go/pkg/build/naming"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	csiSecretsStoreDriver = "secrets-store.csi.k8s.io"
+	testContainerName     = "test"
+	podWaitTimeout        = 2 * time.Minute
+)
+
+var _ = g.Describe("[sig-storage][Feature:SecretsStore][Serial]", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc                     = exutil.NewCLIWithPodSecurityLevel("secrets-store-test-ns", admissionapi.LevelPrivileged)
+		ctx                    = context.Background()
+		baseDir                = exutil.FixturePath("testdata", "storage", "csi-secret-store")
+		e2eSecretProviderClass = filepath.Join(baseDir, "e2e-provider-secretproviderclass.yaml")
+	)
+
+	g.BeforeEach(func() {
+		exutil.PreTestDump()
+
+		// check if the CSIDriver exists, skip if not found
+		_, err := oc.AdminKubeClient().StorageV1().CSIDrivers().Get(ctx, csiSecretsStoreDriver, metav1.GetOptions{})
+		if err != nil {
+			g.Skip(fmt.Sprintf("CSIDriver %s not found", csiSecretsStoreDriver))
+		}
+
+		// Allow creation of privileged pods for this test.
+		// e2e-provider must be privileged to bind to a unix domain socket on the host.
+		// The test pod must be privileged to read the files created by e2e-provider.
+		g.By("adding privileged SCC to namespace")
+		sa := fmt.Sprintf("system:serviceaccount:%s:default", oc.Namespace())
+		err = oc.AsAdmin().Run("adm").Args("policy", "add-scc-to-user", "privileged", sa).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("creating e2e-provider SecretProviderClass")
+		err = oc.AsAdmin().Run("apply").Args("-f", e2eSecretProviderClass).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.AfterEach(func() {
+		if g.CurrentSpecReport().Failed() {
+			exutil.DumpPodStates(oc)
+		}
+	})
+
+	g.It("should allow pods to mount inline volumes from secret provider", func() {
+		g.By("creating test pod with inline volume")
+		pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx,
+			getTestPodWithSecretsStore(oc.Namespace()),
+			metav1.CreateOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
+
+		g.By("waiting for test pod to be ready")
+		podNameLabel := exutil.ParseLabelsOrDie("name=" + pod.Name)
+		pods, err := exutil.WaitForPods(oc.KubeClient().CoreV1().Pods(oc.Namespace()), podNameLabel, exutil.CheckPodIsReady, 1, podWaitTimeout)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(pods)).To(o.Equal(1))
+
+		g.By("checking pod log for secret value")
+		output, err := oc.AsAdmin().Run("logs").WithoutNamespace().Args("pod/"+pod.Name, "-c", testContainerName, "-n", pod.Namespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).To(o.Equal("secret"))
+	})
+})
+
+func getTestPodWithSecretsStore(namespace string) *corev1.Pod {
+	podName := naming.GetPodName("test-pod", uuid.New().String())
+	privileged := true
+	ro := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    map[string]string{"name": podName},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "default",
+			Containers: []corev1.Container{
+				{
+					Name:    testContainerName,
+					Image:   k8simage.GetE2EImage(k8simage.BusyBox),
+					Command: []string{"sh", "-c", "cat /mnt/test-vol/foo && sleep 120"},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &privileged,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "test-vol",
+							MountPath: "/mnt/test-vol",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "test-vol",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           csiSecretsStoreDriver,
+							ReadOnly:         &ro,
+							VolumeAttributes: map[string]string{"secretProviderClass": "e2e-provider"},
+						},
+					},
+				},
+			},
+		},
+	}
+	return pod
+}

--- a/test/extended/storage/csi-secret-store.go
+++ b/test/extended/storage/csi-secret-store.go
@@ -35,8 +35,6 @@ var _ = g.Describe("[sig-storage][Feature:SecretsStore][Serial]", func() {
 	)
 
 	g.BeforeEach(func() {
-		exutil.PreTestDump()
-
 		// check if the CSIDriver exists, skip if not found
 		_, err := oc.AdminKubeClient().StorageV1().CSIDrivers().Get(ctx, csiSecretsStoreDriver, metav1.GetOptions{})
 		if err != nil {

--- a/test/extended/storage/inline.go
+++ b/test/extended/storage/inline.go
@@ -39,7 +39,6 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			if !exutil.IsTechPreviewNoUpgrade(oc) {
 				g.Skip("this test is only expected to work with TechPreviewNoUpgrade clusters")
 			}
-			exutil.PreTestDump()
 
 			// create the secret to share in a new namespace
 			g.By("creating a secret")

--- a/test/extended/storage/storageclass.go
+++ b/test/extended/storage/storageclass.go
@@ -38,8 +38,6 @@ var _ = g.Describe("[sig-storage][Feature:DisableStorageClass][Serial][apigroup:
 	)
 
 	g.BeforeEach(func() {
-		exutil.PreTestDump()
-
 		// find default storage class, skip if not found
 		sc := FindDefaultStorageClass(oc)
 		if sc == nil {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -452,6 +452,7 @@
 // test/extended/testdata/service-serving-cert/nginx-serving-cert.conf
 // test/extended/testdata/signer-buildconfig.yaml
 // test/extended/testdata/stable-busybox.yaml
+// test/extended/testdata/storage/csi-secret-store/e2e-provider-secretproviderclass.yaml
 // test/extended/testdata/storage/inline/csi-sharedresourcerole.yaml
 // test/extended/testdata/storage/inline/csi-sharedresourcerolebinding.yaml
 // test/extended/testdata/storage/inline/csi-sharedsecret.yaml
@@ -50562,6 +50563,38 @@ func testExtendedTestdataStableBusyboxYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataStorageCsiSecretStoreE2eProviderSecretproviderclassYaml = []byte(`apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: e2e-provider
+spec:
+  provider: e2e-provider
+  parameters:
+    objects: |
+      array:
+        - |
+          objectName: foo
+          objectVersion: v1
+        - |
+          objectName: fookey
+          objectVersion: v1
+`)
+
+func testExtendedTestdataStorageCsiSecretStoreE2eProviderSecretproviderclassYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataStorageCsiSecretStoreE2eProviderSecretproviderclassYaml, nil
+}
+
+func testExtendedTestdataStorageCsiSecretStoreE2eProviderSecretproviderclassYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataStorageCsiSecretStoreE2eProviderSecretproviderclassYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/storage/csi-secret-store/e2e-provider-secretproviderclass.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataStorageInlineCsiSharedresourceroleYaml = []byte(`apiVersion: authorization.openshift.io/v1
 kind: Role
 metadata:
@@ -54440,6 +54473,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/service-serving-cert/nginx-serving-cert.conf":                                    testExtendedTestdataServiceServingCertNginxServingCertConf,
 	"test/extended/testdata/signer-buildconfig.yaml":                                                         testExtendedTestdataSignerBuildconfigYaml,
 	"test/extended/testdata/stable-busybox.yaml":                                                             testExtendedTestdataStableBusyboxYaml,
+	"test/extended/testdata/storage/csi-secret-store/e2e-provider-secretproviderclass.yaml":                  testExtendedTestdataStorageCsiSecretStoreE2eProviderSecretproviderclassYaml,
 	"test/extended/testdata/storage/inline/csi-sharedresourcerole.yaml":                                      testExtendedTestdataStorageInlineCsiSharedresourceroleYaml,
 	"test/extended/testdata/storage/inline/csi-sharedresourcerolebinding.yaml":                               testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYaml,
 	"test/extended/testdata/storage/inline/csi-sharedsecret.yaml":                                            testExtendedTestdataStorageInlineCsiSharedsecretYaml,
@@ -55198,6 +55232,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"signer-buildconfig.yaml": {testExtendedTestdataSignerBuildconfigYaml, map[string]*bintree{}},
 				"stable-busybox.yaml":     {testExtendedTestdataStableBusyboxYaml, map[string]*bintree{}},
 				"storage": {nil, map[string]*bintree{
+					"csi-secret-store": {nil, map[string]*bintree{
+						"e2e-provider-secretproviderclass.yaml": {testExtendedTestdataStorageCsiSecretStoreE2eProviderSecretproviderclassYaml, map[string]*bintree{}},
+					}},
 					"inline": {nil, map[string]*bintree{
 						"csi-sharedresourcerole.yaml":        {testExtendedTestdataStorageInlineCsiSharedresourceroleYaml, map[string]*bintree{}},
 						"csi-sharedresourcerolebinding.yaml": {testExtendedTestdataStorageInlineCsiSharedresourcerolebindingYaml, map[string]*bintree{}},

--- a/test/extended/testdata/storage/csi-secret-store/e2e-provider-secretproviderclass.yaml
+++ b/test/extended/testdata/storage/csi-secret-store/e2e-provider-secretproviderclass.yaml
@@ -1,0 +1,15 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: e2e-provider
+spec:
+  provider: e2e-provider
+  parameters:
+    objects: |
+      array:
+        - |
+          objectName: foo
+          objectVersion: v1
+        - |
+          objectName: fookey
+          objectVersion: v1

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1501,6 +1501,8 @@ var Annotations = map[string]string{
 
 	"[sig-storage][Feature:DisableStorageClass][Serial][apigroup:operator.openshift.io] should remove the StorageClass when StorageClassState is Removed": " [Suite:openshift/conformance/serial]",
 
+	"[sig-storage][Feature:SecretsStore][Serial] should allow pods to mount inline volumes from secret provider": " [Suite:openshift/conformance/serial]",
+
 	"[sig-storage][Late] Metrics should report short attach times": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-storage][Late] Metrics should report short mount times": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
[STOR-1315](https://issues.redhat.com//browse/STOR-1315): Add e2e workflow for Secrets Store CSI Driver

This can be tested manually with:
```
make update && make && ./openshift-tests run all --dry-run | grep SecretsStore | ./openshift-tests run -f -
```

The change in `pkg/test/ginkgo/test_runner.go` resolves a nil pointer dereference that I hit with that command where `exutilcluster.LoadConfig(clusterState)` returns nil and then we still try to dereference `config.ProviderName` a couple lines below.

This test requires a DaemonSet that is deployed as part of the workflow in https://github.com/openshift/release/pull/41655 -- but the test is skipped in `openshift-tests` if the CSIDriver does not exist.

cc @openshift/storage
