### PR TITLE
Adjust interval builder before we continue porting

### DIFF
--- a/pkg/disruption/backend/disruption/handler.go
+++ b/pkg/disruption/backend/disruption/handler.go
@@ -74,8 +74,8 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()},
 		nil, v1.EventTypeWarning, string(eventReason), "detected", message)
 
-	condition := monitorapi.NewCondition(level).Locator(h.descriptor.DisruptionLocator()).
-		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
+	condition := monitorapi.NewInterval(monitorapi.SourceDisruption, level).Locator(h.descriptor.DisruptionLocator()).
+		Message(monitorapi.NewMessage().HumanMessage(message).Reason(eventReason)).BuildCondition()
 	openIntervalID := h.monitor.StartInterval(fs.StartedAt, condition)
 	// TODO: unlikely in the real world, if from == to for some reason,
 	//  then we are recording a zero second unavailable window.
@@ -97,8 +97,8 @@ func (h *ciHandler) Available(from, to *backend.SampleResult) {
 	h.eventRecorder.Eventf(
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()}, nil,
 		v1.EventTypeNormal, string(monitorapi.DisruptionEndedEventReason), "detected", message)
-	condition := monitorapi.NewCondition(monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
-		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
+	condition := monitorapi.NewInterval(monitorapi.SourceDisruption, monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
+		Message(monitorapi.NewMessage().HumanMessage(message).Reason(monitorapi.DisruptionEndedEventReason)).BuildCondition()
 	openIntervalID := h.monitor.StartInterval(fs.StartedAt, condition)
 	h.monitor.EndInterval(openIntervalID, ts.StartedAt)
 }

--- a/pkg/disruption/backend/shutdown/handler.go
+++ b/pkg/disruption/backend/shutdown/handler.go
@@ -67,9 +67,9 @@ func (h *ciShutdownIntervalHandler) Handle(shutdown *shutdownInterval) {
 			&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()},
 			nil, v1.EventTypeWarning, reason, "detected", message)
 	}
-	condition := monitorapi.NewCondition(level).
-		Locator(h.descriptor.ShutdownLocator()).
-		Message(monitorapi.NewMessage().HumanMessage(message)).Build()
+	condition := monitorapi.NewInterval(monitorapi.SourceAPIServerShutdown, level).
+		Locator(h.descriptor.ShutdownLocator()).Display().
+		Message(monitorapi.NewMessage().HumanMessage(message).Reason(reason)).BuildCondition()
 	intervalID := h.monitor.StartInterval(shutdown.From, condition)
 	h.monitor.EndInterval(intervalID, shutdown.To)
 }

--- a/pkg/monitor/alerts_test.go
+++ b/pkg/monitor/alerts_test.go
@@ -150,8 +150,8 @@ func Test_blackoutEvents(t *testing.T) {
 		startingEvents  []monitorapi.Interval
 		blackoutWindows []monitorapi.Interval
 	}
-	conditionFoo := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Build()
-	conditionBar := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("bar")).Build()
+	conditionFoo := monitorapi.NewInterval(monitorapi.SourceAlert, monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).BuildCondition()
+	conditionBar := monitorapi.NewInterval(monitorapi.SourceAlert, monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("bar")).BuildCondition()
 	tests := []struct {
 		name string
 		args args

--- a/pkg/monitor/apiserveravailability/summarizer.go
+++ b/pkg/monitor/apiserveravailability/summarizer.go
@@ -33,10 +33,10 @@ func (s *APIServerClientAccessFailureSummary) SummarizeLine(locator monitorapi.L
 		timeOfLog := timeFromPodLogTime(line)
 		// TODO collapse all in the same second into a single interval
 		event := monitorapi.Interval{
-			Condition: monitorapi.NewCondition(monitorapi.Warning).
+			Condition: monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Warning).
 				Locator(locator).
 				Message(monitorapi.NewMessage().Reason(monitorapi.IPTablesNotPermitted).HumanMessage(line)).
-				Build(),
+				BuildCondition(),
 			From: timeOfLog,
 			To:   timeOfLog.Add(1 * time.Second),
 		}

--- a/pkg/monitor/backenddisruption/disruption_locator.go
+++ b/pkg/monitor/backenddisruption/disruption_locator.go
@@ -30,7 +30,7 @@ var DnsLookupRegex = regexp.MustCompile(`dial tcp: lookup.*: i/o timeout`)
 
 // DisruptionBegan examines the error received, attempts to determine if it looks like real disruption to the cluster under test,
 // or other problems possibly on the system running the tests/monitor, and returns an appropriate user message, event reason, and monitoring level.
-func DisruptionBegan(locator string, connectionType monitorapi.BackendConnectionType, err error, auditID string) (string, monitorapi.IntervalReason, monitorapi.ConditionLevel) {
+func DisruptionBegan(locator string, connectionType monitorapi.BackendConnectionType, err error, auditID string) (string, monitorapi.IntervalReason, monitorapi.IntervalLevel) {
 	if DnsLookupRegex.MatchString(err.Error()) {
 		switch connectionType {
 		case monitorapi.NewConnectionType:

--- a/pkg/monitor/intervalcreation/node.go
+++ b/pkg/monitor/intervalcreation/node.go
@@ -266,10 +266,10 @@ func readinessFailure(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
 				Locator(containerRef).
 				Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonReadinessFailed).Node(nodeName).HumanMessage(message)).
-				Build(),
+				BuildCondition(),
 			From: failureTime,
 			To:   failureTime,
 		},
@@ -296,14 +296,14 @@ func readinessError(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
 						Reason(monitorapi.ContainerReasonReadinessErrored).
 						Node(nodeName).
 						HumanMessage(message),
-				).Build(),
+				).BuildCondition(),
 			From: failureTime,
 			To:   failureTime,
 		},
@@ -325,7 +325,7 @@ func errParsingSignature(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
@@ -333,7 +333,7 @@ func errParsingSignature(nodeName, logLine string) monitorapi.Intervals {
 						Cause(monitorapi.ContainerUnrecognizedSignatureFormat).
 						Node(nodeName),
 				).
-				Build(),
+				BuildCondition(),
 			From: failureTime,
 			To:   failureTime,
 		},
@@ -374,14 +374,14 @@ func startupProbeError(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
 						Reason(monitorapi.ContainerReasonStartupProbeFailed).
 						Node(nodeName).
 						HumanMessage(message),
-				).Build(),
+				).BuildCondition(),
 			From: failureTime,
 			To:   failureTime,
 		},
@@ -482,10 +482,10 @@ func failedToDeleteCGroupsPath(nodeLocator monitorapi.Locator, logLine string) m
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Error).
+			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Error).
 				Locator(nodeLocator).
 				Message(monitorapi.NewMessage().Reason("FailedToDeleteCGroupsPath").HumanMessage(logLine)).
-				Build(),
+				BuildCondition(),
 			From: failureTime,
 			To:   failureTime.Add(1 * time.Second),
 		},
@@ -501,10 +501,10 @@ func anonymousCertConnectionError(nodeLocator monitorapi.Locator, logLine string
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Error).
+			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Error).
 				Locator(nodeLocator).
 				Message(monitorapi.NewMessage().Reason("FailedToAuthenticateWithOpenShiftUser").HumanMessage(logLine)).
-				Build(),
+				BuildCondition(),
 			From: failureTime,
 			To:   failureTime.Add(1 * time.Second),
 		},
@@ -555,11 +555,11 @@ func leaseUpdateError(nodeLocator monitorapi.Locator, logLine string) monitorapi
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
 				Locator(nodeLocator).
 				Message(
 					monitorapi.NewMessage().Reason(monitorapi.NodeFailedLease).HumanMessage(fmt.Sprintf("%s - %s", url, msg)),
-				).Build(),
+				).BuildCondition(),
 			From: failureTime,
 			To:   failureTime.Add(1 * time.Second),
 		},
@@ -600,11 +600,11 @@ func commonErrorInterval(nodeName, logLine string, messageExp *regexp.Regexp, re
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewCondition(monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
 				Locator(locator()).
 				Message(
 					monitorapi.NewMessage().Reason(reason).Node(nodeName).HumanMessage(message),
-				).Build(),
+				).BuildCondition(),
 			From: failureTime,
 			To:   failureTime,
 		},

--- a/pkg/monitor/intervalcreation/operator.go
+++ b/pkg/monitor/intervalcreation/operator.go
@@ -20,7 +20,7 @@ func IntervalsFromEvents_OperatorDegraded(intervals monitorapi.Intervals, _ moni
 	return intervalsFromEvents_OperatorStatus(intervals, beginning, end, configv1.OperatorDegraded, configv1.ConditionFalse, monitorapi.Error)
 }
 
-func intervalsFromEvents_OperatorStatus(intervals monitorapi.Intervals, beginning, end time.Time, conditionType configv1.ClusterStatusConditionType, conditionGoodState configv1.ConditionStatus, level monitorapi.ConditionLevel) monitorapi.Intervals {
+func intervalsFromEvents_OperatorStatus(intervals monitorapi.Intervals, beginning, end time.Time, conditionType configv1.ClusterStatusConditionType, conditionGoodState configv1.ConditionStatus, level monitorapi.IntervalLevel) monitorapi.Intervals {
 	ret := monitorapi.Intervals{}
 	operatorToInterestingBadCondition := map[string]*configv1.ClusterOperatorStatusCondition{}
 

--- a/pkg/monitor/intervalcreation/podlogs.go
+++ b/pkg/monitor/intervalcreation/podlogs.go
@@ -20,7 +20,7 @@ import (
 // interval should have. (Info, Warning, Error)
 type SubStringLevel struct {
 	subString string
-	level     monitorapi.ConditionLevel
+	level     monitorapi.IntervalLevel
 }
 
 type PodLogIntervalGenerator struct {
@@ -32,7 +32,7 @@ type PodLogIntervalGenerator struct {
 	subStrings []SubStringLevel
 	// lineParser is called to convert a log line to an EventInterval. Function is only called if
 	// the line matches one of the substrings.
-	lineParser func(locator, line string, intervalLevel monitorapi.ConditionLevel, logger logrus.FieldLogger) (*monitorapi.Interval, error)
+	lineParser func(locator, line string, intervalLevel monitorapi.IntervalLevel, logger logrus.FieldLogger) (*monitorapi.Interval, error)
 }
 
 func (g PodLogIntervalGenerator) ScanLine(pod *kapiv1.Pod, line string, beginning, end time.Time, logger logrus.FieldLogger) (*monitorapi.Interval, error) {
@@ -65,7 +65,7 @@ type etcdLogLine struct {
 // etcdLogParser handles etcd logs which are already nicely json formatted such as:
 //
 // {"level":"info","ts":"2023-03-03T18:09:01.471Z","caller":"mvcc/index.go:214","msg":"compact tree index","revision":738215}
-func etcdLogParser(locator, line string, level monitorapi.ConditionLevel, logger logrus.FieldLogger) (*monitorapi.Interval, error) {
+func etcdLogParser(locator, line string, level monitorapi.IntervalLevel, logger logrus.FieldLogger) (*monitorapi.Interval, error) {
 	parsedLine := etcdLogLine{}
 	err := json.Unmarshal([]byte(line), &parsedLine)
 	if err != nil {

--- a/pkg/monitor/intervalcreation/state_tracker.go
+++ b/pkg/monitor/intervalcreation/state_tracker.go
@@ -20,7 +20,7 @@ type stateTracker struct {
 
 type conditionCreationFunc func(locator string, from, to time.Time) (monitorapi.Condition, bool)
 
-func simpleCondition(constructedBy monitorapi.ConstructionOwner, level monitorapi.ConditionLevel, reason monitorapi.IntervalReason, message string) conditionCreationFunc {
+func simpleCondition(constructedBy monitorapi.ConstructionOwner, level monitorapi.IntervalLevel, reason monitorapi.IntervalReason, message string) conditionCreationFunc {
 	return func(locator string, from, to time.Time) (monitorapi.Condition, bool) {
 		return monitorapi.Condition{
 			Level:   level,

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -18,8 +18,8 @@ func TestMonitor_Newlines(t *testing.T) {
 }
 
 func TestMonitor_Events(t *testing.T) {
-	condition1 := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("1")).Build()
-	condition2 := monitorapi.NewCondition(monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("2")).Build()
+	condition1 := monitorapi.NewInterval(monitorapi.SourceTestData, monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("1")).BuildCondition()
+	condition2 := monitorapi.NewInterval(monitorapi.SourceTestData, monitorapi.Info).Locator(monitorapi.NewLocator().NodeFromName("foo")).Message(monitorapi.NewMessage().HumanMessage("2")).BuildCondition()
 	tests := []struct {
 		name   string
 		events monitorapi.Intervals

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -24,15 +24,15 @@ const (
 	ObservedRecreationCountAnnotation = "monitor.openshift.io/observed-recreation-count"
 )
 
-type ConditionLevel int
+type IntervalLevel int
 
 const (
-	Info ConditionLevel = iota
+	Info IntervalLevel = iota
 	Warning
 	Error
 )
 
-func (e ConditionLevel) String() string {
+func (e IntervalLevel) String() string {
 	switch e {
 	case Info:
 		return "Info"
@@ -45,7 +45,7 @@ func (e ConditionLevel) String() string {
 	}
 }
 
-func ConditionLevelFromString(s string) (ConditionLevel, error) {
+func ConditionLevelFromString(s string) (IntervalLevel, error) {
 	switch s {
 	case "Info":
 		return Info, nil
@@ -60,7 +60,7 @@ func ConditionLevelFromString(s string) (ConditionLevel, error) {
 }
 
 type Condition struct {
-	Level ConditionLevel
+	Level IntervalLevel
 
 	// TODO: Goal here is to drop Locator/Message, and rename the structured variants to Locator/Message
 	Locator           string
@@ -184,8 +184,26 @@ type Message struct {
 	Annotations map[AnnotationKey]string `json:"annotations"`
 }
 
+type IntervalSource string
+
+const (
+	SourceAlert             IntervalSource = "Alert"
+	SourceAPIServerShutdown IntervalSource = "APIServerShutdown"
+	SourceDisruption        IntervalSource = "Disruption"
+	SourceNodeMonitor       IntervalSource = "NodeMonitor"
+	SourcePodLog            IntervalSource = "PodLog"
+	SourcePodMonitor        IntervalSource = "PodMonitor"
+	SourceTestData          IntervalSource = "TestData" // some tests have no real source to assign
+)
+
 type Interval struct {
+	// Deprecated: We hope to fold this into Interval itself.
 	Condition
+	Source IntervalSource
+
+	// Display is a very coarse hint to any UI that this event was considered important enough to *possibly* be displayed by the source that produced it.
+	// UI may apply further filtering.
+	Display bool
 
 	From time.Time
 	To   time.Time


### PR DESCRIPTION
Moved to focus on IntervalBuilding, not ConditionBuilding, we hope to
eliminate Conditions in the future. (move the fields up into Interval)

Add a Display hint, coarse grained, where the generating code can
indicate if something is intended to be displayed in the UI. i.e.
DisruptionBegan DisruptionEnded no, Disruption intervals calculated from
those yes.

Experimenting with a source for each interval so we know where it came
from. This may get removed if we find it too cumbersome. Intent is to
help user see what they're looking at, and help the UI filtering have
something more concrete to filter on beyond message contents.
