### PR TITLE
separate the run, run-upgrade, and run-test

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -1,27 +1,24 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 	"time"
 
-	"github.com/openshift/origin/test/extended/util/image"
-
-	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/library-go/pkg/serviceability"
-	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/cmd/monitor_command"
 	"github.com/openshift/origin/pkg/cmd/monitor_command/timeline"
+	"github.com/openshift/origin/pkg/cmd/openshift-tests/images"
+	"github.com/openshift/origin/pkg/cmd/openshift-tests/run"
+	run_test "github.com/openshift/origin/pkg/cmd/openshift-tests/run-test"
+	run_upgrade "github.com/openshift/origin/pkg/cmd/openshift-tests/run-upgrade"
 	"github.com/openshift/origin/pkg/monitor/resourcewatch/cmd"
 	"github.com/openshift/origin/pkg/riskanalysis"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
-	"github.com/openshift/origin/pkg/testsuites"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -29,7 +26,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
-	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
@@ -74,10 +70,10 @@ func main() {
 	}
 
 	root.AddCommand(
-		newRunCommand(ioStreams),
-		newRunUpgradeCommand(ioStreams),
-		newImagesCommand(),
-		newRunTestCommand(ioStreams),
+		run.NewRunCommand(ioStreams),
+		run_upgrade.NewRunUpgradeCommand(ioStreams),
+		images.NewImagesCommand(),
+		run_test.NewRunTestCommand(ioStreams),
 		newDevCommand(),
 		monitor_command.NewRunMonitorCommand(ioStreams),
 		monitor_command.NewMonitorCommand(),
@@ -137,231 +133,5 @@ The resulting analysis is then also written to the junit artifacts directory.
 	cmd.Flags().StringVar(&riskAnalysisOpts.SippyURL,
 		"sippy-url", sippyDefaultURL,
 		"Sippy URL API endpoint")
-	return cmd
-}
-
-type imagesOptions struct {
-	Repository string
-	Upstream   bool
-	Verify     bool
-}
-
-func newImagesCommand() *cobra.Command {
-	o := &imagesOptions{}
-	cmd := &cobra.Command{
-		Use:   "images",
-		Short: "Gather images required for testing",
-		Long: templates.LongDesc(fmt.Sprintf(`
-		Creates a mapping to mirror test images to a private registry
-
-		This command identifies the locations of all test images referenced by the test
-		suite and outputs a mirror list for use with 'oc image mirror' to copy those images
-		to a private registry. The list may be passed via file or standard input.
-
-				$ openshift-tests images --to-repository private.com/test/repository > /tmp/mirror
-				$ oc image mirror -f /tmp/mirror
-
-		The 'run' and 'run-upgrade' subcommands accept '--from-repository' which will source
-		required test images from your mirror.
-
-		See the help for 'oc image mirror' for more about mirroring to disk or consult the docs
-		for mirroring offline. You may use a file:// prefix in your '--to-repository', but when
-		mirroring from disk to your offline repository you will have to construct the appropriate
-		disk to internal registry statements yourself.
-
-		By default, the test images are sourced from a public container image repository at
-		%[1]s and are provided as-is for testing purposes only. Images are mirrored by the project
-		to the public repository periodically.
-		`, defaultTestImageMirrorLocation)),
-
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if o.Verify {
-				return verifyImages()
-			}
-
-			repository := o.Repository
-			var prefix string
-			for _, validPrefix := range []string{"file://", "s3://"} {
-				if strings.HasPrefix(repository, validPrefix) {
-					repository = strings.TrimPrefix(repository, validPrefix)
-					prefix = validPrefix
-					break
-				}
-			}
-			ref, err := reference.Parse(repository)
-			if err != nil {
-				return fmt.Errorf("--to-repository is not valid: %v", err)
-			}
-			if len(ref.Tag) > 0 || len(ref.ID) > 0 {
-				return fmt.Errorf("--to-repository may not include a tag or image digest")
-			}
-
-			if err := verifyImages(); err != nil {
-				return err
-			}
-			lines, err := createImageMirrorForInternalImages(prefix, ref, !o.Upstream)
-			if err != nil {
-				return err
-			}
-			for _, line := range lines {
-				fmt.Fprintln(os.Stdout, line)
-			}
-			return nil
-		},
-	}
-	cmd.Flags().BoolVar(&o.Upstream, "upstream", o.Upstream, "Retrieve images from the default upstream location")
-	cmd.Flags().StringVar(&o.Repository, "to-repository", o.Repository, "A container image repository to mirror to.")
-	// this is a private flag for debugging only
-	cmd.Flags().BoolVar(&o.Verify, "verify", o.Verify, "Verify the contents of the image mappings")
-	cmd.Flags().MarkHidden("verify")
-	return cmd
-}
-
-func newRunCommand(streams genericclioptions.IOStreams) *cobra.Command {
-	f := NewRunSuiteFlags(streams, defaultTestImageMirrorLocation, testsuites.StandardTestSuites())
-
-	cmd := &cobra.Command{
-		Use:   "run SUITE",
-		Short: "Run a test suite",
-		Long: templates.LongDesc(`
-		Run a test suite against an OpenShift server
-
-		This command will run one of the following suites against a cluster identified by the current
-		KUBECONFIG file. See the suite description for more on what actions the suite will take.
-
-		If you specify the --dry-run argument, the names of each individual test that is part of the
-		suite will be printed, one per line. You may filter this list and pass it back to the run
-		command with the --file argument. You may also pipe a list of test names, one per line, on
-		standard input by passing "-f -".
-
-		`) + testsuites.SuitesString(testsuites.StandardTestSuites(), "\n\nAvailable test suites:\n\n"),
-
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			o, err := f.ToOptions(args)
-			if err != nil {
-				fmt.Fprintf(f.IOStreams.ErrOut, "error converting to options: %v", err)
-				return err
-			}
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			if err := o.Run(ctx); err != nil {
-				fmt.Fprintf(f.IOStreams.ErrOut, "error running options: %v", err)
-				return err
-			}
-			return nil
-		},
-	}
-	f.BindOptions(cmd.Flags())
-	return cmd
-}
-
-func newRunUpgradeCommand(streams genericclioptions.IOStreams) *cobra.Command {
-	f := NewRunUpgradeSuiteFlags(streams, defaultTestImageMirrorLocation, testsuites.UpgradeTestSuites())
-
-	cmd := &cobra.Command{
-		Use:   "run-upgrade SUITE",
-		Short: "Run an upgrade suite",
-		Long: templates.LongDesc(`
-		Run an upgrade test suite against an OpenShift server
-
-		This command will run one of the following suites against a cluster identified by the current
-		KUBECONFIG file. See the suite description for more on what actions the suite will take.
-
-		If you specify the --dry-run argument, the actions the suite will take will be printed to the
-		output.
-
-		Supported options:
-
-		* abort-at=NUMBER - Set to a number between 0 and 100 to control the percent of operators
-		at which to stop the current upgrade and roll back to the current version.
-		* disrupt-reboot=POLICY - During upgrades, periodically reboot master nodes. If set to 'graceful'
-		the reboot will allow the node to shut down services in an orderly fashion. If set to 'force' the
-		machine will terminate immediately without clean shutdown.
-
-		`) + testsuites.SuitesString(testsuites.UpgradeTestSuites(), "\n\nAvailable upgrade suites:\n\n"),
-
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			o, err := f.ToOptions(args)
-			if err != nil {
-				fmt.Fprintf(f.IOStreams.ErrOut, "error converting to options: %v", err)
-				return err
-			}
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			if err := o.Run(ctx); err != nil {
-				fmt.Fprintf(f.IOStreams.ErrOut, "error running options: %v", err)
-				return err
-			}
-			return nil
-		},
-	}
-
-	f.BindOptions(cmd.Flags())
-	return cmd
-}
-
-func newRunTestCommand(streams genericclioptions.IOStreams) *cobra.Command {
-	testOpt := testginkgo.NewTestOptions(streams)
-
-	cmd := &cobra.Command{
-		Use:   "run-test NAME",
-		Short: "Run a single test by name",
-		Long: templates.LongDesc(`
-		Execute a single test
-
-		This executes a single test by name. It is used by the run command during suite execution but may also
-		be used to test in isolation while developing new tests.
-		`),
-
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if v := os.Getenv("TEST_LOG_LEVEL"); len(v) > 0 {
-				cmd.Flags().Lookup("v").Value.Set(v)
-			}
-
-			// set globals so that helpers will create pods with the mapped images if we create them from this process.
-			// we cannot eliminate the env var usage until we convert run-test, which we may be able to do in a followup.
-			image.InitializeImages(os.Getenv("KUBE_TEST_REPO"))
-
-			if err := verifyImagesWithoutEnv(); err != nil {
-				return err
-			}
-
-			config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
-			if err != nil {
-				return err
-			}
-			if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
-				return err
-			}
-			klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
-
-			exutil.TestContext.ReportDir = os.Getenv("TEST_JUNIT_DIR")
-
-			// allow upgrade test to pass some parameters here, although this may be
-			// better handled as an env var within the test itself in the future
-			upgradeOptionsYAML := os.Getenv("TEST_UPGRADE_OPTIONS")
-			upgradeOptions, err := NewUpgradeOptionsFromYAML(upgradeOptionsYAML)
-			if err != nil {
-				return err
-			}
-			if err := upgradeOptions.SetUpgradeGlobals(); err != nil {
-				return err
-			}
-
-			exutil.WithCleanup(func() { err = testOpt.Run(args) })
-			return err
-		},
-	}
-	cmd.Flags().BoolVar(&testOpt.DryRun, "dry-run", testOpt.DryRun, "Print the test to run without executing them.")
 	return cmd
 }

--- a/pkg/clioptions/imagesetup/images.go
+++ b/pkg/clioptions/imagesetup/images.go
@@ -1,4 +1,4 @@
-package main
+package imagesetup
 
 import (
 	"bytes"
@@ -10,13 +10,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
-
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	"github.com/openshift/origin/test/extended/util/image"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -40,124 +39,17 @@ import (
 //
 // See test/extended/util/image/README.md for a description of the process of adding a new image.
 
-// defaultTestImageMirrorLocation is where all Kube test inputs are sourced.
-const defaultTestImageMirrorLocation = "quay.io/openshift/community-e2e-images"
+// DefaultTestImageMirrorLocation is where all Kube test inputs are sourced.
+const DefaultTestImageMirrorLocation = "quay.io/openshift/community-e2e-images"
 
-// createImageMirrorForInternalImages returns a list of 'oc image mirror' mappings from source to
-// target or returns an error. If mirrored is true the images are assumed to have already been copied
-// from their upstream location into our official mirror, in the REPO:TAG format where TAG is a hash
-// of the original internal name and the index of the image in the array. Otherwise the mappings will
-// be set to mirror the location as defined in the test code into our official mirror, where the target
-// TAG is the hash described above.
-func createImageMirrorForInternalImages(prefix string, ref reference.DockerImageReference, mirrored bool) ([]string, error) {
-	source := ref.Exact()
-
-	initialDefaults := k8simage.GetOriginalImageConfigs()
-	exceptions := image.Exceptions.List()
-	defaults := map[k8simage.ImageID]k8simage.Config{}
-
-imageLoop:
-	for i, config := range initialDefaults {
-		for _, exception := range exceptions {
-			if strings.Contains(config.GetE2EImage(), exception) {
-				continue imageLoop
-			}
-		}
-		defaults[i] = config
-	}
-
-	updated := k8simage.GetMappedImageConfigs(defaults, ref.Exact())
-	openshiftDefaults := image.OriginalImages()
-	openshiftUpdated := image.GetMappedImages(openshiftDefaults, defaultTestImageMirrorLocation)
-
-	// if we've mirrored, then the source is going to be our repo, not upstream's
-	if mirrored {
-		baseRef, err := reference.Parse(defaultTestImageMirrorLocation)
-		if err != nil {
-			return nil, fmt.Errorf("invalid default mirror location: %v", err)
-		}
-
-		// calculate the mapping of upstream images by setting defaults to baseRef
-		covered := sets.NewString()
-		for i, config := range updated {
-			defaultConfig := defaults[i]
-			pullSpec := config.GetE2EImage()
-			if pullSpec == defaultConfig.GetE2EImage() {
-				continue
-			}
-			if covered.Has(pullSpec) {
-				continue
-			}
-			covered.Insert(pullSpec)
-			e2eRef, err := reference.Parse(pullSpec)
-			if err != nil {
-				return nil, fmt.Errorf("invalid test image: %s: %v", pullSpec, err)
-			}
-			if len(e2eRef.Tag) == 0 {
-				return nil, fmt.Errorf("invalid test image: %s: no tag", pullSpec)
-			}
-			config.SetRegistry(baseRef.Registry)
-			config.SetName(baseRef.RepositoryName())
-			config.SetVersion(e2eRef.Tag)
-			defaults[i] = config
-		}
-
-		// calculate the mapping for openshift images by populating openshiftUpdated
-		openshiftUpdated = make(map[string]string)
-		sourceMappings := image.GetMappedImages(openshiftDefaults, defaultTestImageMirrorLocation)
-		targetMappings := image.GetMappedImages(openshiftDefaults, source)
-
-		for from, to := range targetMappings {
-			if from == to {
-				continue
-			}
-			if covered.Has(to) {
-				continue
-			}
-			covered.Insert(to)
-			from := sourceMappings[from]
-			openshiftUpdated[from] = to
-		}
-	}
-
-	covered := sets.NewString()
-	var lines []string
-	for i := range updated {
-		a, b := defaults[i], updated[i]
-		from, to := a.GetE2EImage(), b.GetE2EImage()
-		if from == to {
-			continue
-		}
-		if covered.Has(from) {
-			continue
-		}
-		covered.Insert(from)
-		lines = append(lines, fmt.Sprintf("%s %s%s", from, prefix, to))
-	}
-
-	for from, to := range openshiftUpdated {
-		if from == to {
-			continue
-		}
-		if covered.Has(from) {
-			continue
-		}
-		covered.Insert(from)
-		lines = append(lines, fmt.Sprintf("%s %s%s", from, prefix, to))
-	}
-
-	sort.Strings(lines)
-	return lines, nil
-}
-
-func verifyImages() error {
+func VerifyTestImageRepoEnvVarUnset() error {
 	if len(os.Getenv("KUBE_TEST_REPO")) > 0 {
 		return fmt.Errorf("KUBE_TEST_REPO may not be specified when this command is run")
 	}
-	return verifyImagesWithoutEnv()
+	return nil
 }
 
-func verifyImagesWithoutEnv() error {
+func VerifyImages() error {
 	defaults := k8simage.GetOriginalImageConfigs()
 
 	for originalPullSpec, index := range image.OriginalImages() {

--- a/pkg/clioptions/upgradeoptions/upgrade_options.go
+++ b/pkg/clioptions/upgradeoptions/upgrade_options.go
@@ -1,4 +1,4 @@
-package main
+package upgradeoptions
 
 import (
 	"encoding/json"

--- a/pkg/cmd/openshift-tests/images/images_command.go
+++ b/pkg/cmd/openshift-tests/images/images_command.go
@@ -1,0 +1,207 @@
+package images
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	k8simage "k8s.io/kubernetes/test/utils/image"
+
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/origin/pkg/clioptions/imagesetup"
+	"github.com/openshift/origin/test/extended/util/image"
+	"github.com/spf13/cobra"
+	"k8s.io/kube-openapi/pkg/util/sets"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+func NewImagesCommand() *cobra.Command {
+	o := &imagesOptions{}
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "Gather images required for testing",
+		Long: templates.LongDesc(fmt.Sprintf(`
+		Creates a mapping to mirror test images to a private registry
+
+		This command identifies the locations of all test images referenced by the test
+		suite and outputs a mirror list for use with 'oc image mirror' to copy those images
+		to a private registry. The list may be passed via file or standard input.
+
+				$ openshift-tests images --to-repository private.com/test/repository > /tmp/mirror
+				$ oc image mirror -f /tmp/mirror
+
+		The 'run' and 'run-upgrade' subcommands accept '--from-repository' which will source
+		required test images from your mirror.
+
+		See the help for 'oc image mirror' for more about mirroring to disk or consult the docs
+		for mirroring offline. You may use a file:// prefix in your '--to-repository', but when
+		mirroring from disk to your offline repository you will have to construct the appropriate
+		disk to internal registry statements yourself.
+
+		By default, the test images are sourced from a public container image repository at
+		%[1]s and are provided as-is for testing purposes only. Images are mirrored by the project
+		to the public repository periodically.
+		`, imagesetup.DefaultTestImageMirrorLocation)),
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := imagesetup.VerifyTestImageRepoEnvVarUnset(); err != nil {
+				return err
+			}
+
+			if o.Verify {
+				return imagesetup.VerifyImages()
+			}
+
+			repository := o.Repository
+			var prefix string
+			for _, validPrefix := range []string{"file://", "s3://"} {
+				if strings.HasPrefix(repository, validPrefix) {
+					repository = strings.TrimPrefix(repository, validPrefix)
+					prefix = validPrefix
+					break
+				}
+			}
+			ref, err := reference.Parse(repository)
+			if err != nil {
+				return fmt.Errorf("--to-repository is not valid: %v", err)
+			}
+			if len(ref.Tag) > 0 || len(ref.ID) > 0 {
+				return fmt.Errorf("--to-repository may not include a tag or image digest")
+			}
+
+			if err := imagesetup.VerifyImages(); err != nil {
+				return err
+			}
+			lines, err := createImageMirrorForInternalImages(prefix, ref, !o.Upstream)
+			if err != nil {
+				return err
+			}
+			for _, line := range lines {
+				fmt.Fprintln(os.Stdout, line)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&o.Upstream, "upstream", o.Upstream, "Retrieve images from the default upstream location")
+	cmd.Flags().StringVar(&o.Repository, "to-repository", o.Repository, "A container image repository to mirror to.")
+	// this is a private flag for debugging only
+	cmd.Flags().BoolVar(&o.Verify, "verify", o.Verify, "Verify the contents of the image mappings")
+	cmd.Flags().MarkHidden("verify")
+	return cmd
+}
+
+type imagesOptions struct {
+	Repository string
+	Upstream   bool
+	Verify     bool
+}
+
+// createImageMirrorForInternalImages returns a list of 'oc image mirror' mappings from source to
+// target or returns an error. If mirrored is true the images are assumed to have already been copied
+// from their upstream location into our official mirror, in the REPO:TAG format where TAG is a hash
+// of the original internal name and the index of the image in the array. Otherwise the mappings will
+// be set to mirror the location as defined in the test code into our official mirror, where the target
+// TAG is the hash described above.
+func createImageMirrorForInternalImages(prefix string, ref reference.DockerImageReference, mirrored bool) ([]string, error) {
+	source := ref.Exact()
+
+	initialDefaults := k8simage.GetOriginalImageConfigs()
+	exceptions := image.Exceptions.List()
+	defaults := map[k8simage.ImageID]k8simage.Config{}
+
+imageLoop:
+	for i, config := range initialDefaults {
+		for _, exception := range exceptions {
+			if strings.Contains(config.GetE2EImage(), exception) {
+				continue imageLoop
+			}
+		}
+		defaults[i] = config
+	}
+
+	updated := k8simage.GetMappedImageConfigs(defaults, ref.Exact())
+	openshiftDefaults := image.OriginalImages()
+	openshiftUpdated := image.GetMappedImages(openshiftDefaults, imagesetup.DefaultTestImageMirrorLocation)
+
+	// if we've mirrored, then the source is going to be our repo, not upstream's
+	if mirrored {
+		baseRef, err := reference.Parse(imagesetup.DefaultTestImageMirrorLocation)
+		if err != nil {
+			return nil, fmt.Errorf("invalid default mirror location: %v", err)
+		}
+
+		// calculate the mapping of upstream images by setting defaults to baseRef
+		covered := sets.NewString()
+		for i, config := range updated {
+			defaultConfig := defaults[i]
+			pullSpec := config.GetE2EImage()
+			if pullSpec == defaultConfig.GetE2EImage() {
+				continue
+			}
+			if covered.Has(pullSpec) {
+				continue
+			}
+			covered.Insert(pullSpec)
+			e2eRef, err := reference.Parse(pullSpec)
+			if err != nil {
+				return nil, fmt.Errorf("invalid test image: %s: %v", pullSpec, err)
+			}
+			if len(e2eRef.Tag) == 0 {
+				return nil, fmt.Errorf("invalid test image: %s: no tag", pullSpec)
+			}
+			config.SetRegistry(baseRef.Registry)
+			config.SetName(baseRef.RepositoryName())
+			config.SetVersion(e2eRef.Tag)
+			defaults[i] = config
+		}
+
+		// calculate the mapping for openshift images by populating openshiftUpdated
+		openshiftUpdated = make(map[string]string)
+		sourceMappings := image.GetMappedImages(openshiftDefaults, imagesetup.DefaultTestImageMirrorLocation)
+		targetMappings := image.GetMappedImages(openshiftDefaults, source)
+
+		for from, to := range targetMappings {
+			if from == to {
+				continue
+			}
+			if covered.Has(to) {
+				continue
+			}
+			covered.Insert(to)
+			from := sourceMappings[from]
+			openshiftUpdated[from] = to
+		}
+	}
+
+	covered := sets.NewString()
+	var lines []string
+	for i := range updated {
+		a, b := defaults[i], updated[i]
+		from, to := a.GetE2EImage(), b.GetE2EImage()
+		if from == to {
+			continue
+		}
+		if covered.Has(from) {
+			continue
+		}
+		covered.Insert(from)
+		lines = append(lines, fmt.Sprintf("%s %s%s", from, prefix, to))
+	}
+
+	for from, to := range openshiftUpdated {
+		if from == to {
+			continue
+		}
+		if covered.Has(from) {
+			continue
+		}
+		covered.Insert(from)
+		lines = append(lines, fmt.Sprintf("%s %s%s", from, prefix, to))
+	}
+
+	sort.Strings(lines)
+	return lines, nil
+}

--- a/pkg/cmd/openshift-tests/run-test/command.go
+++ b/pkg/cmd/openshift-tests/run-test/command.go
@@ -1,0 +1,75 @@
+package run_test
+
+import (
+	"os"
+
+	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
+	"github.com/openshift/origin/pkg/clioptions/imagesetup"
+	"github.com/openshift/origin/pkg/clioptions/upgradeoptions"
+	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+func NewRunTestCommand(streams genericclioptions.IOStreams) *cobra.Command {
+	testOpt := testginkgo.NewTestOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "run-test NAME",
+		Short: "Run a single test by name",
+		Long: templates.LongDesc(`
+		Execute a single test
+
+		This executes a single test by name. It is used by the run command during suite execution but may also
+		be used to test in isolation while developing new tests.
+		`),
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if v := os.Getenv("TEST_LOG_LEVEL"); len(v) > 0 {
+				cmd.Flags().Lookup("v").Value.Set(v)
+			}
+
+			// set globals so that helpers will create pods with the mapped images if we create them from this process.
+			// we cannot eliminate the env var usage until we convert run-test, which we may be able to do in a followup.
+			image.InitializeImages(os.Getenv("KUBE_TEST_REPO"))
+
+			if err := imagesetup.VerifyImages(); err != nil {
+				return err
+			}
+
+			config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
+			if err != nil {
+				return err
+			}
+			if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
+				return err
+			}
+			klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
+
+			exutil.TestContext.ReportDir = os.Getenv("TEST_JUNIT_DIR")
+
+			// allow upgrade test to pass some parameters here, although this may be
+			// better handled as an env var within the test itself in the future
+			upgradeOptionsYAML := os.Getenv("TEST_UPGRADE_OPTIONS")
+			upgradeOptions, err := upgradeoptions.NewUpgradeOptionsFromYAML(upgradeOptionsYAML)
+			if err != nil {
+				return err
+			}
+			// TODO this is called from run-upgrade and run-test.  At least one of these ought not need it.
+			if err := upgradeOptions.SetUpgradeGlobals(); err != nil {
+				return err
+			}
+
+			exutil.WithCleanup(func() { err = testOpt.Run(args) })
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&testOpt.DryRun, "dry-run", testOpt.DryRun, "Print the test to run without executing them.")
+	return cmd
+}

--- a/pkg/cmd/openshift-tests/run-upgrade/command.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/command.go
@@ -1,0 +1,60 @@
+package run_upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/origin/pkg/clioptions/imagesetup"
+	"github.com/openshift/origin/pkg/testsuites"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+func NewRunUpgradeCommand(streams genericclioptions.IOStreams) *cobra.Command {
+	f := NewRunUpgradeSuiteFlags(streams, imagesetup.DefaultTestImageMirrorLocation, testsuites.UpgradeTestSuites())
+
+	cmd := &cobra.Command{
+		Use:   "run-upgrade SUITE",
+		Short: "Run an upgrade suite",
+		Long: templates.LongDesc(`
+		Run an upgrade test suite against an OpenShift server
+
+		This command will run one of the following suites against a cluster identified by the current
+		KUBECONFIG file. See the suite description for more on what actions the suite will take.
+
+		If you specify the --dry-run argument, the actions the suite will take will be printed to the
+		output.
+
+		Supported options:
+
+		* abort-at=NUMBER - Set to a number between 0 and 100 to control the percent of operators
+		at which to stop the current upgrade and roll back to the current version.
+		* disrupt-reboot=POLICY - During upgrades, periodically reboot master nodes. If set to 'graceful'
+		the reboot will allow the node to shut down services in an orderly fashion. If set to 'force' the
+		machine will terminate immediately without clean shutdown.
+
+		`) + testsuites.SuitesString(testsuites.UpgradeTestSuites(), "\n\nAvailable upgrade suites:\n\n"),
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o, err := f.ToOptions(args)
+			if err != nil {
+				fmt.Fprintf(f.IOStreams.ErrOut, "error converting to options: %v", err)
+				return err
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := o.Run(ctx); err != nil {
+				fmt.Fprintf(f.IOStreams.ErrOut, "error running options: %v", err)
+				return err
+			}
+			return nil
+		},
+	}
+
+	f.BindOptions(cmd.Flags())
+	return cmd
+}

--- a/pkg/cmd/openshift-tests/run-upgrade/flags.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/flags.go
@@ -1,14 +1,13 @@
-package main
+package run_upgrade
 
 import (
 	"fmt"
-
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/clioptions/iooptions"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // TODO collapse this with cmd_runsuite
@@ -64,7 +63,6 @@ func (f *RunUpgradeSuiteFlags) ToOptions(args []string) (*RunUpgradeSuiteOptions
 
 	// shallow copy to mutate
 	ginkgoOptions := f.GinkgoRunSuiteOptions
-	ginkgoOptions.SyntheticEventTests = pulledInvalidImages(f.FromRepository)
 	// Upgrade test output is important for debugging because it shows linear progress
 	// and when the CVO hangs.
 	ginkgoOptions.IncludeSuccessOutput = true

--- a/pkg/cmd/openshift-tests/run-upgrade/options.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/options.go
@@ -1,4 +1,4 @@
-package main
+package run_upgrade
 
 import (
 	"context"
@@ -7,32 +7,43 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
+	"github.com/openshift/origin/pkg/clioptions/imagesetup"
 	"github.com/openshift/origin/pkg/clioptions/iooptions"
+	"github.com/openshift/origin/pkg/clioptions/upgradeoptions"
+	"github.com/openshift/origin/pkg/test/ginkgo"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	"github.com/openshift/origin/pkg/version"
+	"github.com/openshift/origin/test/e2e/upgrade"
+	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
+	"github.com/pkg/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 	k8simage "k8s.io/kubernetes/test/utils/image"
 )
 
 // TODO collapse this with cmd_runsuite
-type RunSuiteOptions struct {
+type RunUpgradeSuiteOptions struct {
 	GinkgoRunSuiteOptions *testginkgo.GinkgoRunSuiteOptions
 	Suite                 *testginkgo.TestSuite
 
-	FromRepository    string
-	CloudProviderJSON string
+	ToImage        string
+	FromRepository string
+	// I don't see where this is initialized in this flow
+	//CloudProviderJSON string
+
+	TestOptions []string
 
 	CloseFn iooptions.CloseFunc
+
 	genericclioptions.IOStreams
 }
 
-func (o *RunSuiteOptions) TestCommandEnvironment() []string {
+func (o *RunUpgradeSuiteOptions) TestCommandEnvironment() []string {
 	var args []string
 	args = append(args, "KUBE_TEST_REPO_LIST=") // explicitly prevent selective override
 	args = append(args, fmt.Sprintf("KUBE_TEST_REPO=%s", o.FromRepository))
-	args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.CloudProviderJSON))
+	//args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.CloudProviderJSON))  I don't think we actually have this.
 	args = append(args, fmt.Sprintf("TEST_JUNIT_DIR=%s", o.GinkgoRunSuiteOptions.JUnitDir))
 	for i := 10; i > 0; i-- {
 		if klog.V(klog.Level(i)).Enabled() {
@@ -40,12 +51,41 @@ func (o *RunSuiteOptions) TestCommandEnvironment() []string {
 			break
 		}
 	}
-	args = append(args, "TEST_UPGRADE_OPTIONS=")
+
+	upgradeOptions := upgradeoptions.UpgradeOptions{
+		Suite:       o.Suite.Name,
+		ToImage:     o.ToImage,
+		TestOptions: o.TestOptions,
+	}
+	args = append(args, fmt.Sprintf("TEST_UPGRADE_OPTIONS=%s", upgradeOptions.ToEnv()))
 
 	return args
 }
 
-func (o *RunSuiteOptions) Run(ctx context.Context) error {
+// UpgradeTestPreSuite validates the test options and gathers data useful prior to launching the upgrade and it's
+// related tests.
+func (o *RunUpgradeSuiteOptions) UpgradeTestPreSuite() error {
+	if !o.GinkgoRunSuiteOptions.DryRun {
+		testOpt := ginkgo.NewTestOptions(o.IOStreams)
+		config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
+		if err != nil {
+			return err
+		}
+		if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
+			return err
+		}
+		klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
+
+		if err := upgrade.GatherPreUpgradeResourceCounts(); err != nil {
+			return errors.Wrap(err, "error gathering preupgrade resource counts")
+		}
+	}
+
+	// TODO this is called from run-upgrade and run-test.  At least one of these ought not need it.
+	return upgradeoptions.SetUpgradeGlobalsFromTestOptions(o.TestOptions)
+}
+
+func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {
 	defer o.CloseFn()
 
 	// set globals so that helpers will create pods with the mapped images if we create them from this process.
@@ -53,7 +93,10 @@ func (o *RunSuiteOptions) Run(ctx context.Context) error {
 	// we cannot eliminate the env var usage until we convert run-test, which we may be able to do in a followup.
 	image.InitializeImages(o.FromRepository)
 
-	if err := verifyImages(); err != nil {
+	if err := imagesetup.VerifyTestImageRepoEnvVarUnset(); err != nil {
+		return err
+	}
+	if err := imagesetup.VerifyImages(); err != nil {
 		return err
 	}
 
@@ -67,16 +110,18 @@ func (o *RunSuiteOptions) Run(ctx context.Context) error {
 	// TODO fix the the upstream so that the AfterReadingAllFlags will properly check for either of the inputs having values.
 	k8simage.Init("")
 
+	if err := o.UpgradeTestPreSuite(); err != nil {
+		return err
+	}
+
 	o.GinkgoRunSuiteOptions.CommandEnv = o.TestCommandEnvironment()
 	if !o.GinkgoRunSuiteOptions.DryRun {
 		fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 	}
-	exitErr := o.GinkgoRunSuiteOptions.Run(o.Suite, "openshift-tests", false)
+	exitErr := o.GinkgoRunSuiteOptions.Run(o.Suite, "openshift-tests-upgrade", true)
 	if exitErr != nil {
 		fmt.Fprintf(os.Stderr, "Suite run returned error: %s\n", exitErr.Error())
 	}
 
-	// Special debugging carve-outs for teams is likely to age poorly.
-	clusterdiscovery.PrintStorageCapabilities(o.GinkgoRunSuiteOptions.Out)
 	return exitErr
 }

--- a/pkg/cmd/openshift-tests/run/command.go
+++ b/pkg/cmd/openshift-tests/run/command.go
@@ -1,0 +1,53 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/origin/pkg/clioptions/imagesetup"
+	"github.com/openshift/origin/pkg/testsuites"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+func NewRunCommand(streams genericclioptions.IOStreams) *cobra.Command {
+	f := NewRunSuiteFlags(streams, imagesetup.DefaultTestImageMirrorLocation, testsuites.StandardTestSuites())
+
+	cmd := &cobra.Command{
+		Use:   "run SUITE",
+		Short: "Run a test suite",
+		Long: templates.LongDesc(`
+		Run a test suite against an OpenShift server
+
+		This command will run one of the following suites against a cluster identified by the current
+		KUBECONFIG file. See the suite description for more on what actions the suite will take.
+
+		If you specify the --dry-run argument, the names of each individual test that is part of the
+		suite will be printed, one per line. You may filter this list and pass it back to the run
+		command with the --file argument. You may also pipe a list of test names, one per line, on
+		standard input by passing "-f -".
+
+		`) + testsuites.SuitesString(testsuites.StandardTestSuites(), "\n\nAvailable test suites:\n\n"),
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o, err := f.ToOptions(args)
+			if err != nil {
+				fmt.Fprintf(f.IOStreams.ErrOut, "error converting to options: %v", err)
+				return err
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := o.Run(ctx); err != nil {
+				fmt.Fprintf(f.IOStreams.ErrOut, "error running options: %v", err)
+				return err
+			}
+			return nil
+		},
+	}
+	f.BindOptions(cmd.Flags())
+	return cmd
+}

--- a/pkg/cmd/openshift-tests/run/flags.go
+++ b/pkg/cmd/openshift-tests/run/flags.go
@@ -1,13 +1,12 @@
-package main
+package run
 
 import (
-	"github.com/openshift/origin/pkg/clioptions/iooptions"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
+	"github.com/openshift/origin/pkg/clioptions/iooptions"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // TODO collapse this with cmd_runsuite
@@ -82,7 +81,6 @@ func (f *RunSuiteFlags) ToOptions(args []string) (*RunSuiteOptions, error) {
 	if err != nil {
 		return nil, err
 	}
-	ginkgoOptions.SyntheticEventTests = pulledInvalidImages(f.FromRepository)
 
 	providerConfig, err := f.SuiteWithKubeTestInitializationPreSuite()
 	if err != nil {

--- a/pkg/cmd/openshift-tests/run/options.go
+++ b/pkg/cmd/openshift-tests/run/options.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"context"
@@ -6,43 +6,34 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
+	"github.com/openshift/origin/pkg/clioptions/imagesetup"
+	"github.com/openshift/origin/pkg/clioptions/iooptions"
+	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
+	"github.com/openshift/origin/pkg/version"
+	"github.com/openshift/origin/test/extended/util/image"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 	k8simage "k8s.io/kubernetes/test/utils/image"
-
-	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
-	"github.com/openshift/origin/pkg/clioptions/iooptions"
-	"github.com/openshift/origin/pkg/test/ginkgo"
-	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
-	"github.com/openshift/origin/pkg/version"
-	"github.com/openshift/origin/test/e2e/upgrade"
-	exutil "github.com/openshift/origin/test/extended/util"
-	"github.com/openshift/origin/test/extended/util/image"
-	"github.com/pkg/errors"
 )
 
 // TODO collapse this with cmd_runsuite
-type RunUpgradeSuiteOptions struct {
+type RunSuiteOptions struct {
 	GinkgoRunSuiteOptions *testginkgo.GinkgoRunSuiteOptions
 	Suite                 *testginkgo.TestSuite
 
-	ToImage        string
-	FromRepository string
-	// I don't see where this is initialized in this flow
-	//CloudProviderJSON string
-
-	TestOptions []string
+	FromRepository    string
+	CloudProviderJSON string
 
 	CloseFn iooptions.CloseFunc
-
 	genericclioptions.IOStreams
 }
 
-func (o *RunUpgradeSuiteOptions) TestCommandEnvironment() []string {
+func (o *RunSuiteOptions) TestCommandEnvironment() []string {
 	var args []string
 	args = append(args, "KUBE_TEST_REPO_LIST=") // explicitly prevent selective override
 	args = append(args, fmt.Sprintf("KUBE_TEST_REPO=%s", o.FromRepository))
-	//args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.CloudProviderJSON))  I don't think we actually have this.
+	args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.CloudProviderJSON))
 	args = append(args, fmt.Sprintf("TEST_JUNIT_DIR=%s", o.GinkgoRunSuiteOptions.JUnitDir))
 	for i := 10; i > 0; i-- {
 		if klog.V(klog.Level(i)).Enabled() {
@@ -50,40 +41,12 @@ func (o *RunUpgradeSuiteOptions) TestCommandEnvironment() []string {
 			break
 		}
 	}
-
-	upgradeOptions := UpgradeOptions{
-		Suite:       o.Suite.Name,
-		ToImage:     o.ToImage,
-		TestOptions: o.TestOptions,
-	}
-	args = append(args, fmt.Sprintf("TEST_UPGRADE_OPTIONS=%s", upgradeOptions.ToEnv()))
+	args = append(args, "TEST_UPGRADE_OPTIONS=")
 
 	return args
 }
 
-// UpgradeTestPreSuite validates the test options and gathers data useful prior to launching the upgrade and it's
-// related tests.
-func (o *RunUpgradeSuiteOptions) UpgradeTestPreSuite() error {
-	if !o.GinkgoRunSuiteOptions.DryRun {
-		testOpt := ginkgo.NewTestOptions(o.IOStreams)
-		config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
-		if err != nil {
-			return err
-		}
-		if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
-			return err
-		}
-		klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
-
-		if err := upgrade.GatherPreUpgradeResourceCounts(); err != nil {
-			return errors.Wrap(err, "error gathering preupgrade resource counts")
-		}
-	}
-
-	return SetUpgradeGlobalsFromTestOptions(o.TestOptions)
-}
-
-func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {
+func (o *RunSuiteOptions) Run(ctx context.Context) error {
 	defer o.CloseFn()
 
 	// set globals so that helpers will create pods with the mapped images if we create them from this process.
@@ -91,7 +54,10 @@ func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {
 	// we cannot eliminate the env var usage until we convert run-test, which we may be able to do in a followup.
 	image.InitializeImages(o.FromRepository)
 
-	if err := verifyImages(); err != nil {
+	if err := imagesetup.VerifyTestImageRepoEnvVarUnset(); err != nil {
+		return err
+	}
+	if err := imagesetup.VerifyImages(); err != nil {
 		return err
 	}
 
@@ -105,18 +71,16 @@ func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {
 	// TODO fix the the upstream so that the AfterReadingAllFlags will properly check for either of the inputs having values.
 	k8simage.Init("")
 
-	if err := o.UpgradeTestPreSuite(); err != nil {
-		return err
-	}
-
 	o.GinkgoRunSuiteOptions.CommandEnv = o.TestCommandEnvironment()
 	if !o.GinkgoRunSuiteOptions.DryRun {
 		fmt.Fprintf(os.Stderr, "%s version: %s\n", filepath.Base(os.Args[0]), version.Get().String())
 	}
-	exitErr := o.GinkgoRunSuiteOptions.Run(o.Suite, "openshift-tests-upgrade", true)
+	exitErr := o.GinkgoRunSuiteOptions.Run(o.Suite, "openshift-tests", false)
 	if exitErr != nil {
 		fmt.Fprintf(os.Stderr, "Suite run returned error: %s\n", exitErr.Error())
 	}
 
+	// Special debugging carve-outs for teams is likely to age poorly.
+	clusterdiscovery.PrintStorageCapabilities(o.GinkgoRunSuiteOptions.Out)
 	return exitErr
 }

--- a/pkg/defaultinvariants/types.go
+++ b/pkg/defaultinvariants/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/origin/pkg/invariants/disruptionserializer"
 	"github.com/openshift/origin/pkg/invariants/disruptionserviceloadbalancer"
 	"github.com/openshift/origin/pkg/invariants/intervalserializer"
+	"github.com/openshift/origin/pkg/invariants/knownimagechecker"
 	"github.com/openshift/origin/pkg/invariants/timelineserializer"
 	"github.com/openshift/origin/pkg/invariants/trackedresourcesserializer"
 	"github.com/openshift/origin/pkg/invariants/watchpods"
@@ -71,7 +72,6 @@ func newDisruptiveInvariants() invariants.InvariantRegistry {
 func newUniversalInvariants() invariants.InvariantRegistry {
 	invariantTests := invariants.NewInvariantRegistry()
 
-	// TODO add invariantTests here
 	invariantTests.AddInvariantOrDie("pod-lifecycle", "Test Framework", watchpods.NewPodWatcher())
 	invariantTests.AddInvariantOrDie("timeline-serializer", "Test Framework", timelineserializer.NewTimelineSerializer())
 	invariantTests.AddInvariantOrDie("interval-serializer", "Test Framework", intervalserializer.NewIntervalSerializer())
@@ -80,6 +80,7 @@ func newUniversalInvariants() invariants.InvariantRegistry {
 	invariantTests.AddInvariantOrDie("alert-summary-serializer", "Test Framework", alertserializer.NewAlertSummarySerializer())
 	invariantTests.AddInvariantOrDie("cluster-info-serializer", "Test Framework", clusterinfoserializer.NewClusterInfoSerializer())
 	invariantTests.AddInvariantOrDie("additional-events-collector", "Test Framework", additionaleventscollector.NewIntervalSerializer())
+	invariantTests.AddInvariantOrDie("known-image-checker", "Test Framework", knownimagechecker.NewEnsureValidImages())
 
 	return invariantTests
 }

--- a/pkg/invariants/knownimagechecker/invariant.go
+++ b/pkg/invariants/knownimagechecker/invariant.go
@@ -1,0 +1,281 @@
+package knownimagechecker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/test/extended/util/image"
+
+	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/origin/pkg/invariants"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const testName = "[sig-arch] Only known images used by tests"
+
+type clusterImageValidator struct {
+	adminKubeConfig *rest.Config
+}
+
+func NewEnsureValidImages() invariants.InvariantTest {
+	return &clusterImageValidator{}
+}
+
+func (w *clusterImageValidator) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	w.adminKubeConfig = adminRESTConfig
+	return nil
+}
+
+func (w *clusterImageValidator) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	return nil, nil, nil
+}
+
+func (*clusterImageValidator) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+// EvaluateTestsFromConstructedIntervals checks whether the cluster pulled an image that is
+// outside the allowed list of images. The list is defined as a set of static test case images, the
+// local cluster registry, any repository referenced by the image streams in the cluster's 'openshift'
+// namespace, or the location that input images are cloned from. Only namespaces prefixed with 'e2e-'
+// are checked.
+// any image not in the allowed prefixes is considered a failure, as the user
+// may have added a new test image without calling the appropriate helpers
+func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	if w.adminKubeConfig == nil {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name:      testName,
+				SystemOut: "missing kubeconfig",
+				FailureOutput: &junitapi.FailureOutput{
+					Output: "missing kubeconfig",
+				},
+			},
+		}, nil
+
+	}
+
+	fromRepository := image.GetGlobalFromRepository()
+
+	// static allowed images
+	allowedImages := sets.NewString("image/webserver:404")
+	allowedPrefixes := sets.NewString(
+		"image-registry.openshift-image-registry.svc",
+		"gcr.io/k8s-authenticated-test/",
+		"gcr.io/authenticated-image-pulling/",
+		"invalid.com/",
+
+		// installed alongside OLM and managed externally
+		"registry.redhat.io/redhat/community-operator-index",
+		"registry.redhat.io/redhat/certified-operator-index",
+		"registry.redhat.io/redhat/redhat-marketplace-index",
+		"registry.redhat.io/redhat/redhat-operator-index",
+
+		// used by OLM tests
+		"registry.redhat.io/amq7/amq-streams-rhel7-operator",
+		"registry.redhat.io/amq7/amqstreams-rhel7-operator-metadata",
+
+		// used to test pull secrets against an authenticated registry
+		// TODO: will not work for a disconnected test environment and should be emulated by launching
+		//   an authenticated registry in a pod on cluster
+		"registry.redhat.io/ubi8/nodejs-14:latest",
+	)
+	if len(fromRepository) > 0 {
+		allowedPrefixes.Insert(fromRepository)
+	}
+
+	imageStreamPrefixes, err := imagePrefixesFromNamespaceImageStreams("openshift")
+	if err != nil {
+		klog.Errorf("Unable to identify image prefixes from the openshift namespace: %v", err)
+	}
+	allowedPrefixes.Insert(imageStreamPrefixes.UnsortedList()...)
+
+	releaseImage, err := getReleaseImage(w.adminKubeConfig)
+	if err != nil {
+		klog.Errorf("failed to get release image: %v", err)
+	} else {
+		allowedPrefixes.Insert(releaseImage)
+	}
+
+	allowedPrefixesSlice := allowedPrefixes.List()
+
+	// these are the possible format we need to work with:
+	// 1. reason/Pulled Container image "quay.io/openshift/community-e2e-images:e2e-7-k8s-gcr-io-e2e-test-images-busybox-1-29-2-cqcP1Tnbm-JjJyUA" already present on machine
+	// 2. reason/Pulled image/quay.io/openshift/community-e2e-images:e2e-7-k8s-gcr-io-e2e-test-images-busybox-1-29-2-cqcP1Tnbm-JjJyUA
+	// the regexp tries to match either image/(group) or image "(group)",
+	// where (group) is constructed from three subgroups divided with /
+	// where each has one or more characters from these:
+	// \w (word characters - [0-9A-Za-z_]), -, :, . (needs escaping)
+	imageRe, err := regexp.Compile(`image/([\w-:\.]+/[\w-:\.]+/[\w-:\.]+)$|image "([\w-:\.]+/[\w-:\.]+/[\w-:\.]+)"`)
+	if err != nil {
+		klog.Errorf("failed to compile regexp for image parsing")
+	}
+
+	pulls := make(map[string]sets.String)
+
+	for _, event := range finalIntervals {
+		// only messages that include a Pulled reason
+		if !strings.Contains(" "+event.Message, " reason/Pulled ") {
+			continue
+		}
+		// only look at pull events from an e2e-* namespace
+		if !strings.Contains(" "+event.Locator, " ns/e2e-") {
+			continue
+		}
+
+		images := imageRe.FindStringSubmatch(event.Message)
+		// the images will contain full match and two group matches, see above
+		// for the regexp definition, so we skip the first in the below for-loop
+		if len(images) < 3 {
+			continue
+		}
+		image := ""
+		for i := 1; i < len(images); i++ {
+			image = images[i]
+			// the match will be either 2nd or 3rd element in the list
+			if image != "" {
+				break
+			}
+		}
+		if hasAnyStringPrefix(image, allowedPrefixesSlice) || allowedImages.Has(image) {
+			continue
+		}
+		byImage, ok := pulls[image]
+		if !ok {
+			byImage = sets.NewString()
+			pulls[image] = byImage
+			fmt.Printf("[sig-arch] unknown image: %s (%v)\n", image, event.Message)
+		}
+		byImage.Insert(event.Locator)
+	}
+
+	if len(pulls) > 0 {
+		images := make([]string, 0, len(pulls))
+		for image := range pulls {
+			images = append(images, image)
+		}
+		sort.Strings(images)
+		buf := &bytes.Buffer{}
+		for _, image := range images {
+			fmt.Fprintf(buf, "%s from pods:\n", image)
+			for _, locator := range pulls[image].List() {
+				fmt.Fprintf(buf, "  %s\n", locator)
+			}
+		}
+		return []*junitapi.JUnitTestCase{
+			{
+				Name:      testName,
+				SystemOut: buf.String(),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: fmt.Sprintf("Cluster accessed images that were not mirrored to the testing repository or already part of the cluster, see test/extended/util/image/README.md in the openshift/origin repo:\n\n%s", buf.String()),
+				},
+			},
+		}, nil
+	}
+
+	// if the test passed, indicate that too.
+	return []*junitapi.JUnitTestCase{
+		{
+			Name: testName,
+		},
+	}, nil
+}
+
+func (*clusterImageValidator) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return monitorserialization.EventsToFile(filepath.Join(storageDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)), finalIntervals)
+}
+
+func (*clusterImageValidator) Cleanup(ctx context.Context) error {
+	// TODO wire up the start to a context we can kill here
+	return nil
+}
+
+func hasAnyStringPrefix(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// imagePrefixesFromNamespaceImageStreams identifies all image repositories referenced by
+// image streams in the provided namespace and returns them as a set (for both tags and
+// digests). This set of prefixes can be used to verify that image references are coming
+// from a location the cluster knows about.
+func imagePrefixesFromNamespaceImageStreams(ns string) (sets.String, error) {
+	clientConfig, err := e2e.LoadConfig(true)
+	if err != nil {
+		return nil, err
+	}
+	client, err := imagev1.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	streams, err := client.ImageStreams(ns).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	allowedPrefixes := sets.NewString()
+	for _, stream := range streams.Items {
+		for _, tag := range stream.Spec.Tags {
+			if tag.From == nil || tag.From.Kind != "DockerImage" {
+				continue
+			}
+			ref, err := reference.Parse(tag.From.Name)
+			if err != nil {
+				continue
+			}
+			repo := ref.AsRepository().Exact()
+			allowedPrefixes.Insert(repo + ":")
+			allowedPrefixes.Insert(repo + "@")
+		}
+		for _, tag := range stream.Status.Tags {
+			for _, event := range tag.Items {
+				if len(event.DockerImageReference) == 0 {
+					continue
+				}
+				ref, err := reference.Parse(event.DockerImageReference)
+				if err != nil {
+					continue
+				}
+				repo := ref.AsRepository().Exact()
+				allowedPrefixes.Insert(repo + ":")
+				allowedPrefixes.Insert(repo + "@")
+			}
+		}
+	}
+	return allowedPrefixes, nil
+}
+
+// getReleaseImage does exactly that. We need to add it as exception, as there are some oauth tests that use it to find the
+// oauth server image when the ControlPlaneToplogy is external, where there is no oauth server deployed inside the cluster that
+// could be used: https://github.com/openshift/origin/blob/176aeb92845af9eb50b1d0fe8e98a78dee29215e/test/extended/util/oauthserver/oauthserver.go#L489-L532
+func getReleaseImage(cfg *rest.Config) (string, error) {
+	client, err := configv1client.NewForConfig(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to construct configv1client: %w", err)
+	}
+	cv, err := client.ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get clusterversion: %w", err)
+	}
+	return cv.Status.Desired.Image, nil
+}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -180,7 +180,6 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, upg
 	}
 
 	syntheticEventTests := JUnitsForAllEvents{
-		o.SyntheticEventTests,
 		suite.SyntheticEventTests,
 	}
 

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -16,6 +16,7 @@ import (
 var (
 	initializationLock sync.RWMutex
 	initialized        bool
+	fromRepository     string
 	images             map[string]string
 
 	allowedImages = map[string]k8simage.ImageID{
@@ -77,8 +78,16 @@ func InitializeImages(repo string) {
 	initializationLock.Lock()
 	defer initializationLock.Unlock()
 
+	if initialized {
+		panic(fmt.Sprintf("attempt to double initialize from %q to %q", fromRepository, repo))
+	}
 	initialized = true
+	fromRepository = repo
 	images = GetMappedImages(allowedImages, repo)
+}
+
+func GetGlobalFromRepository() string {
+	return fromRepository
 }
 
 // ReplaceContents ensures that the provided yaml or json has the


### PR DESCRIPTION
/hold

opening so I don't lose it, but this won't work until the core of the invariant checking lands.  Darn you images!