### PR TITLE
remove [sig-arch] Monitor cluster while tests execute test

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -568,8 +568,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, upg
 	// default is empty string as that is what entries prior to adding this will have
 	wasMasterNodeUpdated := ""
 	if events := monitorEventsOptions.GetEvents(); len(events) > 0 {
-		var buf *bytes.Buffer
-		syntheticTestResults, buf, _ = createSyntheticTestsFromMonitor(events, duration)
+		buf := &bytes.Buffer{}
 		currResState := monitorEventsOptions.GetRecordedResources()
 		testCases := syntheticEventTests.JUnitsForEvents(events, duration, restConfig, suite.Name, &currResState)
 		syntheticTestResults = append(syntheticTestResults, testCases...)


### PR DESCRIPTION
/assign @dgoodwin 

This test provides no unique value.  The intervals are serialized to a file already and this is always true.