### PR TITLE
expedient engineering: inject intervals into recorded events from out…

### DIFF
--- a/pkg/cmd/monitor_command/timeline/timeline_command.go
+++ b/pkg/cmd/monitor_command/timeline/timeline_command.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -247,7 +248,9 @@ func (o *Timeline) Run() error {
 		to = *o.EndDate
 	}
 
-	filteredEvents = intervalcreation.InsertCalculatedIntervals(filteredEvents, recordedResources, from, to)
+	filteredEvents = append(filteredEvents, intervalcreation.CalculateMoreIntervals(filteredEvents, recordedResources, from, to)...)
+	// we must sort the result
+	sort.Sort(monitorapi.Intervals(filteredEvents))
 
 	output, err := o.Renderer(filteredEvents)
 	if err != nil {

--- a/pkg/monitor/intervalcreation/types.go
+++ b/pkg/monitor/intervalcreation/types.go
@@ -27,19 +27,15 @@ func defaultIntervalCreationFns() []simpleIntervalCreationFunc {
 	}
 }
 
-// InsertCalculatedIntervals calculates intervals from the currently known interval set and saves them into the same list
-func InsertCalculatedIntervals(startingIntervals []monitorapi.Interval, recordedResources monitorapi.ResourcesMap, from, to time.Time) monitorapi.Intervals {
-	ret := make([]monitorapi.Interval, len(startingIntervals))
-	copy(ret, startingIntervals)
+// CalculateMoreIntervals calculates intervals from the currently known interval set and saves them into the same list
+func CalculateMoreIntervals(startingIntervals []monitorapi.Interval, recordedResources monitorapi.ResourcesMap, from, to time.Time) monitorapi.Intervals {
+	ret := []monitorapi.Interval{}
 
 	intervalCreationFns := defaultIntervalCreationFns()
 	// create additional intervals from events
 	for _, createIntervals := range intervalCreationFns {
 		ret = append(ret, createIntervals(startingIntervals, recordedResources, from, to)...)
 	}
-
-	// we must sort the result
-	sort.Sort(monitorapi.Intervals(ret))
 
 	return ret
 }

--- a/pkg/test/ginkgo/options_monitor_events.go
+++ b/pkg/test/ginkgo/options_monitor_events.go
@@ -164,13 +164,15 @@ func (o *MonitorEventsOptions) Stop(ctx context.Context, restConfig *rest.Config
 	if err != nil {
 		fmt.Fprintf(o.ErrOut, "InsertIntervalsFromCluster error but continuing processing: %v", err)
 	}
+	o.monitor.AddIntervals(events...) // add intervals to the recorded events, not just the random copy
 	// add events from alerts so we can create the intervals
 	alertEventIntervals, err := monitor.FetchEventIntervalsForAllAlerts(ctx, restConfig, *o.startTime)
 	if err != nil {
 		fmt.Fprintf(o.ErrOut, "FetchEventIntervalsForAllAlerts error but continuing processing: %v", err)
 	}
 	events = append(events, alertEventIntervals...)
-	events = intervalcreation.InsertCalculatedIntervals(events, o.recordedResources, fromTime, endTime)
+	o.monitor.AddIntervals(alertEventIntervals...) // add intervals to the recorded events, not just the random copy
+	o.monitor.AddIntervals(intervalcreation.CalculateMoreIntervals(events, o.recordedResources, fromTime, endTime)...)
 
 	sort.Sort(events)
 	events.Clamp(*o.startTime, *o.endTime)


### PR DESCRIPTION
…side the monitor to serialize into timeline

https://github.com/openshift/origin/pull/28127 has the long term solution, but if it doesn't pass CI, this is small and obvious.

/assign @stbenjam 
/cc @trozet 