### PR TITLE
moves and renames to make the openshift-tests execution more oc-like …

### DIFF
--- a/cmd/openshift-tests/dev.go
+++ b/cmd/openshift-tests/dev.go
@@ -44,7 +44,7 @@ type alertInvariantOpts struct {
 }
 
 func newRunAlertInvariantsCommand() *cobra.Command {
-	opts := alertInvariantOpts{}
+	o := alertInvariantOpts{}
 
 	cmd := &cobra.Command{
 		Use:   "run-alert-invariants",
@@ -58,20 +58,20 @@ a running cluster.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logrus.Info("running alert invariant tests")
 
-			logrus.WithField("intervalsFile", opts.intervalsFile).Info("loading e2e intervals")
-			intervals, err := readIntervalsFromFile(opts.intervalsFile)
+			logrus.WithField("intervalsFile", o.intervalsFile).Info("loading e2e intervals")
+			intervals, err := readIntervalsFromFile(o.intervalsFile)
 			if err != nil {
 				logrus.WithError(err).Fatal("error loading intervals file")
 			}
 			logrus.Infof("loaded %d intervals", len(intervals))
 
 			jobType := &platformidentification.JobType{
-				Release:      opts.release,
-				FromRelease:  opts.fromRelease,
-				Platform:     opts.platform,
-				Architecture: opts.architecture,
-				Network:      opts.network,
-				Topology:     opts.topology,
+				Release:      o.release,
+				FromRelease:  o.fromRelease,
+				Platform:     o.platform,
+				Architecture: o.architecture,
+				Network:      o.network,
+				Topology:     o.topology,
 			}
 
 			logrus.Info("running tests")
@@ -92,31 +92,31 @@ a running cluster.
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&opts.intervalsFile,
+	cmd.Flags().StringVar(&o.intervalsFile,
 		"intervals-file", "e2e-events.json",
 		"Path to an intervals file (i.e. e2e-events_20230214-203340.json). Can be obtained from a CI run in openshift-tests junit artifacts.")
 	cmd.Flags().StringVar(
-		&opts.platform,
+		&o.platform,
 		"platform", "gcp",
 		"Platform for simulated cluster under test when intervals were gathered (aws, azure, gcp, metal, vsphere, etc)")
 	cmd.Flags().StringVar(
-		&opts.network,
+		&o.network,
 		"network", "ocp",
 		"Network plugin for simulated cluster under test when intervals were gathered")
 	cmd.Flags().StringVar(
-		&opts.release,
+		&o.release,
 		"release", "4.13",
 		"Release for simulated cluster under test when intervals were gathered")
 	cmd.Flags().StringVar(
-		&opts.fromRelease,
+		&o.fromRelease,
 		"from-release", "4.13",
 		"FromRelease simulated cluster under test was upgraded from when intervals were gathered (use \"\" for non-upgrade jobs, use matching value to --release for micro upgrades)")
 	cmd.Flags().StringVar(
-		&opts.architecture,
+		&o.architecture,
 		"arch", "amd64",
 		"Architecture for simulated cluster under test when intervals were gathered")
 	cmd.Flags().StringVar(
-		&opts.topology,
+		&o.topology,
 		"topology", "ha",
 		"Topology for simulated cluster under test when intervals were gathered (ha, single)")
 	return cmd

--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openshift/origin/pkg/synthetictests"
 	"github.com/openshift/origin/pkg/test/ginkgo"
-	exutil "github.com/openshift/origin/test/extended/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	// these register framework.NewFrameworkExtensions responsible for
@@ -64,8 +63,8 @@ func shouldSkipUntil(name string) bool {
 type testSuite struct {
 	ginkgo.TestSuite
 
-	PreSuite  func(opt *runOptions) error
-	PostSuite func(opt *runOptions)
+	PreSuite  func(opt *RunSuiteOptions) error
+	PostSuite func(opt *RunSuiteOptions)
 
 	PreTest func() error
 }
@@ -356,8 +355,8 @@ var staticSuites = testSuites{
 			SyntheticEventTests: ginkgo.JUnitForEventsFunc(synthetictests.StableSystemEventInvariants),
 		},
 		PreSuite: suiteWithKubeTestInitializationPreSuite,
-		PostSuite: func(opt *runOptions) {
-			printStorageCapabilities(opt.Out)
+		PostSuite: func(opt *RunSuiteOptions) {
+			printStorageCapabilities(opt.GinkgoRunSuiteOptions.Out)
 		},
 	},
 	{
@@ -508,41 +507,26 @@ func isStandardEarlyOrLateTest(name string) bool {
 
 // suiteWithInitializedProviderPreSuite loads the provider info, but does not
 // exclude any tests specific to that provider.
-func suiteWithInitializedProviderPreSuite(opt *runOptions) error {
-	config, err := decodeProvider(opt.Provider, opt.DryRun, true, nil)
-	if err != nil {
-		return err
-	}
-	opt.config = config
-
-	opt.Provider = config.ToJSONString()
-	return nil
+func suiteWithInitializedProviderPreSuite(o *RunSuiteOptions) error {
+	return o.SuiteWithInitializedProviderPreSuite()
 }
 
 // suiteWithProviderPreSuite ensures that the suite filters out tests from providers
 // that aren't relevant (see exutilcluster.ClusterConfig.MatchFn) by loading the
 // provider info from the cluster or flags.
-func suiteWithProviderPreSuite(opt *runOptions) error {
-	if err := suiteWithInitializedProviderPreSuite(opt); err != nil {
-		return err
-	}
-	opt.MatchFn = opt.config.MatchFn()
-	return nil
+func suiteWithProviderPreSuite(o *RunSuiteOptions) error {
+	return o.SuiteWithProviderPreSuite()
 }
 
 // suiteWithNoProviderPreSuite blocks out provider settings from being passed to
 // child tests. Used with suites that should not have cloud specific behavior.
-func suiteWithNoProviderPreSuite(opt *runOptions) error {
-	opt.Provider = `none`
-	return suiteWithProviderPreSuite(opt)
+func suiteWithNoProviderPreSuite(o *RunSuiteOptions) error {
+	return o.SuiteWithNoProviderPreSuite()
 }
 
 // suiteWithKubeTestInitialization invokes the Kube suite in order to populate
 // data from the environment for the CSI suite. Other suites should use
 // suiteWithProviderPreSuite.
-func suiteWithKubeTestInitializationPreSuite(opt *runOptions) error {
-	if err := suiteWithProviderPreSuite(opt); err != nil {
-		return err
-	}
-	return initializeTestFramework(exutil.TestContext, opt.config, opt.DryRun)
+func suiteWithKubeTestInitializationPreSuite(o *RunSuiteOptions) error {
+	return o.SuiteWithKubeTestInitializationPreSuite()
 }

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -13,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
+
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/library-go/pkg/serviceability"
 	"github.com/openshift/origin/pkg/cmd/monitor_command"
@@ -21,7 +22,6 @@ import (
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	"github.com/openshift/origin/pkg/version"
 	exutil "github.com/openshift/origin/test/extended/util"
-	"github.com/openshift/origin/test/extended/util/cluster"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -146,7 +146,7 @@ type imagesOptions struct {
 }
 
 func newImagesCommand() *cobra.Command {
-	opt := &imagesOptions{}
+	o := &imagesOptions{}
 	cmd := &cobra.Command{
 		Use:   "images",
 		Short: "Gather images required for testing",
@@ -176,11 +176,11 @@ func newImagesCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opt.Verify {
+			if o.Verify {
 				return verifyImages()
 			}
 
-			repository := opt.Repository
+			repository := o.Repository
 			var prefix string
 			for _, validPrefix := range []string{"file://", "s3://"} {
 				if strings.HasPrefix(repository, validPrefix) {
@@ -200,7 +200,7 @@ func newImagesCommand() *cobra.Command {
 			if err := verifyImages(); err != nil {
 				return err
 			}
-			lines, err := createImageMirrorForInternalImages(prefix, ref, !opt.Upstream)
+			lines, err := createImageMirrorForInternalImages(prefix, ref, !o.Upstream)
 			if err != nil {
 				return err
 			}
@@ -210,85 +210,16 @@ func newImagesCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&opt.Upstream, "upstream", opt.Upstream, "Retrieve images from the default upstream location")
-	cmd.Flags().StringVar(&opt.Repository, "to-repository", opt.Repository, "A container image repository to mirror to.")
+	cmd.Flags().BoolVar(&o.Upstream, "upstream", o.Upstream, "Retrieve images from the default upstream location")
+	cmd.Flags().StringVar(&o.Repository, "to-repository", o.Repository, "A container image repository to mirror to.")
 	// this is a private flag for debugging only
-	cmd.Flags().BoolVar(&opt.Verify, "verify", opt.Verify, "Verify the contents of the image mappings")
+	cmd.Flags().BoolVar(&o.Verify, "verify", o.Verify, "Verify the contents of the image mappings")
 	cmd.Flags().MarkHidden("verify")
 	return cmd
 }
 
-type runOptions struct {
-	*testginkgo.Options
-
-	FromRepository string
-	Provider       string
-
-	// Passed to the test process if set
-	UpgradeSuite string
-	ToImage      string
-	TestOptions  []string
-
-	// Shared by initialization code
-	config *cluster.ClusterConfiguration
-}
-
-func NewRunOptions(fromRepository string) *runOptions {
-	return &runOptions{
-		Options: testginkgo.NewOptions(os.Stdout, os.Stderr),
-
-		FromRepository: fromRepository,
-	}
-}
-
-func (opt *runOptions) AsEnv() []string {
-	var args []string
-	args = append(args, "KUBE_TEST_REPO_LIST=") // explicitly prevent selective override
-	args = append(args, fmt.Sprintf("KUBE_TEST_REPO=%s", opt.FromRepository))
-	args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", opt.Provider))
-	args = append(args, fmt.Sprintf("TEST_JUNIT_DIR=%s", opt.JUnitDir))
-	for i := 10; i > 0; i-- {
-		if klog.V(klog.Level(i)).Enabled() {
-			args = append(args, fmt.Sprintf("TEST_LOG_LEVEL=%d", i))
-			break
-		}
-	}
-
-	if len(opt.UpgradeSuite) > 0 {
-		data, err := json.Marshal(UpgradeOptions{
-			Suite:       opt.UpgradeSuite,
-			ToImage:     opt.ToImage,
-			TestOptions: opt.TestOptions,
-		})
-		if err != nil {
-			panic(err)
-		}
-		args = append(args, fmt.Sprintf("TEST_UPGRADE_OPTIONS=%s", string(data)))
-	} else {
-		args = append(args, "TEST_UPGRADE_OPTIONS=")
-	}
-
-	return args
-}
-
-func (opt *runOptions) SelectSuite(suites testSuites, args []string) (*testSuite, error) {
-	suite, err := opt.Options.SelectSuite(suites.TestSuites(), args)
-	if err != nil {
-		return nil, err
-	}
-	for i := range suites {
-		if &suites[i].TestSuite == suite {
-			return &suites[i], nil
-		}
-	}
-	if len(opt.Provider) > 0 {
-		return &testSuite{TestSuite: *suite, PreSuite: suiteWithProviderPreSuite}, nil
-	}
-	return &testSuite{TestSuite: *suite}, nil
-}
-
 func newRunCommand() *cobra.Command {
-	opt := NewRunOptions(defaultTestImageMirrorLocation)
+	o := NewRunSuiteOptions(defaultTestImageMirrorLocation)
 
 	cmd := &cobra.Command{
 		Use:   "run SUITE",
@@ -309,42 +240,42 @@ func newRunCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return mirrorToFile(opt.Options, func() error {
+			return mirrorToFile(o.GinkgoRunSuiteOptions, func() error {
 				if err := verifyImages(); err != nil {
 					return err
 				}
-				opt.SyntheticEventTests = pulledInvalidImages(opt.FromRepository)
+				o.GinkgoRunSuiteOptions.SyntheticEventTests = pulledInvalidImages(o.FromRepository)
 
-				suite, err := opt.SelectSuite(staticSuites, args)
+				suite, err := o.SelectSuite(staticSuites, args)
 				if err != nil {
 					return err
 				}
 				if suite.PreSuite != nil {
-					if err := suite.PreSuite(opt); err != nil {
+					if err := suite.PreSuite(o); err != nil {
 						return err
 					}
 				}
-				opt.CommandEnv = opt.AsEnv()
-				if !opt.DryRun {
+				o.GinkgoRunSuiteOptions.CommandEnv = o.AsEnv()
+				if !o.GinkgoRunSuiteOptions.DryRun {
 					fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 				}
-				err = opt.Run(&suite.TestSuite, "openshift-tests", false)
+				err = o.GinkgoRunSuiteOptions.Run(&suite.TestSuite, "openshift-tests", false)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Suite run returned error: %s\n", err.Error())
 				}
 				if suite.PostSuite != nil {
-					suite.PostSuite(opt)
+					suite.PostSuite(o)
 				}
 				return err
 			})
 		},
 	}
-	bindOptions(opt, cmd.Flags())
+	o.BindOptions(cmd.Flags())
 	return cmd
 }
 
 func newRunUpgradeCommand() *cobra.Command {
-	opt := NewRunOptions(defaultTestImageMirrorLocation)
+	o := NewRunSuiteOptions(defaultTestImageMirrorLocation)
 
 	cmd := &cobra.Command{
 		Use:   "run-upgrade SUITE",
@@ -371,43 +302,43 @@ func newRunUpgradeCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return mirrorToFile(opt.Options, func() error {
-				if len(opt.ToImage) == 0 {
+			return mirrorToFile(o.GinkgoRunSuiteOptions, func() error {
+				if len(o.ToImage) == 0 {
 					return fmt.Errorf("--to-image must be specified to run an upgrade test")
 				}
 				if err := verifyImages(); err != nil {
 					return err
 				}
-				opt.SyntheticEventTests = pulledInvalidImages(opt.FromRepository)
+				o.GinkgoRunSuiteOptions.SyntheticEventTests = pulledInvalidImages(o.FromRepository)
 
-				suite, err := opt.SelectSuite(upgradeSuites, args)
+				suite, err := o.SelectSuite(upgradeSuites, args)
 				if err != nil {
 					return err
 				}
-				opt.UpgradeSuite = suite.Name
+				o.UpgradeSuite = suite.Name
 				if suite.PreSuite != nil {
-					if err := suite.PreSuite(opt); err != nil {
+					if err := suite.PreSuite(o); err != nil {
 						return err
 					}
 				}
-				opt.CommandEnv = opt.AsEnv()
-				if !opt.DryRun {
+				o.GinkgoRunSuiteOptions.CommandEnv = o.AsEnv()
+				if !o.GinkgoRunSuiteOptions.DryRun {
 					fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 				}
-				err = opt.Run(&suite.TestSuite, "openshift-tests-upgrade", true)
+				err = o.GinkgoRunSuiteOptions.Run(&suite.TestSuite, "openshift-tests-upgrade", true)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Suite run returned error: %s\n", err.Error())
 				}
 				if suite.PostSuite != nil {
-					suite.PostSuite(opt)
+					suite.PostSuite(o)
 				}
 				return err
 			})
 		},
 	}
 
-	bindOptions(opt, cmd.Flags())
-	bindUpgradeOptions(opt, cmd.Flags())
+	o.BindOptions(cmd.Flags())
+	o.BindUpgradeOptions(cmd.Flags())
 	return cmd
 }
 
@@ -435,11 +366,11 @@ func newRunTestCommand() *cobra.Command {
 				return err
 			}
 
-			config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
+			config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
 			if err != nil {
 				return err
 			}
-			if err := initializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
+			if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
 				return err
 			}
 			klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
@@ -448,7 +379,12 @@ func newRunTestCommand() *cobra.Command {
 
 			// allow upgrade test to pass some parameters here, although this may be
 			// better handled as an env var within the test itself in the future
-			if err := upgradeTestPreTest(); err != nil {
+			upgradeOptionsYAML := os.Getenv("TEST_UPGRADE_OPTIONS")
+			upgradeOptions, err := NewUpgradeOptionsFromYAML(upgradeOptionsYAML)
+			if err != nil {
+				return err
+			}
+			if err := upgradeOptions.SetUpgradeGlobals(); err != nil {
 				return err
 			}
 
@@ -463,7 +399,7 @@ func newRunTestCommand() *cobra.Command {
 // mirrorToFile ensures a copy of all output goes to the provided OutFile, including
 // any error returned from fn. The function returns fn() or any error encountered while
 // attempting to open the file.
-func mirrorToFile(opt *testginkgo.Options, fn func() error) error {
+func mirrorToFile(opt *testginkgo.GinkgoRunSuiteOptions, fn func() error) error {
 	if len(opt.OutFile) == 0 {
 		return fn()
 	}
@@ -482,24 +418,4 @@ func mirrorToFile(opt *testginkgo.Options, fn func() error) error {
 		fmt.Fprintf(opt.ErrOut, "error: Unable to close output file\n")
 	}
 	return exitErr
-}
-
-func bindOptions(opt *runOptions, flags *pflag.FlagSet) {
-	flags.StringVar(&opt.FromRepository, "from-repository", opt.FromRepository, "A container image repository to retrieve test images from.")
-	flags.StringVar(&opt.Provider, "provider", opt.Provider, "The cluster infrastructure provider. Will automatically default to the correct value.")
-	bindTestOptions(opt.Options, flags)
-}
-
-func bindTestOptions(opt *testginkgo.Options, flags *pflag.FlagSet) {
-	flags.BoolVar(&opt.DryRun, "dry-run", opt.DryRun, "Print the tests to run without executing them.")
-	flags.BoolVar(&opt.PrintCommands, "print-commands", opt.PrintCommands, "Print the sub-commands that would be executed instead.")
-	flags.StringVar(&opt.JUnitDir, "junit-dir", opt.JUnitDir, "The directory to write test reports to.")
-	flags.StringVarP(&opt.TestFile, "file", "f", opt.TestFile, "Create a suite from the newline-delimited test names in this file.")
-	flags.StringVar(&opt.Regex, "run", opt.Regex, "Regular expression of tests to run.")
-	flags.StringVarP(&opt.OutFile, "output-file", "o", opt.OutFile, "Write all test output to this file.")
-	flags.IntVar(&opt.Count, "count", opt.Count, "Run each test a specified number of times. Defaults to 1 or the suite's preferred value. -1 will run forever.")
-	flags.BoolVar(&opt.FailFast, "fail-fast", opt.FailFast, "If a test fails, exit immediately.")
-	flags.DurationVar(&opt.Timeout, "timeout", opt.Timeout, "Set the maximum time a test can run before being aborted. This is read from the suite by default, but will be 10 minutes otherwise.")
-	flags.BoolVar(&opt.IncludeSuccessOutput, "include-success", opt.IncludeSuccessOutput, "Print output from successful tests.")
-	flags.IntVar(&opt.Parallelism, "max-parallel-tests", opt.Parallelism, "Maximum number of tests running in parallel. 0 defaults to test suite recommended value, which is different in each suite.")
 }

--- a/cmd/openshift-tests/runsuite_options.go
+++ b/cmd/openshift-tests/runsuite_options.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
+	"github.com/openshift/origin/pkg/test/ginkgo"
+	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
+	"github.com/openshift/origin/test/e2e/upgrade"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+type RunSuiteOptions struct {
+	GinkgoRunSuiteOptions *testginkgo.GinkgoRunSuiteOptions
+
+	FromRepository string
+	Provider       string
+
+	// Passed to the test process if set
+	UpgradeSuite string
+	ToImage      string
+	TestOptions  []string
+
+	// Shared by initialization code
+	config *clusterdiscovery.ClusterConfiguration
+}
+
+func NewRunSuiteOptions(fromRepository string) *RunSuiteOptions {
+	return &RunSuiteOptions{
+		GinkgoRunSuiteOptions: testginkgo.NewGinkgoRunSuiteOptions(os.Stdout, os.Stderr),
+
+		FromRepository: fromRepository,
+	}
+}
+
+// SuiteWithInitializedProviderPreSuite loads the provider info, but does not
+// exclude any tests specific to that provider.
+func (o *RunSuiteOptions) SuiteWithInitializedProviderPreSuite() error {
+	config, err := clusterdiscovery.DecodeProvider(o.Provider, o.GinkgoRunSuiteOptions.DryRun, true, nil)
+	if err != nil {
+		return err
+	}
+	o.config = config
+
+	o.Provider = config.ToJSONString()
+	return nil
+}
+
+// SuiteWithProviderPreSuite ensures that the suite filters out tests from providers
+// that aren't relevant (see exutilcluster.ClusterConfig.MatchFn) by loading the
+// provider info from the cluster or flags.
+func (o *RunSuiteOptions) SuiteWithProviderPreSuite() error {
+	if err := o.SuiteWithInitializedProviderPreSuite(); err != nil {
+		return err
+	}
+	o.GinkgoRunSuiteOptions.MatchFn = o.config.MatchFn()
+	return nil
+}
+
+// SuiteWithNoProviderPreSuite blocks out provider settings from being passed to
+// child tests. Used with suites that should not have cloud specific behavior.
+func (o *RunSuiteOptions) SuiteWithNoProviderPreSuite() error {
+	o.Provider = `none`
+	return o.SuiteWithProviderPreSuite()
+}
+
+// SuiteWithKubeTestInitializationPreSuite invokes the Kube suite in order to populate
+// data from the environment for the CSI suite. Other suites should use
+// suiteWithProviderPreSuite.
+func (o *RunSuiteOptions) SuiteWithKubeTestInitializationPreSuite() error {
+	if err := o.SuiteWithProviderPreSuite(); err != nil {
+		return err
+	}
+	return clusterdiscovery.InitializeTestFramework(exutil.TestContext, o.config, o.GinkgoRunSuiteOptions.DryRun)
+}
+
+func (o *RunSuiteOptions) AsEnv() []string {
+	var args []string
+	args = append(args, "KUBE_TEST_REPO_LIST=") // explicitly prevent selective override
+	args = append(args, fmt.Sprintf("KUBE_TEST_REPO=%s", o.FromRepository))
+	args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.Provider))
+	args = append(args, fmt.Sprintf("TEST_JUNIT_DIR=%s", o.GinkgoRunSuiteOptions.JUnitDir))
+	for i := 10; i > 0; i-- {
+		if klog.V(klog.Level(i)).Enabled() {
+			args = append(args, fmt.Sprintf("TEST_LOG_LEVEL=%d", i))
+			break
+		}
+	}
+
+	if len(o.UpgradeSuite) > 0 {
+		upgradeOptions := UpgradeOptions{
+			Suite:       o.UpgradeSuite,
+			ToImage:     o.ToImage,
+			TestOptions: o.TestOptions,
+		}
+		args = append(args, fmt.Sprintf("TEST_UPGRADE_OPTIONS=%s", upgradeOptions.ToEnv()))
+	} else {
+		args = append(args, "TEST_UPGRADE_OPTIONS=")
+	}
+
+	return args
+}
+
+func (o *RunSuiteOptions) SelectSuite(suites testSuites, args []string) (*testSuite, error) {
+	suite, err := o.GinkgoRunSuiteOptions.SelectSuite(suites.TestSuites(), args)
+	if err != nil {
+		return nil, err
+	}
+	for i := range suites {
+		if &suites[i].TestSuite == suite {
+			return &suites[i], nil
+		}
+	}
+	if len(o.Provider) > 0 {
+		return &testSuite{TestSuite: *suite, PreSuite: suiteWithProviderPreSuite}, nil
+	}
+	return &testSuite{TestSuite: *suite}, nil
+}
+
+func (o *RunSuiteOptions) BindOptions(flags *pflag.FlagSet) {
+	flags.StringVar(&o.FromRepository, "from-repository", o.FromRepository, "A container image repository to retrieve test images from.")
+	flags.StringVar(&o.Provider, "provider", o.Provider, "The cluster infrastructure provider. Will automatically default to the correct value.")
+	o.GinkgoRunSuiteOptions.BindTestOptions(flags)
+}
+
+func (o *RunSuiteOptions) BindUpgradeOptions(flags *pflag.FlagSet) {
+	flags.StringVar(&o.ToImage, "to-image", o.ToImage, "Specify the image to test an upgrade to.")
+	flags.StringSliceVar(&o.TestOptions, "options", o.TestOptions, "A set of KEY=VALUE options to control the test. See the help text.")
+}
+
+// UpgradeTestPreSuite validates the test options and gathers data useful prior to launching the upgrade and it's
+// related tests.
+func (o *RunSuiteOptions) UpgradeTestPreSuite() error {
+	if !o.GinkgoRunSuiteOptions.DryRun {
+		testOpt := ginkgo.NewTestOptions(os.Stdout, os.Stderr)
+		config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
+		if err != nil {
+			return err
+		}
+		if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
+			return err
+		}
+		klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
+
+		if err := upgrade.GatherPreUpgradeResourceCounts(); err != nil {
+			return errors.Wrap(err, "error gathering preupgrade resource counts")
+		}
+	}
+
+	// Upgrade test output is important for debugging because it shows linear progress
+	// and when the CVO hangs.
+	o.GinkgoRunSuiteOptions.IncludeSuccessOutput = true
+	return SetUpgradeGlobalsFromTestOptions(o.TestOptions)
+}

--- a/cmd/openshift-tests/storagecaps.go
+++ b/cmd/openshift-tests/storagecaps.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
+	"gopkg.in/yaml.v2"
 )
 
 // Manifest yaml structs
@@ -48,7 +50,7 @@ type YamlManifest struct {
 }
 
 func printStorageCapabilities(out io.Writer) {
-	manifestFilename := strings.Split(os.Getenv(manifestEnvVar), ",")[0]
+	manifestFilename := strings.Split(os.Getenv(clusterdiscovery.CSIManifestEnvVar), ",")[0]
 	if manifestFilename == "" {
 		fmt.Fprintln(out, "No manifest filename passed")
 		return

--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -10,12 +9,7 @@ import (
 	"github.com/openshift/origin/pkg/synthetictests"
 	"github.com/openshift/origin/pkg/test/ginkgo"
 	"github.com/openshift/origin/test/e2e/upgrade"
-	exutil "github.com/openshift/origin/test/extended/util"
-	"github.com/pkg/errors"
-	"github.com/spf13/pflag"
-	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/templates"
-	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
 // upgradeSuites are all known upgrade test suites this binary should run
@@ -75,27 +69,8 @@ var upgradeSuites = testSuites{
 
 // upgradeTestPreSuite validates the test options and gathers data useful prior to launching the upgrade and it's
 // related tests.
-func upgradeTestPreSuite(opt *runOptions) error {
-	if !opt.DryRun {
-		testOpt := ginkgo.NewTestOptions(os.Stdout, os.Stderr)
-		config, err := decodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
-		if err != nil {
-			return err
-		}
-		if err := initializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
-			return err
-		}
-		klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
-
-		if err := upgrade.GatherPreUpgradeResourceCounts(); err != nil {
-			return errors.Wrap(err, "error gathering preupgrade resource counts")
-		}
-	}
-
-	// Upgrade test output is important for debugging because it shows linear progress
-	// and when the CVO hangs.
-	opt.IncludeSuccessOutput = true
-	return parseUpgradeOptions(opt.TestOptions)
+func upgradeTestPreSuite(o *RunSuiteOptions) error {
+	return o.UpgradeTestPreSuite()
 }
 
 // upgradeTestPreTest uses variables set at suite execution time to prepare the upgrade
@@ -110,7 +85,7 @@ func upgradeTestPreTest() error {
 	if err := json.Unmarshal([]byte(value), &opt); err != nil {
 		return err
 	}
-	parseUpgradeOptions(opt.TestOptions)
+	SetUpgradeGlobalsFromTestOptions(opt.TestOptions)
 	upgrade.SetToImage(opt.ToImage)
 	switch opt.Suite {
 	case "none":
@@ -122,56 +97,4 @@ func upgradeTestPreTest() error {
 	default:
 		return filterUpgrade(upgrade.AllTests(), func(string) bool { return true })
 	}
-}
-
-func parseUpgradeOptions(options []string) error {
-	for _, opt := range options {
-		parts := strings.SplitN(opt, "=", 2)
-		if len(parts) != 2 {
-			return fmt.Errorf("expected option of the form KEY=VALUE instead of %q", opt)
-		}
-		switch parts[0] {
-		case "abort-at":
-			if err := upgrade.SetUpgradeAbortAt(parts[1]); err != nil {
-				return err
-			}
-		case "disrupt-reboot":
-			if err := upgrade.SetUpgradeDisruptReboot(parts[1]); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unrecognized upgrade option: %s", parts[0])
-		}
-	}
-	return nil
-}
-
-type UpgradeOptions struct {
-	Suite       string
-	ToImage     string
-	TestOptions []string
-}
-
-func (o *UpgradeOptions) ToEnv() string {
-	out, err := json.Marshal(o)
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
-}
-
-func filterUpgrade(tests []upgrades.Test, match func(string) bool) error {
-	var scope []upgrades.Test
-	for _, test := range tests {
-		if match(test.Name()) {
-			scope = append(scope, test)
-		}
-	}
-	upgrade.SetTests(scope)
-	return nil
-}
-
-func bindUpgradeOptions(opt *runOptions, flags *pflag.FlagSet) {
-	flags.StringVar(&opt.ToImage, "to-image", opt.ToImage, "Specify the image to test an upgrade to.")
-	flags.StringSliceVar(&opt.TestOptions, "options", opt.TestOptions, "A set of KEY=VALUE options to control the test. See the help text.")
 }

--- a/cmd/openshift-tests/upgrade_options.go
+++ b/cmd/openshift-tests/upgrade_options.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/openshift/origin/test/e2e/upgrade"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+)
+
+type UpgradeOptions struct {
+	Suite       string
+	ToImage     string
+	TestOptions []string
+}
+
+func NewUpgradeOptionsFromYAML(yaml string) (*UpgradeOptions, error) {
+	var opt UpgradeOptions
+	if err := json.Unmarshal([]byte(yaml), &opt); err != nil {
+		return nil, err
+	}
+	return &opt, nil
+}
+
+func (o *UpgradeOptions) ToEnv() string {
+	out, err := json.Marshal(o)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// SetUpgradeGlobals uses variables set at suite execution time to prepare the upgrade
+// test environment in process (setting constants in the upgrade packages).
+func (o *UpgradeOptions) SetUpgradeGlobals() error {
+	if err := SetUpgradeGlobalsFromTestOptions(o.TestOptions); err != nil {
+		return err
+	}
+
+	upgrade.SetToImage(o.ToImage)
+	switch o.Suite {
+	case "none":
+		return filterUpgrade(upgrade.NoTests(), func(string) bool { return true })
+	case "platform":
+		return filterUpgrade(upgrade.AllTests(), func(name string) bool {
+			return false
+		})
+	default:
+		return filterUpgrade(upgrade.AllTests(), func(string) bool { return true })
+	}
+}
+
+func filterUpgrade(tests []upgrades.Test, match func(string) bool) error {
+	var scope []upgrades.Test
+	for _, test := range tests {
+		if match(test.Name()) {
+			scope = append(scope, test)
+		}
+	}
+	upgrade.SetTests(scope)
+	return nil
+}
+
+func SetUpgradeGlobalsFromTestOptions(testOptions []string) error {
+	for _, opt := range testOptions {
+		parts := strings.SplitN(opt, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("expected option of the form KEY=VALUE instead of %q", opt)
+		}
+		switch parts[0] {
+		case "abort-at":
+			if err := upgrade.SetUpgradeAbortAt(parts[1]); err != nil {
+				return err
+			}
+		case "disrupt-reboot":
+			if err := upgrade.SetUpgradeDisruptReboot(parts[1]); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unrecognized upgrade option: %s", parts[0])
+		}
+	}
+	return nil
+}

--- a/pkg/clioptions/clusterdiscovery/cluster.go
+++ b/pkg/clioptions/clusterdiscovery/cluster.go
@@ -1,4 +1,4 @@
-package cluster
+package clusterdiscovery
 
 import (
 	"context"
@@ -319,21 +319,4 @@ func (c *ClusterConfiguration) MatchFn() func(string) bool {
 		return true
 	}
 	return matchFn
-}
-
-func HasCapability(clusterVersion *configv1.ClusterVersion, desiredCapability string) bool {
-	for _, ec := range clusterVersion.Status.Capabilities.EnabledCapabilities {
-		if string(ec) == desiredCapability {
-			return true
-		}
-	}
-	return false
-}
-func KnowsCapability(clusterVersion *configv1.ClusterVersion, desiredCapability string) bool {
-	for _, ec := range clusterVersion.Status.Capabilities.KnownCapabilities {
-		if string(ec) == desiredCapability {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/clioptions/clusterdiscovery/csi.go
+++ b/pkg/clioptions/clusterdiscovery/csi.go
@@ -1,4 +1,4 @@
-package main
+package clusterdiscovery
 
 import (
 	"fmt"
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	manifestEnvVar = "TEST_CSI_DRIVER_FILES"
+	CSIManifestEnvVar = "TEST_CSI_DRIVER_FILES"
 )
 
 // Initialize openshift/csi suite, i.e. define CSI tests from TEST_CSI_DRIVER_FILES.
 func initCSITests(dryRun bool) error {
-	manifestList := os.Getenv(manifestEnvVar)
+	manifestList := os.Getenv(CSIManifestEnvVar)
 	if manifestList != "" {
 		manifests := strings.Split(manifestList, ",")
 		for _, manifest := range manifests {

--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -1,4 +1,4 @@
-package main
+package clusterdiscovery
 
 import (
 	"encoding/json"
@@ -11,8 +11,6 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
-	exutilcluster "github.com/openshift/origin/test/extended/util/cluster"
-
 	// Initialize baremetal as a provider
 	_ "github.com/openshift/origin/test/extended/util/baremetal"
 
@@ -33,7 +31,7 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/lifecycle"
 )
 
-func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster.ClusterConfiguration, dryRun bool) error {
+func InitializeTestFramework(context *e2e.TestContextType, config *ClusterConfiguration, dryRun bool) error {
 	// update context with loaded config
 	context.Provider = config.ProviderName
 	context.CloudConfig = e2e.CloudConfig{
@@ -75,10 +73,10 @@ func initializeTestFramework(context *e2e.TestContextType, config *exutilcluster
 	return nil
 }
 
-func decodeProvider(provider string, dryRun, discover bool, clusterState *exutilcluster.ClusterState) (*exutilcluster.ClusterConfiguration, error) {
+func DecodeProvider(provider string, dryRun, discover bool, clusterState *ClusterState) (*ClusterConfiguration, error) {
 	switch provider {
 	case "none":
-		config := &exutilcluster.ClusterConfiguration{
+		config := &ClusterConfiguration{
 			ProviderName: "skeleton",
 		}
 		// Add NoOptionalCapabilities for MicroShift
@@ -99,11 +97,11 @@ func decodeProvider(provider string, dryRun, discover bool, clusterState *exutil
 	case "":
 		if _, ok := os.LookupEnv("KUBE_SSH_USER"); ok {
 			if _, ok := os.LookupEnv("LOCAL_SSH_KEY"); ok {
-				return &exutilcluster.ClusterConfiguration{ProviderName: "local"}, nil
+				return &ClusterConfiguration{ProviderName: "local"}, nil
 			}
 		}
 		if dryRun {
-			return &exutilcluster.ClusterConfiguration{ProviderName: "skeleton"}, nil
+			return &ClusterConfiguration{ProviderName: "skeleton"}, nil
 		}
 		fallthrough
 
@@ -113,12 +111,12 @@ func decodeProvider(provider string, dryRun, discover bool, clusterState *exutil
 			if err != nil {
 				return nil, err
 			}
-			clusterState, err = exutilcluster.DiscoverClusterState(clientConfig)
+			clusterState, err = DiscoverClusterState(clientConfig)
 			if err != nil {
 				return nil, err
 			}
 		}
-		config, err := exutilcluster.LoadConfig(clusterState)
+		config, err := LoadConfig(clusterState)
 		if err != nil {
 			return nil, err
 		}
@@ -137,19 +135,19 @@ func decodeProvider(provider string, dryRun, discover bool, clusterState *exutil
 		if len(providerInfo.Type) == 0 {
 			return nil, fmt.Errorf("provider must be a JSON object with the 'type' key")
 		}
-		var config *exutilcluster.ClusterConfiguration
+		var config *ClusterConfiguration
 		if discover {
 			if clusterState == nil {
 				if clientConfig, err := e2e.LoadConfig(true); err == nil {
-					clusterState, _ = exutilcluster.DiscoverClusterState(clientConfig)
+					clusterState, _ = DiscoverClusterState(clientConfig)
 				}
 			}
 			if clusterState != nil {
-				config, _ = exutilcluster.LoadConfig(clusterState)
+				config, _ = LoadConfig(clusterState)
 			}
 		}
 		if config == nil {
-			config = &exutilcluster.ClusterConfiguration{}
+			config = &ClusterConfiguration{}
 		}
 
 		if err := json.Unmarshal([]byte(provider), config); err != nil {

--- a/pkg/clioptions/clusterdiscovery/provider_test.go
+++ b/pkg/clioptions/clusterdiscovery/provider_test.go
@@ -1,4 +1,4 @@
-package main
+package clusterdiscovery
 
 import (
 	"net/url"
@@ -7,7 +7,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	exutilcluster "github.com/openshift/origin/test/extended/util/cluster"
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
@@ -280,18 +279,18 @@ func TestDecodeProvider(t *testing.T) {
 		},
 	}
 
-	// Unset these to keep decodeProvider from returning "local"
+	// Unset these to keep DecodeProvider from returning "local"
 	os.Unsetenv("KUBE_SSH_USER")
 	os.Unsetenv("LOCAL_SSH_KEY")
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			discover := tc.discoveredPlatform != nil
-			var testState *exutilcluster.ClusterState
+			var testState *ClusterState
 			if discover {
 				topology := configv1.HighlyAvailableTopologyMode
 				testURL, _ := url.Parse("https://example.com")
-				testState = &exutilcluster.ClusterState{
+				testState = &ClusterState{
 					PlatformStatus:       tc.discoveredPlatform,
 					Masters:              tc.discoveredMasters,
 					NonMasters:           nonMasters,
@@ -301,7 +300,7 @@ func TestDecodeProvider(t *testing.T) {
 					OptionalCapabilities: tc.optionalCapabilities,
 				}
 			}
-			config, err := decodeProvider(tc.provider, false, discover, testState)
+			config, err := DecodeProvider(tc.provider, false, discover, testState)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -35,9 +36,9 @@ const (
 	postUpgradeEvent = "PostUpgrade"
 )
 
-// Options is used to run a suite of tests by invoking each test
+// GinkgoRunSuiteOptions is used to run a suite of tests by invoking each test
 // as a call to a child worker (the run-tests command).
-type Options struct {
+type GinkgoRunSuiteOptions struct {
 	Parallelism int
 	Count       int
 	FailFast    bool
@@ -68,32 +69,46 @@ type Options struct {
 	StartTime time.Time
 }
 
-func NewOptions(out io.Writer, errOut io.Writer) *Options {
-	return &Options{
+func NewGinkgoRunSuiteOptions(out io.Writer, errOut io.Writer) *GinkgoRunSuiteOptions {
+	return &GinkgoRunSuiteOptions{
 		MonitorEventsOptions: NewMonitorEventsOptions(out, errOut),
 		Out:                  out,
 		ErrOut:               errOut,
 	}
 }
 
-func (opt *Options) AsEnv() []string {
+func (o *GinkgoRunSuiteOptions) BindTestOptions(flags *pflag.FlagSet) {
+	flags.BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print the tests to run without executing them.")
+	flags.BoolVar(&o.PrintCommands, "print-commands", o.PrintCommands, "Print the sub-commands that would be executed instead.")
+	flags.StringVar(&o.JUnitDir, "junit-dir", o.JUnitDir, "The directory to write test reports to.")
+	flags.StringVarP(&o.TestFile, "file", "f", o.TestFile, "Create a suite from the newline-delimited test names in this file.")
+	flags.StringVar(&o.Regex, "run", o.Regex, "Regular expression of tests to run.")
+	flags.StringVarP(&o.OutFile, "output-file", "o", o.OutFile, "Write all test output to this file.")
+	flags.IntVar(&o.Count, "count", o.Count, "Run each test a specified number of times. Defaults to 1 or the suite's preferred value. -1 will run forever.")
+	flags.BoolVar(&o.FailFast, "fail-fast", o.FailFast, "If a test fails, exit immediately.")
+	flags.DurationVar(&o.Timeout, "timeout", o.Timeout, "Set the maximum time a test can run before being aborted. This is read from the suite by default, but will be 10 minutes otherwise.")
+	flags.BoolVar(&o.IncludeSuccessOutput, "include-success", o.IncludeSuccessOutput, "Print output from successful tests.")
+	flags.IntVar(&o.Parallelism, "max-parallel-tests", o.Parallelism, "Maximum number of tests running in parallel. 0 defaults to test suite recommended value, which is different in each suite.")
+}
+
+func (o *GinkgoRunSuiteOptions) AsEnv() []string {
 	var args []string
-	args = append(args, fmt.Sprintf("TEST_SUITE_START_TIME=%d", opt.StartTime.Unix()))
-	args = append(args, opt.CommandEnv...)
+	args = append(args, fmt.Sprintf("TEST_SUITE_START_TIME=%d", o.StartTime.Unix()))
+	args = append(args, o.CommandEnv...)
 	return args
 }
 
-func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite, error) {
+func (o *GinkgoRunSuiteOptions) SelectSuite(suites []*TestSuite, args []string) (*TestSuite, error) {
 	var suite *TestSuite
 
 	// If a test file was provided with no suite, use the "files" suite.
-	if len(opt.TestFile) > 0 && len(args) == 0 {
+	if len(o.TestFile) > 0 && len(args) == 0 {
 		suite = &TestSuite{
 			Name: "files",
 		}
 	}
 	if suite == nil && len(args) == 0 {
-		fmt.Fprintf(opt.ErrOut, SuitesString(suites, "Select a test suite to run against the server:\n\n"))
+		fmt.Fprintf(o.ErrOut, SuitesString(suites, "Select a test suite to run against the server:\n\n"))
 		return nil, fmt.Errorf("specify a test suite to run, for example: %s run %s", filepath.Base(os.Args[0]), suites[0].Name)
 	}
 	if suite == nil && len(args) > 0 {
@@ -105,21 +120,21 @@ func (opt *Options) SelectSuite(suites []*TestSuite, args []string) (*TestSuite,
 		}
 	}
 	if suite == nil {
-		fmt.Fprintf(opt.ErrOut, SuitesString(suites, "Select a test suite to run against the server:\n\n"))
+		fmt.Fprintf(o.ErrOut, SuitesString(suites, "Select a test suite to run against the server:\n\n"))
 		return nil, fmt.Errorf("suite %q does not exist", args[0])
 	}
 	// If a test file was provided, override the Matches function
 	// to match the tests from both the suite and the file.
-	if len(opt.TestFile) > 0 {
+	if len(o.TestFile) > 0 {
 		var in []byte
 		var err error
-		if opt.TestFile == "-" {
+		if o.TestFile == "-" {
 			in, err = ioutil.ReadAll(os.Stdin)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			in, err = ioutil.ReadFile(opt.TestFile)
+			in, err = ioutil.ReadFile(o.TestFile)
 		}
 		if err != nil {
 			return nil, err
@@ -139,23 +154,23 @@ func max(a, b int) int {
 	return b
 }
 
-func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) error {
+func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, upgrade bool) error {
 	ctx := context.Background()
 
-	if len(opt.Regex) > 0 {
-		if err := filterWithRegex(suite, opt.Regex); err != nil {
+	if len(o.Regex) > 0 {
+		if err := filterWithRegex(suite, o.Regex); err != nil {
 			return err
 		}
 	}
-	if opt.MatchFn != nil {
+	if o.MatchFn != nil {
 		original := suite.Matches
 		suite.Matches = func(name string) bool {
-			return original(name) && opt.MatchFn(name)
+			return original(name) && o.MatchFn(name)
 		}
 	}
 
 	syntheticEventTests := JUnitsForAllEvents{
-		opt.SyntheticEventTests,
+		o.SyntheticEventTests,
 		suite.SyntheticEventTests,
 	}
 
@@ -196,13 +211,13 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 				},
 			})
 		}
-		fmt.Fprintf(opt.Out, buf.String())
+		fmt.Fprintf(o.Out, buf.String())
 		fallbackSyntheticTestResult = append(fallbackSyntheticTestResult, &junitapi.JUnitTestCase{
 			Name:      "[sig-arch] External binary usage",
 			SystemOut: buf.String(),
 		})
 	} else {
-		fmt.Fprintf(opt.Out, "Using built-in tests only due to OPENSHIFT_SKIP_EXTERNAL_TESTS being set\n")
+		fmt.Fprintf(o.Out, "Using built-in tests only due to OPENSHIFT_SKIP_EXTERNAL_TESTS being set\n")
 	}
 
 	// this ensures the tests are always run in random order to avoid
@@ -213,15 +228,15 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 
 	discoveryClient, err := getDiscoveryClient()
 	if err != nil {
-		if opt.DryRun {
-			fmt.Fprintf(opt.ErrOut, "Unable to get discovery client, skipping apigroup check in the dry-run mode: %v\n", err)
+		if o.DryRun {
+			fmt.Fprintf(o.ErrOut, "Unable to get discovery client, skipping apigroup check in the dry-run mode: %v\n", err)
 		} else {
 			return err
 		}
 	} else {
 		if _, err := discoveryClient.ServerVersion(); err != nil {
-			if opt.DryRun {
-				fmt.Fprintf(opt.ErrOut, "Unable to get server version through discovery client, skipping apigroup check in the dry-run mode: %v\n", err)
+			if o.DryRun {
+				fmt.Fprintf(o.ErrOut, "Unable to get server version through discovery client, skipping apigroup check in the dry-run mode: %v\n", err)
 			} else {
 				return err
 			}
@@ -243,17 +258,17 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 		return fmt.Errorf("suite %q does not contain any tests", suite.Name)
 	}
 
-	count := opt.Count
+	count := o.Count
 	if count == 0 {
 		count = suite.Count
 	}
 
 	start := time.Now()
-	if opt.StartTime.IsZero() {
-		opt.StartTime = start
+	if o.StartTime.IsZero() {
+		o.StartTime = start
 	}
 
-	timeout := opt.Timeout
+	timeout := o.Timeout
 	if timeout == 0 {
 		timeout = suite.TestTimeout
 	}
@@ -261,31 +276,31 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 		timeout = 15 * time.Minute
 	}
 
-	testRunnerContext := newCommandContext(opt.AsEnv(), timeout)
+	testRunnerContext := newCommandContext(o.AsEnv(), timeout)
 
-	if opt.PrintCommands {
-		newParallelTestQueue(testRunnerContext).OutputCommands(ctx, tests, opt.Out)
+	if o.PrintCommands {
+		newParallelTestQueue(testRunnerContext).OutputCommands(ctx, tests, o.Out)
 		return nil
 	}
-	if opt.DryRun {
+	if o.DryRun {
 		for _, test := range sortedTests(tests) {
-			fmt.Fprintf(opt.Out, "%q\n", test.name)
+			fmt.Fprintf(o.Out, "%q\n", test.name)
 		}
 		return nil
 	}
 
-	if len(opt.JUnitDir) > 0 {
-		if _, err := os.Stat(opt.JUnitDir); err != nil {
+	if len(o.JUnitDir) > 0 {
+		if _, err := os.Stat(o.JUnitDir); err != nil {
 			if !os.IsNotExist(err) {
 				return fmt.Errorf("could not access --junit-dir: %v", err)
 			}
-			if err := os.MkdirAll(opt.JUnitDir, 0755); err != nil {
+			if err := os.MkdirAll(o.JUnitDir, 0755); err != nil {
 				return fmt.Errorf("could not create --junit-dir: %v", err)
 			}
 		}
 	}
 
-	parallelism := opt.Parallelism
+	parallelism := o.Parallelism
 	if parallelism == 0 {
 		parallelism = suite.Parallelism
 	}
@@ -303,11 +318,11 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 	abortCh := make(chan os.Signal, 2)
 	go func() {
 		<-abortCh
-		fmt.Fprintf(opt.ErrOut, "Interrupted, terminating tests\n")
+		fmt.Fprintf(o.ErrOut, "Interrupted, terminating tests\n")
 		sampler.TearDownInClusterMonitors(restConfig)
 		cancelFn()
 		sig := <-abortCh
-		fmt.Fprintf(opt.ErrOut, "Interrupted twice, exiting (%s)\n", sig)
+		fmt.Fprintf(o.ErrOut, "Interrupted twice, exiting (%s)\n", sig)
 		switch sig {
 		case syscall.SIGINT:
 			os.Exit(130)
@@ -317,7 +332,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 	}()
 	signal.Notify(abortCh, syscall.SIGINT, syscall.SIGTERM)
 
-	monitorEventRecorder, err := opt.MonitorEventsOptions.Start(ctx, restConfig)
+	monitorEventRecorder, err := o.MonitorEventsOptions.Start(ctx, restConfig)
 	if err != nil {
 		return err
 	}
@@ -331,12 +346,12 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 	pc.Run(ctx)
 
 	// if we run a single test, always include success output
-	includeSuccess := opt.IncludeSuccessOutput
+	includeSuccess := o.IncludeSuccessOutput
 	if len(tests) == 1 && count == 1 {
 		includeSuccess = true
 	}
 	testOutputLock := &sync.Mutex{}
-	testOutputConfig := newTestOutputConfig(testOutputLock, opt.Out, monitorEventRecorder, includeSuccess)
+	testOutputConfig := newTestOutputConfig(testOutputLock, o.Out, monitorEventRecorder, includeSuccess)
 
 	early, notEarly := splitTests(tests, func(t *testCase) bool {
 		return strings.Contains(t.name, "[Early]")
@@ -377,7 +392,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 
 	abortFn := neverAbort
 	testCtx := ctx
-	if opt.FailFast {
+	if o.FailFast {
 		abortFn, testCtx = abortOnFailure(ctx)
 	}
 
@@ -421,19 +436,19 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 	tests = append(tests, late...)
 
 	// TODO: will move to the monitor
-	if len(opt.JUnitDir) > 0 {
+	if len(o.JUnitDir) > 0 {
 		pc.ComputePodTransitions()
 		data, err := pc.JsonDump()
 		if err != nil {
-			fmt.Fprintf(opt.ErrOut, "Unable to dump pod placement data: %v\n", err)
+			fmt.Fprintf(o.ErrOut, "Unable to dump pod placement data: %v\n", err)
 		} else {
-			if err := ioutil.WriteFile(filepath.Join(opt.JUnitDir, "pod-placement-data.json"), data, 0644); err != nil {
-				fmt.Fprintf(opt.ErrOut, "Unable to write pod placement data: %v\n", err)
+			if err := ioutil.WriteFile(filepath.Join(o.JUnitDir, "pod-placement-data.json"), data, 0644); err != nil {
+				fmt.Fprintf(o.ErrOut, "Unable to write pod placement data: %v\n", err)
 			}
 		}
 		chains := pc.PodDisplacements().Dump(minChainLen)
-		if err := ioutil.WriteFile(filepath.Join(opt.JUnitDir, "pod-transitions.txt"), []byte(chains), 0644); err != nil {
-			fmt.Fprintf(opt.ErrOut, "Unable to write pod placement data: %v\n", err)
+		if err := ioutil.WriteFile(filepath.Join(o.JUnitDir, "pod-transitions.txt"), []byte(chains), 0644); err != nil {
+			fmt.Fprintf(o.ErrOut, "Unable to write pod placement data: %v\n", err)
 		}
 	}
 
@@ -462,7 +477,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 			}
 		}
 
-		fmt.Fprintf(opt.Out, "Retry count: %d\n", len(retries))
+		fmt.Fprintf(o.Out, "Retry count: %d\n", len(retries))
 
 		// Run the tests in the retries list.
 		q := newParallelTestQueue(testRunnerContext)
@@ -484,7 +499,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 		for _, retry := range retries {
 			if retry.flake {
 				// Retry tests that flaked are omitted so that the original test is counted as a failure.
-				fmt.Fprintf(opt.Out, "Ignoring retry that returned a flake, original failure is authoritative for test: %s\n", retry.name)
+				fmt.Fprintf(o.Out, "Ignoring retry that returned a flake, original failure is authoritative for test: %s\n", retry.name)
 				continue
 			}
 			tests = append(tests, retry)
@@ -492,7 +507,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 		if len(flaky) > 0 {
 			failing = repeatFailures
 			sort.Strings(flaky)
-			fmt.Fprintf(opt.Out, "Flaky tests:\n\n%s\n\n", strings.Join(flaky, "\n"))
+			fmt.Fprintf(o.Out, "Flaky tests:\n\n%s\n\n", strings.Join(flaky, "\n"))
 		}
 		if len(skipped) > 0 {
 			// If a retry test got skipped, it means we very likely failed a precondition in the first failure, so
@@ -510,7 +525,7 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 			tests = withoutPreconditionFailures
 			failing = repeatFailures
 			sort.Strings(skipped)
-			fmt.Fprintf(opt.Out, "Skipped tests that failed a precondition:\n\n%s\n\n", strings.Join(skipped, "\n"))
+			fmt.Fprintf(o.Out, "Skipped tests that failed a precondition:\n\n%s\n\n", strings.Join(skipped, "\n"))
 
 		}
 	}
@@ -524,24 +539,24 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 	var syntheticTestResults []*junitapi.JUnitTestCase
 	var syntheticFailure bool
 
-	timeSuffix := fmt.Sprintf("_%s", opt.MonitorEventsOptions.GetStartTime().
+	timeSuffix := fmt.Sprintf("_%s", o.MonitorEventsOptions.GetStartTime().
 		UTC().Format("20060102-150405"))
 
-	if err := opt.MonitorEventsOptions.End(ctx, restConfig, opt.JUnitDir); err != nil {
+	if err := o.MonitorEventsOptions.End(ctx, restConfig, o.JUnitDir); err != nil {
 		return err
 	}
-	if len(opt.JUnitDir) > 0 {
-		if err := opt.MonitorEventsOptions.WriteRunDataToArtifactsDir(opt.JUnitDir, timeSuffix); err != nil {
-			fmt.Fprintf(opt.ErrOut, "error: Failed to write run-data: %v\n", err)
+	if len(o.JUnitDir) > 0 {
+		if err := o.MonitorEventsOptions.WriteRunDataToArtifactsDir(o.JUnitDir, timeSuffix); err != nil {
+			fmt.Fprintf(o.ErrOut, "error: Failed to write run-data: %v\n", err)
 		}
 	}
 
 	// default is empty string as that is what entries prior to adding this will have
 	wasMasterNodeUpdated := ""
-	if events := opt.MonitorEventsOptions.GetEvents(); len(events) > 0 {
+	if events := o.MonitorEventsOptions.GetEvents(); len(events) > 0 {
 		var buf *bytes.Buffer
 		syntheticTestResults, buf, _ = createSyntheticTestsFromMonitor(events, duration)
-		currResState := opt.MonitorEventsOptions.GetRecordedResources()
+		currResState := o.MonitorEventsOptions.GetRecordedResources()
 		testCases := syntheticEventTests.JUnitsForEvents(events, duration, restConfig, suite.Name, &currResState)
 		syntheticTestResults = append(syntheticTestResults, testCases...)
 		if !upgrade {
@@ -578,10 +593,10 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 		}
 
 		// we only write the buffer if we have an artifact location
-		if len(opt.JUnitDir) > 0 {
-			filename := fmt.Sprintf("openshift-tests-monitor_%s.txt", opt.StartTime.UTC().Format("20060102-150405"))
-			if err := ioutil.WriteFile(filepath.Join(opt.JUnitDir, filename), buf.Bytes(), 0644); err != nil {
-				fmt.Fprintf(opt.ErrOut, "error: Failed to write monitor data: %v\n", err)
+		if len(o.JUnitDir) > 0 {
+			filename := fmt.Sprintf("openshift-tests-monitor_%s.txt", o.StartTime.UTC().Format("20060102-150405"))
+			if err := ioutil.WriteFile(filepath.Join(o.JUnitDir, filename), buf.Bytes(), 0644); err != nil {
+				fmt.Fprintf(o.ErrOut, "error: Failed to write monitor data: %v\n", err)
 			}
 		}
 
@@ -591,17 +606,17 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 	// report the outcome of the test
 	if len(failing) > 0 {
 		names := sets.NewString(testNames(failing)...).List()
-		fmt.Fprintf(opt.Out, "Failing tests:\n\n%s\n\n", strings.Join(names, "\n"))
+		fmt.Fprintf(o.Out, "Failing tests:\n\n%s\n\n", strings.Join(names, "\n"))
 	}
 
-	if len(opt.JUnitDir) > 0 {
+	if len(o.JUnitDir) > 0 {
 		finalSuiteResults := generateJUnitTestSuiteResults(junitSuiteName, duration, tests, syntheticTestResults...)
-		if err := writeJUnitReport(finalSuiteResults, "junit_e2e", timeSuffix, opt.JUnitDir, opt.ErrOut); err != nil {
-			fmt.Fprintf(opt.Out, "error: Unable to write e2e JUnit xml results: %v", err)
+		if err := writeJUnitReport(finalSuiteResults, "junit_e2e", timeSuffix, o.JUnitDir, o.ErrOut); err != nil {
+			fmt.Fprintf(o.Out, "error: Unable to write e2e JUnit xml results: %v", err)
 		}
 
-		if err := riskanalysis.WriteJobRunTestFailureSummary(opt.JUnitDir, timeSuffix, finalSuiteResults, wasMasterNodeUpdated); err != nil {
-			fmt.Fprintf(opt.Out, "error: Unable to write e2e job run failures summary: %v", err)
+		if err := riskanalysis.WriteJobRunTestFailureSummary(o.JUnitDir, timeSuffix, finalSuiteResults, wasMasterNodeUpdated); err != nil {
+			fmt.Fprintf(o.Out, "error: Unable to write e2e job run failures summary: %v", err)
 		}
 	}
 
@@ -609,13 +624,13 @@ func (opt *Options) Run(suite *TestSuite, junitSuiteName string, upgrade bool) e
 		if len(failing) > 0 || suite.MaximumAllowedFlakes == 0 {
 			return fmt.Errorf("%d fail, %d pass, %d skip (%s)", fail, pass, skip, duration)
 		}
-		fmt.Fprintf(opt.Out, "%d flakes detected, suite allows passing with only flakes\n\n", fail)
+		fmt.Fprintf(o.Out, "%d flakes detected, suite allows passing with only flakes\n\n", fail)
 	}
 
 	if syntheticFailure {
 		return fmt.Errorf("failed because an invariant was violated, %d pass, %d skip (%s)\n", pass, skip, duration)
 	}
 
-	fmt.Fprintf(opt.Out, "%d pass, %d skip (%s)\n", pass, skip, duration)
+	fmt.Fprintf(o.Out, "%d pass, %d skip (%s)\n", pass, skip, duration)
 	return ctx.Err()
 }

--- a/pkg/test/ginkgo/test_runner.go
+++ b/pkg/test/ginkgo/test_runner.go
@@ -13,11 +13,10 @@ import (
 	"syscall"
 	"time"
 
-	"k8s.io/kubernetes/test/e2e/framework"
-
+	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
-	exutilcluster "github.com/openshift/origin/test/extended/util/cluster"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 type testSuiteRunner interface {
@@ -362,11 +361,11 @@ func updateEnvVars(envs []string) []string {
 	}
 	// copied from provider.go
 	// TODO: add error handling, and maybe turn this into sharable helper?
-	config := &exutilcluster.ClusterConfiguration{}
+	config := &clusterdiscovery.ClusterConfiguration{}
 	clientConfig, _ := framework.LoadConfig(true)
-	clusterState, _ := exutilcluster.DiscoverClusterState(clientConfig)
+	clusterState, _ := clusterdiscovery.DiscoverClusterState(clientConfig)
 	if clusterState != nil {
-		config, _ = exutilcluster.LoadConfig(clusterState)
+		config, _ = clusterdiscovery.LoadConfig(clusterState)
 	}
 	if len(config.ProviderName) == 0 {
 		config.ProviderName = "skeleton"

--- a/test/extended/cli/help.go
+++ b/test/extended/cli/help.go
@@ -28,8 +28,8 @@ var _ = g.Describe("[sig-cli] oc help", func() {
 		out := string(stdout)
 		o.Expect(out).To(o.ContainSubstring("Build and Deploy Commands:"))
 		o.Expect(out).To(o.ContainSubstring("Other Commands:"))
-		o.Expect(out).NotTo(o.ContainSubstring("Options"))
-		o.Expect(out).NotTo(o.ContainSubstring("Global Options"))
+		o.Expect(out).NotTo(o.ContainSubstring("RunSuiteOptions"))
+		o.Expect(out).NotTo(o.ContainSubstring("Global RunSuiteOptions"))
 
 		stdout, err = exec.Command("oc", "--help").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -54,8 +54,8 @@ var _ = g.Describe("[sig-cli] oc help", func() {
 		// help for root commands with --help flag must be consistent
 		out, err = oc.Run("login").Args("--help").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("Options"))
-		o.Expect(out).NotTo(o.ContainSubstring("Global Options"))
+		o.Expect(out).To(o.ContainSubstring("RunSuiteOptions"))
+		o.Expect(out).NotTo(o.ContainSubstring("Global RunSuiteOptions"))
 		o.Expect(out).To(o.ContainSubstring("insecure-skip-tls-verify"))
 
 		// help for given command with --help flag must be consistent

--- a/test/extended/oauth/server_headers.go
+++ b/test/extended/oauth/server_headers.go
@@ -55,14 +55,14 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers][apigroup:route.ope
 			allHeaders := http.Header{}
 			for key, val := range map[string]string{
 				// security related headers that we really care about, should not change
-				"Cache-Control":          "no-cache, no-store, max-age=0, must-revalidate",
-				"Pragma":                 "no-cache",
-				"Expires":                "0",
-				"Referrer-Policy":        "strict-origin-when-cross-origin",
-				"X-Frame-Options":        "DENY",
-				"X-Content-Type-Options": "nosniff",
-				"X-DNS-Prefetch-Control": "off",
-				"X-XSS-Protection":       "1; mode=block",
+				"Cache-Control":                  "no-cache, no-store, max-age=0, must-revalidate",
+				"Pragma":                         "no-cache",
+				"Expires":                        "0",
+				"Referrer-Policy":                "strict-origin-when-cross-origin",
+				"X-Frame-RunSuiteOptions":        "DENY",
+				"X-Content-Type-RunSuiteOptions": "nosniff",
+				"X-DNS-Prefetch-Control":         "off",
+				"X-XSS-Protection":               "1; mode=block",
 
 				// non-security headers, should not change
 				// adding items here should be validated to make sure they do not conflict with any security headers

--- a/tools/junitreport/junitreport.go
+++ b/tools/junitreport/junitreport.go
@@ -94,7 +94,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, junitReportUsageLong+"\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, junitReportUsage+"\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, junitReportExamples+"\n", os.Args[0])
-		fmt.Fprintln(os.Stderr, "Options:")
+		fmt.Fprintln(os.Stderr, "RunSuiteOptions:")
 		flag.PrintDefaults()
 		os.Exit(2)
 	}


### PR DESCRIPTION
…and forward building

Straight moves and renames to take start taking stock of what we have.  The ultimate vision is to the commands abstracted into options that are one per-package with selective re-use.

/assign @dgoodwin 