### PR TITLE
Unrevert pull request #28069 from dgoodwin/interval-builder

### DIFF
--- a/pkg/disruption/backend/descriptor.go
+++ b/pkg/disruption/backend/descriptor.go
@@ -38,8 +38,8 @@ func ParseStringToLoadBalancerType(input string) LoadBalancerType {
 // TestDescriptor describes a backend disruption test
 type TestDescriptor interface {
 	Name() string
-	DisruptionLocator() string
-	ShutdownLocator() string
+	DisruptionLocator() monitorapi.Locator
+	ShutdownLocator() monitorapi.Locator
 	GetLoadBalancerType() LoadBalancerType
 	GetProtocol() ProtocolType
 	GetConnectionType() monitorapi.BackendConnectionType

--- a/pkg/disruption/backend/disruption/handler.go
+++ b/pkg/disruption/backend/disruption/handler.go
@@ -66,7 +66,7 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 		// we have multiple failed samples with the same error
 		info = fmt.Sprintf("range=[%d-%d] %s", fs.ID, ts.ID, info)
 	}
-	message, eventReason, level := backenddisruption.DisruptionBegan(h.descriptor.DisruptionLocator(),
+	message, eventReason, level := backenddisruption.DisruptionBegan(h.descriptor.DisruptionLocator().OldLocator(),
 		h.descriptor.GetConnectionType(), fmt.Errorf("%w - %s", from.AggregateErr(), info), "no-audit-id")
 
 	framework.Logf(message)
@@ -74,11 +74,8 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()},
 		nil, v1.EventTypeWarning, string(eventReason), "detected", message)
 
-	condition := monitorapi.Condition{
-		Level:   level,
-		Locator: h.descriptor.DisruptionLocator(),
-		Message: message,
-	}
+	condition := monitorapi.NewCondition(level).Locator(h.descriptor.DisruptionLocator()).
+		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
 	openIntervalID := h.monitor.StartInterval(fs.StartedAt, condition)
 	// TODO: unlikely in the real world, if from == to for some reason,
 	//  then we are recording a zero second unavailable window.
@@ -93,17 +90,15 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 //	   to the same sample in question.
 func (h *ciHandler) Available(from, to *backend.SampleResult) {
 	fs, ts := from.Sample, to.Sample
-	message := backenddisruption.DisruptionEndedMessage(h.descriptor.DisruptionLocator(), h.descriptor.GetConnectionType())
+	message := backenddisruption.DisruptionEndedMessage(h.descriptor.DisruptionLocator().OldLocator(),
+		h.descriptor.GetConnectionType())
 	framework.Logf(message)
 
 	h.eventRecorder.Eventf(
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()}, nil,
 		v1.EventTypeNormal, string(monitorapi.DisruptionEndedEventReason), "detected", message)
-	condition := monitorapi.Condition{
-		Level:   monitorapi.Info,
-		Locator: h.descriptor.DisruptionLocator(),
-		Message: message,
-	}
+	condition := monitorapi.NewCondition(monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
+		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
 	openIntervalID := h.monitor.StartInterval(fs.StartedAt, condition)
 	h.monitor.EndInterval(openIntervalID, ts.StartedAt)
 }

--- a/pkg/disruption/backend/shutdown/handler.go
+++ b/pkg/disruption/backend/shutdown/handler.go
@@ -67,11 +67,9 @@ func (h *ciShutdownIntervalHandler) Handle(shutdown *shutdownInterval) {
 			&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()},
 			nil, v1.EventTypeWarning, reason, "detected", message)
 	}
-	condition := monitorapi.Condition{
-		Level:   level,
-		Locator: h.descriptor.ShutdownLocator(),
-		Message: message,
-	}
+	condition := monitorapi.NewCondition(level).
+		Locator(h.descriptor.ShutdownLocator()).
+		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
 	intervalID := h.monitor.StartInterval(shutdown.From, condition)
 	h.monitor.EndInterval(intervalID, shutdown.To)
 }

--- a/pkg/disruption/ci/backend_sampler.go
+++ b/pkg/disruption/ci/backend_sampler.go
@@ -21,7 +21,7 @@ type Sampler interface {
 	GetConnectionType() monitorapi.BackendConnectionType
 	GetProtocol() string
 	GetDisruptionBackendName() string
-	GetLocator() string
+	GetLocator() monitorapi.Locator
 	GetURL() (string, error)
 	RunEndpointMonitoring(ctx context.Context, m backenddisruption.Recorder, eventRecorder events.EventRecorder) error
 	StartEndpointMonitoring(ctx context.Context, m backenddisruption.Recorder, eventRecorder events.EventRecorder) error
@@ -60,7 +60,7 @@ func (bs *BackendSampler) GetDisruptionBackendName() string {
 	return bs.Name()
 }
 
-func (bs *BackendSampler) GetLocator() string {
+func (bs *BackendSampler) GetLocator() monitorapi.Locator {
 	return bs.DisruptionLocator()
 }
 

--- a/pkg/disruption/ci/factory.go
+++ b/pkg/disruption/ci/factory.go
@@ -91,13 +91,13 @@ func (t TestDescriptor) Name() string {
 	return fmt.Sprintf("%s-%s-%s-%s-connections", t.TargetServer, t.Protocol, t.LoadBalancerType, t.ConnectionType)
 }
 
-func (t TestDescriptor) DisruptionLocator() string {
-	return fmt.Sprintf("disruption/%s load-balancer/%s connection/%s protocol/%s target/%s",
-		t.Name(), t.LoadBalancerType, t.ConnectionType, t.Protocol, t.TargetServer)
+func (t TestDescriptor) DisruptionLocator() monitorapi.Locator {
+	return monitorapi.NewLocator().Disruption(t.Name(), string(t.LoadBalancerType),
+		string(t.ConnectionType), string(t.Protocol), string(t.TargetServer))
 }
 
-func (t TestDescriptor) ShutdownLocator() string {
-	return fmt.Sprintf("shutdown/graceful server/kube-apiserver load-balancer/%s", t.LoadBalancerType)
+func (t TestDescriptor) ShutdownLocator() monitorapi.Locator {
+	return monitorapi.NewLocator().APIServerShutdown(string(t.LoadBalancerType))
 }
 
 func (t TestDescriptor) Validate() error {

--- a/pkg/disruption/ci/remote_sampler.go
+++ b/pkg/disruption/ci/remote_sampler.go
@@ -45,8 +45,8 @@ func (bs *RemoteSampler) GetDisruptionBackendName() string {
 	return ""
 }
 
-func (bs *RemoteSampler) GetLocator() string {
-	return ""
+func (bs *RemoteSampler) GetLocator() monitorapi.Locator {
+	return monitorapi.Locator{}
 }
 
 func (bs *RemoteSampler) GetURL() (string, error) {

--- a/pkg/duplicateevents/duplicated_event_patterns.go
+++ b/pkg/duplicateevents/duplicated_event_patterns.go
@@ -258,7 +258,7 @@ var KnownEventsBugs = []KnownProblem{
 // IsRepeatedEventOKFunc takes a monitorEvent as input and returns true if the repeated event is OK.
 // This commonly happens for known bugs and for cases where events are repeated intentionally by tests.
 // Use this to handle cases where, "if X is true, then the repeated event is ok".
-type IsRepeatedEventOKFunc func(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, times int) (bool, error)
+type IsRepeatedEventOKFunc func(monitorEvent monitorapi.Interval, kubeClientConfig *rest.Config, times int) (bool, error)
 
 var AllowedRepeatedEventFns = []IsRepeatedEventOKFunc{
 	isConsoleReadinessDuringInstallation,
@@ -294,7 +294,7 @@ func StringPointer(testSuite string) *string {
 // we're looking for something like
 // > ns/openshift-console pod/console-7c6f797fd9-5m94j node/ip-10-0-158-106.us-west-2.compute.internal - reason/ProbeError Readiness probe error: Get "https://10.129.0.49:8443/health": dial tcp 10.129.0.49:8443: connect: connection refused
 // with a firstTimestamp before the cluster completed the initial installation
-func isConsoleReadinessDuringInstallation(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, _ int) (bool, error) {
+func isConsoleReadinessDuringInstallation(monitorEvent monitorapi.Interval, kubeClientConfig *rest.Config, _ int) (bool, error) {
 	if !strings.Contains(monitorEvent.Locator, "ns/openshift-console") {
 		return false, nil
 	}
@@ -318,7 +318,7 @@ func isConsoleReadinessDuringInstallation(monitorEvent monitorapi.EventInterval,
 // in the openshift-config-operator.
 // like this:
 // ...ReadinessFailed Get \"https://10.130.0.16:8443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-func isConfigOperatorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+func isConfigOperatorReadinessFailed(monitorEvent monitorapi.Interval, _ *rest.Config, _ int) (bool, error) {
 	regExp := regexp.MustCompile(ReadinessFailedMessageRegExpStr)
 	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
 }
@@ -327,7 +327,7 @@ func isConfigOperatorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *r
 // in the openshift-config-operator.
 // like this:
 // reason/ProbeError Readiness probe error: Get "https://10.130.0.15:8443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-func isConfigOperatorProbeErrorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+func isConfigOperatorProbeErrorReadinessFailed(monitorEvent monitorapi.Interval, _ *rest.Config, _ int) (bool, error) {
 	regExp := regexp.MustCompile(ProbeErrorReadinessMessageRegExpStr)
 	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
 }
@@ -336,7 +336,7 @@ func isConfigOperatorProbeErrorReadinessFailed(monitorEvent monitorapi.EventInte
 // in the openshift-config-operator.
 // like this:
 // ...reason/ProbeError Liveness probe error: Get "https://10.128.0.21:8443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-func isConfigOperatorProbeErrorLivenessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+func isConfigOperatorProbeErrorLivenessFailed(monitorEvent monitorapi.Interval, _ *rest.Config, _ int) (bool, error) {
 	regExp := regexp.MustCompile(ProbeErrorLivenessMessageRegExpStr)
 	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-config-operator", regExp), nil
 }
@@ -345,7 +345,7 @@ func isConfigOperatorProbeErrorLivenessFailed(monitorEvent monitorapi.EventInter
 // in the openshift-oauth-operator.
 // like this:
 // ...ns/openshift-oauth-apiserver pod/apiserver-65fd7ffc59-bt5sf node/q72hs3bx-ac890-4pxpm-master-2 - reason/ProbeError Readiness probe error: Get "https://10.129.0.8:8443/readyz": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
-func isOauthApiserverProbeErrorReadinessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+func isOauthApiserverProbeErrorReadinessFailed(monitorEvent monitorapi.Interval, _ *rest.Config, _ int) (bool, error) {
 	regExp := regexp.MustCompile(ProbeErrorReadinessMessageRegExpStr)
 	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
 }
@@ -354,7 +354,7 @@ func isOauthApiserverProbeErrorReadinessFailed(monitorEvent monitorapi.EventInte
 // in the openshift-oauth-operator.
 // like this:
 // ...reason/ProbeError Liveness probe error: Get "https://10.130.0.68:8443/healthz": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
-func isOauthApiserverProbeErrorLivenessFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+func isOauthApiserverProbeErrorLivenessFailed(monitorEvent monitorapi.Interval, _ *rest.Config, _ int) (bool, error) {
 	regExp := regexp.MustCompile(ProbeErrorLivenessMessageRegExpStr)
 	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
 }
@@ -363,38 +363,38 @@ func isOauthApiserverProbeErrorLivenessFailed(monitorEvent monitorapi.EventInter
 // in the openshift-oauth-operator.
 // like this:
 // ...ns/openshift-oauth-apiserver pod/apiserver-647fc6c7bf-s8b4h node/ip-10-0-150-209.us-west-1.compute.internal - reason/ProbeError Readiness probe error: Get "https://10.128.0.38:8443/readyz": dial tcp 10.128.0.38:8443: connect: connection refused
-func isOauthApiserverProbeErrorConnectionRefusedFailed(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+func isOauthApiserverProbeErrorConnectionRefusedFailed(monitorEvent monitorapi.Interval, _ *rest.Config, _ int) (bool, error) {
 	regExp := regexp.MustCompile(ProbeErrorConnectionRefusedRegExpStr)
 	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-oauth-apiserver", regExp), nil
 }
 
 // reason/ErrorReconcilingNode roles/worker [k8s.ovn.org/node-chassis-id annotation not found for node ci-op-nzi4gt1b-3efb3-ggmhb-worker-centralus2-jzx86, macAddress annotation not found for node "ci-op-nzi4gt1b-3efb3-ggmhb-worker-centralus2-jzx86" , k8s.ovn.org/l3-gateway-config annotation not found for node "ci-op-nzi4gt1b-3efb3-ggmhb-worker-centralus2-jzx86"]
-func isErrorReconcilingNode(monitorEvent monitorapi.EventInterval, _ *rest.Config, count int) (bool, error) {
+func isErrorReconcilingNode(monitorEvent monitorapi.Interval, _ *rest.Config, count int) (bool, error) {
 	regExp := regexp.MustCompile(ErrorReconcilingNode)
 	return regExp.MatchString(monitorEvent.String()) && count < DuplicateSingleNodeEventThreshold, nil
 }
 
 // reason/FailedScheduling 0/6 nodes are available: 2 node(s) didn't match Pod's node affinity/selector, 2 node(s) didn't match pod anti-affinity rules, 2 node(s) were unschedulable. preemption: 0/6 nodes are available: 2 node(s) didn't match pod anti-affinity rules, 4 Preemption is not helpful for scheduling..
-func isFailedScheduling(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+func isFailedScheduling(monitorEvent monitorapi.Interval, _ *rest.Config, _ int) (bool, error) {
 	regExp := regexp.MustCompile(FailedScheduling)
 	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-route-controller-manager", regExp), nil
 }
 
 // reason/OperatorStatusChanged Status for clusteroperator/etcd changed: Degraded message changed from "NodeControllerDegraded: All master nodes are ready\nEtcdMembersDegraded: 2 of 3 members are available, ip-10-0-217-93.us-west-1.compute.internal is unhealthy" to "NodeControllerDegraded: All master nodes are ready\nEtcdMembersDegraded: No unhealthy members found"
-func isOperatorStatusChanged(monitorEvent monitorapi.EventInterval, _ *rest.Config, _ int) (bool, error) {
+func isOperatorStatusChanged(monitorEvent monitorapi.Interval, _ *rest.Config, _ int) (bool, error) {
 	regExp := regexp.MustCompile(OperatorStatusChanged)
 	return IsOperatorMatchRegexMessage(monitorEvent, "openshift-etcd", regExp), nil
 }
 
 // isConnectionRefusedOnSingleNode returns true if the event matched has a connection refused message for single node events and is with in threshold.
-func isConnectionRefusedOnSingleNode(monitorEvent monitorapi.EventInterval, _ *rest.Config, count int) (bool, error) {
+func isConnectionRefusedOnSingleNode(monitorEvent monitorapi.Interval, _ *rest.Config, count int) (bool, error) {
 	regExp := regexp.MustCompile(SingleNodeErrorConnectionRefusedRegExpStr)
 	return regExp.MatchString(monitorEvent.String()) && count < DuplicateSingleNodeEventThreshold, nil
 }
 
 // IsOperatorMatchRegexMessage returns true if this monitorEvent is for the operator identified by the operatorName
 // and its message matches the given regex.
-func IsOperatorMatchRegexMessage(monitorEvent monitorapi.EventInterval, operatorName string, regExp *regexp.Regexp) bool {
+func IsOperatorMatchRegexMessage(monitorEvent monitorapi.Interval, operatorName string, regExp *regexp.Regexp) bool {
 	locatorParts := monitorapi.LocatorParts(monitorEvent.Locator)
 	if ns, ok := locatorParts["ns"]; ok {
 		if ns != operatorName {
@@ -415,7 +415,7 @@ func IsOperatorMatchRegexMessage(monitorEvent monitorapi.EventInterval, operator
 // isEventDuringInstallation returns true if the monitorEvent represents a real event that happened after installation.
 // regExp defines the pattern of the monitorEvent message. Named match is used in the pattern using `(?P<>)`. The names are placed inside <>. See example below
 // `ns/(?P<NS>openshift-ovn-kubernetes) pod/(?P<POD>ovnkube-node-[a-z0-9-]+) node/(?P<NODE>[a-z0-9.-]+) - reason/(?P<REASON>Unhealthy) (?P<MSG>Readiness probe failed:.*$`
-func IsEventDuringInstallation(monitorEvent monitorapi.EventInterval, kubeClientConfig *rest.Config, regExp *regexp.Regexp) (bool, error) {
+func IsEventDuringInstallation(monitorEvent monitorapi.Interval, kubeClientConfig *rest.Config, regExp *regexp.Regexp) (bool, error) {
 	if kubeClientConfig == nil {
 		// default to OK
 		return true, nil

--- a/pkg/monitor/alerts.go
+++ b/pkg/monitor/alerts.go
@@ -22,15 +22,15 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func WhenWasAlertFiring(ctx context.Context, prometheusClient prometheusv1.API, startTime time.Time, alertName, namespace string) ([]monitorapi.EventInterval, error) {
+func WhenWasAlertFiring(ctx context.Context, prometheusClient prometheusv1.API, startTime time.Time, alertName, namespace string) ([]monitorapi.Interval, error) {
 	return whenWasAlertInState(ctx, prometheusClient, startTime, alertName, "firing", namespace)
 }
 
-func WhenWasAlertPending(ctx context.Context, prometheusClient prometheusv1.API, startTime time.Time, alertName, namespace string) ([]monitorapi.EventInterval, error) {
+func WhenWasAlertPending(ctx context.Context, prometheusClient prometheusv1.API, startTime time.Time, alertName, namespace string) ([]monitorapi.Interval, error) {
 	return whenWasAlertInState(ctx, prometheusClient, startTime, alertName, "pending", namespace)
 }
 
-func whenWasAlertInState(ctx context.Context, prometheusClient prometheusv1.API, startTime time.Time, alertName, alertState, namespace string) ([]monitorapi.EventInterval, error) {
+func whenWasAlertInState(ctx context.Context, prometheusClient prometheusv1.API, startTime time.Time, alertName, alertState, namespace string) ([]monitorapi.Interval, error) {
 	if alertState != "pending" && alertState != "firing" {
 		return nil, fmt.Errorf("unrecognized alertState: %v", alertState)
 	}
@@ -68,7 +68,7 @@ func whenWasAlertInState(ctx context.Context, prometheusClient prometheusv1.API,
 	}
 
 	if namespace == platformidentification.NamespaceOther {
-		ret = monitorapi.Intervals(ret).Filter(func(eventInterval monitorapi.EventInterval) bool {
+		ret = monitorapi.Intervals(ret).Filter(func(eventInterval monitorapi.Interval) bool {
 			namespace := monitorapi.NamespaceFromLocator(eventInterval.Locator)
 			return !platformidentification.KnownNamespaces.Has(namespace)
 		})
@@ -78,7 +78,7 @@ func whenWasAlertInState(ctx context.Context, prometheusClient prometheusv1.API,
 }
 
 func FetchEventIntervalsForAllAlerts(ctx context.Context, restConfig *rest.Config,
-	startTime time.Time) ([]monitorapi.EventInterval, error) {
+	startTime time.Time) ([]monitorapi.Interval, error) {
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func FetchEventIntervalsForAllAlerts(ctx context.Context, restConfig *rest.Confi
 
 	_, err = kubeClient.CoreV1().Namespaces().Get(ctx, "openshift-monitoring", metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		return []monitorapi.EventInterval{}, nil
+		return []monitorapi.Interval{}, nil
 	}
 
 	prometheusClient, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
@@ -160,7 +160,7 @@ func FetchEventIntervalsForAllAlerts(ctx context.Context, restConfig *rest.Confi
 	// broken up by firing, so the alert should not be listed as pending at the same time as it is firing in our intervals.
 	pendingAlerts = blackoutEvents(pendingAlerts, firingAlerts)
 
-	ret := []monitorapi.EventInterval{}
+	ret := []monitorapi.Interval{}
 	ret = append(ret, firingAlerts...)
 	ret = append(ret, pendingAlerts...)
 
@@ -170,8 +170,8 @@ func FetchEventIntervalsForAllAlerts(ctx context.Context, restConfig *rest.Confi
 // blackoutEvents filters startingEvents and rewrites into potentially multiple events to avoid overlap with the blackoutWindows.
 // For instance, if startingEvents for locator/foo covers 1:00-1:45 and blackoutWindows for locator/Foo covers 1:10-1:15 and 1:40-1:50
 // the return has locator/foo 1:00-1:10, 1:15-1:40.
-func blackoutEvents(startingEvents, blackoutWindows []monitorapi.EventInterval) []monitorapi.EventInterval {
-	ret := []monitorapi.EventInterval{}
+func blackoutEvents(startingEvents, blackoutWindows []monitorapi.Interval) []monitorapi.Interval {
+	ret := []monitorapi.Interval{}
 
 	blackoutsByLocator := indexByLocator(blackoutWindows)
 	for i := range startingEvents {
@@ -273,7 +273,7 @@ type blackoutWindow struct {
 	To   time.Time
 }
 
-func nonOverlappingBlackoutWindowsFromEvents(blackoutWindows []monitorapi.EventInterval) []blackoutWindow {
+func nonOverlappingBlackoutWindowsFromEvents(blackoutWindows []monitorapi.Interval) []blackoutWindow {
 	sort.Sort(monitorapi.Intervals(blackoutWindows))
 
 	ret := []blackoutWindow{}
@@ -338,8 +338,8 @@ func nonOverlappingBlackoutWindowsFromEvents(blackoutWindows []monitorapi.EventI
 	return ret
 }
 
-func indexByLocator(events []monitorapi.EventInterval) map[string][]monitorapi.EventInterval {
-	ret := map[string][]monitorapi.EventInterval{}
+func indexByLocator(events []monitorapi.Interval) map[string][]monitorapi.Interval {
+	ret := map[string][]monitorapi.Interval{}
 	for i := range events {
 		event := events[i]
 		ret[event.Locator] = append(ret[event.Locator], event)
@@ -347,8 +347,8 @@ func indexByLocator(events []monitorapi.EventInterval) map[string][]monitorapi.E
 	return ret
 }
 
-func CreateEventIntervalsForAlerts(ctx context.Context, alerts prometheustypes.Value, startTime time.Time) ([]monitorapi.EventInterval, error) {
-	ret := []monitorapi.EventInterval{}
+func CreateEventIntervalsForAlerts(ctx context.Context, alerts prometheustypes.Value, startTime time.Time) ([]monitorapi.Interval, error) {
+	ret := []monitorapi.Interval{}
 
 	switch {
 	case alerts.Type() == prometheustypes.ValMatrix:
@@ -356,41 +356,35 @@ func CreateEventIntervalsForAlerts(ctx context.Context, alerts prometheustypes.V
 		for _, alert := range matrixAlert {
 			alertName := alert.Metric[prometheustypes.AlertNameLabel]
 
-			locator := "alert/" + alertName
-			if node := alert.Metric["instance"]; len(node) > 0 {
-				locator += " node/" + node
-			}
-			if namespace := alert.Metric["namespace"]; len(namespace) > 0 {
-				locator += " ns/" + namespace
-			}
-			if pod := alert.Metric["pod"]; len(pod) > 0 {
-				locator += " pod/" + pod
-			}
-			if container := alert.Metric["container"]; len(container) > 0 {
-				locator += " container/" + container
-			}
+			lb := monitorapi.NewLocator().AlertFromNames(
+				string(alertName),
+				string(alert.Metric["instance"]),
+				string(alert.Metric["namespace"]),
+				string(alert.Metric["pod"]),
+				string(alert.Metric["container"]),
+			)
 
-			alertIntervalTemplate := monitorapi.EventInterval{
-				Condition: monitorapi.Condition{
-					Locator: string(locator),
-					Message: alert.Metric.String(),
-				},
-			}
+			var level monitorapi.ConditionLevel
 			switch {
 			// as I understand it, pending alerts are cases where the conditions except for "how long has been happening"
 			// are all met.  Pending alerts include what level the eventual alert will be, but they are not errors in and
 			// of themselves.  They are you useful to show in time to find patterns of "X fails concurrent with Y"
 			case alert.Metric["alertstate"] == "pending":
-				alertIntervalTemplate.Level = monitorapi.Info
+				level = monitorapi.Info
 
 			case alert.Metric["severity"] == "warning":
-				alertIntervalTemplate.Level = monitorapi.Warning
+				level = monitorapi.Warning
 			case alert.Metric["severity"] == "critical":
-				alertIntervalTemplate.Level = monitorapi.Error
+				level = monitorapi.Error
 			case alert.Metric["severity"] == "info":
-				alertIntervalTemplate.Level = monitorapi.Info
+				level = monitorapi.Info
 			default:
-				alertIntervalTemplate.Level = monitorapi.Error
+				level = monitorapi.Error
+			}
+			alertIntervalTemplate := monitorapi.Interval{
+				Condition: monitorapi.NewCondition(level).
+					Locator(lb).
+					Message(monitorapi.NewMessage().HumanMessage(alert.Metric.String())).Build(),
 			}
 
 			var alertStartTime *time.Time
@@ -435,12 +429,10 @@ func CreateEventIntervalsForAlerts(ctx context.Context, alerts prometheustypes.V
 		}
 
 	default:
-		ret = append(ret, monitorapi.EventInterval{
-			Condition: monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: "alert/all",
-				Message: fmt.Sprintf("unhandled type: %v", alerts.Type()),
-			},
+		ret = append(ret, monitorapi.Interval{
+			Condition: monitorapi.NewCondition(monitorapi.Error).
+				Locator(monitorapi.NewLocator().AlertFromNames("all", "", "", "", "")).
+				Message(monitorapi.NewMessage().HumanMessagef("unhandled type: %v", alerts.Type())).Build(),
 			From: startTime,
 			To:   time.Now(),
 		})

--- a/pkg/monitor/apiserveravailability/pod_log.go
+++ b/pkg/monitor/apiserveravailability/pod_log.go
@@ -113,7 +113,7 @@ func summarizeLogsForPod(ctx context.Context, client kubernetes.Interface, pod *
 			go func(ctx context.Context, previousContainer bool, containerName string) {
 				defer wg.Done()
 
-				locator := monitorapi.LocatePodContainer(pod, containerName)
+				locator := monitorapi.NewLocator().ContainerFromPod(pod, containerName)
 				currSummary := &APIServerClientAccessFailureSummary{}
 				logOptions := &corev1.PodLogOptions{
 					Container:                    containerName,

--- a/pkg/monitor/apiserveravailability/summarizer.go
+++ b/pkg/monitor/apiserveravailability/summarizer.go
@@ -13,7 +13,7 @@ type SummarizationFunc func(locator, line string)
 
 type APIServerClientAccessFailureSummary struct {
 	lock                   sync.Mutex
-	WriteOperationFailures []monitorapi.EventInterval
+	WriteOperationFailures []monitorapi.Interval
 }
 
 func timeFromPodLogTime(line string) time.Time {
@@ -28,16 +28,15 @@ func timeFromPodLogTime(line string) time.Time {
 	return t
 }
 
-func (s *APIServerClientAccessFailureSummary) SummarizeLine(locator, line string) {
+func (s *APIServerClientAccessFailureSummary) SummarizeLine(locator monitorapi.Locator, line string) {
 	if strings.Contains(line, "write: operation not permitted") {
 		timeOfLog := timeFromPodLogTime(line)
 		// TODO collapse all in the same second into a single interval
-		event := monitorapi.EventInterval{
-			Condition: monitorapi.Condition{
-				Level:   monitorapi.Warning,
-				Locator: locator,
-				Message: monitorapi.Message().Reason(monitorapi.IPTablesNotPermitted).Message(line),
-			},
+		event := monitorapi.Interval{
+			Condition: monitorapi.NewCondition(monitorapi.Warning).
+				Locator(locator).
+				Message(monitorapi.NewMessage().Reason(monitorapi.IPTablesNotPermitted).HumanMessage(line)).
+				Build(),
 			From: timeOfLog,
 			To:   timeOfLog.Add(1 * time.Second),
 		}

--- a/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
@@ -156,7 +156,7 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 		name            string
 		estimatedTime   time.Duration
 		produceSamples  func(ctx context.Context, backendSampler *disruptionSampler)
-		validateSamples func(t *testing.T, eventIntervals []monitorapi.EventInterval) error
+		validateSamples func(t *testing.T, eventIntervals []monitorapi.Interval) error
 	}{
 		{
 			name:          "in-order",
@@ -183,7 +183,7 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 				fourthSample.setSampleError(fmt.Errorf("now fail"))
 				close(fourthSample.finished)
 			},
-			validateSamples: func(t *testing.T, eventIntervals []monitorapi.EventInterval) error {
+			validateSamples: func(t *testing.T, eventIntervals []monitorapi.Interval) error {
 				if len(eventIntervals) != 2 {
 					t.Fatal(eventIntervals)
 				}
@@ -228,7 +228,7 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 				close(firstSample.finished)
 				close(thirdSample.finished)
 			},
-			validateSamples: func(t *testing.T, eventIntervals []monitorapi.EventInterval) error {
+			validateSamples: func(t *testing.T, eventIntervals []monitorapi.Interval) error {
 				if len(eventIntervals) != 2 {
 					t.Fatal(eventIntervals)
 				}
@@ -273,7 +273,7 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 				close(firstSample.finished)
 				close(thirdSample.finished)
 			},
-			validateSamples: func(t *testing.T, eventIntervals []monitorapi.EventInterval) error {
+			validateSamples: func(t *testing.T, eventIntervals []monitorapi.Interval) error {
 				if len(eventIntervals) != 2 {
 					t.Fatal(eventIntervals)
 				}
@@ -314,7 +314,7 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 				close(firstSample.finished)
 				close(thirdSample.finished)
 			},
-			validateSamples: func(t *testing.T, eventIntervals []monitorapi.EventInterval) error {
+			validateSamples: func(t *testing.T, eventIntervals []monitorapi.Interval) error {
 
 				if !assert.Equal(t, 3, len(eventIntervals)) {
 					return nil

--- a/pkg/monitor/backenddisruption/disruption_locator.go
+++ b/pkg/monitor/backenddisruption/disruption_locator.go
@@ -30,47 +30,53 @@ var DnsLookupRegex = regexp.MustCompile(`dial tcp: lookup.*: i/o timeout`)
 
 // DisruptionBegan examines the error received, attempts to determine if it looks like real disruption to the cluster under test,
 // or other problems possibly on the system running the tests/monitor, and returns an appropriate user message, event reason, and monitoring level.
-func DisruptionBegan(locator string, connectionType monitorapi.BackendConnectionType, err error, auditID string) (string, monitorapi.IntervalReason, monitorapi.EventLevel) {
+func DisruptionBegan(locator string, connectionType monitorapi.BackendConnectionType, err error, auditID string) (string, monitorapi.IntervalReason, monitorapi.ConditionLevel) {
 	if DnsLookupRegex.MatchString(err.Error()) {
 		switch connectionType {
 		case monitorapi.NewConnectionType:
-			return monitorapi.Message().
+			return monitorapi.NewMessage().
 					Reason(monitorapi.DisruptionSamplerOutageBeganEventReason).
 					WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
-					Messagef("DNS lookup timeouts began for %s GET requests over new connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, err),
+					HumanMessagef("DNS lookup timeouts began for %s GET requests over new connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, err).
+					BuildString(),
 				monitorapi.DisruptionSamplerOutageBeganEventReason, monitorapi.Warning
 		case monitorapi.ReusedConnectionType:
-			return monitorapi.Message().
+			return monitorapi.NewMessage().
 					Reason(monitorapi.DisruptionSamplerOutageBeganEventReason).
 					WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
-					Messagef("DNS lookup timeouts began for %s GET requests over reused connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, err),
+					HumanMessagef("DNS lookup timeouts began for %s GET requests over reused connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, err).
+					BuildString(),
 				monitorapi.DisruptionSamplerOutageBeganEventReason, monitorapi.Warning
 		default:
-			return monitorapi.Message().
+			return monitorapi.NewMessage().
 					Reason(monitorapi.DisruptionSamplerOutageBeganEventReason).
 					WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
-					Messagef("DNS lookup timeouts began for %s GET requests over %v connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, "Unknown", err),
+					HumanMessagef("DNS lookup timeouts began for %s GET requests over %v connections: %v (likely a problem in cluster running tests, not the cluster under test)", locator, "Unknown", err).
+					BuildString(),
 				monitorapi.DisruptionSamplerOutageBeganEventReason, monitorapi.Warning
 		}
 	}
 	switch connectionType {
 	case monitorapi.NewConnectionType:
-		return monitorapi.Message().
+		return monitorapi.NewMessage().
 				Reason(monitorapi.DisruptionBeganEventReason).
 				WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
-				Messagef("%s stopped responding to GET requests over new connections: %v", locator, err),
+				HumanMessagef("%s stopped responding to GET requests over new connections: %v", locator, err).
+				BuildString(),
 			monitorapi.DisruptionBeganEventReason, monitorapi.Error
 	case monitorapi.ReusedConnectionType:
-		return monitorapi.Message().
+		return monitorapi.NewMessage().
 				Reason(monitorapi.DisruptionBeganEventReason).
 				WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
-				Messagef("%s stopped responding to GET requests over reused connections: %v", locator, err),
+				HumanMessagef("%s stopped responding to GET requests over reused connections: %v", locator, err).
+				BuildString(),
 			monitorapi.DisruptionBeganEventReason, monitorapi.Error
 	default:
-		return monitorapi.Message().
+		return monitorapi.NewMessage().
 				Reason(monitorapi.DisruptionBeganEventReason).
 				WithAnnotation(monitorapi.AnnotationRequestAuditID, auditID).
-				Messagef("%s stopped responding to GET requests over %v connections: %v", locator, "Unknown", err),
+				HumanMessagef("%s stopped responding to GET requests over %v connections: %v", locator, "Unknown", err).
+				BuildString(),
 			monitorapi.DisruptionBeganEventReason, monitorapi.Error
 	}
 }

--- a/pkg/monitor/backenddisruption/simple_recorder.go
+++ b/pkg/monitor/backenddisruption/simple_recorder.go
@@ -22,7 +22,7 @@ func newSimpleMonitor() *simpleMonitor {
 func (m *simpleMonitor) StartInterval(t time.Time, condition monitorapi.Condition) int {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	m.unsortedEventIntervals = append(m.unsortedEventIntervals, monitorapi.EventInterval{
+	m.unsortedEventIntervals = append(m.unsortedEventIntervals, monitorapi.Interval{
 		Condition: condition,
 		From:      t,
 	})

--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -102,7 +102,7 @@ func combinedDuplicateEventPatterns() *regexp.Regexp {
 // and returns true if this event is an event we already know about.  Some functions
 // require a kubeconfig, but also handle the kubeconfig being nil (in case we cannot
 // successfully get a kubeconfig).
-func checkAllowedRepeatedEventOKFns(event monitorapi.EventInterval, times int32) bool {
+func checkAllowedRepeatedEventOKFns(event monitorapi.Interval, times int32) bool {
 
 	kubeClient, err := GetMonitorRESTConfig()
 	if err != nil {
@@ -206,11 +206,13 @@ func recordAddOrUpdateEvent(
 	default:
 		message = fmt.Sprintf("reason/%s %s", obj.Reason, message)
 	}
+
 	condition := monitorapi.Condition{
 		Level:   monitorapi.Info,
 		Locator: locateEvent(obj),
 		Message: message,
 	}
+
 	if obj.Type == corev1.EventTypeWarning {
 		condition.Level = monitorapi.Warning
 	}
@@ -224,7 +226,7 @@ func recordAddOrUpdateEvent(
 	}
 	to := pathoFrom.Add(1 * time.Second)
 
-	event := monitorapi.EventInterval{
+	event := monitorapi.Interval{
 		Condition: condition,
 	}
 

--- a/pkg/monitor/intervalcreation/e2etest.go
+++ b/pkg/monitor/intervalcreation/e2etest.go
@@ -50,7 +50,7 @@ func IntervalsFromEvents_E2ETests(events monitorapi.Intervals, _ monitorapi.Reso
 		}
 
 		delete(testNameToLastStart, testName)
-		ret = append(ret, monitorapi.EventInterval{
+		ret = append(ret, monitorapi.Interval{
 			Condition: monitorapi.Condition{
 				Level:   level,
 				Locator: event.Locator,
@@ -62,7 +62,7 @@ func IntervalsFromEvents_E2ETests(events monitorapi.Intervals, _ monitorapi.Reso
 	}
 
 	for testName, testStart := range testNameToLastStart {
-		ret = append(ret, monitorapi.EventInterval{
+		ret = append(ret, monitorapi.Interval{
 			Condition: monitorapi.Condition{
 				Level:   monitorapi.Warning,
 				Locator: monitorapi.E2ETestLocator(testName),

--- a/pkg/monitor/intervalcreation/nodeTest/drain-01/expected.json
+++ b/pkg/monitor/intervalcreation/nodeTest/drain-01/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate phase/Drain roles/worker drained node",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2023-07-17T22:58:52Z",
             "to": "2023-07-17T23:00:24Z"
         },
@@ -11,6 +21,16 @@
             "level": "Warning",
             "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate role/worker state/OperatingSystemUpdate never completed",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2023-07-17T23:00:24Z",
             "to": "2023-07-17T23:58:52Z"
         }

--- a/pkg/monitor/intervalcreation/nodeTest/drain-02/expected.json
+++ b/pkg/monitor/intervalcreation/nodeTest/drain-02/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate phase/Drain roles/worker drained node",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2023-07-18T16:40:16Z",
             "to": "2023-07-18T16:41:49Z"
         },
@@ -11,6 +21,16 @@
             "level": "Warning",
             "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate role/worker state/OperatingSystemUpdate never completed",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2023-07-18T16:41:49Z",
             "to": "2023-07-19T23:58:52Z"
         }

--- a/pkg/monitor/intervalcreation/node_test.go
+++ b/pkg/monitor/intervalcreation/node_test.go
@@ -20,16 +20,33 @@ func TestMonitorApiIntervals(t *testing.T) {
 	testcase := []struct {
 		name    string
 		logLine string
-		want    monitorapi.EventInterval
+		want    monitorapi.Interval
 	}{
 		{
 			name:    "status",
 			logLine: `Sep 27 08:59:59.857303 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: I0927 08:59:59.850662    2397 status_manager.go:667] "Failed to get status for pod" podUID=a1947638-25c2-4fd8-b3c8-4dbaa666bc61 pod="openshift-monitoring/prometheus-k8s-0" err="Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost"`,
-			want: monitorapi.EventInterval{
+			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: "ns/openshift-monitoring pod/prometheus-k8s-0 uid/a1947638-25c2-4fd8-b3c8-4dbaa666bc61 container/",
-					Message: "reason/HttpClientConnectionLost Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost",
+					Message: "reason/HttpClientConnectionLost ",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeContainer,
+						Keys: map[monitorapi.LocatorKey]string{
+							"namespace": "openshift-monitoring",
+							"pod":       "prometheus-k8s-0",
+							"uid":       "a1947638-25c2-4fd8-b3c8-4dbaa666bc61",
+							"container": "",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "HttpClientConnectionLost",
+						HumanMessage: "Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost",
+						Annotations: map[monitorapi.AnnotationKey]string{
+							monitorapi.AnnotationReason: "HttpClientConnectionLost",
+							monitorapi.AnnotationNode:   "testName",
+						},
+					},
 				},
 				From: systemdJournalLogTime("Sep 27 08:59:59.857303"),
 				To:   systemdJournalLogTime("Sep 27 08:59:59.857303"),
@@ -38,11 +55,28 @@ func TestMonitorApiIntervals(t *testing.T) {
 		{
 			name:    "reflector",
 			logLine: `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: W0927 08:59:59.849136    2397 reflector.go:347] object-"openshift-monitoring"/"prometheus-adapter-7m6srg4dfreoi": watch of *v1.Secret ended with: an error on the server ("unable to decode an event from the watch stream: http2: client connection lost") has prevented the request from succeeding`,
-			want: monitorapi.EventInterval{
+			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: "ns/openshift-monitoring pod/prometheus-adapter-7m6srg4dfreoi uid/ container/",
 					Message: "reason/HttpClientConnectionLost unable to decode an event from the watch stream: http2: client connection lost",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeContainer,
+						Keys: map[monitorapi.LocatorKey]string{
+							"namespace": "openshift-monitoring",
+							"pod":       "prometheus-adapter-7m6srg4dfreoi",
+							"uid":       "",
+							"container": "",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "HttpClientConnectionLost",
+						HumanMessage: "unable to decode an event from the watch stream: http2: client connection lost",
+						Annotations: map[monitorapi.AnnotationKey]string{
+							monitorapi.AnnotationReason: "HttpClientConnectionLost",
+							monitorapi.AnnotationNode:   "testName",
+						},
+					},
 				},
 				From: systemdJournalLogTime("Sep 27 08:59:59.853216"),
 				To:   systemdJournalLogTime("Sep 27 08:59:59.853216"),
@@ -51,11 +85,25 @@ func TestMonitorApiIntervals(t *testing.T) {
 		{
 			name:    "kubelet",
 			logLine: `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: E0927 08:59:59.849143    2397 kubelet_node_status.go:487] "Error updating node status, will retry" err="error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost"`,
-			want: monitorapi.EventInterval{
+			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: "node/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s",
 					Message: "reason/HttpClientConnectionLost error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeNode,
+						Keys: map[monitorapi.LocatorKey]string{
+							"node": "testName",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "HttpClientConnectionLost",
+						HumanMessage: "error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost",
+						Annotations: map[monitorapi.AnnotationKey]string{
+							monitorapi.AnnotationReason: "HttpClientConnectionLost",
+							monitorapi.AnnotationNode:   "testName",
+						},
+					},
 				},
 				From: systemdJournalLogTime("Sep 27 08:59:59.853216"),
 				To:   systemdJournalLogTime("Sep 27 08:59:59.853216"),
@@ -64,11 +112,24 @@ func TestMonitorApiIntervals(t *testing.T) {
 		{
 			name:    "leaseUpdateError",
 			logLine: `May 19 19:10:03.753983 ci-op-6clh576g-0dd98-xz4pt-master-2 kubenswrapper[1516]: E0519 19:10:03.753942    1516 controller.go:189] failed to update lease, error: Put "https://api-int.ci-op-6clh576g-0dd98.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-6clh576g-0dd98-xz4pt-master-2?timeout=10s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)`,
-			want: monitorapi.EventInterval{
+			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: "node/testName",
 					Message: "reason/FailedToUpdateLease https://api-int.ci-op-6clh576g-0dd98.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-6clh576g-0dd98-xz4pt-master-2?timeout=10s - net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeNode,
+						Keys: map[monitorapi.LocatorKey]string{
+							"node": "testName",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "FailedToUpdateLease",
+						HumanMessage: "https://api-int.ci-op-6clh576g-0dd98.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-6clh576g-0dd98-xz4pt-master-2?timeout=10s - net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
+						Annotations: map[monitorapi.AnnotationKey]string{
+							monitorapi.AnnotationReason: "FailedToUpdateLease",
+						},
+					},
 				},
 				From: systemdJournalLogTime("May 19 19:10:03.753983"),
 				To:   systemdJournalLogTime("May 19 19:10:04.753983"),
@@ -77,11 +138,24 @@ func TestMonitorApiIntervals(t *testing.T) {
 		{
 			name:    "leaseUpdateErr",
 			logLine: `Jun 29 05:16:54.197389 ci-op-cyqgzj4w-ed5cd-ll5md-master-0 kubenswrapper[2336]: E0629 05:16:54.195979    2336 controller.go:193] "Failed to update lease" err="Put \"https://api-int.ci-op-cyqgzj4w-ed5cd.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-cyqgzj4w-ed5cd-ll5md-master-0?timeout=10s\": http2: client connection lost"`,
-			want: monitorapi.EventInterval{
+			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: "node/testName",
 					Message: "reason/FailedToUpdateLease https://api-int.ci-op-cyqgzj4w-ed5cd.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-cyqgzj4w-ed5cd-ll5md-master-0?timeout=10s - http2: client connection lost",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeNode,
+						Keys: map[monitorapi.LocatorKey]string{
+							"node": "testName",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "FailedToUpdateLease",
+						HumanMessage: "https://api-int.ci-op-cyqgzj4w-ed5cd.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-cyqgzj4w-ed5cd-ll5md-master-0?timeout=10s - http2: client connection lost",
+						Annotations: map[monitorapi.AnnotationKey]string{
+							monitorapi.AnnotationReason: "FailedToUpdateLease",
+						},
+					},
 				},
 				From: systemdJournalLogTime("Jun 29 05:16:54.197389"),
 				To:   systemdJournalLogTime("Jun 29 05:16:55.197389"),
@@ -90,11 +164,28 @@ func TestMonitorApiIntervals(t *testing.T) {
 		{
 			name:    "simple failure",
 			logLine: `Jul 05 17:47:52.807876 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: I0606 17:47:52.807876    1599 prober.go:121] "Probe failed" probeType="Readiness" pod="openshift-authentication/oauth-openshift-77f7b95df5-r4xf7" podUID=1af660b3-ac3a-4182-86eb-2f74725d8415 containerName="oauth-openshift" probeResult=failure output="Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"`,
-			want: monitorapi.EventInterval{
+			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: "ns/openshift-authentication pod/oauth-openshift-77f7b95df5-r4xf7 uid/1af660b3-ac3a-4182-86eb-2f74725d8415 container/oauth-openshift",
 					Message: "reason/ReadinessFailed Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeContainer,
+						Keys: map[monitorapi.LocatorKey]string{
+							"namespace": "openshift-authentication",
+							"pod":       "oauth-openshift-77f7b95df5-r4xf7",
+							"uid":       "1af660b3-ac3a-4182-86eb-2f74725d8415",
+							"container": "oauth-openshift",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "ReadinessFailed",
+						HumanMessage: "Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+						Annotations: map[monitorapi.AnnotationKey]string{
+							monitorapi.AnnotationReason: "ReadinessFailed",
+							monitorapi.AnnotationNode:   "testName",
+						},
+					},
 				},
 				From: systemdJournalLogTime("Jul 05 17:47:52.807876"),
 				To:   systemdJournalLogTime("Jul 05 17:47:52.807876"),
@@ -103,11 +194,28 @@ func TestMonitorApiIntervals(t *testing.T) {
 		{
 			name:    "simple error",
 			logLine: `Jul 05 17:43:12.908344 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: E0606 17:43:12.908344    1500 prober.go:118] "Probe errored" err="rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found" probeType="Readiness" pod="openshift-marketplace/redhat-operators-4jpg4" podUID=0bac4741-a3bd-483c-b119-e97663d64024 containerName="registry-server"`,
-			want: monitorapi.EventInterval{
+			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: "ns/openshift-marketplace pod/redhat-operators-4jpg4 uid/0bac4741-a3bd-483c-b119-e97663d64024 container/registry-server",
 					Message: "reason/ReadinessErrored rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeContainer,
+						Keys: map[monitorapi.LocatorKey]string{
+							"namespace": "openshift-marketplace",
+							"pod":       "redhat-operators-4jpg4",
+							"uid":       "0bac4741-a3bd-483c-b119-e97663d64024",
+							"container": "registry-server",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "ReadinessErrored",
+						HumanMessage: "rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found",
+						Annotations: map[monitorapi.AnnotationKey]string{
+							monitorapi.AnnotationReason: "ReadinessErrored",
+							monitorapi.AnnotationNode:   "testName",
+						},
+					},
 				},
 				From: systemdJournalLogTime("Jul 05 17:43:12.908344"),
 				To:   systemdJournalLogTime("Jul 05 17:43:12.908344"),
@@ -116,11 +224,30 @@ func TestMonitorApiIntervals(t *testing.T) {
 		{
 			name:    "signature error",
 			logLine: `Feb 01 05:37:45.731611 ci-op-vyccmv3h-4ef92-xs5k5-master-0 kubenswrapper[2213]: E0201 05:37:45.730879 2213 pod_workers.go:965] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"oauth-proxy\" with ErrImagePull: \"rpc error: code = Unknown desc = copying system image from manifest list: reading signatures: parsing signature https://registry.redhat.io/containers/sigstore/openshift4/ose-oauth-proxy@sha256=f968922564c3eea1c69d6bbe529d8970784d6cae8935afaf674d9fa7c0f72ea3/signature-9: unrecognized signature format, starting with binary 0x3c\"" pod="openshift-e2e-loki/loki-promtail-plm74" podUID=59b26cbf-3421-407c-98ee-986b5a091ef4`,
-			want: monitorapi.EventInterval{
+			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: "ns/openshift-e2e-loki pod/loki-promtail-plm74 uid/59b26cbf-3421-407c-98ee-986b5a091ef4 container/oauth-proxy",
 					Message: "cause/UnrecognizedSignatureFormat reason/ErrImagePull",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeContainer,
+						Keys: map[monitorapi.LocatorKey]string{
+							"namespace": "openshift-e2e-loki",
+							"pod":       "loki-promtail-plm74",
+							"uid":       "59b26cbf-3421-407c-98ee-986b5a091ef4",
+							"container": "oauth-proxy",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "ErrImagePull",
+						Cause:        "UnrecognizedSignatureFormat",
+						HumanMessage: "",
+						Annotations: map[monitorapi.AnnotationKey]string{
+							monitorapi.AnnotationReason: "ErrImagePull",
+							monitorapi.AnnotationNode:   "testName",
+							monitorapi.AnnotationCause:  "UnrecognizedSignatureFormat",
+						},
+					},
 				},
 				From: systemdJournalLogTime("Feb 01 05:37:45.731611"),
 				To:   systemdJournalLogTime("Feb 01 05:37:45.731611"),
@@ -128,19 +255,26 @@ func TestMonitorApiIntervals(t *testing.T) {
 		},
 	}
 
-	logString := ""
-	for i := range testcase {
-		logString += testcase[i].logLine + "\n"
+	for _, tc := range testcase {
+		t.Run(tc.name, func(t *testing.T) {
+			logString := tc.logLine + "\n"
+
+			intervals := eventsFromKubeletLogs("testName", []byte(logString))
+
+			assert.NotNil(t, intervals, "Invalid intervals")
+			assert.Equal(t, 1, intervals.Len())
+
+			//assert.Equalf(t, intervals[i], testcase[i].want, "Interval compare for %s = %v, want %v", testcase[i].name, intervals[i], testcase[i])
+
+			assert.Equal(t, tc.want.StructuredLocator, intervals[0].StructuredLocator)
+			assert.Equal(t, tc.want.StructuredMessage, intervals[0].StructuredMessage)
+			assert.Equal(t, tc.want.Level, intervals[0].Level)
+			assert.Equal(t, tc.want.From, intervals[0].From)
+			assert.Equal(t, tc.want.To, intervals[0].To)
+
+		})
 	}
 
-	intervals := eventsFromKubeletLogs("testName", []byte(logString))
-
-	assert.NotNil(t, intervals, "Invalid intervals")
-	assert.Equal(t, intervals.Len(), len(testcase), "Mismatched interval count")
-
-	for i := range intervals {
-		assert.Equalf(t, intervals[i], testcase[i].want, "Interval compare for %s = %v, want %v", testcase[i].name, intervals[i], testcase[i])
-	}
 }
 
 func TestRegexToContainerReference(t *testing.T) {
@@ -151,7 +285,7 @@ func TestRegexToContainerReference(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want monitorapi.ContainerReference
+		want monitorapi.Locator
 	}{
 		{
 			name: "statusManager http connection failure",
@@ -159,15 +293,14 @@ func TestRegexToContainerReference(t *testing.T) {
 				logLine:                 `Sep 27 08:59:59.857303 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: I0927 08:59:59.850662    2397 status_manager.go:667] "Failed to get status for pod" podUID=a1947638-25c2-4fd8-b3c8-4dbaa666bc61 pod="openshift-monitoring/prometheus-k8s-0" err="Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/prometheus-k8s-0\": http2: client connection lost"`,
 				containerReferenceMatch: statusRefRegex,
 			},
-			want: monitorapi.ContainerReference{
-				Pod: monitorapi.PodReference{
-					NamespacedReference: monitorapi.NamespacedReference{
-						Namespace: "openshift-monitoring",
-						Name:      "prometheus-k8s-0",
-						UID:       "a1947638-25c2-4fd8-b3c8-4dbaa666bc61",
-					},
+			want: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeContainer,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorContainerKey: "",
+					monitorapi.LocatorNamespaceKey: "openshift-monitoring",
+					monitorapi.LocatorPodKey:       "prometheus-k8s-0",
+					monitorapi.LocatorUIDKey:       "a1947638-25c2-4fd8-b3c8-4dbaa666bc61",
 				},
-				ContainerName: "",
 			},
 		},
 		{
@@ -176,15 +309,14 @@ func TestRegexToContainerReference(t *testing.T) {
 				logLine:                 `Sep 27 08:59:59.853216 ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s kubenswrapper[2397]: W0927 08:59:59.849136    2397 reflector.go:347] object-"openshift-monitoring"/"prometheus-adapter-7m6srg4dfreoi": watch of *v1.Secret ended with: an error on the server ("unable to decode an event from the watch stream: http2: client connection lost") has prevented the request from succeeding`,
 				containerReferenceMatch: reflectorRefRegex,
 			},
-			want: monitorapi.ContainerReference{
-				Pod: monitorapi.PodReference{
-					NamespacedReference: monitorapi.NamespacedReference{
-						Namespace: "openshift-monitoring",
-						Name:      "prometheus-adapter-7m6srg4dfreoi",
-						UID:       "",
-					},
+			want: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeContainer,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorContainerKey: "",
+					monitorapi.LocatorNamespaceKey: "openshift-monitoring",
+					monitorapi.LocatorPodKey:       "prometheus-adapter-7m6srg4dfreoi",
+					monitorapi.LocatorUIDKey:       "",
 				},
-				ContainerName: "",
 			},
 		},
 		{
@@ -193,15 +325,14 @@ func TestRegexToContainerReference(t *testing.T) {
 				logLine:                 `Jul 05 17:47:52.807876 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: I0606 17:47:52.807876    1599 prober.go:121] "Probe failed" probeType="Readiness" pod="openshift-authentication/oauth-openshift-77f7b95df5-r4xf7" podUID=1af660b3-ac3a-4182-86eb-2f74725d8415 containerName="oauth-openshift" probeResult=failure output="Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"`,
 				containerReferenceMatch: containerRefRegex,
 			},
-			want: monitorapi.ContainerReference{
-				Pod: monitorapi.PodReference{
-					NamespacedReference: monitorapi.NamespacedReference{
-						Namespace: "openshift-authentication",
-						Name:      "oauth-openshift-77f7b95df5-r4xf7",
-						UID:       "1af660b3-ac3a-4182-86eb-2f74725d8415",
-					},
+			want: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeContainer,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorContainerKey: "oauth-openshift",
+					monitorapi.LocatorNamespaceKey: "openshift-authentication",
+					monitorapi.LocatorPodKey:       "oauth-openshift-77f7b95df5-r4xf7",
+					monitorapi.LocatorUIDKey:       "1af660b3-ac3a-4182-86eb-2f74725d8415",
 				},
-				ContainerName: "oauth-openshift",
 			},
 		},
 		{
@@ -210,23 +341,21 @@ func TestRegexToContainerReference(t *testing.T) {
 				logLine:                 `Jul 05 17:43:12.908344 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: E0606 17:43:12.908344    1500 prober.go:118] "Probe errored" err="rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found" probeType="Readiness" pod="openshift-marketplace/redhat-operators-4jpg4" podUID=0bac4741-a3bd-483c-b119-e97663d64024 containerName="registry-server"`,
 				containerReferenceMatch: containerRefRegex,
 			},
-			want: monitorapi.ContainerReference{
-				Pod: monitorapi.PodReference{
-					NamespacedReference: monitorapi.NamespacedReference{
-						Namespace: "openshift-marketplace",
-						Name:      "redhat-operators-4jpg4",
-						UID:       "0bac4741-a3bd-483c-b119-e97663d64024",
-					},
+			want: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeContainer,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorContainerKey: "registry-server",
+					monitorapi.LocatorNamespaceKey: "openshift-marketplace",
+					monitorapi.LocatorPodKey:       "redhat-operators-4jpg4",
+					monitorapi.LocatorUIDKey:       "0bac4741-a3bd-483c-b119-e97663d64024",
 				},
-				ContainerName: "registry-server",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := regexToContainerReference(tt.args.logLine, tt.args.containerReferenceMatch); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("regexToContainerReference() = %v, want %v", got, tt.want)
-			}
+			got := regexToContainerReference(tt.args.logLine, tt.args.containerReferenceMatch)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -259,22 +388,21 @@ func Test_probeProblemToContainerReference(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want monitorapi.ContainerReference
+		want monitorapi.Locator
 	}{
 		{
 			name: "simple failure",
 			args: args{
 				logLine: `Jul 05 17:47:52.807876 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: I0606 17:47:52.807876    1599 prober.go:121] "Probe failed" probeType="Readiness" pod="openshift-authentication/oauth-openshift-77f7b95df5-r4xf7" podUID=1af660b3-ac3a-4182-86eb-2f74725d8415 containerName="oauth-openshift" probeResult=failure output="Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"`,
 			},
-			want: monitorapi.ContainerReference{
-				Pod: monitorapi.PodReference{
-					NamespacedReference: monitorapi.NamespacedReference{
-						Namespace: "openshift-authentication",
-						Name:      "oauth-openshift-77f7b95df5-r4xf7",
-						UID:       "1af660b3-ac3a-4182-86eb-2f74725d8415",
-					},
+			want: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeContainer,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorContainerKey: "oauth-openshift",
+					monitorapi.LocatorNamespaceKey: "openshift-authentication",
+					monitorapi.LocatorPodKey:       "oauth-openshift-77f7b95df5-r4xf7",
+					monitorapi.LocatorUIDKey:       "1af660b3-ac3a-4182-86eb-2f74725d8415",
 				},
-				ContainerName: "oauth-openshift",
 			},
 		},
 		{
@@ -282,23 +410,21 @@ func Test_probeProblemToContainerReference(t *testing.T) {
 			args: args{
 				logLine: `Jul 05 17:43:12.908344 ci-op-lxqqvl5x-d3bee-gl4hp-master-0 hyperkube[1495]: E0606 17:43:12.908344    1500 prober.go:118] "Probe errored" err="rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found" probeType="Readiness" pod="openshift-marketplace/redhat-operators-4jpg4" podUID=0bac4741-a3bd-483c-b119-e97663d64024 containerName="registry-server"`,
 			},
-			want: monitorapi.ContainerReference{
-				Pod: monitorapi.PodReference{
-					NamespacedReference: monitorapi.NamespacedReference{
-						Namespace: "openshift-marketplace",
-						Name:      "redhat-operators-4jpg4",
-						UID:       "0bac4741-a3bd-483c-b119-e97663d64024",
-					},
+			want: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeContainer,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorContainerKey: "registry-server",
+					monitorapi.LocatorNamespaceKey: "openshift-marketplace",
+					monitorapi.LocatorPodKey:       "redhat-operators-4jpg4",
+					monitorapi.LocatorUIDKey:       "0bac4741-a3bd-483c-b119-e97663d64024",
 				},
-				ContainerName: "registry-server",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := probeProblemToContainerReference(tt.args.logLine); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("probeProblemToContainerReference() = %v, want %v", got, tt.want)
-			}
+			got := probeProblemToContainerReference(tt.args.logLine)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -382,9 +508,27 @@ func Test_readinessFailure(t *testing.T) {
 			want: monitorapi.Intervals{
 				{
 					Condition: monitorapi.Condition{
-						Level:   0,
+						Level:   monitorapi.Info,
 						Locator: `ns/openshift-authentication pod/oauth-openshift-77f7b95df5-r4xf7 uid/1af660b3-ac3a-4182-86eb-2f74725d8415 container/oauth-openshift`,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeContainer,
+							Keys: map[monitorapi.LocatorKey]string{
+								"namespace": "openshift-authentication",
+								"pod":       "oauth-openshift-77f7b95df5-r4xf7",
+								"uid":       "1af660b3-ac3a-4182-86eb-2f74725d8415",
+								"container": "oauth-openshift",
+							},
+						},
 						Message: `reason/ReadinessFailed Get "https://10.129.0.12:6443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)`,
+						StructuredMessage: monitorapi.Message{
+							Reason:       "ReadinessFailed",
+							Cause:        "",
+							HumanMessage: "Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: "ReadinessFailed",
+								monitorapi.AnnotationNode:   "fakenode",
+							},
+						},
 					},
 					From: mustTime(fmt.Sprintf("05 Jul %d 17:47:52.807876 UTC", time.Now().Year())),
 					To:   mustTime(fmt.Sprintf("05 Jul %d 17:47:52.807876 UTC", time.Now().Year())),
@@ -394,9 +538,16 @@ func Test_readinessFailure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := readinessFailure(tt.args.logLine); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("readinessFailure() = %#v, \nwant %#v", got, tt.want)
-			}
+			got := readinessFailure("fakenode", tt.args.logLine)
+			//assert.Equal(t, tt.want, got)
+			// TODO: we can't deep test because now we're building things from maps of annotations with a
+			// non-predictable order, on the legacy Message and Locator. Once we eliminate these we could, in meantime
+			// we'll have to selectively test the other fields that we can compare.
+			assert.Equal(t, tt.want[0].StructuredLocator, got[0].StructuredLocator)
+			assert.Equal(t, tt.want[0].StructuredMessage, got[0].StructuredMessage)
+			assert.Equal(t, tt.want[0].Level, got[0].Level)
+			assert.Equal(t, tt.want[0].From, got[0].From)
+			assert.Equal(t, tt.want[0].To, got[0].To)
 		})
 	}
 }
@@ -464,10 +615,7 @@ func (p nodeIntervalTest) test(t *testing.T) {
 	}
 
 	resultJSON := string(resultBytes)
-	if p.results != resultJSON {
-		t.Log(p.results)
-		t.Fatal(resultJSON)
-	}
+	assert.Equal(t, strings.TrimSpace(p.results), resultJSON)
 }
 
 //go:embed nodeTest/*

--- a/pkg/monitor/intervalcreation/operator.go
+++ b/pkg/monitor/intervalcreation/operator.go
@@ -20,7 +20,7 @@ func IntervalsFromEvents_OperatorDegraded(intervals monitorapi.Intervals, _ moni
 	return intervalsFromEvents_OperatorStatus(intervals, beginning, end, configv1.OperatorDegraded, configv1.ConditionFalse, monitorapi.Error)
 }
 
-func intervalsFromEvents_OperatorStatus(intervals monitorapi.Intervals, beginning, end time.Time, conditionType configv1.ClusterStatusConditionType, conditionGoodState configv1.ConditionStatus, level monitorapi.EventLevel) monitorapi.Intervals {
+func intervalsFromEvents_OperatorStatus(intervals monitorapi.Intervals, beginning, end time.Time, conditionType configv1.ClusterStatusConditionType, conditionGoodState configv1.ConditionStatus, level monitorapi.ConditionLevel) monitorapi.Intervals {
 	ret := monitorapi.Intervals{}
 	operatorToInterestingBadCondition := map[string]*configv1.ClusterOperatorStatusCondition{}
 
@@ -71,7 +71,7 @@ func intervalsFromEvents_OperatorStatus(intervals monitorapi.Intervals, beginnin
 				lastStatus = "True"
 			}
 		}
-		ret = append(ret, monitorapi.EventInterval{
+		ret = append(ret, monitorapi.Interval{
 			Condition: monitorapi.Condition{
 				Level:   level,
 				Locator: event.Locator,
@@ -83,7 +83,7 @@ func intervalsFromEvents_OperatorStatus(intervals monitorapi.Intervals, beginnin
 	}
 
 	for operatorName, lastCondition := range operatorToInterestingBadCondition {
-		ret = append(ret, monitorapi.EventInterval{
+		ret = append(ret, monitorapi.Interval{
 			Condition: monitorapi.Condition{
 				Level:   level,
 				Locator: monitorapi.OperatorLocator(operatorName),

--- a/pkg/monitor/intervalcreation/operator_test.go
+++ b/pkg/monitor/intervalcreation/operator_test.go
@@ -20,7 +20,7 @@ func timeFor(asString string) time.Time {
 func TestIntervalsFromEvents_OperatorProgressing(t *testing.T) {
 	intervals := monitorapi.Intervals{}
 	intervals = append(intervals,
-		monitorapi.EventInterval{
+		monitorapi.Interval{
 			Condition: monitorapi.Condition{
 				Level:   monitorapi.Info,
 				Locator: "clusteroperator/network",
@@ -28,7 +28,7 @@ func TestIntervalsFromEvents_OperatorProgressing(t *testing.T) {
 			},
 			From: timeFor("2021-03-29T15:56:00Z"),
 		},
-		monitorapi.EventInterval{
+		monitorapi.Interval{
 			Condition: monitorapi.Condition{
 				Level:   monitorapi.Info,
 				Locator: "clusteroperator/network",

--- a/pkg/monitor/intervalcreation/pod.go
+++ b/pkg/monitor/intervalcreation/pod.go
@@ -58,11 +58,11 @@ func pendingPodCondition(locator string, from, to time.Time) (monitorapi.Conditi
 func CreatePodIntervalsFromInstants(input monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, startTime, endTime time.Time) monitorapi.Intervals {
 	sort.Stable(ByPodLifecycle(input))
 	// these *static* locators to events. These are NOT the same as the actual event locators because nodes are not consistently assigned.
-	podToStateTransitions := map[string][]monitorapi.EventInterval{}
-	allPodTransitions := map[string][]monitorapi.EventInterval{}
-	containerToLifecycleTransitions := map[string][]monitorapi.EventInterval{}
-	containerToReadinessTransitions := map[string][]monitorapi.EventInterval{}
-	containerToKubeletReadinessChecks := map[string][]monitorapi.EventInterval{}
+	podToStateTransitions := map[string][]monitorapi.Interval{}
+	allPodTransitions := map[string][]monitorapi.Interval{}
+	containerToLifecycleTransitions := map[string][]monitorapi.Interval{}
+	containerToReadinessTransitions := map[string][]monitorapi.Interval{}
+	containerToKubeletReadinessChecks := map[string][]monitorapi.Interval{}
 
 	for i := range input {
 		event := input[i]
@@ -133,11 +133,12 @@ func CreatePodIntervalsFromInstants(input monitorapi.Intervals, recordedResource
 	// broken up and the timeline rendering logic we have
 	for locator, instantEvents := range containerToKubeletReadinessChecks {
 		for _, instantEvent := range instantEvents {
-			ret = append(ret, monitorapi.EventInterval{
+			ret = append(ret, monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: locator,
-					Message: monitorapi.Message().Constructed(monitorapi.ConstructionOwnerPodLifecycle).Message(instantEvent.Message),
+					Message: monitorapi.NewMessage().Constructed(monitorapi.ConstructionOwnerPodLifecycle).
+						HumanMessage(instantEvent.Message).BuildString(),
 				},
 				From: instantEvent.From,
 				To:   instantEvent.From.Add(1 * time.Second),
@@ -170,8 +171,8 @@ func (t simpleTimeBounder) getEndTime(locator string) time.Time {
 
 type podLifecycleTimeBounder struct {
 	delegate              timeBounder
-	podToStateTransitions map[string][]monitorapi.EventInterval
-	allPodTransitions     map[string][]monitorapi.EventInterval
+	podToStateTransitions map[string][]monitorapi.Interval
+	allPodTransitions     map[string][]monitorapi.Interval
 	recordedPods          monitorapi.InstanceMap
 }
 
@@ -348,7 +349,7 @@ func (t podLifecycleTimeBounder) getRunOnceContainerEnd(inLocator string) *time.
 
 type containerLifecycleTimeBounder struct {
 	delegate                             timeBounder
-	podToContainerToLifecycleTransitions map[string][]monitorapi.EventInterval
+	podToContainerToLifecycleTransitions map[string][]monitorapi.Interval
 	recordedPods                         monitorapi.InstanceMap
 }
 
@@ -456,7 +457,7 @@ func (t containerLifecycleTimeBounder) getContainerEnd(inLocator string) *time.T
 
 type containerReadinessTimeBounder struct {
 	delegate                             timeBounder
-	podToContainerToLifecycleTransitions map[string][]monitorapi.EventInterval
+	podToContainerToLifecycleTransitions map[string][]monitorapi.Interval
 }
 
 func (t containerReadinessTimeBounder) getStartTime(inLocator string) time.Time {
@@ -487,7 +488,7 @@ type timeBounder interface {
 	getEndTime(locator string) time.Time
 }
 
-func buildTransitionsForCategory(locatorToConditions map[string][]monitorapi.EventInterval, startReason, endReason monitorapi.IntervalReason, timeBounder timeBounder) monitorapi.Intervals {
+func buildTransitionsForCategory(locatorToConditions map[string][]monitorapi.Interval, startReason, endReason monitorapi.IntervalReason, timeBounder timeBounder) monitorapi.Intervals {
 	ret := monitorapi.Intervals{}
 	// now step through each category and build the to/from interval
 	for locator, instantEvents := range locatorToConditions {
@@ -501,11 +502,11 @@ func buildTransitionsForCategory(locatorToConditions map[string][]monitorapi.Eve
 			prevAnnotations := monitorapi.AnnotationsFromMessage(prevEvent.Message)
 			prevBareMessage := monitorapi.NonAnnotationMessage(prevEvent.Message)
 
-			nextInterval := monitorapi.EventInterval{
+			nextInterval := monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: locator,
-					Message: monitorapi.Message().Constructed(monitorapi.ConstructionOwnerPodLifecycle).WithAnnotations(prevAnnotations).Message(prevBareMessage),
+					Message: monitorapi.NewMessage().Constructed(monitorapi.ConstructionOwnerPodLifecycle).WithAnnotations(prevAnnotations).HumanMessage(prevBareMessage).BuildString(),
 				},
 				From: prevEvent.From,
 				To:   currEvent.From,
@@ -524,7 +525,7 @@ func buildTransitionsForCategory(locatorToConditions map[string][]monitorapi.Eve
 			case !hasPrev && currReason != startReason:
 				// we missed the startReason (it probably happened before the watch was established).
 				// adjust the message to indicate that we missed the start event for this locator
-				nextInterval.Message = monitorapi.Message().Constructed(monitorapi.ConstructionOwnerPodLifecycle).Reason(startReason).Messagef("missed real %q", startReason)
+				nextInterval.Message = monitorapi.NewMessage().Constructed(monitorapi.ConstructionOwnerPodLifecycle).Reason(startReason).HumanMessagef("missed real %q", startReason).BuildString()
 			}
 
 			// if the current reason is a logical ending point, reset to an empty previous
@@ -536,11 +537,11 @@ func buildTransitionsForCategory(locatorToConditions map[string][]monitorapi.Eve
 			ret = append(ret, nextInterval)
 		}
 		if len(prevEvent.Message) > 0 {
-			nextInterval := monitorapi.EventInterval{
+			nextInterval := monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Info,
 					Locator: locator,
-					Message: monitorapi.ExpandMessage(prevEvent.Message).Constructed(monitorapi.ConstructionOwnerPodLifecycle).NoDetails(),
+					Message: monitorapi.ExpandMessage(prevEvent.Message).Constructed(monitorapi.ConstructionOwnerPodLifecycle).BuildString(),
 				},
 				From: prevEvent.From,
 				To:   timeBounder.getEndTime(locator),
@@ -553,7 +554,7 @@ func buildTransitionsForCategory(locatorToConditions map[string][]monitorapi.Eve
 	return ret
 }
 
-func sanitizeTime(nextInterval monitorapi.EventInterval, startTime, endTime time.Time) monitorapi.EventInterval {
+func sanitizeTime(nextInterval monitorapi.Interval, startTime, endTime time.Time) monitorapi.Interval {
 	if !endTime.IsZero() && nextInterval.To.After(endTime) {
 		nextInterval.To = endTime
 	}
@@ -566,8 +567,8 @@ func sanitizeTime(nextInterval monitorapi.EventInterval, startTime, endTime time
 	return nextInterval
 }
 
-func emptyEvent(startTime time.Time) monitorapi.EventInterval {
-	return monitorapi.EventInterval{
+func emptyEvent(startTime time.Time) monitorapi.Interval {
+	return monitorapi.Interval{
 		Condition: monitorapi.Condition{
 			Level: monitorapi.Info,
 		},

--- a/pkg/monitor/intervalcreation/podTest/container-life/expected.json
+++ b/pkg/monitor/intervalcreation/podTest/container-life/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T18:41:46Z",
             "to": "2022-03-07T18:41:46Z"
         },
@@ -11,6 +21,16 @@
             "level": "Info",
             "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-141-9.us-west-2.compute.internal reason/Scheduled",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T18:41:46Z",
             "to": "2022-03-07T18:41:54Z"
         },
@@ -18,6 +38,16 @@
             "level": "Info",
             "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T18:41:46Z",
             "to": "2022-03-07T18:41:52Z"
         },
@@ -25,6 +55,16 @@
             "level": "Info",
             "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T18:41:52Z",
             "to": "2022-03-07T18:41:52Z"
         },
@@ -32,6 +72,16 @@
             "level": "Info",
             "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/6.00s reason/ContainerStart",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T18:41:52Z",
             "to": "2022-03-07T18:41:54Z"
         },
@@ -39,6 +89,16 @@
             "level": "Info",
             "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T18:41:52Z",
             "to": "2022-03-07T18:41:54Z"
         }

--- a/pkg/monitor/intervalcreation/podTest/end-before-begin/expected.json
+++ b/pkg/monitor/intervalcreation/podTest/end-before-begin/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-214-214.us-west-1.compute.internal reason/Scheduled",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T16:43:14Z",
             "to": "2022-03-21T16:43:14Z"
         },
@@ -11,6 +21,16 @@
             "level": "Info",
             "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T16:43:14Z",
             "to": "2022-03-21T16:43:14Z"
         },
@@ -18,6 +38,16 @@
             "level": "Info",
             "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9 container/pruner",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T16:43:14Z",
             "to": "2022-03-21T16:43:14Z"
         }

--- a/pkg/monitor/intervalcreation/podTest/installer-pod/expected.json
+++ b/pkg/monitor/intervalcreation/podTest/installer-pod/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T21:37:20Z",
             "to": "2022-03-21T21:37:20Z"
         },
@@ -11,6 +21,16 @@
             "level": "Info",
             "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
             "message": "constructed/pod-lifecycle-constructor node/ci-op-97t906zm-db044-bwrrn-master-0 reason/Scheduled",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T21:37:20Z",
             "to": "2022-03-21T21:37:56Z"
         },
@@ -18,6 +38,16 @@
             "level": "Info",
             "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T21:37:20Z",
             "to": "2022-03-21T21:37:23Z"
         },
@@ -25,6 +55,16 @@
             "level": "Info",
             "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T21:37:23Z",
             "to": "2022-03-21T21:37:23Z"
         },
@@ -32,6 +72,16 @@
             "level": "Info",
             "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/3.00s reason/ContainerStart",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T21:37:23Z",
             "to": "2022-03-21T21:37:56Z"
         },
@@ -39,6 +89,16 @@
             "level": "Info",
             "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T21:37:23Z",
             "to": "2022-03-21T21:37:56Z"
         },
@@ -46,6 +106,16 @@
             "level": "Info",
             "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-21T21:37:56Z",
             "to": "2022-03-21T21:37:56Z"
         }

--- a/pkg/monitor/intervalcreation/podTest/long-not-ready/expected.json
+++ b/pkg/monitor/intervalcreation/podTest/long-not-ready/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T18:48:41Z",
             "to": "2022-03-22T19:00:26Z"
         },
@@ -11,6 +21,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/fix-audit-permissions",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T18:48:41Z",
             "to": "2022-03-22T18:49:50Z"
         },
@@ -18,6 +38,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T18:48:41Z",
             "to": "2022-03-22T19:00:26Z"
         },
@@ -25,6 +55,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver-check-endpoints",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T18:48:41Z",
             "to": "2022-03-22T19:00:26Z"
         },
@@ -32,6 +72,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/fix-audit-permissions",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T18:49:50Z",
             "to": "2022-03-22T18:49:50Z"
         },
@@ -39,6 +89,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-142-23.us-east-2.compute.internal reason/Scheduled",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T19:00:26Z",
             "to": "2022-03-22T19:11:18Z"
         },
@@ -46,6 +106,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T19:00:26Z",
             "to": "2022-03-22T19:11:18Z"
         },
@@ -53,6 +123,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver-check-endpoints",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T19:00:26Z",
             "to": "2022-03-22T19:11:18Z"
         }

--- a/pkg/monitor/intervalcreation/podTest/run-once-done/expected.json
+++ b/pkg/monitor/intervalcreation/podTest/run-once-done/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-10T22:46:20Z",
             "to": "2022-03-10T22:46:20Z"
         },
@@ -11,6 +21,16 @@
             "level": "Info",
             "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-136-132.us-west-2.compute.internal reason/Scheduled",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-10T22:46:20Z",
             "to": "2022-03-14T15:00:00Z"
         },
@@ -18,6 +38,16 @@
             "level": "Info",
             "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-10T22:46:20Z",
             "to": "2022-03-14T15:00:00Z"
         }

--- a/pkg/monitor/intervalcreation/podTest/simple/expected.json
+++ b/pkg/monitor/intervalcreation/podTest/simple/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T21:41:54Z",
             "to": "2022-03-22T22:02:53Z"
         },
@@ -11,6 +21,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T21:41:54Z",
             "to": "2022-03-22T22:02:53Z"
         },
@@ -18,6 +38,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T21:41:54Z",
             "to": "2022-03-22T22:29:35Z"
         },
@@ -25,6 +55,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor node/ci-op-ckiwry67-db044-lzjpd-master-0 reason/Scheduled",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T22:02:53Z",
             "to": "2022-03-22T22:29:35Z"
         },
@@ -32,6 +72,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T22:02:53Z",
             "to": "2022-03-22T22:29:35Z"
         },
@@ -39,6 +89,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor duration/30s reason/GracefulDelete",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T22:29:35Z",
             "to": "2022-03-22T22:29:36Z"
         },
@@ -46,6 +106,16 @@
             "level": "Info",
             "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-22T22:29:35Z",
             "to": "2022-03-22T22:29:35Z"
         }

--- a/pkg/monitor/intervalcreation/podTest/trailing-ready-2/expected.json
+++ b/pkg/monitor/intervalcreation/podTest/trailing-ready-2/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-08T23:17:18Z",
             "to": "2022-03-08T23:17:18Z"
         },
@@ -11,6 +21,16 @@
             "level": "Info",
             "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-231-18.us-east-2.compute.internal reason/Scheduled",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-08T23:17:18Z",
             "to": "2022-03-10T23:00:00Z"
         },
@@ -18,6 +38,16 @@
             "level": "Info",
             "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f container/machine-config-operator",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-08T23:17:18Z",
             "to": "2022-03-08T23:17:18Z"
         },
@@ -25,6 +55,16 @@
             "level": "Info",
             "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f container/machine-config-operator",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-08T23:17:18Z",
             "to": "2022-03-10T23:00:00Z"
         }

--- a/pkg/monitor/intervalcreation/podTest/trailing-ready/expected.json
+++ b/pkg/monitor/intervalcreation/podTest/trailing-ready/expected.json
@@ -4,6 +4,16 @@
             "level": "Info",
             "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T22:47:04Z",
             "to": "2022-03-07T22:47:04Z"
         },
@@ -11,6 +21,16 @@
             "level": "Info",
             "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-154-151.ec2.internal reason/Scheduled",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T22:47:04Z",
             "to": "2022-03-07T22:47:14Z"
         },
@@ -18,6 +38,16 @@
             "level": "Info",
             "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T22:47:04Z",
             "to": "2022-03-07T22:47:07Z"
         },
@@ -25,6 +55,16 @@
             "level": "Info",
             "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T22:47:07Z",
             "to": "2022-03-07T22:47:14Z"
         },
@@ -32,6 +72,16 @@
             "level": "Info",
             "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/3.00s reason/ContainerStart",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T22:47:07Z",
             "to": "2022-03-07T22:47:15Z"
         },
@@ -39,6 +89,16 @@
             "level": "Info",
             "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "constructed/pod-lifecycle-constructor duration/1s reason/GracefulDelete",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T22:47:14Z",
             "to": "2022-03-07T22:47:15Z"
         },
@@ -46,6 +106,16 @@
             "level": "Info",
             "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T22:47:14Z",
             "to": "2022-03-07T22:47:15Z"
         },
@@ -53,6 +123,16 @@
             "level": "Info",
             "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempStructuredLocator": {
+                "type": "",
+                "keys": null
+            },
+            "tempStructuredMessage": {
+                "reason": "",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": null
+            },
             "from": "2022-03-07T22:47:15Z",
             "to": "2022-03-07T22:47:15Z"
         }

--- a/pkg/monitor/intervalcreation/pod_test.go
+++ b/pkg/monitor/intervalcreation/pod_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -103,10 +104,7 @@ func (p podIntervalTest) test(t *testing.T) {
 	}
 
 	resultJSON := string(resultBytes)
-	if p.results != resultJSON {
-		t.Log(p.results)
-		t.Fatal(resultJSON)
-	}
+	assert.Equal(t, strings.TrimSpace(p.results), resultJSON)
 }
 
 //go:embed podTest/*

--- a/pkg/monitor/intervalcreation/podlogs.go
+++ b/pkg/monitor/intervalcreation/podlogs.go
@@ -20,7 +20,7 @@ import (
 // interval should have. (Info, Warning, Error)
 type SubStringLevel struct {
 	subString string
-	level     monitorapi.EventLevel
+	level     monitorapi.ConditionLevel
 }
 
 type PodLogIntervalGenerator struct {
@@ -32,10 +32,10 @@ type PodLogIntervalGenerator struct {
 	subStrings []SubStringLevel
 	// lineParser is called to convert a log line to an EventInterval. Function is only called if
 	// the line matches one of the substrings.
-	lineParser func(locator, line string, intervalLevel monitorapi.EventLevel, logger logrus.FieldLogger) (*monitorapi.EventInterval, error)
+	lineParser func(locator, line string, intervalLevel monitorapi.ConditionLevel, logger logrus.FieldLogger) (*monitorapi.Interval, error)
 }
 
-func (g PodLogIntervalGenerator) ScanLine(pod *kapiv1.Pod, line string, beginning, end time.Time, logger logrus.FieldLogger) (*monitorapi.EventInterval, error) {
+func (g PodLogIntervalGenerator) ScanLine(pod *kapiv1.Pod, line string, beginning, end time.Time, logger logrus.FieldLogger) (*monitorapi.Interval, error) {
 	for _, subStr := range g.subStrings {
 		if strings.Contains(line, subStr.subString) {
 			locator := monitorapi.LocatePodContainer(pod, g.container)
@@ -65,14 +65,14 @@ type etcdLogLine struct {
 // etcdLogParser handles etcd logs which are already nicely json formatted such as:
 //
 // {"level":"info","ts":"2023-03-03T18:09:01.471Z","caller":"mvcc/index.go:214","msg":"compact tree index","revision":738215}
-func etcdLogParser(locator, line string, level monitorapi.EventLevel, logger logrus.FieldLogger) (*monitorapi.EventInterval, error) {
+func etcdLogParser(locator, line string, level monitorapi.ConditionLevel, logger logrus.FieldLogger) (*monitorapi.Interval, error) {
 	parsedLine := etcdLogLine{}
 	err := json.Unmarshal([]byte(line), &parsedLine)
 	if err != nil {
 		logger.WithError(err).Errorf("error parsing matched log line: %s", line)
 		return nil, err
 	}
-	return &monitorapi.EventInterval{
+	return &monitorapi.Interval{
 		Condition: monitorapi.Condition{
 			Level:   level,
 			Locator: locator,

--- a/pkg/monitor/intervalcreation/podlogs_test.go
+++ b/pkg/monitor/intervalcreation/podlogs_test.go
@@ -42,7 +42,7 @@ func TestPodLogScanner(t *testing.T) {
 		pod              *kapi.Pod
 		beginning        time.Time
 		end              time.Time
-		expectedInterval *monitorapi.EventInterval
+		expectedInterval *monitorapi.Interval
 	}{
 		{
 			name:             "no match",
@@ -56,7 +56,7 @@ func TestPodLogScanner(t *testing.T) {
 			pod:       buildFakePod("openshift-etcd", "etcd-1", "master-0", "fakeuuid"),
 			beginning: parseTimeOrDie("2023-03-03T00:00:00.871Z"),
 			end:       parseTimeOrDie("2023-03-03T03:00:00.871Z"),
-			expectedInterval: &monitorapi.EventInterval{
+			expectedInterval: &monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Level:   monitorapi.Warning,
 					Locator: "ns/openshift-etcd pod/etcd-1 node/master-0 uid/fakeuuid container/etcd src/podLog",
@@ -79,7 +79,7 @@ func TestPodLogScanner(t *testing.T) {
 	for _, test := range tests {
 		scanners := buildLogGatherers()
 		logger := logrus.WithField("test", test.name)
-		var interval *monitorapi.EventInterval
+		var interval *monitorapi.Interval
 		var err error
 		t.Run(test.name, func(t *testing.T) {
 			for _, scanner := range scanners {

--- a/pkg/monitor/intervalcreation/rendering.go
+++ b/pkg/monitor/intervalcreation/rendering.go
@@ -78,18 +78,18 @@ func (r eventIntervalRenderer) writeEventData(artifactDir, filenameBase string, 
 	return utilerrors.NewAggregate(errs)
 }
 
-func BelongsInEverything(eventInterval monitorapi.EventInterval) bool {
+func BelongsInEverything(eventInterval monitorapi.Interval) bool {
 	return true
 }
 
-func isInterestingOrPathological(eventInterval monitorapi.EventInterval) bool {
+func isInterestingOrPathological(eventInterval monitorapi.Interval) bool {
 	if strings.Contains(eventInterval.Locator, duplicateevents.InterestingMark) || strings.Contains(eventInterval.Locator, duplicateevents.PathologicalMark) {
 		return true
 	}
 	return false
 }
 
-func BelongsInSpyglass(eventInterval monitorapi.EventInterval) bool {
+func BelongsInSpyglass(eventInterval monitorapi.Interval) bool {
 	if isLessInterestingAlert(eventInterval) {
 		return false
 	}
@@ -105,7 +105,7 @@ func BelongsInSpyglass(eventInterval monitorapi.EventInterval) bool {
 	return true
 }
 
-func BelongsInOperatorRollout(eventInterval monitorapi.EventInterval) bool {
+func BelongsInOperatorRollout(eventInterval monitorapi.Interval) bool {
 	if monitorapi.IsE2ETest(eventInterval.Locator) {
 		return false
 	}
@@ -119,7 +119,7 @@ func BelongsInOperatorRollout(eventInterval monitorapi.EventInterval) bool {
 	return true
 }
 
-func BelongsInKubeAPIServer(eventInterval monitorapi.EventInterval) bool {
+func BelongsInKubeAPIServer(eventInterval monitorapi.Interval) bool {
 	if monitorapi.IsE2ETest(eventInterval.Locator) {
 		return false
 	}
@@ -139,11 +139,11 @@ func BelongsInKubeAPIServer(eventInterval monitorapi.EventInterval) bool {
 	return true
 }
 
-func IsPodLifecycle(eventInterval monitorapi.EventInterval) bool {
+func IsPodLifecycle(eventInterval monitorapi.Interval) bool {
 	return monitorapi.ConstructionOwnerFrom(eventInterval.Message) == monitorapi.ConstructionOwnerPodLifecycle
 }
 
-func IsOriginalPodEvent(eventInterval monitorapi.EventInterval) bool {
+func IsOriginalPodEvent(eventInterval monitorapi.Interval) bool {
 	// constructed events are not original
 	if len(monitorapi.ConstructionOwnerFrom(eventInterval.Message)) > 0 {
 		return false
@@ -151,7 +151,7 @@ func IsOriginalPodEvent(eventInterval monitorapi.EventInterval) bool {
 	return strings.Contains(eventInterval.Locator, "pod/")
 }
 
-func isPlatformPodEvent(eventInterval monitorapi.EventInterval) bool {
+func isPlatformPodEvent(eventInterval monitorapi.Interval) bool {
 	// only include pod events that were created in CreatePodIntervalsFromInstants
 	if !IsPodLifecycle(eventInterval) {
 		return false
@@ -187,13 +187,13 @@ var kubeAPIServerDependentNamespaces = sets.NewString(
 	"openshift-authentication-operator", "openshift-oauth-apiserver",
 )
 
-func isInterestingNamespace(eventInterval monitorapi.EventInterval, interestingNamespaces sets.String) bool {
+func isInterestingNamespace(eventInterval monitorapi.Interval, interestingNamespaces sets.String) bool {
 	locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
 	namespace := monitorapi.NamespaceFrom(locatorParts)
 	return interestingNamespaces.Has(namespace)
 }
 
-func isLessInterestingAlert(eventInterval monitorapi.EventInterval) bool {
+func isLessInterestingAlert(eventInterval monitorapi.Interval) bool {
 	locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
 	alertName := monitorapi.AlertFrom(locatorParts)
 	if len(alertName) == 0 {

--- a/pkg/monitor/intervalcreation/rendering_per_namespace.go
+++ b/pkg/monitor/intervalcreation/rendering_per_namespace.go
@@ -132,7 +132,7 @@ func (r podRendering) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap
 	errs := []error{}
 	for _, namespaceGroup := range namespaceGroups {
 		writer := NewNonSpyglassEventIntervalRenderer(namespaceGroup.name,
-			func(eventInterval monitorapi.EventInterval) bool {
+			func(eventInterval monitorapi.Interval) bool {
 				if !IsPodLifecycle(eventInterval) {
 					return false
 				}
@@ -171,7 +171,7 @@ func (r ingressServicePodRendering) WriteRunData(artifactDir string, _ monitorap
 		monitorapi.DisruptionSamplerOutageBeganEventReason)
 	relevantNamespaces := sets.NewString("openshift-authentication", "openshift-console", "openshift-image-registry", "openshift-ingress", "openshift-ovn-kubernetes")
 	writer := NewNonSpyglassEventIntervalRenderer("image-reg-console-oauth",
-		func(eventInterval monitorapi.EventInterval) bool {
+		func(eventInterval monitorapi.Interval) bool {
 			switch {
 			case isInterestingNamespace(eventInterval, relevantNamespaces):
 				return true

--- a/pkg/monitor/intervalcreation/state_tracker.go
+++ b/pkg/monitor/intervalcreation/state_tracker.go
@@ -20,12 +20,12 @@ type stateTracker struct {
 
 type conditionCreationFunc func(locator string, from, to time.Time) (monitorapi.Condition, bool)
 
-func simpleCondition(constructedBy monitorapi.ConstructionOwner, level monitorapi.EventLevel, reason monitorapi.IntervalReason, message string) conditionCreationFunc {
+func simpleCondition(constructedBy monitorapi.ConstructionOwner, level monitorapi.ConditionLevel, reason monitorapi.IntervalReason, message string) conditionCreationFunc {
 	return func(locator string, from, to time.Time) (monitorapi.Condition, bool) {
 		return monitorapi.Condition{
 			Level:   level,
 			Locator: locator,
-			Message: monitorapi.Message().Reason(reason).Constructed(constructedBy).Message(message),
+			Message: monitorapi.NewMessage().Reason(reason).Constructed(constructedBy).HumanMessage(message).BuildString(),
 		}, true
 	}
 }
@@ -96,7 +96,7 @@ func (t *stateTracker) openInterval(locator string, state stateInfo, from time.T
 
 	return false
 }
-func (t *stateTracker) closeIfOpenedInterval(locator string, state stateInfo, conditionCreator conditionCreationFunc, to time.Time) []monitorapi.EventInterval {
+func (t *stateTracker) closeIfOpenedInterval(locator string, state stateInfo, conditionCreator conditionCreationFunc, to time.Time) []monitorapi.Interval {
 	states := t.getStates(locator)
 	if _, ok := states[state]; !ok {
 		return nil
@@ -105,7 +105,7 @@ func (t *stateTracker) closeIfOpenedInterval(locator string, state stateInfo, co
 	return t.closeInterval(locator, state, conditionCreator, to)
 }
 
-func (t *stateTracker) closeInterval(locator string, state stateInfo, conditionCreator conditionCreationFunc, to time.Time) []monitorapi.EventInterval {
+func (t *stateTracker) closeInterval(locator string, state stateInfo, conditionCreator conditionCreationFunc, to time.Time) []monitorapi.Interval {
 	states := t.getStates(locator)
 
 	from, ok := states[state]
@@ -123,7 +123,7 @@ func (t *stateTracker) closeInterval(locator string, state stateInfo, conditionC
 	if !hasCondition {
 		return nil
 	}
-	return []monitorapi.EventInterval{
+	return []monitorapi.Interval{
 		{
 			Condition: condition,
 			From:      from,
@@ -132,8 +132,8 @@ func (t *stateTracker) closeInterval(locator string, state stateInfo, conditionC
 	}
 }
 
-func (t *stateTracker) closeAllIntervals(locatorToMessageAnnotations map[string]map[string]string, end time.Time) []monitorapi.EventInterval {
-	ret := []monitorapi.EventInterval{}
+func (t *stateTracker) closeAllIntervals(locatorToMessageAnnotations map[string]map[string]string, end time.Time) []monitorapi.Interval {
+	ret := []monitorapi.Interval{}
 	for locator, states := range t.locatorToStateMap {
 		annotationStrings := []string{}
 		for k, v := range locatorToMessageAnnotations[locator] {

--- a/pkg/monitor/intervalcreation/types.go
+++ b/pkg/monitor/intervalcreation/types.go
@@ -30,8 +30,8 @@ func defaultIntervalCreationFns() []simpleIntervalCreationFunc {
 }
 
 // InsertCalculatedIntervals calculates intervals from the currently known interval set and saves them into the same list
-func InsertCalculatedIntervals(startingIntervals []monitorapi.EventInterval, recordedResources monitorapi.ResourcesMap, from, to time.Time) monitorapi.Intervals {
-	ret := make([]monitorapi.EventInterval, len(startingIntervals))
+func InsertCalculatedIntervals(startingIntervals []monitorapi.Interval, recordedResources monitorapi.ResourcesMap, from, to time.Time) monitorapi.Intervals {
+	ret := make([]monitorapi.Interval, len(startingIntervals))
 	copy(ret, startingIntervals)
 
 	intervalCreationFns := defaultIntervalCreationFns()
@@ -47,8 +47,8 @@ func InsertCalculatedIntervals(startingIntervals []monitorapi.EventInterval, rec
 }
 
 // InsertIntervalsFromCluster contacts the cluster, retrieves information deemed pertinent, and creates intervals for them.
-func InsertIntervalsFromCluster(ctx context.Context, kubeConfig *rest.Config, startingIntervals []monitorapi.EventInterval, recordedResources monitorapi.ResourcesMap, from, to time.Time) (*nodedetails.AuditLogSummary, monitorapi.Intervals, error) {
-	ret := make([]monitorapi.EventInterval, len(startingIntervals))
+func InsertIntervalsFromCluster(ctx context.Context, kubeConfig *rest.Config, startingIntervals []monitorapi.Interval, recordedResources monitorapi.ResourcesMap, from, to time.Time) (*nodedetails.AuditLogSummary, monitorapi.Intervals, error) {
+	ret := make([]monitorapi.Interval, len(startingIntervals))
 	copy(ret, startingIntervals)
 
 	kubeClient, err := kubernetes.NewForConfig(kubeConfig)

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -136,7 +136,7 @@ func (m *Monitor) Record(conditions ...monitorapi.Condition) {
 	defer m.lock.Unlock()
 	t := time.Now().UTC()
 	for _, condition := range conditions {
-		m.events = append(m.events, monitorapi.EventInterval{
+		m.events = append(m.events, monitorapi.Interval{
 			Condition: condition,
 			From:      t,
 			To:        t,
@@ -145,7 +145,7 @@ func (m *Monitor) Record(conditions ...monitorapi.Condition) {
 }
 
 // AddIntervals provides a mechanism to directly inject eventIntervals
-func (m *Monitor) AddIntervals(eventIntervals ...monitorapi.EventInterval) {
+func (m *Monitor) AddIntervals(eventIntervals ...monitorapi.Interval) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.events = append(m.events, eventIntervals...)
@@ -156,7 +156,7 @@ func (m *Monitor) AddIntervals(eventIntervals ...monitorapi.EventInterval) {
 func (m *Monitor) StartInterval(t time.Time, condition monitorapi.Condition) int {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	m.unsortedEvents = append(m.unsortedEvents, monitorapi.EventInterval{
+	m.unsortedEvents = append(m.unsortedEvents, monitorapi.Interval{
 		Condition: condition,
 		From:      t,
 	})
@@ -184,7 +184,7 @@ func (m *Monitor) RecordAt(t time.Time, conditions ...monitorapi.Condition) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	for _, condition := range conditions {
-		m.unsortedEvents = append(m.unsortedEvents, monitorapi.EventInterval{
+		m.unsortedEvents = append(m.unsortedEvents, monitorapi.Interval{
 			Condition: condition,
 			From:      t,
 			To:        t,

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMonitor_Newlines(t *testing.T) {
-	evt := &monitorapi.EventInterval{Condition: monitorapi.Condition{Message: "a\nb\n"}}
+	evt := &monitorapi.Interval{Condition: monitorapi.Condition{Message: "a\nb\n"}}
 	expected := "Jan 01 00:00:00.000 I  a\\nb\\n"
 	if evt.String() != expected {
 		t.Fatalf("unexpected:\n%s\n%s", expected, evt.String())
@@ -18,6 +18,8 @@ func TestMonitor_Newlines(t *testing.T) {
 }
 
 func TestMonitor_Events(t *testing.T) {
+	condition1 := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("1")).Build()
+	condition2 := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("2")).Build()
 	tests := []struct {
 		name   string
 		events monitorapi.Intervals
@@ -28,42 +30,42 @@ func TestMonitor_Events(t *testing.T) {
 		{
 			name: "one",
 			events: monitorapi.Intervals{
-				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: condition1, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: condition2, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 			want: monitorapi.Intervals{
-				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: condition1, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: condition2, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
 			name: "two",
 			events: monitorapi.Intervals{
-				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: condition1, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: condition2, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 			from: time.Unix(1, 0),
 			want: monitorapi.Intervals{
-				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: condition2, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
 			name: "three",
 			events: monitorapi.Intervals{
-				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: condition1, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: condition2, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 			from: time.Unix(1, 0),
 			to:   time.Unix(2, 0),
 			want: monitorapi.Intervals{
-				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: condition2, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 		},
 		{
 			name: "four",
 			events: monitorapi.Intervals{
-				{Condition: monitorapi.Condition{Message: "1"}, From: time.Unix(1, 0), To: time.Unix(1, 0)},
-				{Condition: monitorapi.Condition{Message: "2"}, From: time.Unix(2, 0), To: time.Unix(2, 0)},
+				{Condition: condition1, From: time.Unix(1, 0), To: time.Unix(1, 0)},
+				{Condition: condition2, From: time.Unix(2, 0), To: time.Unix(2, 0)},
 			},
 			from: time.Unix(2, 0),
 			want: monitorapi.Intervals{},

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -1,0 +1,286 @@
+package monitorapi
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kube-openapi/pkg/util/sets"
+)
+
+type ConditionBuilder struct {
+	level             ConditionLevel
+	structuredLocator Locator
+	structuredMessage Message
+}
+
+func NewCondition(level ConditionLevel) *ConditionBuilder {
+	return &ConditionBuilder{
+		level: level,
+	}
+}
+
+func (b *ConditionBuilder) Build() Condition {
+	ret := Condition{
+		Level:             b.level,
+		Locator:           b.structuredLocator.OldLocator(),
+		StructuredLocator: b.structuredLocator,
+		Message:           b.structuredMessage.OldMessage(),
+		StructuredMessage: b.structuredMessage,
+	}
+
+	return ret
+}
+
+func (b *ConditionBuilder) Message(mb *MessageBuilder) *ConditionBuilder {
+	b.structuredMessage = mb.build()
+	return b
+}
+
+func (b *ConditionBuilder) Locator(locator Locator) *ConditionBuilder {
+	b.structuredLocator = locator
+	return b
+}
+
+// LocatorBuilder is used to create locators. We do not want to allow chaining of locators however
+// as this has led to illegal definitions of locators in the past. (such as node + namespace)
+// Instead the builder serves primarily as a place to store the builder functions.
+type LocatorBuilder struct {
+	targetType  LocatorType
+	annotations map[LocatorKey]string
+}
+
+func NewLocator() *LocatorBuilder {
+	return &LocatorBuilder{
+		annotations: map[LocatorKey]string{},
+	}
+}
+
+func (b *LocatorBuilder) NodeFromName(nodeName string) Locator {
+	b.targetType = LocatorTypeNode
+	b.annotations[LocatorNodeKey] = nodeName
+	return b.Build()
+}
+
+func (b *LocatorBuilder) AlertFromNames(alertName, node, namespace, pod, container string) Locator {
+	b.targetType = LocatorTypeAlert
+	if len(alertName) > 0 {
+		b.annotations[LocatorAlertKey] = alertName
+	}
+	if len(node) > 0 {
+		b.annotations[LocatorNodeKey] = node
+	}
+	if len(namespace) > 0 {
+		b.annotations[LocatorNamespaceKey] = namespace
+	}
+	if len(pod) > 0 {
+		b.annotations[LocatorPodKey] = pod
+	}
+	if len(container) > 0 {
+		b.annotations[LocatorContainerKey] = container
+	}
+	return b.Build()
+}
+
+func (b *LocatorBuilder) Disruption(disruptionName, loadBalancer, connection, protocol, target string) Locator {
+	b.targetType = LocatorTypeDisruption
+	b.annotations[LocatorDisruptionKey] = disruptionName
+	if len(loadBalancer) > 0 {
+		b.annotations[LocatorLoadBalancerKey] = loadBalancer
+	}
+	if len(connection) > 0 {
+		b.annotations[LocatorConnectionKey] = connection
+	}
+	if len(protocol) > 0 {
+		b.annotations[LocatorProtocolKey] = protocol
+	}
+	if len(target) > 0 {
+		b.annotations[LocatorTargetKey] = target
+	}
+	return b.Build()
+}
+
+func (b *LocatorBuilder) KubeEvent(event *corev1.Event) Locator {
+	b.targetType = LocatorTypeKubeEvent
+
+	// WARNING: we're trying to use an enum for the locator keys, but we cannot know
+	// all kinds in a cluster. Instead we'll split the kind and name into two different Keys
+	// for Events:
+	b.annotations[LocatorKindKey] = event.InvolvedObject.Kind
+	b.annotations[LocatorNameKey] = event.InvolvedObject.Name
+
+	if len(event.InvolvedObject.Namespace) > 0 {
+		b.annotations[LocatorNamespaceKey] = event.InvolvedObject.Namespace
+	}
+
+	// TODO: node + namespace is illegal, look at original impl, it may have handled this better
+	if len(event.Source.Host) > 0 && event.InvolvedObject.Kind != "Node" {
+		b.annotations[LocatorNodeKey] = event.Source.Host
+	}
+
+	return b.Build()
+}
+
+func (b *LocatorBuilder) APIServerShutdown(loadBalancer string) Locator {
+	b.targetType = LocatorTypeAPIServerShutdown
+	b.annotations[LocatorShutdownKey] = "graceful"
+	b.annotations[LocatorServerKey] = "kube-apiserver"
+	if len(loadBalancer) > 0 {
+		b.annotations[LocatorLoadBalancerKey] = loadBalancer
+	}
+	return b.Build()
+}
+
+func (b *LocatorBuilder) ContainerFromPod(pod *corev1.Pod, containerName string) Locator {
+	b.PodFromPod(pod)
+	b.targetType = LocatorTypeContainer
+	b.annotations[LocatorContainerKey] = containerName
+	return b.Build()
+}
+
+func (b *LocatorBuilder) ContainerFromNames(namespace, podName, uid, containerName string) Locator {
+	b.PodFromNames(namespace, podName, uid)
+	b.targetType = LocatorTypeContainer
+	b.annotations[LocatorContainerKey] = containerName
+	return b.Build()
+}
+
+func (b *LocatorBuilder) PodFromNames(namespace, podName, uid string) Locator {
+	b.targetType = LocatorTypePod
+	b.annotations[LocatorNamespaceKey] = namespace
+	b.annotations[LocatorPodKey] = podName
+	b.annotations[LocatorUIDKey] = uid
+
+	return b.Build()
+}
+
+func (b *LocatorBuilder) PodFromPod(pod *corev1.Pod) Locator {
+	b.PodFromNames(pod.Namespace, pod.Name, string(pod.UID))
+	// TODO, to be removed.  this should be in the message, not in the locator
+	if len(pod.Spec.NodeName) > 0 {
+		b.annotations[LocatorNodeKey] = pod.Spec.NodeName
+	}
+	if mirrorUID := pod.Annotations["kubernetes.io/config.mirror"]; len(mirrorUID) > 0 {
+		b.annotations[LocatorMirrorUIDKey] = mirrorUID
+	}
+
+	return b.Build()
+}
+
+func (b *LocatorBuilder) Build() Locator {
+	ret := Locator{
+		Type: b.targetType,
+		Keys: map[LocatorKey]string{},
+	}
+	for k, v := range b.annotations {
+		ret.Keys[k] = v
+	}
+	return ret
+}
+
+type MessageBuilder struct {
+	annotations  map[AnnotationKey]string
+	humanMessage string
+}
+
+func NewMessage() *MessageBuilder {
+	return &MessageBuilder{
+		annotations: map[AnnotationKey]string{},
+	}
+}
+
+// ExpandMessage parses a message that was collapsed into a string to extract each annotation
+// and the original message.
+func ExpandMessage(prevMessage string) *MessageBuilder {
+	prevAnnotations := AnnotationsFromMessage(prevMessage)
+	prevNonAnnotationMessage := NonAnnotationMessage(prevMessage)
+	return &MessageBuilder{
+		annotations:  prevAnnotations,
+		humanMessage: prevNonAnnotationMessage,
+	}
+}
+
+func (m *MessageBuilder) Reason(reason IntervalReason) *MessageBuilder {
+	return m.WithAnnotation(AnnotationReason, string(reason))
+}
+
+func (m *MessageBuilder) Cause(cause string) *MessageBuilder {
+	return m.WithAnnotation(AnnotationCause, cause)
+}
+
+func (m *MessageBuilder) Node(node string) *MessageBuilder {
+	return m.WithAnnotation(AnnotationNode, node)
+}
+
+func (m *MessageBuilder) Constructed(constructedBy ConstructionOwner) *MessageBuilder {
+	return m.WithAnnotation(AnnotationConstructed, string(constructedBy))
+}
+
+func (m *MessageBuilder) WithAnnotation(name AnnotationKey, value string) *MessageBuilder {
+	m.annotations[name] = value
+	return m
+}
+
+func (m *MessageBuilder) WithAnnotations(annotations map[AnnotationKey]string) *MessageBuilder {
+	for k, v := range annotations {
+		m.annotations[k] = v
+	}
+	return m
+}
+
+// HumanMessage adds the human readable message. If called multiple times, the message is appended.
+func (m *MessageBuilder) HumanMessage(message string) *MessageBuilder {
+	if len(m.humanMessage) == 0 {
+		m.humanMessage = message
+		return m
+	}
+	// TODO: track a slice of human messages? we are aiming for structure here...
+	m.humanMessage = fmt.Sprintf("%v %v", m.humanMessage, message)
+	return m
+}
+
+// HumanMessagef adds a formatted string to the human readable message. If called multiple times, the message is appended.
+func (m *MessageBuilder) HumanMessagef(messageFormat string, args ...interface{}) *MessageBuilder {
+	return m.HumanMessage(fmt.Sprintf(messageFormat, args...))
+}
+
+// build creates the final StructuredMessage with all data assembled by this builder.
+func (m *MessageBuilder) build() Message {
+	ret := Message{
+		Annotations: map[AnnotationKey]string{},
+	}
+	// TODO: what do we gain from a mStructuredMessage with fixed keys, vs fields on the StructuredMessage?
+	// They're not really fixed, some WithAnnotation calls are floating around, but could those also be functions here?
+	for k, v := range m.annotations {
+		ret.Annotations[k] = v
+		switch k {
+		case AnnotationReason:
+			ret.Reason = IntervalReason(v)
+		case AnnotationCause:
+			ret.Cause = v
+		}
+	}
+	ret.HumanMessage = m.humanMessage
+	return ret
+}
+
+// BuildString creates the final message as a flat single string.
+// Each annotation is prepended in the form name/value, followed by the human message, if any.
+func (m *MessageBuilder) BuildString() string {
+	keys := sets.NewString()
+	for k := range m.annotations {
+		keys.Insert(string(k))
+	}
+
+	annotations := []string{}
+	for _, k := range keys.List() {
+		v := m.annotations[AnnotationKey(k)]
+		annotations = append(annotations, fmt.Sprintf("%v/%v", k, v))
+	}
+	retString := strings.Join(annotations, " ")
+
+	if len(m.humanMessage) > 0 {
+		retString = fmt.Sprintf("%v %v", retString, m.humanMessage)
+	}
+	return retString
+}

--- a/pkg/monitor/monitorapi/disruption.go
+++ b/pkg/monitor/monitorapi/disruption.go
@@ -21,7 +21,7 @@ func BackendDisruptionSeconds(locator string, events Intervals) (time.Duration, 
 	return disruptionEvents.Duration(1 * time.Second).Round(time.Second), disruptionMessages, connectionType
 }
 
-func IsDisruptionEvent(eventInterval EventInterval) bool {
+func IsDisruptionEvent(eventInterval Interval) bool {
 	if disruptionBackend := DisruptionFrom(LocatorParts(eventInterval.Locator)); len(disruptionBackend) > 0 {
 		return true
 	}

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -144,7 +144,7 @@ func DisruptionTargetAPIFrom(locatorParts map[string]string) string {
 }
 
 func IsEventForLocator(locator string) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		if eventInterval.Locator == locator {
 			return true
 		}

--- a/pkg/monitor/monitorapi/identification_node.go
+++ b/pkg/monitor/monitorapi/identification_node.go
@@ -5,7 +5,7 @@ import (
 )
 
 // GetNodeRoles extract the node roles from the event message.
-func GetNodeRoles(event EventInterval) string {
+func GetNodeRoles(event Interval) string {
 	var roles string
 	if i := strings.Index(event.Message, "roles/"); i != -1 {
 		roles = event.Message[i+len("roles/"):]

--- a/pkg/monitor/monitorapi/identification_node_test.go
+++ b/pkg/monitor/monitorapi/identification_node_test.go
@@ -4,11 +4,11 @@ import "testing"
 
 func TestGetNodeRoles(t *testing.T) {
 	var testCases = []struct {
-		event    EventInterval
+		event    Interval
 		expected string
 	}{
 		{
-			event: EventInterval{
+			event: Interval{
 				Condition: Condition{
 					Message: "",
 				},
@@ -16,7 +16,7 @@ func TestGetNodeRoles(t *testing.T) {
 			expected: "",
 		},
 		{
-			event: EventInterval{
+			event: Interval{
 				Condition: Condition{
 					Message: "roles/master",
 				},
@@ -24,7 +24,7 @@ func TestGetNodeRoles(t *testing.T) {
 			expected: "master",
 		},
 		{
-			event: EventInterval{
+			event: Interval{
 				Condition: Condition{
 					Message: "roles/worker",
 				},
@@ -32,7 +32,7 @@ func TestGetNodeRoles(t *testing.T) {
 			expected: "worker",
 		},
 		{
-			event: EventInterval{
+			event: Interval{
 				Condition: Condition{
 					Message: "roles/master,worker",
 				},

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -56,6 +56,7 @@ func ContainerFrom(locator string) ContainerReference {
 	}
 }
 
+// TODO: delete all these
 type PodReference struct {
 	NamespacedReference
 }
@@ -111,145 +112,6 @@ func PhaseFrom(message string) string {
 	return annotations[AnnotationPodPhase]
 }
 
-type IntervalReason string
-
-const (
-	IPTablesNotPermitted IntervalReason = "iptables-operation-not-permitted"
-
-	DisruptionBeganEventReason              IntervalReason = "DisruptionBegan"
-	DisruptionEndedEventReason              IntervalReason = "DisruptionEnded"
-	DisruptionSamplerOutageBeganEventReason IntervalReason = "DisruptionSamplerOutageBegan"
-
-	HttpClientConnectionLost IntervalReason = "HttpClientConnectionLost"
-
-	PodPendingReason               IntervalReason = "PodIsPending"
-	PodNotPendingReason            IntervalReason = "PodIsNotPending"
-	PodReasonCreated               IntervalReason = "Created"
-	PodReasonGracefulDeleteStarted IntervalReason = "GracefulDelete"
-	PodReasonForceDelete           IntervalReason = "ForceDelete"
-	PodReasonDeleted               IntervalReason = "Deleted"
-	PodReasonScheduled             IntervalReason = "Scheduled"
-
-	ContainerReasonContainerExit      IntervalReason = "ContainerExit"
-	ContainerReasonContainerStart     IntervalReason = "ContainerStart"
-	ContainerReasonContainerWait      IntervalReason = "ContainerWait"
-	ContainerReasonReadinessFailed    IntervalReason = "ReadinessFailed"
-	ContainerReasonReadinessErrored   IntervalReason = "ReadinessErrored"
-	ContainerReasonStartupProbeFailed IntervalReason = "StartupProbeFailed"
-	ContainerReasonReady              IntervalReason = "Ready"
-	ContainerReasonNotReady           IntervalReason = "NotReady"
-
-	PodReasonDeletedBeforeScheduling IntervalReason = "DeletedBeforeScheduling"
-	PodReasonDeletedAfterCompletion  IntervalReason = "DeletedAfterCompletion"
-
-	NodeUpdateReason   IntervalReason = "NodeUpdate"
-	NodeNotReadyReason IntervalReason = "NotReady"
-)
-
-type AnnotationKey string
-
-const (
-	AnnotationReason            AnnotationKey = "reason"
-	AnnotationContainerExitCode AnnotationKey = "code"
-	AnnotationCause             AnnotationKey = "cause"
-	AnnotationNode              AnnotationKey = "node"
-	AnnotationConstructed       AnnotationKey = "constructed"
-	AnnotationPodPhase          AnnotationKey = "phase"
-	AnnotationIsStaticPod       AnnotationKey = "mirrored"
-	// TODO this looks wrong. seems like it ought to be set in the to/from
-	AnnotationDuration       AnnotationKey = "duration"
-	AnnotationRequestAuditID AnnotationKey = "request-audit-id"
-)
-
-type ConstructionOwner string
-
-const (
-	ConstructionOwnerNodeLifecycle = "node-lifecycle-constructor"
-	ConstructionOwnerPodLifecycle  = "pod-lifecycle-constructor"
-)
-
-type MessageBuilder struct {
-	annotations     map[AnnotationKey]string
-	originalMessage string
-}
-
-func Message() *MessageBuilder {
-	return &MessageBuilder{
-		annotations: map[AnnotationKey]string{},
-	}
-}
-
-func ExpandMessage(prevMessage string) *MessageBuilder {
-	prevAnnotations := AnnotationsFromMessage(prevMessage)
-	prevNonAnnotationMessage := NonAnnotationMessage(prevMessage)
-	return &MessageBuilder{
-		annotations:     prevAnnotations,
-		originalMessage: prevNonAnnotationMessage,
-	}
-}
-
-func (m *MessageBuilder) Reason(reason IntervalReason) *MessageBuilder {
-	return m.WithAnnotation(AnnotationReason, string(reason))
-}
-
-func (m *MessageBuilder) Cause(cause string) *MessageBuilder {
-	return m.WithAnnotation(AnnotationCause, cause)
-}
-
-func (m *MessageBuilder) Node(node string) *MessageBuilder {
-	return m.WithAnnotation(AnnotationNode, node)
-}
-
-func (m *MessageBuilder) Constructed(constructedBy ConstructionOwner) *MessageBuilder {
-	return m.WithAnnotation(AnnotationConstructed, string(constructedBy))
-}
-
-func (m *MessageBuilder) WithAnnotation(name AnnotationKey, value string) *MessageBuilder {
-	m.annotations[name] = value
-	return m
-}
-
-func (m *MessageBuilder) WithAnnotations(annotations map[AnnotationKey]string) *MessageBuilder {
-	for k, v := range annotations {
-		m.annotations[k] = v
-	}
-	return m
-}
-
-func (m *MessageBuilder) NoDetails() string {
-	keys := sets.NewString()
-	for k := range m.annotations {
-		keys.Insert(string(k))
-	}
-
-	annotations := []string{}
-	for _, k := range keys.List() {
-		v := m.annotations[AnnotationKey(k)]
-		annotations = append(annotations, fmt.Sprintf("%v/%v", k, v))
-	}
-	annotationString := strings.Join(annotations, " ")
-	return m.appendPreviousMessage(annotationString)
-}
-
-func (m *MessageBuilder) Messagef(messageFormat string, args ...interface{}) string {
-	return m.Message(fmt.Sprintf(messageFormat, args...))
-}
-
-func (m *MessageBuilder) Message(message string) string {
-	if len(message) == 0 {
-		return m.NoDetails()
-	}
-	annotationString := m.NoDetails()
-	return m.appendPreviousMessage(fmt.Sprintf("%v %v", annotationString, message))
-}
-
-func (m *MessageBuilder) appendPreviousMessage(newMessage string) string {
-	if len(m.originalMessage) == 0 {
-		return newMessage
-	}
-	return fmt.Sprintf("%v %v", m.originalMessage, newMessage)
-}
-
 const (
 	// PodIPReused means the same pod IP is in use by two pods at the same time.
 	PodIPReused = "ReusedPodIP"
@@ -296,7 +158,7 @@ var (
 	)
 )
 
-type ByTimeWithNamespacedPods []EventInterval
+type ByTimeWithNamespacedPods []Interval
 
 func (intervals ByTimeWithNamespacedPods) Less(i, j int) bool {
 	lhsIsPodConstructed := strings.Contains(intervals[i].Message, "constructed") && strings.Contains(intervals[i].Locator, "pod/")

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -24,15 +24,15 @@ const (
 	ObservedRecreationCountAnnotation = "monitor.openshift.io/observed-recreation-count"
 )
 
-type EventLevel int
+type ConditionLevel int
 
 const (
-	Info EventLevel = iota
+	Info ConditionLevel = iota
 	Warning
 	Error
 )
 
-func (e EventLevel) String() string {
+func (e ConditionLevel) String() string {
 	switch e {
 	case Info:
 		return "Info"
@@ -45,7 +45,7 @@ func (e EventLevel) String() string {
 	}
 }
 
-func EventLevelFromString(s string) (EventLevel, error) {
+func ConditionLevelFromString(s string) (ConditionLevel, error) {
 	switch s {
 	case "Info":
 		return Info, nil
@@ -60,20 +60,138 @@ func EventLevelFromString(s string) (EventLevel, error) {
 }
 
 type Condition struct {
-	Level EventLevel
+	Level ConditionLevel
 
-	Locator string
-	Message string
+	// TODO: Goal here is to drop Locator/Message, and rename the structured variants to Locator/Message
+	Locator           string
+	StructuredLocator Locator
+	Message           string
+	StructuredMessage Message
 }
 
-type EventInterval struct {
+type LocatorType string
+
+const (
+	LocatorTypePod               LocatorType = "Pod"
+	LocatorTypeContainer         LocatorType = "Container"
+	LocatorTypeNode              LocatorType = "Node"
+	LocatorTypeAlert             LocatorType = "Alert"
+	LocatorTypeClusterOperator   LocatorType = "ClusterOperator"
+	LocatorTypeOther             LocatorType = "Other"
+	LocatorTypeDisruption        LocatorType = "Disruption"
+	LocatorTypeKubeEvent         LocatorType = "KubeEvent"
+	LocatorTypeAPIServerShutdown LocatorType = "APIServerShutdown"
+)
+
+type LocatorKey string
+
+const (
+	LocatorClusterOperatorKey LocatorKey = "clusteroperator"
+	LocatorNamespaceKey       LocatorKey = "namespace"
+	LocatorNodeKey            LocatorKey = "node"
+	LocatorKindKey            LocatorKey = "kind"
+	LocatorNameKey            LocatorKey = "name"
+	LocatorPodKey             LocatorKey = "pod"
+	LocatorUIDKey             LocatorKey = "uid"
+	LocatorMirrorUIDKey       LocatorKey = "mirror-uid"
+	LocatorContainerKey       LocatorKey = "container"
+	LocatorAlertKey           LocatorKey = "alert"
+	LocatorRouteKey           LocatorKey = "route"
+	LocatorDisruptionKey      LocatorKey = "disruption"
+	LocatorE2ETestKey         LocatorKey = "e2e-test"
+	LocatorLoadBalancerKey    LocatorKey = "load-balancer"
+	LocatorConnectionKey      LocatorKey = "connection"
+	LocatorProtocolKey        LocatorKey = "protocol"
+	LocatorTargetKey          LocatorKey = "target"
+	LocatorShutdownKey        LocatorKey = "shutdown"
+	LocatorServerKey          LocatorKey = "server"
+)
+
+type Locator struct {
+	Type LocatorType `json:"type"`
+
+	// annotations will include the Reason and Cause under their respective keys
+	Keys map[LocatorKey]string `json:"keys"`
+}
+
+type IntervalReason string
+
+const (
+	IPTablesNotPermitted IntervalReason = "iptables-operation-not-permitted"
+
+	DisruptionBeganEventReason              IntervalReason = "DisruptionBegan"
+	DisruptionEndedEventReason              IntervalReason = "DisruptionEnded"
+	DisruptionSamplerOutageBeganEventReason IntervalReason = "DisruptionSamplerOutageBegan"
+
+	HttpClientConnectionLost IntervalReason = "HttpClientConnectionLost"
+
+	PodPendingReason               IntervalReason = "PodIsPending"
+	PodNotPendingReason            IntervalReason = "PodIsNotPending"
+	PodReasonCreated               IntervalReason = "Created"
+	PodReasonGracefulDeleteStarted IntervalReason = "GracefulDelete"
+	PodReasonForceDelete           IntervalReason = "ForceDelete"
+	PodReasonDeleted               IntervalReason = "Deleted"
+	PodReasonScheduled             IntervalReason = "Scheduled"
+
+	ContainerReasonContainerExit      IntervalReason = "ContainerExit"
+	ContainerReasonContainerStart     IntervalReason = "ContainerStart"
+	ContainerReasonContainerWait      IntervalReason = "ContainerWait"
+	ContainerReasonReadinessFailed    IntervalReason = "ReadinessFailed"
+	ContainerReasonReadinessErrored   IntervalReason = "ReadinessErrored"
+	ContainerReasonStartupProbeFailed IntervalReason = "StartupProbeFailed"
+	ContainerReasonReady              IntervalReason = "Ready"
+	ContainerReasonRestarted          IntervalReason = "Restarted"
+	ContainerReasonNotReady           IntervalReason = "NotReady"
+	TerminationStateCleared           IntervalReason = "TerminationStateCleared"
+
+	PodReasonDeletedBeforeScheduling IntervalReason = "DeletedBeforeScheduling"
+	PodReasonDeletedAfterCompletion  IntervalReason = "DeletedAfterCompletion"
+
+	NodeUpdateReason   IntervalReason = "NodeUpdate"
+	NodeNotReadyReason IntervalReason = "NotReady"
+	NodeFailedLease    IntervalReason = "FailedToUpdateLease"
+)
+
+type AnnotationKey string
+
+const (
+	AnnotationReason            AnnotationKey = "reason"
+	AnnotationContainerExitCode AnnotationKey = "code"
+	AnnotationCause             AnnotationKey = "cause"
+	AnnotationNode              AnnotationKey = "node"
+	AnnotationConstructed       AnnotationKey = "constructed"
+	AnnotationPodPhase          AnnotationKey = "phase"
+	AnnotationIsStaticPod       AnnotationKey = "mirrored"
+	// TODO this looks wrong. seems like it ought to be set in the to/from
+	AnnotationDuration       AnnotationKey = "duration"
+	AnnotationRequestAuditID AnnotationKey = "request-audit-id"
+)
+
+type ConstructionOwner string
+
+const (
+	ConstructionOwnerNodeLifecycle = "node-lifecycle-constructor"
+	ConstructionOwnerPodLifecycle  = "pod-lifecycle-constructor"
+)
+
+type Message struct {
+	// TODO: reason/cause both fields and annotations...
+	Reason       IntervalReason `json:"reason"`
+	Cause        string         `json:"cause"`
+	HumanMessage string         `json:"humanMessage"`
+
+	// annotations will include the Reason and Cause under their respective keys
+	Annotations map[AnnotationKey]string `json:"annotations"`
+}
+
+type Interval struct {
 	Condition
 
 	From time.Time
 	To   time.Time
 }
 
-func (i EventInterval) String() string {
+func (i Interval) String() string {
 	if i.From.Equal(i.To) {
 		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), i.Level.String()[:1], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 	}
@@ -84,11 +202,47 @@ func (i EventInterval) String() string {
 	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Second))+"s", i.Level.String()[:1], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 }
 
-type IntervalFilter func(i EventInterval) bool
+func (i Message) OldMessage() string {
+	keys := sets.NewString()
+	for k := range i.Annotations {
+		keys.Insert(string(k))
+	}
+
+	annotations := []string{}
+	for _, k := range keys.List() {
+		v := i.Annotations[AnnotationKey(k)]
+		annotations = append(annotations, fmt.Sprintf("%v/%v", k, v))
+	}
+	annotationString := strings.Join(annotations, " ")
+
+	if len(i.HumanMessage) == 0 {
+		return annotationString
+	}
+
+	return fmt.Sprintf("%v %v", annotationString, i.HumanMessage)
+}
+
+func (i Locator) OldLocator() string {
+	keys := sets.NewString()
+	for k := range i.Keys {
+		keys.Insert(string(k))
+	}
+
+	annotations := []string{}
+	for _, k := range keys.List() {
+		v := i.Keys[LocatorKey(k)]
+		annotations = append(annotations, fmt.Sprintf("%v/%v", k, v))
+	}
+	annotationString := strings.Join(annotations, " ")
+
+	return annotationString
+}
+
+type IntervalFilter func(i Interval) bool
 
 type IntervalFilters []IntervalFilter
 
-func (filters IntervalFilters) All(i EventInterval) bool {
+func (filters IntervalFilters) All(i Interval) bool {
 	for _, filter := range filters {
 		if !filter(i) {
 			return false
@@ -97,7 +251,7 @@ func (filters IntervalFilters) All(i EventInterval) bool {
 	return true
 }
 
-func (filters IntervalFilters) Any(i EventInterval) bool {
+func (filters IntervalFilters) Any(i Interval) bool {
 	for _, filter := range filters {
 		if filter(i) {
 			return true
@@ -106,7 +260,7 @@ func (filters IntervalFilters) Any(i EventInterval) bool {
 	return false
 }
 
-type Intervals []EventInterval
+type Intervals []Interval
 
 var _ sort.Interface = Intervals{}
 
@@ -166,33 +320,38 @@ func (intervals Intervals) Duration(minCurrentDuration time.Duration) time.Durat
 }
 
 // EventIntervalMatchesFunc is a function for matching eventIntervales
-type EventIntervalMatchesFunc func(eventInterval EventInterval) bool
+type EventIntervalMatchesFunc func(eventInterval Interval) bool
 
 // IsErrorEvent returns true if the eventInterval is an Error
-func IsErrorEvent(eventInterval EventInterval) bool {
+func IsErrorEvent(eventInterval Interval) bool {
 	return eventInterval.Level == Error
 }
 
 // IsWarningEvent returns true if the eventInterval is an Warning
-func IsWarningEvent(eventInterval EventInterval) bool {
+func IsWarningEvent(eventInterval Interval) bool {
 	return eventInterval.Level == Warning
 }
 
 // IsInfoEvent returns true if the eventInterval is an Info
-func IsInfoEvent(eventInterval EventInterval) bool {
+func IsInfoEvent(eventInterval Interval) bool {
 	return eventInterval.Level == Info
 }
 
 // IsInE2ENamespace returns true if the eventInterval is in an e2e namespace
-func IsInE2ENamespace(eventInterval EventInterval) bool {
+func IsInE2ENamespace(eventInterval Interval) bool {
+	// Old style
 	if strings.Contains(eventInterval.Locator, "ns/e2e-") {
+		return true
+	}
+	// New style
+	if strings.Contains(eventInterval.Locator, "namespace/e2e-") {
 		return true
 	}
 	return false
 }
 
 func IsInNamespaces(namespaces sets.String) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		ns := NamespaceFromLocator(eventInterval.Locator)
 		return namespaces.Has(ns)
 	}
@@ -200,7 +359,7 @@ func IsInNamespaces(namespaces sets.String) EventIntervalMatchesFunc {
 
 // ContainsAllParts ensures that all listed key match at least one of the values.
 func ContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		actualParts := LocatorParts(eventInterval.Locator)
 		for key, possibleValues := range matchers {
 			actualValue := actualParts[key]
@@ -223,7 +382,7 @@ func ContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatches
 
 // NotContainsAllParts returns a function that returns false if any key matches.
 func NotContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		actualParts := LocatorParts(eventInterval.Locator)
 		for key, possibleValues := range matchers {
 			actualValue := actualParts[key]
@@ -239,7 +398,7 @@ func NotContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatc
 }
 
 func And(filters ...EventIntervalMatchesFunc) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		for _, filter := range filters {
 			if !filter(eventInterval) {
 				return false
@@ -250,7 +409,7 @@ func And(filters ...EventIntervalMatchesFunc) EventIntervalMatchesFunc {
 }
 
 func Or(filters ...EventIntervalMatchesFunc) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		for _, filter := range filters {
 			if filter(eventInterval) {
 				return true
@@ -261,32 +420,32 @@ func Or(filters ...EventIntervalMatchesFunc) EventIntervalMatchesFunc {
 }
 
 func Not(filter EventIntervalMatchesFunc) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		return !filter(eventInterval)
 	}
 }
 
 func StartedBefore(limit time.Time) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		return eventInterval.From.Before(limit)
 	}
 }
 
 func EndedAfter(limit time.Time) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		return eventInterval.To.After(limit)
 	}
 }
 
-func NodeUpdate(eventInterval EventInterval) bool {
+func NodeUpdate(eventInterval Interval) bool {
 	reason := ReasonFrom(eventInterval.Message)
 	return NodeUpdateReason == reason
 }
 
 func AlertFiringInNamespace(alertName, namespace string) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		return And(
-			func(eventInterval EventInterval) bool {
+			func(eventInterval Interval) bool {
 				locatorParts := LocatorParts(eventInterval.Locator)
 				eventAlertName := AlertFrom(locatorParts)
 				if eventAlertName != alertName {
@@ -303,9 +462,9 @@ func AlertFiringInNamespace(alertName, namespace string) EventIntervalMatchesFun
 }
 
 func AlertPendingInNamespace(alertName, namespace string) EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		return And(
-			func(eventInterval EventInterval) bool {
+			func(eventInterval Interval) bool {
 				locatorParts := LocatorParts(eventInterval.Locator)
 				eventAlertName := AlertFrom(locatorParts)
 				if eventAlertName != alertName {
@@ -322,7 +481,7 @@ func AlertPendingInNamespace(alertName, namespace string) EventIntervalMatchesFu
 }
 
 func AlertFiring() EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		if strings.Contains(eventInterval.Message, `alertstate="firing"`) {
 			return true
 		}
@@ -331,7 +490,7 @@ func AlertFiring() EventIntervalMatchesFunc {
 }
 
 func AlertPending() EventIntervalMatchesFunc {
-	return func(eventInterval EventInterval) bool {
+	return func(eventInterval Interval) bool {
 		if strings.Contains(eventInterval.Message, `alertstate="pending"`) {
 			return true
 		}
@@ -340,8 +499,8 @@ func AlertPending() EventIntervalMatchesFunc {
 }
 
 // InNamespace if namespace == "", then every event matches, same as kube-api
-func InNamespace(namespace string) func(event EventInterval) bool {
-	return func(event EventInterval) bool {
+func InNamespace(namespace string) func(event Interval) bool {
+	return func(event Interval) bool {
 		switch {
 		case len(namespace) == 0:
 			return true

--- a/pkg/monitor/monitorapi/types_test.go
+++ b/pkg/monitor/monitorapi/types_test.go
@@ -27,7 +27,7 @@ func TestIntervals_Duration(t *testing.T) {
 		{
 			name: "about-three-seconds",
 			intervals: Intervals{
-				EventInterval{
+				Interval{
 					Condition: Condition{
 						Level:   Info,
 						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
@@ -36,7 +36,7 @@ func TestIntervals_Duration(t *testing.T) {
 					From: start1,
 					To:   start2,
 				},
-				EventInterval{
+				Interval{
 					Condition: Condition{
 						Level:   Error,
 						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
@@ -45,7 +45,7 @@ func TestIntervals_Duration(t *testing.T) {
 					From: start2,
 					To:   start3,
 				},
-				EventInterval{
+				Interval{
 					Condition: Condition{
 						Level:   Info,
 						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
@@ -54,7 +54,7 @@ func TestIntervals_Duration(t *testing.T) {
 					From: start3,
 					To:   start4,
 				},
-				EventInterval{
+				Interval{
 					Condition: Condition{
 						Level:   Error,
 						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
@@ -63,7 +63,7 @@ func TestIntervals_Duration(t *testing.T) {
 					From: start4,
 					To:   start5,
 				},
-				EventInterval{
+				Interval{
 					Condition: Condition{
 						Level:   Info,
 						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
@@ -72,7 +72,7 @@ func TestIntervals_Duration(t *testing.T) {
 					From: start5,
 					To:   start6,
 				},
-				EventInterval{
+				Interval{
 					Condition: Condition{
 						Level:   Error,
 						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
@@ -81,7 +81,7 @@ func TestIntervals_Duration(t *testing.T) {
 					From: start6,
 					To:   start7,
 				},
-				EventInterval{
+				Interval{
 					Condition: Condition{
 						Level:   Info,
 						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",

--- a/pkg/monitor/podipcontroller/pod_ip_controller.go
+++ b/pkg/monitor/podipcontroller/pod_ip_controller.go
@@ -181,7 +181,8 @@ func (c *SimultaneousPodIPController) sync(ctx context.Context, key string) erro
 			c.recorder.Record(monitorapi.Condition{
 				Level:   monitorapi.Error,
 				Locator: podLocator,
-				Message: monitorapi.Message().Reason(monitorapi.PodIPReused).Messagef("podIP %v is currently assigned to multiple pods: %v", currPodIP, strings.Join(podNames.List(), ";")),
+				Message: monitorapi.NewMessage().Reason(monitorapi.PodIPReused).
+					HumanMessagef("podIP %v is currently assigned to multiple pods: %v", currPodIP, strings.Join(podNames.List(), ";")).BuildString(),
 			})
 		}
 	}

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -18,6 +18,10 @@ type EventInterval struct {
 	Locator string `json:"locator"`
 	Message string `json:"message"`
 
+	// TODO: we're hoping to move these to just locator/message when everything is ready.
+	StructuredLocator monitorapi.Locator `json:"tempStructuredLocator"`
+	StructuredMessage monitorapi.Message `json:"tempStructuredMessage"`
+
 	From metav1.Time `json:"from"`
 	To   metav1.Time `json:"to"`
 }
@@ -50,11 +54,11 @@ func EventsFromJSON(data []byte) (monitorapi.Intervals, error) {
 	}
 	events := make(monitorapi.Intervals, 0, len(list.Items))
 	for _, interval := range list.Items {
-		level, err := monitorapi.EventLevelFromString(interval.Level)
+		level, err := monitorapi.ConditionLevelFromString(interval.Level)
 		if err != nil {
 			return nil, err
 		}
-		events = append(events, monitorapi.EventInterval{
+		events = append(events, monitorapi.Interval{
 			Condition: monitorapi.Condition{
 				Level:   level,
 				Locator: interval.Locator,
@@ -102,11 +106,13 @@ func EventsIntervalsToJSON(events monitorapi.Intervals) ([]byte, error) {
 	return json.MarshalIndent(list, "", "    ")
 }
 
-func monitorEventIntervalToEventInterval(interval monitorapi.EventInterval) EventInterval {
+func monitorEventIntervalToEventInterval(interval monitorapi.Interval) EventInterval {
 	ret := EventInterval{
-		Level:   fmt.Sprintf("%v", interval.Level),
-		Locator: interval.Locator,
-		Message: interval.Message,
+		Level:             fmt.Sprintf("%v", interval.Level),
+		Locator:           interval.Locator,
+		Message:           interval.Message,
+		StructuredLocator: interval.StructuredLocator,
+		StructuredMessage: interval.StructuredMessage,
 
 		From: metav1.Time{Time: interval.From},
 		To:   metav1.Time{Time: interval.To},

--- a/pkg/monitor/write_job_run_data_test.go
+++ b/pkg/monitor/write_job_run_data_test.go
@@ -19,7 +19,7 @@ func TestComputeDisruptionData(t *testing.T) {
 	}{
 		{
 			name: "no disruption",
-			intervals: []monitorapi.EventInterval{
+			intervals: []monitorapi.Interval{
 				{
 					Condition: monitorapi.Condition{
 						Level:   monitorapi.Info,
@@ -42,7 +42,7 @@ func TestComputeDisruptionData(t *testing.T) {
 		},
 		{
 			name: "single backend single disruption",
-			intervals: []monitorapi.EventInterval{
+			intervals: []monitorapi.Interval{
 				{
 					Condition: monitorapi.Condition{
 						Level:   monitorapi.Info,
@@ -82,7 +82,7 @@ func TestComputeDisruptionData(t *testing.T) {
 		},
 		{
 			name: "single backend multi disruption",
-			intervals: []monitorapi.EventInterval{
+			intervals: []monitorapi.Interval{
 				{
 					Condition: monitorapi.Condition{
 						Level:   monitorapi.Info,
@@ -140,7 +140,7 @@ func TestComputeDisruptionData(t *testing.T) {
 		},
 		{
 			name: "multi backend single disruption",
-			intervals: []monitorapi.EventInterval{
+			intervals: []monitorapi.Interval{
 				{
 					Condition: monitorapi.Condition{
 						Level:   monitorapi.Info,

--- a/pkg/synthetictests/allowedalerts/job_run_data.go
+++ b/pkg/synthetictests/allowedalerts/job_run_data.go
@@ -114,7 +114,7 @@ func writeAlertData(filename string, alertData *AlertList) error {
 	return ioutil.WriteFile(filename, jsonContent, 0644)
 }
 
-func getAlertLevelFromEvent(event monitorapi.EventInterval) AlertLevel {
+func getAlertLevelFromEvent(event monitorapi.Interval) AlertLevel {
 	if event.Level == monitorapi.Error {
 		return CriticalAlertLevel
 	}
@@ -126,7 +126,7 @@ func getAlertLevelFromEvent(event monitorapi.EventInterval) AlertLevel {
 
 func computeAlertData(events monitorapi.Intervals) *AlertList {
 	alertEvents := events.Filter(
-		func(eventInterval monitorapi.EventInterval) bool {
+		func(eventInterval monitorapi.Interval) bool {
 			locator := monitorapi.LocatorParts(eventInterval.Locator)
 			alertName := monitorapi.AlertFrom(locator)
 			if len(alertName) == 0 {

--- a/pkg/synthetictests/allowedalerts/watchdog.go
+++ b/pkg/synthetictests/allowedalerts/watchdog.go
@@ -70,8 +70,9 @@ func (a *watchdogAlertTest) TestAlert(ctx context.Context, prometheusClient prom
 	return nil
 }
 
-func IsWatchdogAlert(eventInterval monitorapi.EventInterval) bool {
-	return eventInterval.Locator == "alert/Watchdog ns/openshift-monitoring"
+func IsWatchdogAlert(eventInterval monitorapi.Interval) bool {
+	return eventInterval.StructuredLocator.Keys[monitorapi.LocatorAlertKey] == "Watchdog" &&
+		eventInterval.StructuredLocator.Keys[monitorapi.LocatorNamespaceKey] == "openshift-monitoring"
 }
 
 func (a *watchdogAlertTest) InvariantCheck(alertIntervals monitorapi.Intervals, _ monitorapi.ResourcesMap) ([]*junitapi.JUnitTestCase, error) {

--- a/pkg/synthetictests/disruption.go
+++ b/pkg/synthetictests/disruption.go
@@ -323,7 +323,7 @@ func testMultipleSingleSecondDisruptions(events monitorapi.Intervals) []*junitap
 	return ret
 }
 
-func isOneSecondEvent(eventInterval monitorapi.EventInterval) bool {
+func isOneSecondEvent(eventInterval monitorapi.Interval) bool {
 	duration := eventInterval.To.Sub(eventInterval.From)
 	switch {
 	case duration <= 0:
@@ -338,8 +338,8 @@ func isOneSecondEvent(eventInterval monitorapi.EventInterval) bool {
 func testDNSOverlapDisruption(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-network] Disruption should not overlap with DNS problems in cluster running tests"
 	failures := []string{}
-	dnsIntervals := []monitorapi.EventInterval{}
-	disruptionIntervals := []monitorapi.EventInterval{}
+	dnsIntervals := []monitorapi.Interval{}
+	disruptionIntervals := []monitorapi.Interval{}
 	for _, event := range events {
 		// DNS outage
 		if reason := monitorapi.ReasonFrom(event.Message); reason == "DisruptionSamplerOutageBegan" {

--- a/pkg/synthetictests/disruption_test.go
+++ b/pkg/synthetictests/disruption_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_dnsOverlapDisruption(t *testing.T) {
-	events := []monitorapi.EventInterval{
+	events := []monitorapi.Interval{
 		{
 			Condition: monitorapi.Condition{
 				Locator: "disruption/openshift-api connection/new",
@@ -72,7 +72,7 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 		},
 		{
 			name: "Partial Overlap between DNS and disruption",
-			events: append(events, monitorapi.EventInterval{
+			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Message: "reason/DisruptionBegan disruption",
 				},
@@ -83,7 +83,7 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 		},
 		{
 			name: "Complete Overlap between DNS and disruption",
-			events: append(events, monitorapi.EventInterval{
+			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Message: "reason/DisruptionSamplerOutageBegan DNS lookup timeouts began",
 				},
@@ -94,7 +94,7 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 		},
 		{
 			name: "Overlap within 10 seconds between DNS and disruption",
-			events: append(events, monitorapi.EventInterval{
+			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Message: "reason/DisruptionSamplerOutageBegan DNS lookup timeouts began",
 				},
@@ -105,7 +105,7 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 		},
 		{
 			name: "Overlap between DNS and disruption with same start time",
-			events: append(events, monitorapi.EventInterval{
+			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Message: "reason/DisruptionBegan disruption",
 				},
@@ -116,7 +116,7 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 		},
 		{
 			name: "Overlap between DNS and disruption with same end time",
-			events: append(events, monitorapi.EventInterval{
+			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
 					Message: "reason/DisruptionBegan disruption",
 				},

--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -364,7 +364,7 @@ func newDuplicatedEventsAllowedWhenEtcdRevisionChange(ctx context.Context, opera
 }
 
 // allowEtcdGuardReadinessProbeFailure tolerates events that match allowedGuardProbeFailurePattern unless we receive more than a.maxAllowedGuardProbeFailurePerRevision*a.currentRevision
-func (a *etcdRevisionChangeAllowance) allowEtcdGuardReadinessProbeFailure(monitorEvent monitorapi.EventInterval, _ *rest.Config, times int) (bool, error) {
+func (a *etcdRevisionChangeAllowance) allowEtcdGuardReadinessProbeFailure(monitorEvent monitorapi.Interval, _ *rest.Config, times int) (bool, error) {
 	eventMessage := fmt.Sprintf("%s - %s", monitorEvent.Locator, monitorEvent.Message)
 
 	// allow for a.maxAllowedGuardProbeFailurePerRevision * a.currentRevision failed readiness probe from the etcd-guard pods

--- a/pkg/synthetictests/duplicated_events_special.go
+++ b/pkg/synthetictests/duplicated_events_special.go
@@ -13,11 +13,11 @@ import (
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 )
 
-type eventRecognizerFunc func(event monitorapi.EventInterval) bool
+type eventRecognizerFunc func(event monitorapi.Interval) bool
 
 func matchEventForRegexOrDie(regex string) eventRecognizerFunc {
 	regExp := regexp.MustCompile(regex)
-	return func(e monitorapi.EventInterval) bool {
+	return func(e monitorapi.Interval) bool {
 		return regExp.MatchString(e.Message)
 	}
 }
@@ -181,14 +181,14 @@ func testOperatorStatusChanged(events monitorapi.Intervals) []*junitapi.JUnitTes
 
 func makeProbeTest(testName string, events monitorapi.Intervals, operatorName string, regExStr string, eventFlakeThreshold int) []*junitapi.JUnitTestCase {
 	messageRegExp := regexp.MustCompile(regExStr)
-	return eventMatchThresholdTest(testName, events, func(event monitorapi.EventInterval) bool {
+	return eventMatchThresholdTest(testName, events, func(event monitorapi.Interval) bool {
 		return duplicateevents.IsOperatorMatchRegexMessage(event, operatorName, messageRegExp)
 	}, eventFlakeThreshold)
 }
 
 func eventExprMatchThresholdTest(testName string, events monitorapi.Intervals, regExStr string, eventFlakeThreshold int) []*junitapi.JUnitTestCase {
 	messageRegExp := regexp.MustCompile(regExStr)
-	return eventMatchThresholdTest(testName, events, func(event monitorapi.EventInterval) bool { return messageRegExp.MatchString(event.Message) }, eventFlakeThreshold)
+	return eventMatchThresholdTest(testName, events, func(event monitorapi.Interval) bool { return messageRegExp.MatchString(event.Message) }, eventFlakeThreshold)
 }
 
 func eventMatchThresholdTest(testName string, events monitorapi.Intervals, eventMatch eventRecognizerFunc, eventFlakeThreshold int) []*junitapi.JUnitTestCase {

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -181,7 +181,7 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			for _, message := range test.messages {
 
 				events = append(events,
-					monitorapi.EventInterval{
+					monitorapi.Interval{
 						Condition: monitorapi.Condition{Message: message},
 						From:      time.Unix(872827200, 0),
 						To:        time.Unix(872827200, 0)},
@@ -201,13 +201,9 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			jUnitName := getJUnitName(testName, test.namespace)
 			for _, junit := range junits {
 				if (junit.Name == jUnitName) && (test.expectedMessage != "") {
-					if strings.Compare(junit.FailureOutput.Output, test.expectedMessage) != 0 {
-						t.Fatalf("expected case to match, but it didn't: %s.  Expected:\n%s\nReceived:\n%s\n", test.name, test.expectedMessage, junit.FailureOutput.Output)
-					}
+					assert.Equal(t, test.expectedMessage, junit.FailureOutput.Output)
 				} else {
-					if junit.FailureOutput != nil {
-						t.Fatalf("expected success, but got failure with output: %s.", junit.FailureOutput.Output)
-					}
+					assert.Nil(t, junit.FailureOutput, "expected success but got failure output")
 				}
 			}
 
@@ -311,7 +307,7 @@ func TestKnownBugEvents(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			events := monitorapi.Intervals{}
 			events = append(events,
-				monitorapi.EventInterval{
+				monitorapi.Interval{
 					Condition: monitorapi.Condition{Message: test.message},
 					From:      time.Unix(1, 0),
 					To:        time.Unix(1, 0)},
@@ -388,7 +384,7 @@ func TestKnownBugEventsGroup(t *testing.T) {
 			for _, message := range test.messages {
 
 				events = append(events,
-					monitorapi.EventInterval{
+					monitorapi.Interval{
 						Condition: monitorapi.Condition{Message: message},
 						From:      time.Unix(872827200, 0),
 						To:        time.Unix(872827200, 0)},
@@ -477,7 +473,7 @@ func TestMakeProbeTestEventsGroup(t *testing.T) {
 			for _, message := range test.messages {
 
 				events = append(events,
-					monitorapi.EventInterval{
+					monitorapi.Interval{
 						Condition: monitorapi.Condition{Message: message},
 						From:      time.Unix(1, 0),
 						To:        time.Unix(1, 0)},

--- a/pkg/synthetictests/networking.go
+++ b/pkg/synthetictests/networking.go
@@ -46,7 +46,7 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 	failures := []string{}
 	flakes := []string{}
 	operatorsProgressing := intervalcreation.IntervalsFromEvents_OperatorProgressing(events, nil, time.Time{}, time.Time{})
-	networkOperatorProgressing := operatorsProgressing.Filter(func(ev monitorapi.EventInterval) bool {
+	networkOperatorProgressing := operatorsProgressing.Filter(func(ev monitorapi.Interval) bool {
 		return ev.Locator == "clusteroperator/network" || ev.Locator == "clusteroperator/machine-config"
 	})
 	eventsForPods := getEventsByPodName(events)

--- a/pkg/test/ginkgo/options_monitor_events.go
+++ b/pkg/test/ginkgo/options_monitor_events.go
@@ -244,7 +244,7 @@ func (o *MonitorEventsOptions) WriteRunDataToArtifactsDir(artifactDir string, ti
 
 	// use custom sorting here so that we can prioritize the sort order to make the intervals html page as readable
 	// as possible. This makes the events *not* sorted by time.
-	events := make([]monitorapi.EventInterval, len(o.recordedEvents))
+	events := make([]monitorapi.Interval, len(o.recordedEvents))
 	for i := range o.recordedEvents {
 		events[i] = o.recordedEvents[i]
 	}

--- a/pkg/test/ginkgo/options_monitor_events_test.go
+++ b/pkg/test/ginkgo/options_monitor_events_test.go
@@ -24,7 +24,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 		{
 			name: "two pathos, one previous event each",
 			args: args{
-				events: []monitorapi.EventInterval{
+				events: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0",
@@ -58,7 +58,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 						To:   to.Add(-105 * time.Second),
 					},
 				},
-				mutatedEvents: []monitorapi.EventInterval{
+				mutatedEvents: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0 hmsg/f33a7e39ac",
@@ -97,7 +97,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 		{
 			name: "locatorMatch, msgDifferent",
 			args: args{
-				events: []monitorapi.EventInterval{
+				events: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "ns/openshift-kube-controller-manager pod/revision-pruner-6-ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0 node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0",
@@ -115,7 +115,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 						To:   to.Add(-89 * time.Second),
 					},
 				},
-				mutatedEvents: []monitorapi.EventInterval{
+				mutatedEvents: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "ns/openshift-kube-controller-manager pod/revision-pruner-6-ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0 node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0",
@@ -138,7 +138,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 		{
 			name: "locatorDifferent, msgMatch",
 			args: args{
-				events: []monitorapi.EventInterval{
+				events: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-DIFFERENT",
@@ -156,7 +156,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 						To:   to.Add(-105 * time.Second),
 					},
 				},
-				mutatedEvents: []monitorapi.EventInterval{
+				mutatedEvents: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-DIFFERENT",
@@ -179,7 +179,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 		{
 			name: "no patho events",
 			args: args{
-				events: []monitorapi.EventInterval{
+				events: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0",
@@ -197,7 +197,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 						To:   to.Add(-105 * time.Second),
 					},
 				},
-				mutatedEvents: []monitorapi.EventInterval{
+				mutatedEvents: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0",
@@ -220,7 +220,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 		{
 			name: "two pathos (with one already known), one previous event each",
 			args: args{
-				events: []monitorapi.EventInterval{
+				events: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0",
@@ -254,7 +254,7 @@ func Test_markMissedPathologicalEvents(t *testing.T) {
 						To:   to.Add(-105 * time.Second),
 					},
 				},
-				mutatedEvents: []monitorapi.EventInterval{
+				mutatedEvents: []monitorapi.Interval{
 					{
 						Condition: monitorapi.Condition{
 							Locator: "node/ci-op-i20psv8m-6a467-xftbs-master-j6mzw-0 hmsg/f33a7e39ac",

--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -159,7 +159,7 @@ func (c MetricConditions) Matches(sample *model.Sample) *MetricCondition {
 	return nil
 }
 
-func (c MetricConditions) MatchesInterval(alertInterval monitorapi.EventInterval) *MetricCondition {
+func (c MetricConditions) MatchesInterval(alertInterval monitorapi.Interval) *MetricCondition {
 
 	// Parse out the alertInterval:
 	checkAlertName := monitorapi.AlertFromLocator(alertInterval.Locator)


### PR DESCRIPTION
This reverts commit 1b203624e88b014c2401f41d6e53ba1935b900d5.

We believe this change built upon the bad commit(s) but was not
involved. Being reintroduced first.

[TRT-1147](https://issues.redhat.com//browse/TRT-1147)

Intervals are an important part of our debugging toolkit, but suffer from some shortcomings in their design that limit their use. (examples: e2e tests with spaces and quotations in locators making them hard/impossible to parse, inability to carry request audit IDs with messages without breaking disruption checks to see if the error changed, etc)

Old interval:
```json
        {
            "level": "Info",
            "locator": "ns/openshift-e2e-loki pod/event-exporter-55f76dcbf6-rgvxz uid/d8508825-aa23-4549-b1cc-a9f737cec5ba",
            "message": "constructed/true reason/Created",
            "from": "2023-07-15T09:46:05Z",
            "to": "2023-07-15T10:10:31Z"
        },
```

Interval in this PR:

```json
        {
            "level": "Error",
            "locator": "node/ci-op-yv5xrq3b-206af-tjlcx-master-0",
            "message": "reason/FailedToAuthenticateWithOpenShiftUser Jul 21 17:53:17.491460 ci-op-yv5xrq3b-206af-tjlcx-master-0 kubenswrapper[2187]: E0721 17:53:17.374007    2187 event.go:280] Server rejected event '\u0026v1.Event{TypeMeta:v1.TypeMeta{Kind:\"\", APIVersion:\"\"}, ObjectMeta:v1.ObjectMeta{Name:\"ci-op-yv5xrq3b-206af-tjlcx-master-0.1773f37b98a2b824\", GenerateName:\"\", Namespace:\"default\", SelfLink:\"\", UID:\"\", ResourceVersion:\"\", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:\u003cnil\u003e, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:\"Node\", Namespace:\"\", Name:\"ci-op-yv5xrq3b-206af-tjlcx-master-0\", UID:\"ci-op-yv5xrq3b-206af-tjlcx-master-0\", APIVersion:\"\", ResourceVersion:\"\", FieldPath:\"\"}, Reason:\"Starting\", Message:\"Starting kubelet.\", Source:v1.EventSource{Component:\"kubelet\", Host:\"ci-op-yv5xrq3b-206af-tjlcx-master-0\"}, FirstTimestamp:time.Date(2023, time.July, 21, 17, 53, 17, 361395748, time.Local), LastTimestamp:time.Date(2023, time.July, 21, 17, 53, 17, 361395748, time.Local), Count:1, Type:\"Normal\", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:\"\", Related:(*v1.ObjectReference)(nil), ReportingController:\"\", ReportingInstance:\"\"}': 'events is forbidden: User \"system:anonymous\" cannot create resource \"events\" in API group \"\" in the namespace \"default\"' (will not retry!)",
            "tempStructuredLocator": {
                "type": "Node",
                "keys": {
                    "node": "ci-op-yv5xrq3b-206af-tjlcx-master-0"
                }
            },
            "tempStructuredMessage": {
                "reason": "FailedToAuthenticateWithOpenShiftUser",
                "cause": "",
                "humanMessage": "Jul 21 17:53:17.491460 ci-op-yv5xrq3b-206af-tjlcx-master-0 kubenswrapper[2187]: E0721 17:53:17.374007    2187 event.go:280] Server rejected event '\u0026v1.Event{TypeMeta:v1.TypeMeta{Kind:\"\", APIVersion:\"\"}, ObjectMeta:v1.ObjectMeta{Name:\"ci-op-yv5xrq3b-206af-tjlcx-master-0.1773f37b98a2b824\", GenerateName:\"\", Namespace:\"default\", SelfLink:\"\", UID:\"\", ResourceVersion:\"\", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:\u003cnil\u003e, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:\"Node\", Namespace:\"\", Name:\"ci-op-yv5xrq3b-206af-tjlcx-master-0\", UID:\"ci-op-yv5xrq3b-206af-tjlcx-master-0\", APIVersion:\"\", ResourceVersion:\"\", FieldPath:\"\"}, Reason:\"Starting\", Message:\"Starting kubelet.\", Source:v1.EventSource{Component:\"kubelet\", Host:\"ci-op-yv5xrq3b-206af-tjlcx-master-0\"}, FirstTimestamp:time.Date(2023, time.July, 21, 17, 53, 17, 361395748, time.Local), LastTimestamp:time.Date(2023, time.July, 21, 17, 53, 17, 361395748, time.Local), Count:1, Type:\"Normal\", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:\"\", Related:(*v1.ObjectReference)(nil), ReportingController:\"\", ReportingInstance:\"\"}': 'events is forbidden: User \"system:anonymous\" cannot create resource \"events\" in API group \"\" in the namespace \"default\"' (will not retry!)",
                "annotations": {
                    "reason": "FailedToAuthenticateWithOpenShiftUser"
                }
            },
            "from": "2023-07-21T17:53:17Z",
            "to": "2023-07-21T17:53:18Z"
        },
```

Goal in this PR is to move slowly to structured locators and messages both. This PR introduces the builders for condition/message/locator, and migrates SOME but not all uses of Conditions. Serialization temporarily includes structuredLocator and structuredMessage, which we hope will move to locator/message in the future and take over their plain string counterparts.
