### PR TITLE
remove unnecessary global modification from upgrade

### DIFF
--- a/pkg/clioptions/upgradeoptions/upgrade_options.go
+++ b/pkg/clioptions/upgradeoptions/upgrade_options.go
@@ -47,8 +47,23 @@ func (o *UpgradeOptions) SetUpgradeGlobals() error {
 		return nil
 	}
 
-	if err := SetUpgradeGlobalsFromTestOptions(o.TestOptions); err != nil {
-		return err
+	for _, opt := range o.TestOptions {
+		parts := strings.SplitN(opt, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("expected option of the form KEY=VALUE instead of %q", opt)
+		}
+		switch parts[0] {
+		case "abort-at":
+			if err := upgrade.SetUpgradeAbortAt(parts[1]); err != nil {
+				return err
+			}
+		case "disrupt-reboot":
+			if err := upgrade.SetUpgradeDisruptReboot(parts[1]); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unrecognized upgrade option: %s", parts[0])
+		}
 	}
 
 	upgrade.SetToImage(o.ToImage)
@@ -72,27 +87,5 @@ func filterUpgrade(tests []upgrades.Test, match func(string) bool) error {
 		}
 	}
 	upgrade.SetTests(scope)
-	return nil
-}
-
-func SetUpgradeGlobalsFromTestOptions(testOptions []string) error {
-	for _, opt := range testOptions {
-		parts := strings.SplitN(opt, "=", 2)
-		if len(parts) != 2 {
-			return fmt.Errorf("expected option of the form KEY=VALUE instead of %q", opt)
-		}
-		switch parts[0] {
-		case "abort-at":
-			if err := upgrade.SetUpgradeAbortAt(parts[1]); err != nil {
-				return err
-			}
-		case "disrupt-reboot":
-			if err := upgrade.SetUpgradeDisruptReboot(parts[1]); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unrecognized upgrade option: %s", parts[0])
-		}
-	}
 	return nil
 }

--- a/pkg/cmd/openshift-tests/run-upgrade/options.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/options.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/origin/pkg/clioptions/imagesetup"
 	"github.com/openshift/origin/pkg/clioptions/iooptions"
 	"github.com/openshift/origin/pkg/clioptions/upgradeoptions"
-	"github.com/openshift/origin/pkg/test/ginkgo"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	"github.com/openshift/origin/pkg/version"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -63,20 +62,16 @@ func (o *RunUpgradeSuiteOptions) TestCommandEnvironment() []string {
 // UpgradeTestPreSuite validates the test options and gathers data useful prior to launching the upgrade and it's
 // related tests.
 func (o *RunUpgradeSuiteOptions) UpgradeTestPreSuite() error {
-	if !o.GinkgoRunSuiteOptions.DryRun {
-		testOpt := ginkgo.NewTestOptions(o.IOStreams)
-		config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun, false, nil)
-		if err != nil {
-			return err
-		}
-		if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
-			return err
-		}
-		klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
+	config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), o.GinkgoRunSuiteOptions.DryRun, false, nil)
+	if err != nil {
+		return err
 	}
+	if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, o.GinkgoRunSuiteOptions.DryRun); err != nil {
+		return err
+	}
+	klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
 
-	// TODO this is called from run-upgrade and run-test.  At least one of these ought not need it.
-	return upgradeoptions.SetUpgradeGlobalsFromTestOptions(o.TestOptions)
+	return nil
 }
 
 func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {


### PR DESCRIPTION
Only the actual run test needs to set the global.