### PR TITLE
Fix ClusterOperator tests that can only report failures

### DIFF
--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -39,7 +39,7 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 	}
 	duration := stop.Sub(start).Seconds()
 
-	knownOperators := allOperators(events)
+	knownOperators := sets.NewString(platformidentification.KnownOperators.List()...)
 	eventsByOperator := getEventsByOperator(events)
 	e2eEventIntervals := monitor.E2ETestEventIntervals(events)
 	for _, condition := range conditionTypes {
@@ -256,21 +256,6 @@ func testOperatorOSUpdateStartedEventRecorded(events monitorapi.Intervals, clien
 	}
 
 	return []*junitapi.JUnitTestCase{success}
-}
-
-func allOperators(events monitorapi.Intervals) sets.String {
-	// start with a list of known values
-	knownOperators := sets.NewString(platformidentification.KnownOperators.List()...)
-
-	// now add all the operators we see in the events.
-	for _, event := range events {
-		operatorName, ok := monitorapi.OperatorFromLocator(event.Locator)
-		if !ok {
-			continue
-		}
-		knownOperators.Insert(operatorName)
-	}
-	return knownOperators
 }
 
 // getEventsByOperator returns map keyed by operator locator with all events associated with it.

--- a/pkg/synthetictests/operators.go
+++ b/pkg/synthetictests/operators.go
@@ -14,7 +14,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/pkg/monitor"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 )
 
@@ -39,11 +38,10 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 	}
 	duration := stop.Sub(start).Seconds()
 
-	knownOperators := sets.NewString(platformidentification.KnownOperators.List()...)
 	eventsByOperator := getEventsByOperator(events)
 	e2eEventIntervals := monitor.E2ETestEventIntervals(events)
 	for _, condition := range conditionTypes {
-		for _, operatorName := range knownOperators.List() {
+		for _, operatorName := range platformidentification.KnownOperators.List() {
 			bzComponent := platformidentification.GetBugzillaComponentForOperator(operatorName)
 			if bzComponent == "Unknown" {
 				bzComponent = operatorName

--- a/pkg/synthetictests/platformidentification/operator_mapping.go
+++ b/pkg/synthetictests/platformidentification/operator_mapping.go
@@ -93,6 +93,7 @@ var (
 		"cluster-autoscaler",
 		"config-operator",
 		"console",
+		"control-plane-machine-set",
 		"csi-snapshot-controller",
 		"dns",
 		"etcd",
@@ -135,6 +136,7 @@ func init() {
 	utilruntime.Must(addOperatorMapping("cluster-autoscaler", "Cloud Compute"))
 	utilruntime.Must(addOperatorMapping("config-operator", "config-operator"))
 	utilruntime.Must(addOperatorMapping("console", "Management Console"))
+	utilruntime.Must(addOperatorMapping("control-plane-machine-set", "Cloud Compute"))
 	utilruntime.Must(addOperatorMapping("csi-snapshot-controller", "Storage"))
 	utilruntime.Must(addOperatorMapping("dns", "DNS"))
 	utilruntime.Must(addOperatorMapping("etcd", "Etcd"))


### PR DESCRIPTION
We have discovered that if there are no clusteroperator intervals in the
e2e/conformance test portion, this test is omitted entirely which breaks
test pass rates in a variety of tooling, as well as the aggregator. In
this case if the operator does trigger an unexpected transition in the
conformance stage, a fail is recorded, and the other jobs in aggregation
report no result, resulting in < 6 results to aggregate on and a
failure.

Switch to always checking for, and including tests for, all operators,
regardless if they have recorded any intervals.

[TRT-1100](https://issues.redhat.com//browse/TRT-1100)
