### PR TITLE
WIP: Sketch out ideas around completing interval model

### DIFF
--- a/pkg/disruption/backend/disruption/handler.go
+++ b/pkg/disruption/backend/disruption/handler.go
@@ -74,7 +74,7 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()},
 		nil, v1.EventTypeWarning, string(eventReason), "detected", message)
 
-	condition := monitorapi.NewCondition(level).Locator(h.descriptor.DisruptionLocator()).
+	condition := monitorapi.NewInterval(level).Locator(h.descriptor.DisruptionLocator()).
 		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
 	openIntervalID := h.monitor.StartInterval(fs.StartedAt, condition)
 	// TODO: unlikely in the real world, if from == to for some reason,
@@ -97,7 +97,7 @@ func (h *ciHandler) Available(from, to *backend.SampleResult) {
 	h.eventRecorder.Eventf(
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()}, nil,
 		v1.EventTypeNormal, string(monitorapi.DisruptionEndedEventReason), "detected", message)
-	condition := monitorapi.NewCondition(monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
+	condition := monitorapi.NewInterval(monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
 		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
 	openIntervalID := h.monitor.StartInterval(fs.StartedAt, condition)
 	h.monitor.EndInterval(openIntervalID, ts.StartedAt)

--- a/pkg/disruption/backend/shutdown/handler.go
+++ b/pkg/disruption/backend/shutdown/handler.go
@@ -67,7 +67,7 @@ func (h *ciShutdownIntervalHandler) Handle(shutdown *shutdownInterval) {
 			&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()},
 			nil, v1.EventTypeWarning, reason, "detected", message)
 	}
-	condition := monitorapi.NewCondition(level).
+	condition := monitorapi.NewInterval(level).
 		Locator(h.descriptor.ShutdownLocator()).
 		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
 	intervalID := h.monitor.StartInterval(shutdown.From, condition)

--- a/pkg/monitor/alerts.go
+++ b/pkg/monitor/alerts.go
@@ -381,11 +381,10 @@ func CreateEventIntervalsForAlerts(ctx context.Context, alerts prometheustypes.V
 			default:
 				level = monitorapi.Error
 			}
-			alertIntervalTemplate := monitorapi.Interval{
-				Condition: monitorapi.NewCondition(level).
-					Locator(lb).
-					Message(monitorapi.NewMessage().HumanMessage(alert.Metric.String())).Build(),
-			}
+			alertIntervalTemplate := monitorapi.NewInterval(monitorapi.IntervalCategoryAlert, level).
+				Locator(lb).
+				Message(monitorapi.NewMessage().
+					HumanMessage(alert.Metric.String())).Build()
 
 			var alertStartTime *time.Time
 			var lastTime *time.Time
@@ -430,7 +429,7 @@ func CreateEventIntervalsForAlerts(ctx context.Context, alerts prometheustypes.V
 
 	default:
 		ret = append(ret, monitorapi.Interval{
-			Condition: monitorapi.NewCondition(monitorapi.Error).
+			Condition: monitorapi.NewInterval(monitorapi.Error).
 				Locator(monitorapi.NewLocator().AlertFromNames("all", "", "", "", "")).
 				Message(monitorapi.NewMessage().HumanMessagef("unhandled type: %v", alerts.Type())).Build(),
 			From: startTime,

--- a/pkg/monitor/alerts_test.go
+++ b/pkg/monitor/alerts_test.go
@@ -150,8 +150,8 @@ func Test_blackoutEvents(t *testing.T) {
 		startingEvents  []monitorapi.Interval
 		blackoutWindows []monitorapi.Interval
 	}
-	conditionFoo := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Build()
-	conditionBar := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("bar")).Build()
+	conditionFoo := monitorapi.NewInterval(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Build()
+	conditionBar := monitorapi.NewInterval(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("bar")).Build()
 	tests := []struct {
 		name string
 		args args

--- a/pkg/monitor/apiserveravailability/summarizer.go
+++ b/pkg/monitor/apiserveravailability/summarizer.go
@@ -33,7 +33,7 @@ func (s *APIServerClientAccessFailureSummary) SummarizeLine(locator monitorapi.L
 		timeOfLog := timeFromPodLogTime(line)
 		// TODO collapse all in the same second into a single interval
 		event := monitorapi.Interval{
-			Condition: monitorapi.NewCondition(monitorapi.Warning).
+			Condition: monitorapi.NewInterval(monitorapi.Warning).
 				Locator(locator).
 				Message(monitorapi.NewMessage().Reason(monitorapi.IPTablesNotPermitted).HumanMessage(line)).
 				Build(),

--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -266,7 +266,7 @@ func readinessFailure(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.Info).
 				Locator(containerRef).
 				Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonReadinessFailed).Node(nodeName).HumanMessage(message)).
 				Build(),
@@ -296,7 +296,7 @@ func readinessError(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
@@ -325,7 +325,7 @@ func errParsingSignature(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
@@ -374,7 +374,7 @@ func startupProbeError(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
@@ -482,7 +482,7 @@ func failedToDeleteCGroupsPath(nodeLocator monitorapi.Locator, logLine string) m
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Error).
+			Condition: monitorapi.NewInterval(monitorapi.Error).
 				Locator(nodeLocator).
 				Message(monitorapi.NewMessage().Reason("FailedToDeleteCGroupsPath").HumanMessage(logLine)).
 				Build(),
@@ -501,7 +501,7 @@ func anonymousCertConnectionError(nodeLocator monitorapi.Locator, logLine string
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Error).
+			Condition: monitorapi.NewInterval(monitorapi.Error).
 				Locator(nodeLocator).
 				Message(monitorapi.NewMessage().Reason("FailedToAuthenticateWithOpenShiftUser").HumanMessage(logLine)).
 				Build(),
@@ -555,7 +555,7 @@ func leaseUpdateError(nodeLocator monitorapi.Locator, logLine string) monitorapi
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.Info).
 				Locator(nodeLocator).
 				Message(
 					monitorapi.NewMessage().Reason(monitorapi.NodeFailedLease).HumanMessage(fmt.Sprintf("%s - %s", url, msg)),
@@ -600,7 +600,7 @@ func commonErrorInterval(nodeName, logLine string, messageExp *regexp.Regexp, re
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.Info).
 				Locator(locator()).
 				Message(
 					monitorapi.NewMessage().Reason(reason).Node(nodeName).HumanMessage(message),

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -18,8 +18,8 @@ func TestMonitor_Newlines(t *testing.T) {
 }
 
 func TestMonitor_Events(t *testing.T) {
-	condition1 := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("1")).Build()
-	condition2 := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("2")).Build()
+	condition1 := monitorapi.NewInterval(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("1")).Build()
+	condition2 := monitorapi.NewInterval(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("2")).Build()
 	tests := []struct {
 		name   string
 		events monitorapi.Intervals

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -8,21 +8,24 @@ import (
 	"k8s.io/kube-openapi/pkg/util/sets"
 )
 
-type ConditionBuilder struct {
+type IntervalBuilder struct {
 	level             ConditionLevel
+	category          IntervalCategory
 	structuredLocator Locator
 	structuredMessage Message
 }
 
-func NewCondition(level ConditionLevel) *ConditionBuilder {
-	return &ConditionBuilder{
-		level: level,
+func NewInterval(cat IntervalCategory, level ConditionLevel) *IntervalBuilder {
+	return &IntervalBuilder{
+		level:    level,
+		category: cat,
 	}
 }
 
-func (b *ConditionBuilder) Build() Condition {
-	ret := Condition{
+func (b *IntervalBuilder) Build() Interval {
+	ret := Interval{
 		Level:             b.level,
+		Category:          b.category,
 		Locator:           b.structuredLocator.OldLocator(),
 		StructuredLocator: b.structuredLocator,
 		Message:           b.structuredMessage.OldMessage(),
@@ -32,12 +35,12 @@ func (b *ConditionBuilder) Build() Condition {
 	return ret
 }
 
-func (b *ConditionBuilder) Message(mb *MessageBuilder) *ConditionBuilder {
+func (b *IntervalBuilder) Message(mb *MessageBuilder) *IntervalBuilder {
 	b.structuredMessage = mb.build()
 	return b
 }
 
-func (b *ConditionBuilder) Locator(locator Locator) *ConditionBuilder {
+func (b *IntervalBuilder) Locator(locator Locator) *IntervalBuilder {
 	b.structuredLocator = locator
 	return b
 }

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -59,16 +59,6 @@ func ConditionLevelFromString(s string) (ConditionLevel, error) {
 
 }
 
-type Condition struct {
-	Level ConditionLevel
-
-	// TODO: Goal here is to drop Locator/Message, and rename the structured variants to Locator/Message
-	Locator           string
-	StructuredLocator Locator
-	Message           string
-	StructuredMessage Message
-}
-
 type LocatorType string
 
 const (
@@ -184,8 +174,30 @@ type Message struct {
 	Annotations map[AnnotationKey]string `json:"annotations"`
 }
 
+type IntervalCategory string
+
+const (
+	IntervalCategoryAlert              IntervalCategory = "alert"
+	IntervalCategoryPodLog             IntervalCategory = "pod-log"
+	IntervalCategoryContainerLifecycle IntervalCategory = "container-lifecycle"
+	// TODO: view actually would split this into operator-available and operator-degraded....
+	// This would imply categories can be subdivided in the UI.
+	IntervalCategoryOperatorStatus IntervalCategory = "operator-status"
+)
+
 type Interval struct {
-	Condition
+	Level ConditionLevel
+
+	// Category is an indicator of what the interval contains and where it came from. It is used by the UI
+	// to group intervals into sections in the charts, but often with additional view specific
+	// filtering applied. Some types may be split into sub-categories for display.
+	Category IntervalCategory
+
+	// TODO: Goal here is to drop Locator/Message, and rename the structured variants to Locator/Message
+	Locator           string
+	StructuredLocator Locator
+	Message           string
+	StructuredMessage Message
 
 	From time.Time
 	To   time.Time

--- a/pkg/monitor/pod.go
+++ b/pkg/monitor/pod.go
@@ -92,13 +92,13 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 
 			// always produce conditions during create
 			if (isCreate && !newContainerReady) || (oldContainerReady && !newContainerReady) {
-				conditions = append(conditions, monitorapi.NewCondition(monitorapi.Warning).
+				conditions = append(conditions, monitorapi.NewInterval(monitorapi.Warning).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonNotReady)).
 					Build())
 			}
 			if (isCreate && newContainerReady) || (!oldContainerReady && newContainerReady) {
-				conditions = append(conditions, monitorapi.NewCondition(monitorapi.Info).
+				conditions = append(conditions, monitorapi.NewInterval(monitorapi.Info).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(
 						monitorapi.NewMessage().Reason(monitorapi.ContainerReasonReady),
@@ -202,7 +202,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 			}
 
 			if oldContainerStatus != nil && oldContainerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated == nil {
-				conditions = append(conditions, monitorapi.NewCondition(monitorapi.Error).
+				conditions = append(conditions, monitorapi.NewInterval(monitorapi.Error).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(
 						monitorapi.NewMessage().Reason(monitorapi.TerminationStateCleared).HumanMessage("lastState.terminated was cleared on a pod (bug https://bugzilla.redhat.com/show_bug.cgi?id=1933760 or similar)"),
@@ -226,7 +226,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 				// if we are transitioning to a terminated state
 				if containerStatus.LastTerminationState.Terminated.ExitCode != 0 {
 					conditions = append(conditions,
-						monitorapi.NewCondition(monitorapi.Error).
+						monitorapi.NewInterval(monitorapi.Error).
 							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 							Message(monitorapi.NewMessage().
 								Reason(monitorapi.ContainerReasonContainerExit).
@@ -237,7 +237,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 					)
 				} else {
 					conditions = append(conditions,
-						monitorapi.NewCondition(monitorapi.Info).
+						monitorapi.NewInterval(monitorapi.Info).
 							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 							Message(monitorapi.NewMessage().
 								Reason(monitorapi.ContainerReasonContainerExit).
@@ -252,7 +252,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 				// if we are transitioning to a terminated state
 				if containerStatus.State.Terminated.ExitCode != 0 {
 					conditions = append(conditions,
-						monitorapi.NewCondition(monitorapi.Error).
+						monitorapi.NewInterval(monitorapi.Error).
 							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 							Message(monitorapi.NewMessage().
 								Reason(monitorapi.ContainerReasonContainerExit).
@@ -264,7 +264,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 					)
 				} else {
 					conditions = append(conditions,
-						monitorapi.NewCondition(monitorapi.Error).
+						monitorapi.NewInterval(monitorapi.Error).
 							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 							Message(monitorapi.NewMessage().
 								Reason(monitorapi.ContainerReasonContainerExit).
@@ -303,7 +303,7 @@ func startPodMonitoring(ctx context.Context, m Recorder, client kubernetes.Inter
 			}
 
 			if containerStatus.RestartCount != oldContainerStatus.RestartCount {
-				conditions = append(conditions, monitorapi.NewCondition(monitorapi.Warning).
+				conditions = append(conditions, monitorapi.NewInterval(monitorapi.Warning).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(
 						monitorapi.NewMessage().Reason(monitorapi.ContainerReasonRestarted),
@@ -620,7 +620,7 @@ func lastContainerTimeFromStatus(current *corev1.ContainerStatus) time.Time {
 
 func conditionsForTransitioningContainer(pod *corev1.Pod, current *corev1.ContainerStatus, reason monitorapi.IntervalReason, cause, message string) []monitorapi.Condition {
 	return []monitorapi.Condition{
-		monitorapi.NewCondition(monitorapi.Info).
+		monitorapi.NewInterval(monitorapi.Info).
 			Locator(monitorapi.NewLocator().ContainerFromPod(pod, current.Name)).
 			Message(monitorapi.NewMessage().Reason(reason).Cause(cause).HumanMessage(message)).
 			Build(),

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -24,6 +24,14 @@ type EventInterval struct {
 
 	From metav1.Time `json:"from"`
 	To   metav1.Time `json:"to"`
+
+	ViewHints *ViewHints `json:"viewHints"`
+}
+
+type ViewHints struct {
+	Group    string
+	HexColor string
+	// Row would be represented by locator?
 }
 
 // EventList is not an interval.  It is an instant.  The instant removes any ambiguity about "when"
@@ -100,6 +108,19 @@ func EventsIntervalsToJSON(events monitorapi.Intervals) ([]byte, error) {
 		}
 		outputEvents = append(outputEvents, monitorEventIntervalToEventInterval(curr))
 	}
+
+	// Here we would case by Interval.Category, and decide if an interval should get ViewHints
+	// or not. ViewHints could sub-categorize (i.e. break apart ClusterOperator Available status
+	// to only specify ViewHint if the condition is False)
+	//
+	// Should the UI be able to "optionally" show intervals that do not have ViewHints?
+	//
+	// Or should we limit what we display to only those that this code said to? The problem there
+	// of course is that we're mixing view logic into our model, and the result is that we could
+	// not retroactively decide to display something in old job runs.
+	//
+	// It would however mean that origin authors writing new intervals could, in the same PR,
+	// specify that they should be displayed and how.
 
 	sort.Sort(byTime(outputEvents))
 	list := EventIntervalList{Items: outputEvents}


### PR DESCRIPTION
I am struggling with classification of intervals.

I believe that intervals should have some kind of type/category information that indicates where they came from and what they represent.

We need UI groupings that are sometimes linked directly 1-1 with type information, but also sometimes require sub-classification. 

And I cannot decide if we should tie view specifics into the go code (allowing pr authors to add new intervals AND specify that they should be shown in the chart, in what color, all in one PR), or if they should remain in the JS UI (in sippy) allowing us to retroactively decide what to show for jobs that have already run and stored their intervals.