### PR TITLE
TRT-930: Update test to support 2 release query_results.json

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/matches_test.go
+++ b/pkg/monitortestlibrary/allowedalerts/matches_test.go
@@ -208,14 +208,14 @@ func TestAlertDataFileParsing(t *testing.T) {
 			foundMetalOVN = true
 		}
 	}
-
+	currentRelease = historicaldata.CurrentReleaseFromMap(releasesInQueryResults)
 	assert.Greater(t, dataOver100Runs, 5,
 		"expected at least 5 entries in query_results.json to have over 100 runs")
 	assert.True(t, foundAWSOVN, "no aws ovn job data in query_results.json")
 	assert.True(t, foundGCPOVN, "no gcp ovn job data in query_results.json")
 	assert.True(t, foundAzureOVN, "no azure ovn job data in query_results.json")
 	assert.True(t, foundMetalOVN, "no metal ovn job data in query_results.json")
-	assert.Equal(t, 1, len(releasesInQueryResults),
+	assert.Equal(t, 2, len(releasesInQueryResults),
 		"expected only one Release in query_results.json")
 
 	// Check that we get a real value for something we know should be there for every release. This alert

--- a/pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go
+++ b/pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go
@@ -274,14 +274,14 @@ func TestDisruptionDataFileParsing(t *testing.T) {
 			foundMetalOVN = true
 		}
 	}
-
+	currentRelease = historicaldata.CurrentReleaseFromMap(releasesInQueryResults)
 	assert.Greater(t, dataOver100Runs, 5,
 		"expected at least 5 entries in query_results.json to have over 100 runs")
 	assert.True(t, foundAWSOVN, "no aws ovn job data in query_results.json")
 	assert.True(t, foundGCPOVN, "no gcp ovn job data in query_results.json")
 	assert.True(t, foundAzureOVN, "no azure ovn job data in query_results.json")
 	assert.True(t, foundMetalOVN, "no metal ovn job data in query_results.json")
-	assert.Equal(t, 1, len(releasesInQueryResults),
+	assert.Equal(t, 2, len(releasesInQueryResults),
 		"expected only one Release in query_results.json")
 
 	// Check that we get a real value for something we know should be there for every release.
@@ -299,5 +299,4 @@ func TestDisruptionDataFileParsing(t *testing.T) {
 	// so instead we'll make sure we didn't get a msg complaining about no match:
 	assert.Equal(t, "", msg, "BestMatchDuration reported a problem finding data for kube-api-new-connections aws amd64 ovn ha")
 	assert.NoError(t, err)
-
 }

--- a/pkg/monitortestlibrary/allowedbackenddisruption/query_results.json
+++ b/pkg/monitortestlibrary/allowedbackenddisruption/query_results.json
@@ -2,15 +2,32 @@
   {
     "BackendName": "cache-kube-api-new-connections",
     "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
     "FromRelease": "4.13",
     "Platform": "aws",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -22,8 +39,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "203.0",
-    "P99": "203.8"
+    "P95": "202.6",
+    "P99": "203.72",
+    "P75": "197.0",
+    "P50": "190.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -34,9 +53,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "3.02",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -49,7 +70,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -60,9 +83,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 914,
+    "JobRuns": 878,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -73,9 +98,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 574,
-    "P95": "2.0",
-    "P99": "4.0"
+    "JobRuns": 613,
+    "P95": "3.0",
+    "P99": "7.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -86,9 +113,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "2.0",
-    "P99": "2.48"
+    "JobRuns": 41,
+    "P95": "1.0",
+    "P99": "3.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -99,9 +128,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "8.9",
-    "P99": "10.38"
+    "JobRuns": 65,
+    "P95": "8.0",
+    "P99": "10.36",
+    "P75": "6.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -112,9 +143,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "11.0",
-    "P99": "11.49"
+    "JobRuns": 50,
+    "P95": "10.55",
+    "P99": "11.0",
+    "P75": "7.75",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -125,9 +158,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.8",
+    "P99": "1.96",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -138,9 +173,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "8.75",
-    "P99": "8.95"
+    "JobRuns": 7,
+    "P95": "7.7",
+    "P99": "7.94",
+    "P75": "6.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -151,9 +188,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "5.7",
+    "P99": "5.94",
+    "P75": "4.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -164,9 +203,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "1.3",
-    "P99": "9.26"
+    "JobRuns": 87,
+    "P95": "0.0",
+    "P99": "9.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -177,9 +218,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "796.5",
-    "P99": "1044.9"
+    "JobRuns": 17,
+    "P95": "775.8",
+    "P99": "1040.76",
+    "P75": "2.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -190,9 +233,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "635.0",
-    "P99": "648.6"
+    "JobRuns": 19,
+    "P95": "621.4",
+    "P99": "645.88",
+    "P75": "305.0",
+    "P50": "208.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -203,9 +248,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -217,8 +264,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "191.5",
-    "P99": "194.3"
+    "P95": "188.35",
+    "P99": "193.67",
+    "P75": "174.5",
+    "P50": "156.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -229,9 +278,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "0.0",
-    "P99": "0.53"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -242,9 +293,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 493,
+    "JobRuns": 455,
     "P95": "0.0",
-    "P99": "2.08"
+    "P99": "0.46",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -255,9 +308,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
+    "JobRuns": 46,
     "P95": "0.0",
-    "P99": "12.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -268,48 +323,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 979,
+    "JobRuns": 850,
     "P95": "2.0",
-    "P99": "4.0"
+    "P99": "6.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "2.0",
-    "P99": "3.88"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "9.0",
-    "P99": "10.35"
-  },
-  {
-    "BackendName": "cache-kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "9.7",
-    "P99": "10.54"
+    "P95": "3.0",
+    "P99": "3.54",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "8.85",
+    "P99": "9.78",
+    "P75": "2.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "10.25",
+    "P99": "11.65",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -320,9 +383,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "5.54"
+    "P99": "5.48",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "0.0",
+    "P99": "0.49",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "4.23",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "46.0",
+    "P99": "112.61",
+    "P75": "42.0",
+    "P50": "26.5"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "0.0",
+    "P99": "3.25",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "3.0",
+    "P99": "5.97",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "0.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "10.66",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "5.4",
+    "P99": "27.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "3.0",
+    "P99": "7.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "8.22",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "301.3",
+    "P99": "365.72",
+    "P75": "197.0",
+    "P50": "135.5"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "6.16",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.0",
+    "P99": "2.28",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "7.0",
+    "P99": "9.73",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "41.4",
+    "P99": "88.36",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "454.25",
+    "P99": "775.94",
+    "P75": "188.0",
+    "P50": "84.5"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -333,9 +848,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -348,7 +865,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -359,9 +878,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
+    "JobRuns": 38,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -372,9 +893,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -387,7 +910,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -398,9 +923,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -411,9 +938,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -425,8 +954,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "4.25",
-    "P99": "4.85"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -439,7 +970,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
     "P95": "55.0",
-    "P99": "74.85"
+    "P99": "57.65",
+    "P75": "52.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -450,9 +983,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -465,7 +1000,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -478,7 +1015,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -489,9 +1028,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -504,7 +1045,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "2.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -517,7 +1060,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -530,7 +1075,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -541,9 +1088,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -556,7 +1120,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -567,9 +1133,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "15.0",
-    "P99": "39.4"
+    "JobRuns": 32,
+    "P95": "14.1",
+    "P99": "39.18",
+    "P75": "1.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -580,9 +1148,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "6.15",
-    "P99": "1085.9"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "30.04",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -595,7 +1165,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -608,7 +1180,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "299.75",
-    "P99": "307.15"
+    "P99": "307.15",
+    "P75": "241.75",
+    "P50": "148.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -619,9 +1193,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "3.9"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -632,9 +1208,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
+    "JobRuns": 72,
     "P95": "0.0",
-    "P99": "0.75"
+    "P99": "0.87",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -647,7 +1225,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -658,9 +1238,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "10.05",
-    "P99": "556.2"
+    "JobRuns": 87,
+    "P95": "47.5",
+    "P99": "196.34",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-new-connections",
@@ -671,9 +1268,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "351.1",
-    "P99": "1050.6"
+    "JobRuns": 145,
+    "P95": "316.8",
+    "P99": "1016.4",
+    "P75": "99.0",
+    "P50": "33.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -684,9 +1298,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -698,8 +1314,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "202.9",
-    "P99": "203.78"
+    "P95": "202.6",
+    "P99": "203.72",
+    "P75": "197.0",
+    "P50": "190.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -710,9 +1328,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -725,7 +1345,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.85",
-    "P99": "0.97"
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -736,9 +1358,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 920,
-    "P95": "2.0",
-    "P99": "3.0"
+    "JobRuns": 884,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -749,9 +1373,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 573,
+    "JobRuns": 612,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -762,9 +1388,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "0.0",
-    "P99": "0.48"
+    "P99": "0.6",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -775,9 +1403,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "10.0",
-    "P99": "13.0"
+    "JobRuns": 65,
+    "P95": "9.8",
+    "P99": "13.0",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -788,9 +1418,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "13.0",
-    "P99": "14.49"
+    "JobRuns": 50,
+    "P95": "12.55",
+    "P99": "14.0",
+    "P75": "10.0",
+    "P50": "6.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -801,9 +1433,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.8",
+    "P99": "1.96",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -814,9 +1448,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "8.75",
-    "P99": "8.95"
+    "JobRuns": 7,
+    "P95": "7.1",
+    "P99": "7.82",
+    "P75": "5.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -827,9 +1463,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.0",
-    "P99": "9.0"
+    "JobRuns": 7,
+    "P95": "5.7",
+    "P99": "5.94",
+    "P75": "4.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -840,9 +1478,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
+    "JobRuns": 87,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -853,9 +1493,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "790.25",
-    "P99": "1030.85"
+    "JobRuns": 17,
+    "P95": "770.2",
+    "P99": "1026.84",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -866,9 +1508,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "398.0",
-    "P99": "404.4"
+    "JobRuns": 19,
+    "P95": "354.9",
+    "P99": "382.98",
+    "P75": "205.0",
+    "P50": "106.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -879,9 +1523,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -893,8 +1539,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "191.5",
-    "P99": "194.3"
+    "P95": "188.35",
+    "P99": "193.67",
+    "P75": "174.5",
+    "P50": "156.5"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -905,9 +1553,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -918,35 +1568,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 495,
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "2.0",
-    "P99": "2.5"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 978,
+    "JobRuns": 457,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "2.44",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 46,
+    "P95": "1.0",
+    "P99": "1.55",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -954,38 +1595,59 @@
     "FromRelease": "4.14",
     "Platform": "gcp",
     "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "0.0",
-    "P99": "0.44"
-  },
-  {
-    "BackendName": "cache-kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.75",
-    "P99": "13.05"
+    "JobRuns": 849,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
-    "Platform": "metal",
+    "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "12.0",
-    "P99": "12.54"
+    "P95": "0.0",
+    "P99": "0.54",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "8.85",
+    "P99": "12.56",
+    "P75": "3.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "12.25",
+    "P99": "14.3",
+    "P75": "8.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -996,9 +1658,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.7",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "0.47",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "45.0",
+    "P99": "117.07",
+    "P75": "42.0",
+    "P50": "22.5"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "1.0",
+    "P99": "2.05",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "0.46",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "1.0",
+    "P99": "11.76",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "1.38",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "273.55",
+    "P99": "365.72",
+    "P75": "196.75",
+    "P50": "135.5"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "29.2",
+    "P99": "72.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "319.6",
+    "P99": "697.74",
+    "P75": "132.25",
+    "P50": "69.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1009,9 +2123,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1024,7 +2140,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1035,9 +2153,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
+    "JobRuns": 38,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1048,9 +2168,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1063,7 +2185,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1074,9 +2198,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1087,9 +2213,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1102,7 +2230,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1115,7 +2245,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
     "P95": "55.0",
-    "P99": "74.85"
+    "P99": "56.65",
+    "P75": "52.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1126,9 +2258,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1140,8 +2274,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "1.0",
-    "P99": "1.0"
+    "P95": "0.85",
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1154,7 +2290,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "2.15",
-    "P99": "2.83"
+    "P99": "2.83",
+    "P75": "0.75",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1165,9 +2303,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1180,7 +2320,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1193,7 +2335,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1206,7 +2350,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1217,9 +2363,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1232,7 +2395,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1243,9 +2408,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "2.0",
-    "P99": "3.0"
+    "JobRuns": 32,
+    "P95": "1.9",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1256,9 +2423,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "1.0",
-    "P99": "13.45"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "2.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1271,7 +2440,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1284,7 +2455,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "299.5",
-    "P99": "307.1"
+    "P99": "307.1",
+    "P75": "241.0",
+    "P50": "148.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1295,9 +2468,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1308,9 +2483,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
+    "JobRuns": 72,
     "P95": "0.0",
-    "P99": "0.25"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1323,7 +2500,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1334,9 +2513,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "3.8",
-    "P99": "543.07"
+    "JobRuns": 87,
+    "P95": "17.7",
+    "P99": "73.48",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-kube-api-reused-connections",
@@ -1347,9 +2543,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "245.7",
-    "P99": "780.88"
+    "JobRuns": 145,
+    "P95": "203.0",
+    "P99": "760.72",
+    "P75": "52.0",
+    "P50": "16.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1360,9 +2573,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "0.0",
-    "P99": "1.01"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1374,8 +2589,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "691.5",
-    "P99": "692.7"
+    "P95": "478.5",
+    "P99": "479.7",
+    "P75": "472.5",
+    "P50": "465.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1386,9 +2603,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "3.33"
+    "P99": "4.68",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1400,8 +2619,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.85",
-    "P99": "0.97"
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "0.5"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1412,9 +2633,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 915,
+    "JobRuns": 879,
     "P95": "2.0",
-    "P99": "6.86"
+    "P99": "6.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1425,9 +2648,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 575,
-    "P95": "3.0",
-    "P99": "5.0"
+    "JobRuns": 614,
+    "P95": "2.0",
+    "P99": "5.87",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1438,9 +2663,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "2.0",
-    "P99": "2.96"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1451,9 +2678,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "15.0",
-    "P99": "16.76"
+    "JobRuns": 65,
+    "P95": "14.4",
+    "P99": "19.8",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1464,9 +2693,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "11.0",
-    "P99": "11.49"
+    "JobRuns": 50,
+    "P95": "10.55",
+    "P99": "11.51",
+    "P75": "7.75",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1477,9 +2708,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.8",
+    "P99": "1.96",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1490,9 +2723,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "9.0",
-    "P99": "9.0"
+    "JobRuns": 7,
+    "P95": "8.7",
+    "P99": "8.94",
+    "P75": "7.0",
+    "P50": "6.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1503,9 +2738,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "5.7",
+    "P99": "5.94",
+    "P75": "5.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1516,9 +2753,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "7.8",
-    "P99": "27.26"
+    "JobRuns": 87,
+    "P95": "0.0",
+    "P99": "27.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1529,9 +2768,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "796.75",
-    "P99": "1045.75"
+    "JobRuns": 17,
+    "P95": "776.0",
+    "P99": "1041.6",
+    "P75": "21.0",
+    "P50": "10.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1542,9 +2783,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "672.5",
-    "P99": "675.3"
+    "JobRuns": 19,
+    "P95": "669.7",
+    "P99": "674.74",
+    "P75": "346.5",
+    "P50": "251.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1555,9 +2798,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "2.34"
+    "P99": "2.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1570,7 +2815,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
     "P95": "559.65",
-    "P99": "610.33"
+    "P99": "610.33",
+    "P75": "436.75",
+    "P50": "318.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1581,9 +2828,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "0.0",
-    "P99": "3.53"
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1594,9 +2843,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 494,
+    "JobRuns": 456,
     "P95": "2.0",
-    "P99": "5.14"
+    "P99": "4.45",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1607,9 +2858,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "2.0",
-    "P99": "14.5"
+    "JobRuns": 46,
+    "P95": "0.0",
+    "P99": "2.65",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1620,48 +2873,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 980,
-    "P95": "2.0",
-    "P99": "5.0"
+    "JobRuns": 851,
+    "P95": "3.0",
+    "P99": "5.5",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "2.0",
-    "P99": "3.44"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.75",
-    "P99": "12.7"
-  },
-  {
-    "BackendName": "cache-oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "9.7",
-    "P99": "10.54"
+    "P95": "3.0",
+    "P99": "9.48",
+    "P75": "0.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "9.0",
+    "P99": "14.78",
+    "P75": "4.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "11.25",
+    "P99": "12.0",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1672,9 +2933,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "31.49"
+    "P99": "31.38",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "4104.35",
+    "P99": "4223.3",
+    "P75": "3858.0",
+    "P50": "2978.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "3.35",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "1.48",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "129.55",
+    "P99": "225.82",
+    "P75": "123.0",
+    "P50": "90.5"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "1.0",
+    "P99": "9.05",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "3.0",
+    "P99": "5.97",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.25",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.1",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "9.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "7.63",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "6.4",
+    "P99": "25.44",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "3.0",
+    "P99": "7.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.7",
+    "P99": "25.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "879.85",
+    "P99": "1291.77",
+    "P75": "675.75",
+    "P50": "472.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "22.16",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.0",
+    "P99": "15.44",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "16.0",
+    "P99": "19.0",
+    "P75": "8.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "41.3",
+    "P99": "87.57",
+    "P75": "0.25",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "452.85",
+    "P99": "775.94",
+    "P75": "188.25",
+    "P50": "85.5"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1685,9 +3398,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1700,7 +3415,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1711,9 +3428,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "1.65",
-    "P99": "21.53"
+    "JobRuns": 38,
+    "P95": "5.55",
+    "P99": "21.89",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1724,9 +3443,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1739,7 +3460,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1750,9 +3473,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1763,9 +3488,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1777,8 +3504,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.85",
-    "P99": "0.97"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1790,8 +3519,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "134.0",
-    "P99": "151.65"
+    "P95": "239.0",
+    "P99": "269.7",
+    "P75": "129.25",
+    "P50": "3.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1802,9 +3533,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 520,
+    "JobRuns": 540,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1817,7 +3550,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1830,7 +3565,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.15",
-    "P99": "0.83"
+    "P99": "0.83",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1841,9 +3578,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.8",
+    "P99": "1.96",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1856,7 +3595,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.4",
-    "P99": "3.28"
+    "P99": "3.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1869,7 +3610,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1882,7 +3625,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1893,9 +3638,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1908,7 +3670,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1919,9 +3683,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "23.0",
-    "P99": "58.5"
+    "JobRuns": 32,
+    "P95": "21.9",
+    "P99": "58.15",
+    "P75": "2.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1932,9 +3698,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "6.15",
-    "P99": "1416.62"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "32.08",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1947,7 +3715,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "24.0",
-    "P99": "24.0"
+    "P99": "24.0",
+    "P75": "24.0",
+    "P50": "24.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1960,7 +3730,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "900.25",
-    "P99": "904.05"
+    "P99": "904.05",
+    "P75": "785.0",
+    "P50": "475.5"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1971,9 +3743,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "10.4"
+    "P99": "1.42",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1984,9 +3758,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "1.25",
-    "P99": "15.25"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "0.58",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -1999,7 +3775,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "8.0",
-    "P99": "8.0"
+    "P99": "8.0",
+    "P75": "8.0",
+    "P50": "8.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -2010,9 +3788,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "10.05",
-    "P99": "556.07"
+    "JobRuns": 87,
+    "P95": "47.8",
+    "P99": "204.94",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-new-connections",
@@ -2023,9 +3818,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "351.7",
-    "P99": "1065.12"
+    "JobRuns": 145,
+    "P95": "319.4",
+    "P99": "1031.28",
+    "P75": "100.0",
+    "P50": "33.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2036,9 +3848,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2050,8 +3864,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "690.6",
-    "P99": "691.72"
+    "P95": "478.3",
+    "P99": "479.66",
+    "P75": "471.5",
+    "P50": "463.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2062,9 +3878,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.34",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2076,8 +3894,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "1.0",
-    "P99": "1.0"
+    "P95": "0.85",
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2088,9 +3908,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 920,
+    "JobRuns": 884,
     "P95": "3.0",
-    "P99": "7.0"
+    "P99": "7.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2101,9 +3923,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 573,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 612,
+    "P95": "0.45",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2114,9 +3938,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "0.0",
-    "P99": "1.48"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2127,9 +3953,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "10.0",
-    "P99": "13.0"
+    "JobRuns": 65,
+    "P95": "9.0",
+    "P99": "13.0",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2140,9 +3968,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "13.0",
-    "P99": "14.49"
+    "JobRuns": 50,
+    "P95": "12.55",
+    "P99": "14.0",
+    "P75": "10.0",
+    "P50": "6.5"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2153,9 +3983,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.8",
+    "P99": "1.96",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2166,9 +3998,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "9.75",
-    "P99": "9.95"
+    "JobRuns": 7,
+    "P95": "8.5",
+    "P99": "9.7",
+    "P75": "5.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2179,9 +4013,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.0",
-    "P99": "9.0"
+    "JobRuns": 7,
+    "P95": "6.7",
+    "P99": "6.94",
+    "P75": "5.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2192,9 +4028,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "5.55",
-    "P99": "24.13"
+    "JobRuns": 87,
+    "P95": "0.0",
+    "P99": "24.14",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2205,9 +4043,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "790.25",
-    "P99": "1030.85"
+    "JobRuns": 17,
+    "P95": "770.2",
+    "P99": "1026.84",
+    "P75": "2.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2218,9 +4058,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "423.5",
-    "P99": "430.3"
+    "JobRuns": 19,
+    "P95": "405.0",
+    "P99": "426.6",
+    "P75": "209.0",
+    "P50": "128.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2231,9 +4073,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "2.7"
+    "P99": "2.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2246,7 +4090,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
     "P95": "560.0",
-    "P99": "610.4"
+    "P99": "610.4",
+    "P75": "437.75",
+    "P50": "318.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2257,9 +4103,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "4.18",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2270,9 +4118,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 497,
-    "P95": "3.0",
-    "P99": "5.0"
+    "JobRuns": 459,
+    "P95": "2.1",
+    "P99": "5.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2283,22 +4133,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "2.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 978,
+    "JobRuns": 46,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "2.65",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2306,38 +4145,59 @@
     "FromRelease": "4.14",
     "Platform": "gcp",
     "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "0.0",
-    "P99": "0.44"
-  },
-  {
-    "BackendName": "cache-oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.75",
-    "P99": "12.7"
+    "JobRuns": 849,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
-    "Platform": "metal",
+    "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "11.7",
-    "P99": "12.54"
+    "P95": "0.7",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "8.9",
+    "P99": "12.17",
+    "P75": "3.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "12.25",
+    "P99": "14.3",
+    "P75": "8.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2348,9 +4208,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "22.59"
+    "P99": "22.58",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "4104.35",
+    "P99": "4223.3",
+    "P75": "3858.0",
+    "P50": "2978.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "0.47",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "129.55",
+    "P99": "226.35",
+    "P75": "123.0",
+    "P50": "90.5"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "2.0",
+    "P99": "4.15",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "1.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "6.63",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "1.4",
+    "P99": "11.64",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "21.18",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "879.85",
+    "P99": "1292.77",
+    "P75": "675.75",
+    "P50": "472.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "20.4",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.0",
+    "P99": "16.4",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "4.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "29.2",
+    "P99": "71.21",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "319.35",
+    "P99": "701.88",
+    "P75": "132.25",
+    "P50": "65.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2361,9 +4673,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2376,7 +4690,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2387,9 +4703,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "1.65",
-    "P99": "22.02"
+    "JobRuns": 38,
+    "P95": "5.7",
+    "P99": "22.26",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2400,9 +4718,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2415,7 +4735,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2426,9 +4748,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2439,9 +4763,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2454,7 +4780,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2466,8 +4794,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "135.0",
-    "P99": "151.65"
+    "P95": "239.0",
+    "P99": "271.0",
+    "P75": "129.25",
+    "P50": "3.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2478,9 +4808,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 520,
+    "JobRuns": 540,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2492,8 +4824,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.85",
-    "P99": "0.97"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2506,7 +4840,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "2.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2517,9 +4853,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2532,7 +4870,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.1",
-    "P99": "0.82"
+    "P99": "0.82",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2545,7 +4885,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2558,7 +4900,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2569,9 +4913,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2584,7 +4945,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.4",
-    "P99": "0.88"
+    "P99": "0.88",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2595,9 +4958,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "1.5",
-    "P99": "9.0"
+    "JobRuns": 32,
+    "P95": "1.45",
+    "P99": "8.9",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2608,9 +4973,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "1.0",
-    "P99": "13.97"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "3.68",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2623,7 +4990,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "25.0",
-    "P99": "25.0"
+    "P99": "25.0",
+    "P75": "25.0",
+    "P50": "25.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2636,7 +5005,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "901.0",
-    "P99": "905.0"
+    "P99": "905.0",
+    "P75": "785.0",
+    "P50": "475.5"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2647,9 +5018,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "8.15"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2660,9 +5033,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
+    "JobRuns": 72,
     "P95": "0.0",
-    "P99": "18.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2675,7 +5050,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2686,9 +5063,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "3.8",
-    "P99": "543.07"
+    "JobRuns": 87,
+    "P95": "17.8",
+    "P99": "73.34",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.35",
+    "P99": "0.87",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-oauth-api-reused-connections",
@@ -2699,9 +5093,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "246.9",
-    "P99": "788.98"
+    "JobRuns": 145,
+    "P95": "199.8",
+    "P99": "766.12",
+    "P75": "50.0",
+    "P50": "16.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2712,9 +5123,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2726,8 +5139,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "479.8",
-    "P99": "481.56"
+    "P95": "472.7",
+    "P99": "472.94",
+    "P75": "471.5",
+    "P50": "470.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2738,9 +5153,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "2.7",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2753,7 +5170,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2764,9 +5183,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 915,
+    "JobRuns": 879,
     "P95": "2.0",
-    "P99": "3.0"
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2777,9 +5198,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 573,
-    "P95": "3.0",
-    "P99": "5.0"
+    "JobRuns": 612,
+    "P95": "2.45",
+    "P99": "6.78",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2790,9 +5213,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "2.0",
-    "P99": "3.0"
+    "P99": "3.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2803,9 +5228,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
+    "JobRuns": 65,
     "P95": "14.0",
-    "P99": "18.14"
+    "P99": "16.52",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2816,9 +5243,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "11.0",
-    "P99": "11.49"
+    "JobRuns": 50,
+    "P95": "10.55",
+    "P99": "11.51",
+    "P75": "6.75",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2829,9 +5258,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.8",
+    "P99": "1.96",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2842,9 +5273,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "9.5",
-    "P99": "9.9"
+    "JobRuns": 7,
+    "P95": "7.7",
+    "P99": "7.94",
+    "P75": "6.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2855,9 +5288,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "5.7",
+    "P99": "5.94",
+    "P75": "4.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2868,9 +5303,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "9.1",
-    "P99": "29.17"
+    "JobRuns": 87,
+    "P95": "0.0",
+    "P99": "29.26",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2881,9 +5318,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "796.5",
-    "P99": "1044.9"
+    "JobRuns": 17,
+    "P95": "775.8",
+    "P99": "1040.76",
+    "P75": "14.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2894,9 +5333,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "677.0",
-    "P99": "681.8"
+    "JobRuns": 19,
+    "P95": "672.2",
+    "P99": "680.84",
+    "P75": "338.0",
+    "P50": "254.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2907,9 +5348,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2921,8 +5364,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "389.0",
-    "P99": "389.0"
+    "P95": "383.4",
+    "P99": "387.88",
+    "P75": "341.5",
+    "P50": "322.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2933,9 +5378,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.18",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2946,9 +5393,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 494,
+    "JobRuns": 456,
     "P95": "0.0",
-    "P99": "4.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2959,9 +5408,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
+    "JobRuns": 46,
     "P95": "0.0",
-    "P99": "10.5"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -2972,48 +5423,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 980,
-    "P95": "2.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
+    "JobRuns": 851,
     "P95": "3.0",
-    "P99": "4.44"
+    "P99": "5.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "11.75",
-    "P99": "13.7"
-  },
-  {
-    "BackendName": "cache-openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
+    "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "9.7",
-    "P99": "10.54"
+    "P95": "2.7",
+    "P99": "4.54",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "9.95",
+    "P99": "14.34",
+    "P75": "4.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "10.25",
+    "P99": "11.65",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3024,9 +5483,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "28.85"
+    "P99": "28.7",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "4104.35",
+    "P99": "4223.3",
+    "P75": "3858.0",
+    "P50": "2978.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "5.23",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "147.55",
+    "P99": "149.0",
+    "P75": "141.75",
+    "P50": "48.5"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "0.0",
+    "P99": "10.05",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "2.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "3.0",
+    "P99": "5.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.05",
+    "P99": "2.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "7.82",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "6.12",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "5.4",
+    "P99": "22.8",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "3.0",
+    "P99": "7.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "1.0",
+    "P99": "23.48",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "893.7",
+    "P99": "1308.37",
+    "P75": "676.75",
+    "P50": "472.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "21.32",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.0",
+    "P99": "12.8",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "17.0",
+    "P99": "26.73",
+    "P75": "8.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "41.25",
+    "P99": "88.36",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "453.85",
+    "P99": "775.23",
+    "P75": "187.75",
+    "P50": "85.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3037,9 +5948,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3052,7 +5965,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3063,9 +5978,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "14.0"
+    "JobRuns": 38,
+    "P95": "2.1",
+    "P99": "14.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3076,9 +5993,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3091,7 +6010,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3102,9 +6023,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3115,9 +6038,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3129,8 +6054,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.85",
-    "P99": "0.97"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3142,8 +6069,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "151.75",
-    "P99": "168.9"
+    "P95": "244.25",
+    "P99": "272.55",
+    "P75": "147.5",
+    "P50": "96.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3154,9 +6083,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3169,7 +6100,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.85",
-    "P99": "0.97"
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3182,7 +6115,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3193,9 +6128,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3208,7 +6145,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "1.1",
-    "P99": "1.82"
+    "P99": "1.82",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3221,7 +6160,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3234,7 +6175,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3245,9 +6188,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3260,7 +6220,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3271,9 +6233,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "20.5",
-    "P99": "43.4"
+    "JobRuns": 32,
+    "P95": "19.75",
+    "P99": "43.18",
+    "P75": "2.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3284,9 +6248,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "8.1",
-    "P99": "1297.49"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "30.44",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3299,7 +6265,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "27.0",
-    "P99": "27.0"
+    "P99": "27.0",
+    "P75": "27.0",
+    "P50": "27.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3312,7 +6280,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "931.75",
-    "P99": "958.35"
+    "P99": "958.35",
+    "P75": "747.5",
+    "P50": "488.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3323,9 +6293,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "10.1"
+    "P99": "0.71",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3336,9 +6308,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "0.25",
-    "P99": "16.25"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "0.29",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3351,7 +6325,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "6.0",
-    "P99": "6.0"
+    "P99": "6.0",
+    "P75": "6.0",
+    "P50": "6.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3362,9 +6338,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "10.05",
-    "P99": "556.07"
+    "JobRuns": 87,
+    "P95": "47.4",
+    "P99": "196.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-new-connections",
@@ -3375,9 +6368,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "351.1",
-    "P99": "1058.86"
+    "JobRuns": 145,
+    "P95": "318.6",
+    "P99": "1024.84",
+    "P75": "100.0",
+    "P50": "33.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3388,9 +6398,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3402,8 +6414,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "479.8",
-    "P99": "481.56"
+    "P95": "471.0",
+    "P99": "471.0",
+    "P75": "471.0",
+    "P50": "471.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3414,9 +6428,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.34",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3428,8 +6444,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
+    "P95": "0.85",
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3440,9 +6458,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 918,
+    "JobRuns": 882,
     "P95": "2.0",
-    "P99": "5.0"
+    "P99": "4.19",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3453,9 +6473,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 573,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 612,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3466,9 +6488,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.6",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3479,9 +6503,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "10.0",
-    "P99": "13.0"
+    "JobRuns": 65,
+    "P95": "9.8",
+    "P99": "13.0",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3492,9 +6518,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "13.0",
-    "P99": "14.49"
+    "JobRuns": 50,
+    "P95": "12.55",
+    "P99": "14.0",
+    "P75": "9.75",
+    "P50": "6.5"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3505,9 +6533,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "2.7",
+    "P99": "2.94",
+    "P75": "1.5",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3518,9 +6548,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "9.5",
-    "P99": "9.9"
+    "JobRuns": 7,
+    "P95": "7.1",
+    "P99": "7.82",
+    "P75": "5.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3531,9 +6563,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.0",
-    "P99": "9.0"
+    "JobRuns": 7,
+    "P95": "5.4",
+    "P99": "5.88",
+    "P75": "4.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3544,9 +6578,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "4.55",
-    "P99": "24.91"
+    "JobRuns": 87,
+    "P95": "0.0",
+    "P99": "24.98",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3557,9 +6593,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "790.5",
-    "P99": "1031.7"
+    "JobRuns": 17,
+    "P95": "770.4",
+    "P99": "1027.68",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3570,9 +6608,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "417.0",
-    "P99": "421.0"
+    "JobRuns": 19,
+    "P95": "382.4",
+    "P99": "414.08",
+    "P75": "208.5",
+    "P50": "125.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3583,9 +6623,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3597,8 +6639,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "390.95",
-    "P99": "391.79"
+    "P95": "383.4",
+    "P99": "387.88",
+    "P75": "340.75",
+    "P50": "322.5"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3609,9 +6653,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3622,74 +6668,86 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 497,
+    "JobRuns": 459,
     "P95": "2.0",
-    "P99": "3.04"
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "2.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 979,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.75",
-    "P99": "12.7"
-  },
-  {
-    "BackendName": "cache-openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "12.0",
-    "P99": "12.54"
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 850,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 47,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "8.85",
+    "P99": "12.17",
+    "P75": "3.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "12.25",
+    "P99": "14.3",
+    "P75": "8.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3700,9 +6758,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "26.03"
+    "P99": "25.86",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "4104.35",
+    "P99": "4223.3",
+    "P75": "3858.0",
+    "P50": "2978.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "148.0",
+    "P99": "229.08",
+    "P75": "141.0",
+    "P50": "99.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "1.0",
+    "P99": "4.05",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.05",
+    "P99": "2.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "6.63",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "1.0",
+    "P99": "11.64",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "1.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "23.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "894.7",
+    "P99": "1308.37",
+    "P75": "676.75",
+    "P50": "472.5"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "21.16",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.0",
+    "P99": "16.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "2.73",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "33.1",
+    "P99": "71.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "321.15",
+    "P99": "697.17",
+    "P75": "130.5",
+    "P50": "66.5"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3713,9 +7223,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3728,7 +7240,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3739,9 +7253,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "14.0"
+    "JobRuns": 38,
+    "P95": "2.1",
+    "P99": "14.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3752,9 +7268,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3767,7 +7285,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3778,9 +7298,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3791,9 +7313,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3806,7 +7330,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3818,8 +7344,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "151.5",
-    "P99": "170.55"
+    "P95": "244.25",
+    "P99": "273.25",
+    "P75": "148.25",
+    "P50": "96.5"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3830,9 +7358,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3845,7 +7375,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.85",
-    "P99": "0.97"
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3858,7 +7390,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "2.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3869,9 +7403,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3884,7 +7420,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.1",
-    "P99": "0.82"
+    "P99": "0.82",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3897,7 +7435,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3910,7 +7450,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3921,9 +7463,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3936,7 +7495,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.4",
-    "P99": "0.88"
+    "P99": "0.88",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3947,9 +7508,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
+    "JobRuns": 32,
     "P95": "2.0",
-    "P99": "6.9"
+    "P99": "6.83",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3960,9 +7523,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "1.0",
-    "P99": "10.89"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "2.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3975,7 +7540,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "19.0",
-    "P99": "19.0"
+    "P99": "19.0",
+    "P75": "19.0",
+    "P50": "19.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3988,7 +7555,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "931.5",
-    "P99": "958.3"
+    "P99": "958.3",
+    "P75": "746.75",
+    "P50": "488.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -3999,9 +7568,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "10.4"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -4012,9 +7583,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
+    "JobRuns": 72,
     "P95": "0.0",
-    "P99": "15.5"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -4027,7 +7600,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -4038,9 +7613,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "3.15",
-    "P99": "542.81"
+    "JobRuns": 87,
+    "P95": "17.8",
+    "P99": "71.76",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "cache-openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "cache-openshift-api-reused-connections",
@@ -4051,9 +7643,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "248.2",
-    "P99": "785.36"
+    "JobRuns": 145,
+    "P95": "199.8",
+    "P99": "764.84",
+    "P75": "50.0",
+    "P50": "15.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "9.5",
+    "P99": "9.9",
+    "P75": "7.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4064,9 +7673,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1006,
-    "P95": "4.0",
-    "P99": "7.0"
+    "JobRuns": 1075,
+    "P95": "1.0",
+    "P99": "6.26",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4079,7 +7690,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4091,8 +7704,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 168,
-    "P95": "4.0",
-    "P99": "7.0"
+    "P95": "2.0",
+    "P99": "7.33",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4105,7 +7720,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "1.7",
-    "P99": "1.94"
+    "P99": "1.94",
+    "P75": "0.5",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4116,9 +7733,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 922,
-    "P95": "4.0",
-    "P99": "8.0"
+    "JobRuns": 894,
+    "P95": "0.0",
+    "P99": "7.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4129,9 +7748,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 576,
+    "JobRuns": 615,
     "P95": "4.0",
-    "P99": "8.0"
+    "P99": "7.86",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4142,9 +7763,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "8.0",
-    "P99": "19.04"
+    "JobRuns": 41,
+    "P95": "0.0",
+    "P99": "7.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4155,9 +7778,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "6.9",
-    "P99": "8.38"
+    "JobRuns": 65,
+    "P95": "2.0",
+    "P99": "8.36",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4168,9 +7793,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "4.25",
-    "P99": "9.49"
+    "JobRuns": 50,
+    "P95": "2.0",
+    "P99": "8.02",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4181,9 +7808,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4194,9 +7823,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "1.5",
-    "P99": "1.9"
+    "JobRuns": 7,
+    "P95": "1.4",
+    "P99": "1.88",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4207,9 +7838,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 7,
+    "P95": "1.4",
+    "P99": "1.88",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4220,9 +7853,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "0.65",
-    "P99": "5.13"
+    "JobRuns": 87,
+    "P95": "0.7",
+    "P99": "5.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4233,9 +7868,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
+    "JobRuns": 17,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4246,9 +7883,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "1.5",
-    "P99": "2.7"
+    "JobRuns": 19,
+    "P95": "0.3",
+    "P99": "2.46",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4259,9 +7898,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "0.65",
-    "P99": "8.0"
+    "JobRuns": 242,
+    "P95": "0.0",
+    "P99": "5.18",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4274,7 +7915,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4285,9 +7928,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "4.0",
-    "P99": "16.0"
+    "JobRuns": 483,
+    "P95": "0.0",
+    "P99": "6.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4298,9 +7943,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 496,
-    "P95": "4.0",
-    "P99": "12.05"
+    "JobRuns": 458,
+    "P95": "1.0",
+    "P99": "5.43",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4311,22 +7958,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "4.0",
-    "P99": "7.0"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 984,
+    "JobRuns": 46,
     "P95": "3.0",
-    "P99": "6.17"
+    "P99": "6.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4334,38 +7970,59 @@
     "FromRelease": "4.14",
     "Platform": "gcp",
     "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "4.2",
-    "P99": "9.96"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "2.5",
-    "P99": "7.0"
+    "JobRuns": 865,
+    "P95": "0.8",
+    "P99": "6.36",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
-    "Platform": "metal",
+    "Platform": "gcp",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "3.7",
-    "P99": "8.54"
+    "P95": "0.0",
+    "P99": "4.16",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "1.95",
+    "P99": "6.39",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "3.25",
+    "P99": "6.6",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4376,22 +8033,476 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "3.8",
-    "P99": "5.77"
+    "JobRuns": 43,
+    "P95": "3.6",
+    "P99": "5.74",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
-    "Release": "4.14",
+    "Release": "4.13",
     "FromRelease": "",
     "Platform": "",
     "Architecture": "amd64",
     "Network": "ovn",
     "Topology": "external",
-    "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "8.8",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "10.36",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "0.0",
+    "P99": "6.49",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "6.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "1.73",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "7.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "5.55",
+    "P99": "32.38",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "1.0",
+    "P99": "6.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "6.84",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "1.0",
+    "P99": "10.25",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "1.0",
+    "P99": "9.37",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "3.0",
+    "P99": "10.94",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 272,
+    "P95": "0.0",
+    "P99": "13.87",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "3.3",
+    "P99": "15.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "1.51",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "1.0",
+    "P99": "5.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "5.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
     "P95": "0.35",
-    "P99": "0.87"
+    "P99": "7.51",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "1.0",
+    "P99": "4.24",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.0",
+    "P99": "0.32",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "6.95",
+    "P99": "25.46",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "0.0",
+    "P99": "2.63",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "1.3",
+    "P99": "3.43",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 18,
+    "P95": "0.15",
+    "P99": "0.83",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4404,7 +8515,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4415,9 +8528,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "2.04"
+    "JobRuns": 38,
+    "P95": "2.3",
+    "P99": "4.63",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4428,9 +8543,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4443,7 +8560,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4454,9 +8573,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4467,9 +8588,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "6.0"
+    "P99": "5.7",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4482,7 +8605,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4495,7 +8620,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
     "P95": "0.0",
-    "P99": "9.9"
+    "P99": "1.65",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4506,9 +8633,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 543,
     "P95": "0.0",
-    "P99": "7.0"
+    "P99": "6.58",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4521,7 +8650,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4534,7 +8665,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.3",
-    "P99": "1.66"
+    "P99": "1.66",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4545,9 +8678,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4560,7 +8695,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.3",
-    "P99": "2.46"
+    "P99": "2.46",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4573,7 +8710,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4586,7 +8725,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "2.5",
-    "P99": "4.5"
+    "P99": "4.5",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4597,9 +8738,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4612,7 +8770,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.4",
-    "P99": "0.88"
+    "P99": "0.88",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4623,9 +8783,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "1.5",
-    "P99": "2.7"
+    "JobRuns": 32,
+    "P95": "1.45",
+    "P99": "2.69",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4636,9 +8798,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 137,
+    "JobRuns": 92,
     "P95": "0.0",
-    "P99": "1.92"
+    "P99": "3.18",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4651,7 +8815,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4664,7 +8830,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4675,9 +8843,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "8.65"
+    "P99": "6.13",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4688,9 +8858,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
+    "JobRuns": 72,
     "P95": "0.0",
-    "P99": "6.75"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4703,7 +8875,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4714,9 +8888,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
+    "JobRuns": 87,
     "P95": "0.0",
-    "P99": "5.87"
+    "P99": "2.28",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-new-connections",
@@ -4727,9 +8918,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
+    "JobRuns": 145,
     "P95": "0.0",
-    "P99": "7.44"
+    "P99": "1.12",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4740,9 +8948,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1004,
+    "JobRuns": 1073,
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4755,7 +8965,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4768,7 +8980,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 168,
     "P95": "0.0",
-    "P99": "1.99"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4781,7 +8995,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4792,9 +9008,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 922,
+    "JobRuns": 894,
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4805,9 +9023,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 576,
+    "JobRuns": 615,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4818,9 +9038,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "0.4",
-    "P99": "1.0"
+    "JobRuns": 41,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4831,9 +9053,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
+    "JobRuns": 65,
     "P95": "0.0",
-    "P99": "0.38"
+    "P99": "0.36",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4844,9 +9068,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
+    "JobRuns": 50,
     "P95": "0.0",
-    "P99": "0.49"
+    "P99": "0.51",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4857,9 +9083,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4870,9 +9098,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
+    "JobRuns": 7,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4883,9 +9113,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
+    "JobRuns": 7,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4896,9 +9128,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
+    "JobRuns": 87,
     "P95": "0.0",
-    "P99": "0.13"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4909,9 +9143,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
+    "JobRuns": 17,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4922,9 +9158,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
+    "JobRuns": 19,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4935,9 +9173,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 242,
     "P95": "0.0",
-    "P99": "0.33"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4950,7 +9190,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4961,9 +9203,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "0.0",
-    "P99": "1.53"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4974,9 +9218,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 496,
+    "JobRuns": 458,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -4987,9 +9233,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
+    "JobRuns": 46,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "1.1",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5000,48 +9248,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 983,
+    "JobRuns": 864,
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "0.0",
-    "P99": "0.44"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "0.0",
-    "P99": "4.75"
-  },
-  {
-    "BackendName": "ci-cluster-network-liveness-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "0.0",
+    "P99": "3.12",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5052,9 +9308,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "2.8",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "0.0",
+    "P99": "0.49",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.35",
+    "P99": "1.47",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "2.1",
+    "P99": "105.26",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "0.46",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "0.0",
+    "P99": "1.05",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "0.0",
+    "P99": "2.97",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 273,
+    "P95": "0.0",
+    "P99": "1.28",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "0.0",
+    "P99": "6.08",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "0.08",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.65",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "0.0",
+    "P99": "0.43",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5065,9 +9773,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5080,7 +9790,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5091,9 +9803,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 38,
+    "P95": "0.15",
+    "P99": "1.63",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5104,9 +9818,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5119,7 +9835,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5130,9 +9848,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5143,9 +9863,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5158,7 +9880,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5171,7 +9895,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
     "P95": "0.0",
-    "P99": "0.65"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5182,9 +9908,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 543,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5197,7 +9925,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5210,7 +9940,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5221,9 +9953,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5236,7 +9970,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5249,7 +9985,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5262,7 +10000,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5273,9 +10013,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5288,7 +10045,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5299,9 +10058,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
+    "JobRuns": 32,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5312,9 +10073,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 137,
+    "JobRuns": 92,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.09",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5327,7 +10090,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5340,7 +10105,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5351,9 +10118,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5364,9 +10133,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
+    "JobRuns": 72,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5379,7 +10150,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
@@ -5390,1010 +10163,2366 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
+    "JobRuns": 87,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.14",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ci-cluster-network-liveness-reused-connections",
     "Release": "4.14",
     "FromRelease": "",
-    "Platform": "libvirt",
+    "Platform": "ibmcloud",
     "Architecture": "s390x",
     "Network": "ovn",
     "Topology": "ha",
-    "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "0.0",
-    "P99": "0.74"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 1009,
-    "P95": "1.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 3,
-    "P95": "329.9",
-    "P99": "329.98"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "6.0",
-    "P99": "10.33"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 924,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 582,
-    "P95": "2.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "2.0",
-    "P99": "3.92"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "43.0",
-    "P99": "45.76"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "45.9",
-    "P99": "48.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "277.15",
-    "P99": "284.23"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "43.5",
-    "P99": "46.3"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "21.85",
-    "P99": "21.97"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "4.65",
-    "P99": "10.26"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "825.0",
-    "P99": "1050.6"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "846.5",
-    "P99": "924.5"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "1.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 8,
-    "P95": "257.45",
-    "P99": "266.69"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "2.0",
-    "P99": "7.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 497,
-    "P95": "1.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "0.5",
-    "P99": "10.5"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 987,
-    "P95": "3.0",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "2.0",
-    "P99": "3.88"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "40.0",
-    "P99": "44.45"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "41.0",
-    "P99": "43.08"
-  },
-  {
-    "BackendName": "image-registry-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "1.0",
-    "P99": "3.36"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 1009,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 3,
-    "P95": "307.0",
-    "P99": "307.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "6.0",
-    "P99": "7.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 924,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 582,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "3.0",
-    "P99": "3.48"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "23.0",
-    "P99": "27.18"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "38.0",
-    "P99": "39.49"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "251.2",
-    "P99": "258.24"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "23.5",
-    "P99": "23.9"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "17.15",
-    "P99": "19.43"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "5.3",
-    "P99": "6.65"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "803.0",
-    "P99": "1047.8"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "602.5",
-    "P99": "682.9"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 8,
-    "P95": "240.55",
-    "P99": "242.51"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "0.0",
-    "P99": "8.59"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 497,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "0.0",
-    "P99": "0.5"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 987,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "3.0",
-    "P99": "3.44"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "36.0",
-    "P99": "37.7"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "37.4",
-    "P99": "38.54"
-  },
-  {
-    "BackendName": "image-registry-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 1006,
-    "P95": "1.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 3,
-    "P95": "320.7",
-    "P99": "320.94"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "6.0",
-    "P99": "7.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 922,
-    "P95": "0.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 577,
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "0.0",
-    "P99": "0.48"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "1.0",
-    "P99": "1.38"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "ovirt",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "vsphere",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "1.7",
-    "P99": "1.94"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "6.0",
-    "P99": "10.39"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "ppc64le",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "789.0",
-    "P99": "1043.4"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "libvirt",
-    "Architecture": "s390x",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "672.5",
-    "P99": "691.3"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "1.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "single",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 8,
-    "P95": "260.9",
-    "P99": "268.18"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "3.0",
-    "P99": "9.59"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 497,
-    "P95": "2.0",
-    "P99": "1068.08"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "2.0",
-    "P99": "118.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 986,
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "0.2",
-    "P99": "1.44"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "1.75",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "0.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "arm64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "1.0",
-    "P99": "1.59"
-  },
-  {
-    "BackendName": "ingress-to-console-new-connections",
-    "Release": "4.14",
-    "FromRelease": "",
-    "Platform": "",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "external",
     "MasterNodesUpdated": "N",
     "JobRuns": 14,
-    "P95": "3655.05",
-    "P99": "3687.81"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ci-cluster-network-liveness-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 145,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 1078,
+    "P95": "1.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 3,
+    "P95": "327.3",
+    "P99": "328.66",
+    "P75": "320.5",
+    "P50": "312.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 168,
+    "P95": "6.0",
+    "P99": "11.33",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 4,
+    "P95": "0.85",
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 896,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 621,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 41,
+    "P95": "2.0",
+    "P99": "5.6",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 65,
+    "P95": "47.8",
+    "P99": "57.92",
+    "P75": "39.0",
+    "P50": "24.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 50,
+    "P95": "48.0",
+    "P99": "59.65",
+    "P75": "41.0",
+    "P50": "33.5"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 3,
+    "P95": "272.7",
+    "P99": "283.34",
+    "P75": "219.5",
+    "P50": "153.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 7,
+    "P95": "35.8",
+    "P99": "36.76",
+    "P75": "28.0",
+    "P50": "20.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 7,
+    "P95": "39.6",
+    "P99": "41.52",
+    "P75": "28.5",
+    "P50": "22.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 87,
+    "P95": "12.4",
+    "P99": "121.78",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 17,
+    "P95": "806.2",
+    "P99": "1046.84",
+    "P75": "60.0",
+    "P50": "36.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 19,
+    "P95": "768.5",
+    "P99": "908.9",
+    "P75": "381.0",
+    "P50": "334.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 242,
+    "P95": "1.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 8,
+    "P95": "234.25",
+    "P99": "235.65",
+    "P75": "222.75",
+    "P50": "219.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 483,
+    "P95": "1.0",
+    "P99": "6.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 463,
+    "P95": "0.9",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 46,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 868,
+    "P95": "3.0",
+    "P99": "5.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 47,
+    "P95": "1.0",
+    "P99": "3.62",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "48.95",
+    "P99": "66.73",
+    "P75": "38.75",
+    "P50": "20.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "41.0",
+    "P99": "66.35",
+    "P75": "36.75",
+    "P50": "27.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 43,
+    "P95": "1.0",
+    "P99": "3.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 5,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 103,
+    "P95": "0.0",
+    "P99": "9.8",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 125,
+    "P95": "0.0",
+    "P99": "1.76",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 22,
+    "P95": "493.35",
+    "P99": "528.12",
+    "P75": "230.25",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 101,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 71,
+    "P95": "0.0",
+    "P99": "5.5",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 60,
+    "P95": "0.05",
+    "P99": "18.1",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 37,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 80,
+    "P95": "0.0",
+    "P99": "3.52",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 46,
+    "P95": "15.0",
+    "P99": "43.5",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 10,
+    "P95": "138.75",
+    "P99": "162.15",
+    "P75": "97.75",
+    "P50": "75.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 34,
+    "P95": "17.4",
+    "P99": "26.7",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 67,
+    "P95": "17.7",
+    "P99": "1598.5",
+    "P75": "0.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 30,
+    "P95": "31.1",
+    "P99": "41.23",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 8,
+    "P95": "313.35",
+    "P99": "318.67",
+    "P75": "75.25",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 19,
+    "P95": "3.6",
+    "P99": "22.32",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 7,
+    "P95": "3.7",
+    "P99": "3.94",
+    "P75": "2.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 5,
+    "P95": "90.8",
+    "P99": "95.76",
+    "P75": "66.0",
+    "P50": "64.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 6,
+    "P95": "396.5",
+    "P99": "400.9",
+    "P75": "294.25",
+    "P50": "31.5"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 10,
+    "P95": "183.25",
+    "P99": "188.65",
+    "P75": "128.5",
+    "P50": "79.5"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 1078,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 3,
+    "P95": "311.5",
+    "P99": "311.9",
+    "P75": "309.5",
+    "P50": "307.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 168,
+    "P95": "6.0",
+    "P99": "11.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 896,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 621,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 41,
+    "P95": "3.0",
+    "P99": "3.0",
+    "P75": "2.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 65,
+    "P95": "21.0",
+    "P99": "27.24",
+    "P75": "11.0",
+    "P50": "4.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 50,
+    "P95": "40.65",
+    "P99": "53.73",
+    "P75": "22.0",
+    "P50": "21.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 3,
+    "P95": "245.0",
+    "P99": "257.0",
+    "P75": "185.0",
+    "P50": "110.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 7,
+    "P95": "18.2",
+    "P99": "19.64",
+    "P75": "13.5",
+    "P50": "6.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 7,
+    "P95": "14.4",
+    "P99": "17.28",
+    "P75": "4.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 87,
+    "P95": "6.0",
+    "P99": "17.66",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 17,
+    "P95": "782.6",
+    "P99": "1043.72",
+    "P75": "12.0",
+    "P50": "2.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 19,
+    "P95": "460.0",
+    "P99": "654.4",
+    "P75": "256.5",
+    "P50": "185.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 242,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 8,
+    "P95": "234.25",
+    "P99": "235.65",
+    "P75": "230.25",
+    "P50": "217.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 483,
+    "P95": "0.0",
+    "P99": "6.18",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 463,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 46,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 868,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 47,
+    "P95": "2.7",
+    "P99": "3.54",
+    "P75": "1.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "40.0",
+    "P99": "55.9",
+    "P75": "21.0",
+    "P50": "17.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "36.75",
+    "P99": "61.75",
+    "P75": "23.25",
+    "P50": "20.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 43,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 5,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 103,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 125,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 22,
+    "P95": "486.55",
+    "P99": "517.17",
+    "P75": "226.0",
+    "P50": "0.5"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 101,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 71,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "3.64",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 37,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 80,
+    "P95": "0.0",
+    "P99": "0.21",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 46,
+    "P95": "6.0",
+    "P99": "43.05",
+    "P75": "0.75",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 10,
+    "P95": "138.75",
+    "P99": "162.15",
+    "P75": "97.75",
+    "P50": "75.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 34,
+    "P95": "1.35",
+    "P99": "11.38",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 67,
+    "P95": "0.0",
+    "P99": "179.42",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 30,
+    "P95": "10.0",
+    "P99": "10.71",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 8,
+    "P95": "308.1",
+    "P99": "317.62",
+    "P75": "72.25",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 19,
+    "P95": "1.2",
+    "P99": "9.84",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 7,
+    "P95": "1.7",
+    "P99": "1.94",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 5,
+    "P95": "66.0",
+    "P99": "66.0",
+    "P75": "66.0",
+    "P50": "64.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 6,
+    "P95": "395.75",
+    "P99": "399.95",
+    "P75": "287.25",
+    "P50": "7.5"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "image-registry-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 10,
+    "P95": "108.8",
+    "P99": "114.56",
+    "P75": "54.0",
+    "P50": "33.5"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 1075,
+    "P95": "2.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 3,
+    "P95": "320.8",
+    "P99": "320.96",
+    "P75": "320.0",
+    "P50": "319.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 168,
+    "P95": "6.0",
+    "P99": "12.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 894,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 616,
+    "P95": "2.0",
+    "P99": "3.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 41,
+    "P95": "0.0",
+    "P99": "0.6",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 65,
+    "P95": "1.8",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 50,
+    "P95": "0.55",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 7,
+    "P95": "8.4",
+    "P99": "11.28",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 7,
+    "P95": "1.7",
+    "P99": "1.94",
+    "P75": "0.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 87,
+    "P95": "6.0",
+    "P99": "116.04",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 17,
+    "P95": "767.8",
+    "P99": "1039.16",
+    "P75": "2.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 19,
+    "P95": "653.7",
+    "P99": "687.54",
+    "P75": "329.5",
+    "P50": "215.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 242,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 8,
+    "P95": "242.6",
+    "P99": "243.72",
+    "P75": "231.75",
+    "P50": "226.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 483,
+    "P95": "1.9",
+    "P99": "8.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 459,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 46,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 867,
+    "P95": "2.0",
+    "P99": "4.34",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 47,
+    "P95": "0.0",
+    "P99": "0.54",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "1.95",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "0.0",
+    "P99": "0.65",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 43,
+    "P95": "1.0",
+    "P99": "1.58",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "2191.0",
+    "P99": "2192.6",
+    "P75": "2168.0",
+    "P50": "2083.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.7",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "105.84",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 5,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "244.9",
+    "P99": "328.66",
+    "P75": "2.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "9.3",
+    "P99": "18.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 749,
+    "P95": "1.0",
+    "P99": "1.52",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "145.4",
+    "P99": "202.04",
+    "P75": "121.75",
+    "P50": "31.5"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "1.0",
+    "P99": "5.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "4.0",
+    "P99": "10.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "1.0",
+    "P99": "3.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "2.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 273,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.1",
+    "P99": "8.05",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "7.44",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "2.55",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "6.0",
+    "P99": "42.24",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "1.38",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "4.7",
+    "P99": "24.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "968.5",
+    "P99": "1492.11",
+    "P75": "767.0",
+    "P50": "542.5"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "1.0",
+    "P99": "28.48",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "146.2",
+    "P99": "193.64",
+    "P75": "10.0",
+    "P50": "3.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "66.0",
+    "P99": "75.84",
+    "P75": "50.25",
+    "P50": "19.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "40.35",
+    "P99": "88.83",
+    "P75": "7.25",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "439.15",
+    "P99": "772.8",
+    "P75": "185.5",
+    "P50": "80.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 18,
+    "P95": "3699.45",
+    "P99": "3715.09",
+    "P75": "3519.0",
+    "P50": "3093.5"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6406,7 +12535,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6417,9 +12548,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
+    "JobRuns": 38,
     "P95": "0.0",
-    "P99": "0.51"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6430,9 +12563,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6444,8 +12579,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
+    "P95": "4.4",
+    "P99": "4.88",
+    "P75": "2.0",
+    "P50": "0.5"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6456,9 +12593,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6469,9 +12608,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
-    "P95": "0.75",
-    "P99": "127.3"
+    "JobRuns": 531,
+    "P95": "0.0",
+    "P99": "16.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6484,7 +12625,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.85",
-    "P99": "0.97"
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6496,8 +12639,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "167.5",
-    "P99": "330.85"
+    "P95": "532.25",
+    "P99": "544.0",
+    "P75": "175.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6508,9 +12653,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 543,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6523,7 +12670,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6536,7 +12685,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "1.15",
-    "P99": "1.83"
+    "P99": "1.83",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6547,9 +12698,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6562,7 +12715,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6575,7 +12730,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6588,7 +12745,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6599,9 +12758,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "1.6"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6614,7 +12790,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6625,9 +12803,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "9.0",
-    "P99": "54.0"
+    "JobRuns": 32,
+    "P95": "8.7",
+    "P99": "53.4",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6638,9 +12818,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "1.0",
-    "P99": "1509.75"
+    "JobRuns": 93,
+    "P95": "0.4",
+    "P99": "27.4",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6653,7 +12835,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6666,7 +12850,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "1046.0",
-    "P99": "1067.6"
+    "P99": "1067.6",
+    "P75": "864.5",
+    "P50": "547.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6677,9 +12863,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "1.71",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6690,9 +12878,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "171.75",
-    "P99": "249.0"
+    "JobRuns": 72,
+    "P95": "35.4",
+    "P99": "170.9",
+    "P75": "4.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6705,7 +12895,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "46.0",
-    "P99": "46.0"
+    "P99": "46.0",
+    "P75": "46.0",
+    "P50": "46.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6716,9 +12908,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "5265.15",
-    "P99": "6405.4"
+    "JobRuns": 87,
+    "P95": "4334.1",
+    "P99": "5246.34",
+    "P75": "44.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-new-connections",
@@ -6729,9 +12938,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "347.7",
-    "P99": "1043.58"
+    "JobRuns": 145,
+    "P95": "315.8",
+    "P99": "1004.52",
+    "P75": "96.0",
+    "P50": "33.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6742,9 +12968,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1006,
+    "JobRuns": 1075,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6756,8 +12984,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "319.8",
-    "P99": "319.96"
+    "P95": "320.8",
+    "P99": "320.96",
+    "P75": "320.0",
+    "P50": "319.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6770,7 +13000,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 168,
     "P95": "6.0",
-    "P99": "7.0"
+    "P99": "8.32",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6783,7 +13015,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6794,9 +13028,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 922,
+    "JobRuns": 894,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6807,9 +13043,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 576,
+    "JobRuns": 615,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6820,9 +13058,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "2.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6833,9 +13073,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
+    "JobRuns": 65,
     "P95": "3.0",
-    "P99": "3.38"
+    "P99": "4.0",
+    "P75": "2.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6846,9 +13088,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
+    "JobRuns": 50,
     "P95": "4.0",
-    "P99": "4.0"
+    "P99": "4.0",
+    "P75": "3.0",
+    "P50": "2.5"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6859,9 +13103,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6872,9 +13118,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 7,
+    "P95": "8.4",
+    "P99": "11.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6885,9 +13133,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
+    "JobRuns": 7,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6898,9 +13148,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "4.65",
-    "P99": "10.26"
+    "JobRuns": 87,
+    "P95": "6.0",
+    "P99": "89.72",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6911,9 +13163,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "786.75",
-    "P99": "1042.95"
+    "JobRuns": 17,
+    "P95": "765.4",
+    "P99": "1038.68",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6924,9 +13178,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "428.5",
-    "P99": "442.5"
+    "JobRuns": 19,
+    "P95": "392.9",
+    "P99": "435.38",
+    "P75": "206.5",
+    "P50": "120.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6937,9 +13193,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "0.0",
-    "P99": "1.0"
+    "JobRuns": 242,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6951,8 +13209,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "260.9",
-    "P99": "268.18"
+    "P95": "242.6",
+    "P99": "243.72",
+    "P75": "231.75",
+    "P50": "226.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6963,9 +13223,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "1.0",
-    "P99": "7.0"
+    "P99": "7.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6976,9 +13238,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 499,
+    "JobRuns": 461,
     "P95": "1.0",
-    "P99": "1066.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -6989,9 +13253,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "0.5",
-    "P99": "108.5"
+    "JobRuns": 46,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7002,48 +13268,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 985,
+    "JobRuns": 866,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "3.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ingress-to-console-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
+    "P95": "1.0",
+    "P99": "1.54",
+    "P75": "0.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "3.0",
+    "P99": "3.0",
+    "P75": "2.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
     "P95": "4.0",
-    "P99": "4.0"
+    "P99": "6.6",
+    "P75": "2.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7054,9 +13328,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
+    "P95": "0.9",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "2191.0",
+    "P99": "2192.6",
+    "P75": "2168.0",
+    "P50": "2083.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "105.84",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 5,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "244.25",
+    "P99": "329.19",
+    "P75": "2.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "8.65",
+    "P99": "17.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 749,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "140.0",
+    "P99": "160.37",
+    "P75": "120.0",
+    "P50": "14.5"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "1.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 272,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.1",
+    "P99": "7.64",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.72",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "5.1",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "3.0",
+    "P99": "12.88",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "1.38",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "4.0",
+    "P99": "23.22",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "968.5",
+    "P99": "1492.11",
+    "P75": "761.5",
+    "P50": "542.5"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "26.64",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "142.6",
+    "P99": "179.6",
+    "P75": "4.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "39.0",
+    "P99": "45.73",
+    "P75": "31.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "29.25",
+    "P99": "71.42",
+    "P75": "2.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "331.55",
+    "P99": "700.02",
+    "P75": "133.0",
+    "P50": "66.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7067,9 +13793,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
-    "P95": "3654.7",
-    "P99": "3686.94"
+    "JobRuns": 18,
+    "P95": "3698.6",
+    "P99": "3714.92",
+    "P75": "3519.0",
+    "P50": "3093.5"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7082,7 +13810,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7093,9 +13823,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
+    "JobRuns": 38,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7106,9 +13838,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7120,8 +13854,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
-    "P95": "6.1",
-    "P99": "6.82"
+    "P95": "6.4",
+    "P99": "6.88",
+    "P75": "4.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7132,9 +13868,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7145,9 +13883,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
-    "P95": "1.6",
-    "P99": "127.3"
+    "JobRuns": 531,
+    "P95": "0.0",
+    "P99": "16.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7160,7 +13900,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7172,8 +13914,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "166.25",
-    "P99": "329.55"
+    "P95": "532.0",
+    "P99": "543.65",
+    "P75": "172.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7184,9 +13928,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 543,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7199,7 +13945,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7212,7 +13960,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7223,9 +13973,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7238,7 +13990,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.1",
-    "P99": "0.82"
+    "P99": "0.82",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7251,7 +14005,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7264,7 +14020,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7275,9 +14033,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "1.6"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7290,7 +14065,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7301,9 +14078,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
+    "JobRuns": 32,
     "P95": "4.0",
-    "P99": "4.7"
+    "P99": "4.69",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7314,9 +14093,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "1.0",
-    "P99": "29.3"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "3.68",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7329,7 +14110,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7342,7 +14125,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "1045.75",
-    "P99": "1067.55"
+    "P99": "1067.55",
+    "P75": "863.75",
+    "P50": "546.5"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7353,9 +14138,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "1.65"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7366,9 +14153,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "171.0",
-    "P99": "247.25"
+    "JobRuns": 72,
+    "P95": "29.4",
+    "P99": "169.9",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7381,7 +14170,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "30.0",
-    "P99": "30.0"
+    "P99": "30.0",
+    "P75": "30.0",
+    "P50": "30.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7392,9 +14183,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "5265.15",
-    "P99": "6404.53"
+    "JobRuns": 87,
+    "P95": "4334.4",
+    "P99": "5246.2",
+    "P75": "14.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-console-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-console-reused-connections",
@@ -7405,9 +14213,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "253.8",
-    "P99": "769.64"
+    "JobRuns": 145,
+    "P95": "210.0",
+    "P99": "753.08",
+    "P75": "52.0",
+    "P50": "15.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7418,9 +14243,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1002,
-    "P95": "2.0",
-    "P99": "3.0"
+    "JobRuns": 1071,
+    "P95": "1.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7432,8 +14259,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "425.0",
-    "P99": "431.4"
+    "P95": "428.0",
+    "P99": "432.0",
+    "P75": "408.0",
+    "P50": "383.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7446,7 +14275,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 168,
     "P95": "6.0",
-    "P99": "9.32"
+    "P99": "11.33",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7459,7 +14290,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7470,9 +14303,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 916,
+    "JobRuns": 888,
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7483,9 +14318,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 577,
-    "P95": "1.0",
-    "P99": "2.0"
+    "JobRuns": 616,
+    "P95": "2.0",
+    "P99": "3.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7496,9 +14333,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "0.0",
-    "P99": "0.48"
+    "P99": "0.6",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7509,9 +14348,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "0.9",
-    "P99": "2.0"
+    "JobRuns": 65,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7522,9 +14363,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 50,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7535,9 +14378,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7548,9 +14393,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "0.75",
-    "P99": "0.95"
+    "JobRuns": 7,
+    "P95": "8.7",
+    "P99": "11.34",
+    "P75": "0.5",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7561,9 +14408,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "2.0",
-    "P99": "2.0"
+    "JobRuns": 7,
+    "P95": "1.7",
+    "P99": "1.94",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7574,9 +14423,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "6.0",
-    "P99": "29.26"
+    "JobRuns": 87,
+    "P95": "8.0",
+    "P99": "105.54",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7587,9 +14438,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "789.0",
-    "P99": "1043.4"
+    "JobRuns": 17,
+    "P95": "767.8",
+    "P99": "1039.16",
+    "P75": "21.0",
+    "P50": "7.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7600,9 +14453,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "685.0",
-    "P99": "685.8"
+    "JobRuns": 19,
+    "P95": "684.2",
+    "P99": "685.64",
+    "P75": "337.0",
+    "P50": "227.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7613,9 +14468,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "1.0",
-    "P99": "1.34"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7627,8 +14484,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "285.55",
-    "P99": "293.11"
+    "P95": "264.5",
+    "P99": "267.3",
+    "P75": "257.25",
+    "P50": "237.5"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7639,9 +14498,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "2.65",
-    "P99": "8.59"
+    "JobRuns": 483,
+    "P95": "1.0",
+    "P99": "7.54",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7652,9 +14513,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 494,
-    "P95": "1.35",
-    "P99": "1068.14"
+    "JobRuns": 456,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7665,9 +14528,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "1.5",
-    "P99": "118.0"
+    "JobRuns": 46,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7678,48 +14543,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 983,
+    "JobRuns": 864,
     "P95": "2.0",
-    "P99": "2.0"
+    "P99": "3.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "1.0",
-    "P99": "2.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "0.0",
-    "P99": "0.0"
+    "P95": "1.0",
+    "P99": "1.54",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "1.95",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "0.25",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7730,9 +14603,401 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "2.95",
-    "P99": "18.34"
+    "JobRuns": 43,
+    "P95": "1.9",
+    "P99": "18.08",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 5,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "245.25",
+    "P99": "328.19",
+    "P75": "2.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "236.65",
+    "P99": "551.3",
+    "P75": "178.75",
+    "P50": "73.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "1.0",
+    "P99": "2.8",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "4.0",
+    "P99": "10.35",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "2.0",
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "1.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "8.36",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "6.0",
+    "P99": "17.52",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "3.38",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "2.0",
+    "P99": "21.58",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "930.8",
+    "P99": "1440.33",
+    "P75": "725.0",
+    "P50": "524.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "1.0",
+    "P99": "10.08",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "146.0",
+    "P99": "189.24",
+    "P75": "8.0",
+    "P50": "3.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "65.65",
+    "P99": "70.46",
+    "P75": "50.0",
+    "P50": "19.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "41.35",
+    "P99": "90.78",
+    "P75": "4.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "451.05",
+    "P99": "777.66",
+    "P75": "187.25",
+    "P50": "84.5"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7745,7 +15010,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7756,9 +15023,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7770,8 +15039,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
+    "P95": "1.7",
+    "P99": "1.94",
+    "P75": "0.5",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7782,9 +15053,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7797,7 +15070,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7809,8 +15084,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "226.5",
-    "P99": "385.95"
+    "P95": "587.25",
+    "P99": "600.15",
+    "P75": "237.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7821,9 +15098,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 543,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7836,7 +15115,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7849,7 +15130,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.3",
-    "P99": "1.66"
+    "P99": "1.66",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7860,9 +15143,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7875,7 +15160,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7888,7 +15175,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7901,7 +15190,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7912,9 +15203,11 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.96"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7927,7 +15220,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7938,9 +15233,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "18.5",
-    "P99": "41.0"
+    "JobRuns": 32,
+    "P95": "17.65",
+    "P99": "40.8",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7951,9 +15248,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "1.3",
-    "P99": "2010.34"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "31.92",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7966,7 +15265,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7979,7 +15280,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "1006.5",
-    "P99": "1027.7"
+    "P99": "1027.7",
+    "P75": "831.5",
+    "P50": "522.5"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -7990,9 +15293,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "1.0",
-    "P99": "3.95"
+    "P99": "1.71",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -8003,9 +15308,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "172.25",
-    "P99": "250.25"
+    "JobRuns": 72,
+    "P95": "33.05",
+    "P99": "171.9",
+    "P75": "4.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -8018,7 +15325,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "46.0",
-    "P99": "46.0"
+    "P99": "46.0",
+    "P75": "46.0",
+    "P50": "46.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -8029,9 +15338,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "5266.15",
-    "P99": "6406.53"
+    "JobRuns": 87,
+    "P95": "4335.1",
+    "P99": "5244.76",
+    "P75": "45.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-new-connections",
@@ -8042,9 +15368,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "349.9",
-    "P99": "1073.94"
+    "JobRuns": 145,
+    "P95": "316.4",
+    "P99": "1041.36",
+    "P75": "101.0",
+    "P50": "33.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8055,9 +15398,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1069,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8069,8 +15414,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "400.0",
-    "P99": "406.4"
+    "P95": "400.5",
+    "P99": "406.5",
+    "P75": "370.5",
+    "P50": "333.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8083,7 +15430,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 168,
     "P95": "6.0",
-    "P99": "8.32"
+    "P99": "11.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8096,7 +15445,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8107,9 +15458,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 915,
+    "JobRuns": 887,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8120,9 +15473,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 577,
+    "JobRuns": 616,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8133,9 +15488,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "2.0",
-    "P99": "3.0"
+    "P99": "2.6",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8146,9 +15503,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
+    "JobRuns": 65,
     "P95": "4.0",
-    "P99": "4.0"
+    "P99": "4.0",
+    "P75": "3.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8159,9 +15518,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
+    "JobRuns": 50,
     "P95": "4.0",
-    "P99": "4.0"
+    "P99": "4.0",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8172,9 +15533,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8185,9 +15548,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 7,
+    "P95": "8.4",
+    "P99": "11.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8198,9 +15563,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
+    "JobRuns": 7,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8211,9 +15578,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "5.65",
-    "P99": "13.0"
+    "JobRuns": 87,
+    "P95": "6.0",
+    "P99": "69.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8224,9 +15593,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "786.75",
-    "P99": "1042.95"
+    "JobRuns": 17,
+    "P95": "765.4",
+    "P99": "1038.68",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8237,9 +15608,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "428.0",
-    "P99": "434.4"
+    "JobRuns": 19,
+    "P95": "419.8",
+    "P99": "432.76",
+    "P75": "206.5",
+    "P50": "103.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8250,9 +15623,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "0.34"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8264,8 +15639,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "261.25",
-    "P99": "268.25"
+    "P95": "241.5",
+    "P99": "244.3",
+    "P75": "232.0",
+    "P50": "222.5"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8276,9 +15653,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "0.0",
-    "P99": "7.0"
+    "P99": "7.54",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8289,9 +15668,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 493,
+    "JobRuns": 455,
     "P95": "0.0",
-    "P99": "1064.16"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8302,9 +15683,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
+    "JobRuns": 46,
     "P95": "0.0",
-    "P99": "109.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8315,48 +15698,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 980,
+    "JobRuns": 861,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "3.0",
-    "P99": "3.35"
-  },
-  {
-    "BackendName": "ingress-to-oauth-server-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
+    "P95": "2.0",
+    "P99": "2.54",
+    "P75": "1.0",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "3.0",
+    "P99": "4.0",
+    "P75": "3.0",
+    "P50": "2.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
     "P95": "4.0",
-    "P99": "4.0"
+    "P99": "6.6",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8367,9 +15758,401 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "0.0",
-    "P99": "7.49"
+    "P99": "7.38",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 5,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "242.3",
+    "P99": "329.66",
+    "P75": "1.0",
+    "P50": "0.5"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "145.2",
+    "P99": "194.94",
+    "P75": "120.5",
+    "P50": "19.5"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "1.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 275,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "0.82",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "0.0",
+    "P99": "10.76",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "0.0",
+    "P99": "0.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "18.62",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "930.8",
+    "P99": "1440.33",
+    "P75": "725.0",
+    "P50": "523.5"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "4.56",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "135.2",
+    "P99": "178.24",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "11.65",
+    "P99": "19.46",
+    "P75": "2.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "29.25",
+    "P99": "72.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "327.7",
+    "P99": "700.89",
+    "P75": "129.75",
+    "P50": "65.5"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8382,7 +16165,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8393,9 +16178,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8408,7 +16195,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "1.85",
-    "P99": "1.97"
+    "P99": "1.97",
+    "P75": "1.25",
+    "P50": "0.5"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8419,9 +16208,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8434,7 +16225,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8446,8 +16239,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "158.75",
-    "P99": "333.9"
+    "P95": "527.25",
+    "P99": "535.65",
+    "P75": "155.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8458,9 +16253,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 543,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8473,7 +16270,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8486,7 +16285,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8497,9 +16298,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8512,7 +16315,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8525,7 +16330,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8538,7 +16345,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8549,9 +16358,11 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.96"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8564,7 +16375,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8575,9 +16388,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
+    "JobRuns": 32,
     "P95": "1.0",
-    "P99": "1.7"
+    "P99": "1.69",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8588,9 +16403,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "0.15",
-    "P99": "8.93"
+    "JobRuns": 93,
+    "P95": "0.0",
+    "P99": "3.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8603,7 +16420,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8616,7 +16435,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "1006.5",
-    "P99": "1027.7"
+    "P99": "1027.7",
+    "P75": "831.5",
+    "P50": "522.5"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8627,9 +16448,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "0.65"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8640,9 +16463,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "170.75",
-    "P99": "246.0"
+    "JobRuns": 72,
+    "P95": "27.3",
+    "P99": "170.19",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8655,7 +16480,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8666,9 +16493,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "5265.85",
-    "P99": "6406.66"
+    "JobRuns": 87,
+    "P95": "4335.1",
+    "P99": "5246.48",
+    "P75": "14.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "ingress-to-oauth-server-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "ingress-to-oauth-server-reused-connections",
@@ -8679,9 +16523,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "242.8",
-    "P99": "785.08"
+    "JobRuns": 145,
+    "P95": "202.8",
+    "P99": "768.52",
+    "P75": "53.0",
+    "P50": "14.0"
+  },
+  {
+    "BackendName": "kube-api-http1-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8692,9 +16553,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1001,
+    "JobRuns": 1034,
     "P95": "1.0",
-    "P99": "4.0"
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8706,8 +16569,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "262.6",
-    "P99": "263.72"
+    "P95": "262.4",
+    "P99": "263.68",
+    "P75": "256.0",
+    "P50": "248.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8718,9 +16583,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 163,
     "P95": "1.0",
-    "P99": "4.99"
+    "P99": "7.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8732,8 +16599,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "4.55",
-    "P99": "4.91"
+    "P95": "3.7",
+    "P99": "3.94",
+    "P75": "2.5",
+    "P50": "1.5"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8744,9 +16613,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 922,
-    "P95": "5.95",
-    "P99": "9.0"
+    "JobRuns": 859,
+    "P95": "5.0",
+    "P99": "9.0",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8757,9 +16628,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 576,
+    "JobRuns": 595,
     "P95": "3.0",
-    "P99": "7.0"
+    "P99": "7.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8770,9 +16643,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "3.0",
-    "P99": "4.0"
+    "JobRuns": 40,
+    "P95": "2.1",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8783,9 +16658,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "8.9",
-    "P99": "10.38"
+    "JobRuns": 64,
+    "P95": "8.85",
+    "P99": "10.37",
+    "P75": "6.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8796,9 +16673,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "11.0",
-    "P99": "11.49"
+    "JobRuns": 49,
+    "P95": "10.6",
+    "P99": "11.52",
+    "P75": "8.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8809,9 +16688,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 3,
+    "P95": "1.9",
+    "P99": "1.98",
+    "P75": "1.5",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8822,9 +16703,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "10.25",
-    "P99": "10.85"
+    "JobRuns": 7,
+    "P95": "7.7",
+    "P99": "7.94",
+    "P75": "6.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8835,9 +16718,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "6.0",
+    "P99": "6.0",
+    "P75": "5.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8848,9 +16733,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "1.65",
-    "P99": "12.13"
+    "JobRuns": 87,
+    "P95": "2.0",
+    "P99": "9.56",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8861,9 +16748,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "907.25",
-    "P99": "1071.05"
+    "JobRuns": 17,
+    "P95": "932.0",
+    "P99": "1076.0",
+    "P75": "16.0",
+    "P50": "9.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8874,9 +16763,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "997.5",
-    "P99": "1041.9"
+    "JobRuns": 19,
+    "P95": "953.1",
+    "P99": "1033.02",
+    "P75": "478.0",
+    "P50": "392.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8887,9 +16778,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
-    "P95": "0.7",
-    "P99": "1.0"
+    "JobRuns": 238,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8901,8 +16794,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "257.5",
-    "P99": "265.9"
+    "P95": "256.8",
+    "P99": "265.76",
+    "P75": "227.0",
+    "P50": "222.5"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8913,9 +16808,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "1.0",
-    "P99": "1.53"
+    "JobRuns": 465,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8926,9 +16823,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 499,
-    "P95": "3.0",
-    "P99": "10.0"
+    "JobRuns": 444,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8939,9 +16838,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "1.5",
-    "P99": "17.0"
+    "JobRuns": 44,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8952,9 +16853,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 982,
-    "P95": "3.0",
-    "P99": "5.19"
+    "JobRuns": 825,
+    "P95": "4.0",
+    "P99": "7.76",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8965,9 +16868,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
+    "JobRuns": 45,
     "P95": "3.0",
-    "P99": "5.76"
+    "P99": "13.64",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8978,9 +16883,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
+    "JobRuns": 61,
     "P95": "9.0",
-    "P99": "11.0"
+    "P99": "9.8",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -8991,9 +16898,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "9.7",
-    "P99": "10.54"
+    "JobRuns": 36,
+    "P95": "11.25",
+    "P99": "12.0",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9004,9 +16913,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "1.0",
-    "P99": "5.18"
+    "JobRuns": 43,
+    "P95": "0.9",
+    "P99": "5.16",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9017,9 +16928,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9032,7 +16945,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9043,9 +16958,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "8.25",
-    "P99": "43.59"
+    "JobRuns": 38,
+    "P95": "18.6",
+    "P99": "44.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9056,9 +16973,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9071,7 +16990,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9082,9 +17003,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9095,9 +17018,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9110,7 +17035,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9121,9 +17048,11 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 136,
+    "JobRuns": 132,
     "P95": "55.0",
-    "P99": "74.2"
+    "P99": "57.69",
+    "P75": "52.0",
+    "P50": "9.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9134,9 +17063,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 519,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9148,8 +17079,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "1.7",
-    "P99": "1.94"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9162,7 +17095,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9173,9 +17108,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
+    "JobRuns": 3,
+    "P95": "0.9",
+    "P99": "0.98",
+    "P75": "0.5",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9188,7 +17125,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "2.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9201,7 +17140,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9214,7 +17155,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9227,7 +17170,24 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 69,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http1-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9240,7 +17200,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9251,9 +17213,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "33.0",
-    "P99": "91.2"
+    "JobRuns": 32,
+    "P95": "31.1",
+    "P99": "90.64",
+    "P75": "6.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9264,9 +17228,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "12.4",
-    "P99": "1460.37"
+    "JobRuns": 90,
+    "P95": "1.0",
+    "P99": "38.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9279,7 +17245,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "4.0",
-    "P99": "4.0"
+    "P99": "4.0",
+    "P75": "4.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9292,7 +17260,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "299.75",
-    "P99": "307.15"
+    "P99": "307.15",
+    "P75": "241.75",
+    "P50": "148.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9303,9 +17273,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "4.25"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9316,9 +17288,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "1.25",
-    "P99": "6.0"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "1.29",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9331,7 +17305,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9342,9 +17318,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "14.9",
-    "P99": "585.45"
+    "JobRuns": 87,
+    "P95": "95.9",
+    "P99": "412.92",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http1-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-new-connections",
@@ -9355,9 +17348,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "521.8",
-    "P99": "1291.98"
+    "JobRuns": 145,
+    "P95": "519.0",
+    "P99": "1514.4",
+    "P75": "196.0",
+    "P50": "77.0"
+  },
+  {
+    "BackendName": "kube-api-http1-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9368,9 +17378,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1033,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "1.68",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9382,8 +17394,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "262.6",
-    "P99": "263.72"
+    "P95": "262.4",
+    "P99": "263.68",
+    "P75": "256.0",
+    "P50": "248.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9394,9 +17408,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "0.65",
-    "P99": "1.66"
+    "JobRuns": 163,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9408,8 +17424,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "3.55",
-    "P99": "3.91"
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "0.5"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9420,9 +17438,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 923,
+    "JobRuns": 860,
     "P95": "5.0",
-    "P99": "8.78"
+    "P99": "9.0",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9433,9 +17453,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 574,
+    "JobRuns": 593,
     "P95": "1.0",
-    "P99": "2.54"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9446,9 +17468,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 40,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.61",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9459,9 +17483,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "10.0",
-    "P99": "13.0"
+    "JobRuns": 64,
+    "P95": "9.85",
+    "P99": "13.0",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9472,9 +17498,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "13.0",
-    "P99": "14.49"
+    "JobRuns": 49,
+    "P95": "12.6",
+    "P99": "14.0",
+    "P75": "10.0",
+    "P50": "6.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9485,9 +17513,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "1.9",
-    "P99": "1.98"
+    "JobRuns": 3,
+    "P95": "2.0",
+    "P99": "2.0",
+    "P75": "2.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9498,9 +17528,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "10.75",
-    "P99": "10.95"
+    "JobRuns": 7,
+    "P95": "7.4",
+    "P99": "7.88",
+    "P75": "5.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9511,9 +17543,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "6.7",
+    "P99": "6.94",
+    "P75": "5.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9524,9 +17558,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
+    "JobRuns": 87,
     "P95": "1.0",
-    "P99": "6.39"
+    "P99": "4.7",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9537,9 +17573,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "826.0",
-    "P99": "1039.6"
+    "JobRuns": 17,
+    "P95": "808.2",
+    "P99": "1036.04",
+    "P75": "6.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9550,9 +17588,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "822.0",
-    "P99": "844.4"
+    "JobRuns": 19,
+    "P95": "799.6",
+    "P99": "839.92",
+    "P75": "391.5",
+    "P50": "311.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9563,9 +17603,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 239,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9577,8 +17619,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "257.5",
-    "P99": "265.9"
+    "P95": "256.8",
+    "P99": "265.76",
+    "P75": "227.0",
+    "P50": "222.5"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9589,9 +17633,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 465,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9602,9 +17648,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 500,
+    "JobRuns": 445,
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "4.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9615,9 +17663,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "2.5",
-    "P99": "3.0"
+    "JobRuns": 44,
+    "P95": "2.0",
+    "P99": "3.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9628,9 +17678,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 978,
+    "JobRuns": 821,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9641,9 +17693,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
+    "JobRuns": 45,
     "P95": "1.0",
-    "P99": "1.44"
+    "P99": "10.96",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9654,9 +17708,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.75",
-    "P99": "12.7"
+    "JobRuns": 61,
+    "P95": "9.0",
+    "P99": "12.2",
+    "P75": "3.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9667,9 +17723,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "12.0",
-    "P99": "12.54"
+    "JobRuns": 36,
+    "P95": "12.25",
+    "P99": "14.3",
+    "P75": "8.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9680,9 +17738,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "0.95",
-    "P99": "3.18"
+    "JobRuns": 43,
+    "P95": "1.0",
+    "P99": "3.16",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9693,9 +17753,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9708,7 +17770,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9719,9 +17783,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "8.25",
-    "P99": "43.59"
+    "JobRuns": 38,
+    "P95": "18.6",
+    "P99": "44.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9732,9 +17798,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9747,7 +17815,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9758,9 +17828,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9771,9 +17843,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9785,8 +17859,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.85",
-    "P99": "0.97"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9797,9 +17873,11 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 136,
+    "JobRuns": 132,
     "P95": "55.0",
-    "P99": "74.85"
+    "P99": "56.69",
+    "P75": "52.0",
+    "P50": "9.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9810,9 +17888,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 519,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9824,8 +17904,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
+    "P95": "1.7",
+    "P99": "1.94",
+    "P75": "0.5",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9838,7 +17920,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "2.15",
-    "P99": "2.83"
+    "P99": "2.83",
+    "P75": "1.75",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9849,9 +17933,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9864,7 +17950,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.2",
-    "P99": "1.64"
+    "P99": "1.64",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9877,7 +17965,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9890,7 +17980,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9903,7 +17995,24 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 69,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http1-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9916,7 +18025,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9927,9 +18038,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
+    "JobRuns": 32,
     "P95": "9.0",
-    "P99": "11.1"
+    "P99": "11.07",
+    "P75": "4.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9940,9 +18053,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "3.0",
-    "P99": "24.26"
+    "JobRuns": 90,
+    "P95": "1.0",
+    "P99": "5.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9955,7 +18070,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9968,7 +18085,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "299.5",
-    "P99": "307.1"
+    "P99": "307.1",
+    "P75": "241.0",
+    "P50": "148.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9979,9 +18098,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "1.3"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -9992,9 +18113,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "1.0",
-    "P99": "3.5"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "0.29",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -10007,7 +18130,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -10018,9 +18143,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "6.05",
-    "P99": "562.57"
+    "JobRuns": 87,
+    "P95": "79.9",
+    "P99": "273.14",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http1-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http1-external-lb-reused-connections",
@@ -10031,9 +18173,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "431.8",
-    "P99": "1126.94"
+    "JobRuns": 145,
+    "P95": "428.4",
+    "P99": "1272.0",
+    "P75": "158.0",
+    "P50": "51.0"
+  },
+  {
+    "BackendName": "kube-api-http2-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.95",
+    "P99": "0.99",
+    "P75": "0.75",
+    "P50": "0.5"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10044,9 +18203,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1001,
+    "JobRuns": 1034,
     "P95": "1.0",
-    "P99": "3.0"
+    "P99": "2.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10058,8 +18219,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "262.7",
-    "P99": "263.74"
+    "P95": "262.4",
+    "P99": "263.68",
+    "P75": "256.0",
+    "P50": "248.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10070,9 +18233,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 163,
     "P95": "0.0",
-    "P99": "3.33"
+    "P99": "4.52",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10084,8 +18249,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "3.85",
-    "P99": "3.97"
+    "P95": "3.55",
+    "P99": "3.91",
+    "P75": "1.75",
+    "P50": "0.5"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10096,9 +18263,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 922,
-    "P95": "5.0",
-    "P99": "9.0"
+    "JobRuns": 859,
+    "P95": "6.0",
+    "P99": "9.0",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10109,9 +18278,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 576,
-    "P95": "3.0",
-    "P99": "7.0"
+    "JobRuns": 595,
+    "P95": "4.0",
+    "P99": "8.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10122,9 +18293,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "2.0",
-    "P99": "2.0"
+    "JobRuns": 40,
+    "P95": "1.05",
+    "P99": "2.61",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10135,9 +18308,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "8.9",
-    "P99": "10.38"
+    "JobRuns": 64,
+    "P95": "8.85",
+    "P99": "10.37",
+    "P75": "6.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10148,9 +18323,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
+    "JobRuns": 49,
     "P95": "11.0",
-    "P99": "11.49"
+    "P99": "11.52",
+    "P75": "8.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10161,9 +18338,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "1.9",
-    "P99": "1.98"
+    "P99": "1.98",
+    "P75": "1.5",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10174,9 +18353,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "11.0",
-    "P99": "11.0"
+    "JobRuns": 7,
+    "P95": "7.7",
+    "P99": "7.94",
+    "P75": "6.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10187,9 +18368,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "6.0",
+    "P99": "6.0",
+    "P75": "5.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10200,9 +18383,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "3.0",
-    "P99": "13.13"
+    "JobRuns": 87,
+    "P95": "2.4",
+    "P99": "10.56",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10213,9 +18398,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "909.5",
-    "P99": "1073.9"
+    "JobRuns": 17,
+    "P95": "931.8",
+    "P99": "1078.36",
+    "P75": "15.0",
+    "P50": "9.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10226,9 +18413,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "999.0",
-    "P99": "1048.6"
+    "JobRuns": 19,
+    "P95": "949.4",
+    "P99": "1038.68",
+    "P75": "477.0",
+    "P50": "392.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10239,9 +18428,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 238,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10253,8 +18444,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "257.5",
-    "P99": "265.9"
+    "P95": "256.8",
+    "P99": "265.76",
+    "P75": "227.0",
+    "P50": "222.5"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10265,9 +18458,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 465,
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10278,9 +18473,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 499,
-    "P95": "3.0",
-    "P99": "9.0"
+    "JobRuns": 444,
+    "P95": "2.0",
+    "P99": "5.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10291,9 +18488,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "1.5",
-    "P99": "18.5"
+    "JobRuns": 44,
+    "P95": "1.85",
+    "P99": "4.14",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10304,22 +18503,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 981,
-    "P95": "3.0",
-    "P99": "5.0"
-  },
-  {
-    "BackendName": "kube-api-http2-external-lb-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
+    "JobRuns": 824,
     "P95": "4.0",
-    "P99": "5.0"
+    "P99": "8.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http2-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 45,
+    "P95": "4.6",
+    "P99": "23.48",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10330,9 +18533,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
+    "JobRuns": 61,
     "P95": "9.0",
-    "P99": "11.0"
+    "P99": "9.8",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10343,9 +18548,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "9.7",
-    "P99": "10.54"
+    "JobRuns": 36,
+    "P95": "11.0",
+    "P99": "11.65",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10356,9 +18563,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "0.95",
-    "P99": "8.31"
+    "JobRuns": 43,
+    "P95": "0.0",
+    "P99": "8.22",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10369,9 +18578,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10384,7 +18595,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10395,9 +18608,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "8.25",
-    "P99": "43.59"
+    "JobRuns": 38,
+    "P95": "18.6",
+    "P99": "44.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10408,9 +18623,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10423,7 +18640,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10434,9 +18653,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10447,9 +18668,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10461,8 +18684,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "2.55",
-    "P99": "2.91"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10473,9 +18698,11 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 136,
+    "JobRuns": 132,
     "P95": "55.0",
-    "P99": "74.85"
+    "P99": "57.0",
+    "P75": "52.0",
+    "P50": "9.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10486,9 +18713,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 519,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10500,8 +18729,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "2.55",
-    "P99": "2.91"
+    "P95": "1.7",
+    "P99": "1.94",
+    "P75": "0.5",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10514,7 +18745,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10525,9 +18758,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10540,7 +18775,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "1.3",
-    "P99": "3.46"
+    "P99": "3.46",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10553,7 +18790,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10566,7 +18805,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10579,7 +18820,24 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 69,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http2-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10592,7 +18850,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10603,9 +18863,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "31.5",
-    "P99": "96.6"
+    "JobRuns": 32,
+    "P95": "29.75",
+    "P99": "95.92",
+    "P75": "5.0",
+    "P50": "1.5"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10616,9 +18878,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "12.4",
-    "P99": "1515.99"
+    "JobRuns": 90,
+    "P95": "1.0",
+    "P99": "38.43",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10631,7 +18895,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "3.0",
-    "P99": "3.0"
+    "P99": "3.0",
+    "P75": "3.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10644,7 +18910,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "299.75",
-    "P99": "307.15"
+    "P99": "307.15",
+    "P75": "241.75",
+    "P50": "148.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10655,9 +18923,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "5.55"
+    "P99": "0.71",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10668,9 +18938,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "1.75",
-    "P99": "5.5"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "1.87",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10683,7 +18955,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10694,9 +18968,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "15.55",
-    "P99": "585.97"
+    "JobRuns": 87,
+    "P95": "94.5",
+    "P99": "416.08",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http2-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-new-connections",
@@ -10707,9 +18998,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "521.9",
-    "P99": "1288.28"
+    "JobRuns": 145,
+    "P95": "520.2",
+    "P99": "1513.32",
+    "P75": "197.0",
+    "P50": "79.0"
+  },
+  {
+    "BackendName": "kube-api-http2-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "6.85",
+    "P99": "6.97",
+    "P75": "6.25",
+    "P50": "5.5"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10720,9 +19028,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1009,
-    "P95": "5.0",
-    "P99": "6.0"
+    "JobRuns": 1042,
+    "P95": "5.95",
+    "P99": "8.0",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10734,8 +19044,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "261.7",
-    "P99": "262.74"
+    "P95": "261.5",
+    "P99": "262.7",
+    "P75": "255.5",
+    "P50": "248.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10746,9 +19058,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 163,
     "P95": "5.0",
-    "P99": "7.66"
+    "P99": "8.76",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10760,8 +19074,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "2.7",
-    "P99": "2.94"
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "0.5"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10772,9 +19088,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 923,
-    "P95": "90.0",
-    "P99": "120.56"
+    "JobRuns": 860,
+    "P95": "70.0",
+    "P99": "111.82",
+    "P75": "45.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10785,9 +19103,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 581,
+    "JobRuns": 600,
     "P95": "5.0",
-    "P99": "11.0"
+    "P99": "11.04",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10798,9 +19118,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "6.2",
-    "P99": "8.48"
+    "JobRuns": 40,
+    "P95": "5.15",
+    "P99": "8.61",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10811,9 +19133,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "12.9",
-    "P99": "15.38"
+    "JobRuns": 64,
+    "P95": "11.85",
+    "P99": "16.0",
+    "P75": "9.0",
+    "P50": "6.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10824,9 +19148,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "16.0",
-    "P99": "17.49"
+    "JobRuns": 49,
+    "P95": "14.6",
+    "P99": "17.0",
+    "P75": "12.0",
+    "P50": "8.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10837,9 +19163,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "1.95",
-    "P99": "1.99"
+    "JobRuns": 3,
+    "P95": "2.9",
+    "P99": "2.98",
+    "P75": "2.5",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10850,9 +19178,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "14.0",
-    "P99": "14.0"
+    "JobRuns": 7,
+    "P95": "9.1",
+    "P99": "9.82",
+    "P75": "6.5",
+    "P50": "6.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10863,9 +19193,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "11.85",
-    "P99": "11.97"
+    "JobRuns": 7,
+    "P95": "7.7",
+    "P99": "7.94",
+    "P75": "7.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10876,9 +19208,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "7.3",
-    "P99": "36.3"
+    "JobRuns": 87,
+    "P95": "5.7",
+    "P99": "43.28",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10889,9 +19223,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "832.25",
-    "P99": "1041.65"
+    "JobRuns": 17,
+    "P95": "814.8",
+    "P99": "1038.16",
+    "P75": "5.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10902,9 +19238,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "331.5",
-    "P99": "371.1"
+    "JobRuns": 19,
+    "P95": "291.9",
+    "P99": "363.18",
+    "P75": "166.0",
+    "P50": "72.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10915,9 +19253,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 239,
     "P95": "5.0",
-    "P99": "6.33"
+    "P99": "6.0",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10929,8 +19269,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "257.5",
-    "P99": "265.9"
+    "P95": "256.8",
+    "P99": "265.76",
+    "P75": "227.0",
+    "P50": "222.5"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10941,9 +19283,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 465,
     "P95": "5.0",
-    "P99": "6.0"
+    "P99": "6.72",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10954,9 +19298,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 498,
-    "P95": "90.0",
-    "P99": "135.03"
+    "JobRuns": 443,
+    "P95": "46.0",
+    "P99": "90.58",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10967,9 +19313,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "90.0",
-    "P99": "135.5"
+    "JobRuns": 44,
+    "P95": "83.25",
+    "P99": "116.22",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10980,9 +19328,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 985,
+    "JobRuns": 828,
     "P95": "5.0",
-    "P99": "10.0"
+    "P99": "8.0",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -10993,9 +19343,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "4.2",
-    "P99": "6.88"
+    "JobRuns": 45,
+    "P95": "5.8",
+    "P99": "12.48",
+    "P75": "3.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11006,9 +19358,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "12.75",
-    "P99": "14.7"
+    "JobRuns": 61,
+    "P95": "11.0",
+    "P99": "14.2",
+    "P75": "4.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11019,9 +19373,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "13.7",
-    "P99": "15.0"
+    "JobRuns": 36,
+    "P95": "15.0",
+    "P99": "16.95",
+    "P75": "10.25",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11032,9 +19388,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "5.95",
-    "P99": "36.75"
+    "JobRuns": 43,
+    "P95": "6.0",
+    "P99": "36.5",
+    "P75": "3.5",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11045,9 +19403,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11060,7 +19420,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11071,9 +19433,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "8.25",
-    "P99": "43.59"
+    "JobRuns": 38,
+    "P95": "18.6",
+    "P99": "44.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11084,9 +19448,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11099,7 +19465,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11110,9 +19478,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11123,9 +19493,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11137,8 +19509,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "3.85",
-    "P99": "3.97"
+    "P95": "2.85",
+    "P99": "2.97",
+    "P75": "2.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11149,9 +19523,11 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 136,
+    "JobRuns": 132,
     "P95": "55.0",
-    "P99": "74.85"
+    "P99": "56.69",
+    "P75": "52.0",
+    "P50": "9.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11162,9 +19538,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 520,
-    "P95": "4.0",
-    "P99": "5.0"
+    "JobRuns": 528,
+    "P95": "5.0",
+    "P99": "6.0",
+    "P75": "3.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11176,8 +19554,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.0",
-    "P99": "0.0"
+    "P95": "24.8",
+    "P99": "28.16",
+    "P75": "8.0",
+    "P50": "0.5"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11190,7 +19570,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "128.2",
-    "P99": "133.64"
+    "P99": "133.64",
+    "P75": "18.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11201,9 +19583,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "3.85",
-    "P99": "3.97"
+    "JobRuns": 3,
+    "P95": "1.9",
+    "P99": "1.98",
+    "P75": "1.5",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11216,7 +19600,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "7.2",
-    "P99": "8.64"
+    "P99": "8.64",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11229,7 +19615,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11242,7 +19630,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11255,7 +19645,24 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 69,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http2-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11268,7 +19675,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11279,9 +19688,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "46.5",
-    "P99": "58.9"
+    "JobRuns": 32,
+    "P95": "45.45",
+    "P99": "58.42",
+    "P75": "5.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11292,9 +19703,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "6.95",
-    "P99": "45.0"
+    "JobRuns": 90,
+    "P95": "1.55",
+    "P99": "45.22",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11307,7 +19720,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "36.0",
-    "P99": "36.0"
+    "P99": "36.0",
+    "P75": "36.0",
+    "P50": "36.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11320,7 +19735,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "299.5",
-    "P99": "307.1"
+    "P99": "307.1",
+    "P75": "241.0",
+    "P50": "148.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11331,9 +19748,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "5.0",
-    "P99": "6.0"
+    "P99": "6.0",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11344,9 +19763,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "3.75",
-    "P99": "45.25"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "13.05",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11359,7 +19780,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11370,9 +19793,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "4.05",
-    "P99": "541.9"
+    "JobRuns": 87,
+    "P95": "21.7",
+    "P99": "56.36",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-http2-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-http2-external-lb-reused-connections",
@@ -11383,9 +19823,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "190.1",
-    "P99": "671.9"
+    "JobRuns": 145,
+    "P95": "192.4",
+    "P99": "673.52",
+    "P75": "43.0",
+    "P50": "11.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11396,9 +19853,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11410,8 +19869,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "262.7",
-    "P99": "263.74"
+    "P95": "262.4",
+    "P99": "263.68",
+    "P75": "256.0",
+    "P50": "248.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11422,9 +19883,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "0.0",
-    "P99": "2.0"
+    "JobRuns": 167,
+    "P95": "0.7",
+    "P99": "3.02",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11436,8 +19899,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "3.4",
-    "P99": "3.88"
+    "P95": "4.25",
+    "P99": "4.85",
+    "P75": "1.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11448,9 +19913,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 918,
+    "JobRuns": 882,
     "P95": "4.0",
-    "P99": "8.0"
+    "P99": "6.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11461,9 +19928,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 575,
+    "JobRuns": 614,
     "P95": "3.0",
-    "P99": "6.0"
+    "P99": "6.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11474,9 +19943,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "2.0",
-    "P99": "4.0"
+    "P99": "3.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11487,9 +19958,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "8.9",
-    "P99": "10.38"
+    "JobRuns": 65,
+    "P95": "8.0",
+    "P99": "10.36",
+    "P75": "6.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11500,9 +19973,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "11.0",
-    "P99": "11.49"
+    "JobRuns": 50,
+    "P95": "10.55",
+    "P99": "11.0",
+    "P75": "7.75",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11513,9 +19988,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.9",
+    "P99": "1.98",
+    "P75": "1.5",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11526,9 +20003,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "10.5",
-    "P99": "10.9"
+    "JobRuns": 7,
+    "P95": "8.4",
+    "P99": "8.88",
+    "P75": "6.5",
+    "P50": "6.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11539,9 +20018,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "6.0",
+    "P99": "6.0",
+    "P75": "5.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11552,9 +20033,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "1.65",
-    "P99": "10.95"
+    "JobRuns": 87,
+    "P95": "1.0",
+    "P99": "11.1",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11565,9 +20048,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "796.5",
-    "P99": "1044.9"
+    "JobRuns": 17,
+    "P95": "775.8",
+    "P99": "1040.76",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11578,9 +20063,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "633.5",
-    "P99": "646.7"
+    "JobRuns": 19,
+    "P95": "620.3",
+    "P99": "644.06",
+    "P75": "304.5",
+    "P50": "211.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11591,9 +20078,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11605,8 +20094,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "252.3",
-    "P99": "258.46"
+    "P95": "251.25",
+    "P99": "258.25",
+    "P75": "226.75",
+    "P50": "222.5"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11617,9 +20108,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "0.65",
-    "P99": "1.0"
+    "JobRuns": 483,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11630,9 +20123,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 495,
-    "P95": "5.0",
-    "P99": "10.0"
+    "JobRuns": 457,
+    "P95": "1.0",
+    "P99": "2.44",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11643,9 +20138,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "4.5",
-    "P99": "12.5"
+    "JobRuns": 46,
+    "P95": "1.75",
+    "P99": "3.55",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11656,48 +20153,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 981,
-    "P95": "2.0",
-    "P99": "4.0"
+    "JobRuns": 852,
+    "P95": "3.0",
+    "P99": "6.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "2.2",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "9.0",
-    "P99": "11.35"
-  },
-  {
-    "BackendName": "kube-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "9.0",
-    "P99": "10.54"
+    "P95": "2.7",
+    "P99": "3.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "8.85",
+    "P99": "10.17",
+    "P75": "2.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "10.25",
+    "P99": "11.65",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11708,9 +20213,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "0.95",
-    "P99": "6.54"
+    "JobRuns": 43,
+    "P95": "0.9",
+    "P99": "6.48",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "2.82",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "46.0",
+    "P99": "128.99",
+    "P75": "42.0",
+    "P50": "31.5"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "1.0",
+    "P99": "10.1",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "3.0",
+    "P99": "4.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.25",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "0.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "6.9",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "2.02",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "7.0",
+    "P99": "23.04",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "3.0",
+    "P99": "10.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "6.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "274.2",
+    "P99": "374.48",
+    "P75": "197.75",
+    "P50": "135.5"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "4.24",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.6",
+    "P99": "6.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "9.0",
+    "P99": "13.73",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "41.25",
+    "P99": "88.15",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "452.85",
+    "P99": "776.09",
+    "P75": "187.0",
+    "P50": "85.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11721,9 +20678,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11736,7 +20695,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11747,9 +20708,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "4.95",
-    "P99": "37.59"
+    "JobRuns": 38,
+    "P95": "12.6",
+    "P99": "38.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11760,9 +20723,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11775,7 +20740,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11786,9 +20753,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11799,9 +20768,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11813,8 +20784,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "1.7",
-    "P99": "1.94"
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11827,7 +20800,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
     "P95": "55.0",
-    "P99": "74.85"
+    "P99": "57.0",
+    "P75": "52.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11838,9 +20813,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11853,7 +20830,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.85",
-    "P99": "0.97"
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11866,7 +20845,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11877,9 +20858,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11892,7 +20875,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "1.2",
-    "P99": "2.64"
+    "P99": "2.64",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11905,7 +20890,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11918,7 +20905,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11929,9 +20918,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11944,7 +20950,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11955,9 +20963,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "19.5",
-    "P99": "40.7"
+    "JobRuns": 32,
+    "P95": "18.85",
+    "P99": "40.49",
+    "P75": "4.5",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11968,9 +20978,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "8.7",
-    "P99": "1100.15"
+    "JobRuns": 93,
+    "P95": "1.0",
+    "P99": "31.12",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11983,7 +20995,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "7.0",
-    "P99": "7.0"
+    "P99": "7.0",
+    "P75": "7.0",
+    "P50": "7.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -11996,7 +21010,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "299.5",
-    "P99": "307.1"
+    "P99": "307.1",
+    "P75": "241.0",
+    "P50": "148.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -12007,9 +21023,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "2.6"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -12020,9 +21038,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "0.25",
-    "P99": "2.5"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "1.16",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -12035,7 +21055,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -12046,9 +21068,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "13.05",
-    "P99": "555.94"
+    "JobRuns": 87,
+    "P95": "46.8",
+    "P99": "193.76",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-new-connections",
@@ -12059,9 +21098,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "350.4",
-    "P99": "1053.48"
+    "JobRuns": 145,
+    "P95": "316.8",
+    "P99": "1017.12",
+    "P75": "99.0",
+    "P50": "33.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.95",
+    "P99": "0.99",
+    "P75": "0.75",
+    "P50": "0.5"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12072,9 +21128,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12086,8 +21144,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "262.6",
-    "P99": "263.72"
+    "P95": "262.4",
+    "P99": "263.68",
+    "P75": "256.0",
+    "P50": "248.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12098,9 +21158,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12112,8 +21174,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "3.7",
+    "P99": "3.94",
+    "P75": "2.5",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12124,9 +21188,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 920,
-    "P95": "5.0",
-    "P99": "8.0"
+    "JobRuns": 884,
+    "P95": "4.0",
+    "P99": "8.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12137,9 +21203,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 574,
+    "JobRuns": 613,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12150,9 +21218,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "1.0",
-    "P99": "1.48"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12163,9 +21233,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "10.0",
-    "P99": "13.0"
+    "JobRuns": 65,
+    "P95": "9.8",
+    "P99": "13.0",
+    "P75": "7.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12176,9 +21248,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "13.0",
-    "P99": "14.49"
+    "JobRuns": 50,
+    "P95": "12.55",
+    "P99": "14.0",
+    "P75": "9.75",
+    "P50": "6.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12189,9 +21263,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.9",
+    "P99": "1.98",
+    "P75": "1.5",
+    "P50": "1.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12202,9 +21278,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "11.0",
-    "P99": "11.8"
+    "JobRuns": 7,
+    "P95": "7.1",
+    "P99": "7.82",
+    "P75": "5.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12215,9 +21293,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.0",
-    "P99": "9.0"
+    "JobRuns": 7,
+    "P95": "5.7",
+    "P99": "5.94",
+    "P75": "4.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12228,9 +21308,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
+    "JobRuns": 87,
     "P95": "1.0",
-    "P99": "3.52"
+    "P99": "6.14",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12241,9 +21323,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "790.25",
-    "P99": "1030.85"
+    "JobRuns": 17,
+    "P95": "770.2",
+    "P99": "1026.84",
+    "P75": "3.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12254,9 +21338,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "397.5",
-    "P99": "404.3"
+    "JobRuns": 19,
+    "P95": "361.1",
+    "P99": "383.42",
+    "P75": "207.0",
+    "P50": "106.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12267,9 +21353,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 242,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12281,8 +21369,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "252.3",
-    "P99": "258.46"
+    "P95": "251.25",
+    "P99": "258.25",
+    "P75": "226.75",
+    "P50": "222.5"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12293,9 +21383,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 483,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12306,9 +21398,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 496,
-    "P95": "4.0",
-    "P99": "8.0"
+    "JobRuns": 458,
+    "P95": "2.0",
+    "P99": "3.43",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12319,9 +21413,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "3.0",
-    "P99": "5.5"
+    "JobRuns": 46,
+    "P95": "1.75",
+    "P99": "4.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12332,48 +21428,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 978,
+    "JobRuns": 849,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.75",
-    "P99": "12.7"
-  },
-  {
-    "BackendName": "kube-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "12.0",
-    "P99": "12.54"
+    "P95": "0.7",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "8.9",
+    "P99": "12.17",
+    "P75": "3.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "12.25",
+    "P99": "14.3",
+    "P75": "8.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12384,9 +21488,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "0.95",
-    "P99": "2.59"
+    "JobRuns": 43,
+    "P95": "1.0",
+    "P99": "2.58",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "45.0",
+    "P99": "121.62",
+    "P75": "42.0",
+    "P50": "32.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "1.25",
+    "P99": "4.05",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "0.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.46",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "1.02",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "3.0",
+    "P99": "13.88",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "3.0",
+    "P99": "10.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "274.2",
+    "P99": "374.48",
+    "P75": "197.0",
+    "P50": "135.5"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.6",
+    "P99": "5.6",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "28.2",
+    "P99": "72.21",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "319.5",
+    "P99": "700.74",
+    "P75": "130.5",
+    "P50": "64.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12397,9 +21953,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12412,7 +21970,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12423,9 +21983,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "4.95",
-    "P99": "37.59"
+    "JobRuns": 38,
+    "P95": "12.6",
+    "P99": "38.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12436,9 +21998,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12451,7 +22015,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12462,9 +22028,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12475,9 +22043,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12490,7 +22060,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12503,7 +22075,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
     "P95": "55.0",
-    "P99": "74.85"
+    "P99": "56.65",
+    "P75": "52.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12514,9 +22088,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12529,7 +22105,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "1.85",
-    "P99": "1.97"
+    "P99": "1.97",
+    "P75": "1.25",
+    "P50": "0.5"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12542,7 +22120,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "1.3",
-    "P99": "2.66"
+    "P99": "2.66",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12553,9 +22133,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12568,7 +22150,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12581,7 +22165,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12594,7 +22180,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12605,9 +22193,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12620,7 +22225,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12631,9 +22238,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
+    "JobRuns": 32,
     "P95": "7.0",
-    "P99": "7.7"
+    "P99": "7.69",
+    "P75": "3.25",
+    "P50": "1.5"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12644,9 +22253,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "2.0",
-    "P99": "22.63"
+    "JobRuns": 93,
+    "P95": "1.0",
+    "P99": "2.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12659,7 +22270,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "5.0",
-    "P99": "5.0"
+    "P99": "5.0",
+    "P75": "5.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12672,7 +22285,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "299.5",
-    "P99": "307.1"
+    "P99": "307.1",
+    "P75": "241.0",
+    "P50": "148.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12683,9 +22298,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "2.3"
+    "P99": "0.71",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12696,9 +22313,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "1.0",
-    "P99": "3.75"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "0.58",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12711,7 +22330,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12722,9 +22343,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "5.5",
-    "P99": "543.07"
+    "JobRuns": 87,
+    "P95": "18.4",
+    "P99": "73.48",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "kube-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "kube-api-reused-connections",
@@ -12735,9 +22373,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "244.2",
-    "P99": "781.98"
+    "JobRuns": 145,
+    "P95": "200.0",
+    "P99": "759.12",
+    "P75": "52.0",
+    "P50": "15.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.95",
+    "P99": "0.99",
+    "P75": "0.75",
+    "P50": "0.5"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12748,9 +22403,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1062,
     "P95": "1.0",
-    "P99": "2.01"
+    "P99": "1.39",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12762,8 +22419,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "748.2",
-    "P99": "749.64"
+    "P95": "536.7",
+    "P99": "539.34",
+    "P75": "523.5",
+    "P50": "507.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12774,9 +22433,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "0.65",
-    "P99": "2.99"
+    "JobRuns": 167,
+    "P95": "0.0",
+    "P99": "3.36",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12788,8 +22449,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "1.7",
-    "P99": "1.94"
+    "P95": "3.7",
+    "P99": "3.94",
+    "P75": "2.5",
+    "P50": "1.5"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12800,9 +22463,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 918,
+    "JobRuns": 882,
     "P95": "4.0",
-    "P99": "8.83"
+    "P99": "10.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12813,9 +22478,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 575,
+    "JobRuns": 614,
     "P95": "3.0",
-    "P99": "5.0"
+    "P99": "5.87",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12826,9 +22493,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "2.0",
-    "P99": "3.48"
+    "JobRuns": 41,
+    "P95": "1.0",
+    "P99": "2.6",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12839,9 +22508,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "15.0",
-    "P99": "17.9"
+    "JobRuns": 65,
+    "P95": "14.0",
+    "P99": "17.8",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12852,9 +22523,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "11.0",
-    "P99": "11.49"
+    "JobRuns": 50,
+    "P95": "10.55",
+    "P99": "11.51",
+    "P75": "7.75",
+    "P50": "5.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12865,9 +22538,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.8",
+    "P99": "1.96",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12878,9 +22553,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "9.75",
-    "P99": "9.95"
+    "JobRuns": 7,
+    "P95": "9.1",
+    "P99": "9.82",
+    "P75": "6.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12891,9 +22568,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "6.0",
+    "P99": "6.0",
+    "P75": "5.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12904,9 +22583,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "8.8",
-    "P99": "30.78"
+    "JobRuns": 87,
+    "P95": "0.7",
+    "P99": "30.84",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12917,9 +22598,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "797.75",
-    "P99": "1046.75"
+    "JobRuns": 17,
+    "P95": "777.0",
+    "P99": "1042.6",
+    "P75": "14.0",
+    "P50": "10.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12930,9 +22613,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "678.5",
-    "P99": "678.9"
+    "JobRuns": 19,
+    "P95": "678.1",
+    "P99": "678.82",
+    "P75": "338.5",
+    "P50": "248.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12943,9 +22628,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "2.68"
+    "P99": "2.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12957,8 +22644,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "617.6",
-    "P99": "669.12"
+    "P95": "618.65",
+    "P99": "669.33",
+    "P75": "498.75",
+    "P50": "376.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12969,9 +22658,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "1.0",
-    "P99": "4.0"
+    "P99": "3.18",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12982,9 +22673,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 496,
-    "P95": "5.0",
-    "P99": "11.0"
+    "JobRuns": 458,
+    "P95": "3.0",
+    "P99": "6.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -12995,9 +22688,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "4.5",
-    "P99": "18.5"
+    "JobRuns": 46,
+    "P95": "2.5",
+    "P99": "4.55",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13008,48 +22703,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 979,
-    "P95": "2.0",
-    "P99": "5.0"
+    "JobRuns": 850,
+    "P95": "3.0",
+    "P99": "6.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "2.0",
-    "P99": "3.0"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "11.0",
-    "P99": "12.7"
-  },
-  {
-    "BackendName": "oauth-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "9.7",
-    "P99": "11.08"
+    "P95": "2.7",
+    "P99": "3.54",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "9.95",
+    "P99": "16.73",
+    "P75": "4.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "10.5",
+    "P99": "12.0",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13060,9 +22763,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "0.95",
-    "P99": "27.9"
+    "JobRuns": 43,
+    "P95": "0.9",
+    "P99": "27.8",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "4104.35",
+    "P99": "4223.3",
+    "P75": "3858.0",
+    "P50": "2978.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "2.82",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "129.55",
+    "P99": "225.82",
+    "P75": "123.0",
+    "P50": "99.5"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "2.0",
+    "P99": "6.46",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "1.0",
+    "P99": "8.7",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "2.0",
+    "P99": "4.74",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "3.0",
+    "P99": "4.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.05",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "7.82",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "7.63",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "8.0",
+    "P99": "24.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "3.0",
+    "P99": "11.46",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "1.0",
+    "P99": "26.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "879.85",
+    "P99": "1300.53",
+    "P75": "676.5",
+    "P50": "472.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "26.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.6",
+    "P99": "21.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "15.65",
+    "P99": "18.0",
+    "P75": "9.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "41.35",
+    "P99": "88.15",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "454.85",
+    "P99": "777.8",
+    "P75": "187.5",
+    "P50": "84.5"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13073,9 +23228,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13088,7 +23245,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13099,9 +23258,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "17.6",
-    "P99": "49.08"
+    "JobRuns": 38,
+    "P95": "33.95",
+    "P99": "50.04",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13112,9 +23273,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13127,7 +23290,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13138,9 +23303,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13151,9 +23318,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13166,7 +23335,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13178,8 +23349,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "134.0",
-    "P99": "151.65"
+    "P95": "239.0",
+    "P99": "270.35",
+    "P75": "129.25",
+    "P50": "3.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13190,9 +23363,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13205,7 +23380,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13218,7 +23395,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13229,9 +23408,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13244,7 +23425,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "1.3",
-    "P99": "3.46"
+    "P99": "3.46",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13257,7 +23440,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13270,7 +23455,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13281,9 +23468,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13296,7 +23500,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13307,9 +23513,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "19.5",
-    "P99": "50.2"
+    "JobRuns": 32,
+    "P95": "18.95",
+    "P99": "49.84",
+    "P75": "6.0",
+    "P50": "2.5"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13320,9 +23528,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "6.3",
-    "P99": "1536.05"
+    "JobRuns": 93,
+    "P95": "1.0",
+    "P99": "32.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13335,7 +23545,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "23.0",
-    "P99": "23.0"
+    "P99": "23.0",
+    "P75": "23.0",
+    "P50": "23.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13348,7 +23560,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "900.5",
-    "P99": "904.1"
+    "P99": "904.1",
+    "P75": "785.75",
+    "P50": "475.5"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13359,9 +23573,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "9.1"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13372,9 +23588,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "0.25",
-    "P99": "22.0"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13387,7 +23605,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "11.0",
-    "P99": "11.0"
+    "P99": "11.0",
+    "P75": "11.0",
+    "P50": "11.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13398,9 +23618,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "12.7",
-    "P99": "556.2"
+    "JobRuns": 87,
+    "P95": "46.8",
+    "P99": "201.36",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-new-connections",
@@ -13411,9 +23648,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "351.1",
-    "P99": "1066.34"
+    "JobRuns": 145,
+    "P95": "317.8",
+    "P99": "1031.96",
+    "P75": "100.0",
+    "P50": "33.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13424,9 +23678,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1001,
+    "JobRuns": 1063,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13438,8 +23694,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "747.3",
-    "P99": "748.66"
+    "P95": "536.5",
+    "P99": "539.3",
+    "P75": "522.5",
+    "P50": "505.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13450,9 +23708,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "1.99"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13464,8 +23724,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.85",
-    "P99": "0.97"
+    "P95": "2.7",
+    "P99": "2.94",
+    "P75": "1.5",
+    "P50": "0.5"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13476,9 +23738,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 921,
+    "JobRuns": 885,
     "P95": "4.0",
-    "P99": "10.0"
+    "P99": "10.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13489,9 +23753,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 574,
+    "JobRuns": 613,
     "P95": "1.0",
-    "P99": "2.27"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13502,9 +23768,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "0.6",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13515,9 +23783,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "10.0",
-    "P99": "13.0"
+    "JobRuns": 65,
+    "P95": "9.0",
+    "P99": "13.0",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13528,9 +23798,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "13.0",
-    "P99": "14.49"
+    "JobRuns": 50,
+    "P95": "12.55",
+    "P99": "14.0",
+    "P75": "10.0",
+    "P50": "6.5"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13541,9 +23813,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "2.0",
+    "P99": "2.0",
+    "P75": "2.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13554,9 +23828,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "10.0",
-    "P99": "10.0"
+    "JobRuns": 7,
+    "P95": "8.5",
+    "P99": "9.7",
+    "P75": "5.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13567,9 +23843,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.0",
-    "P99": "9.0"
+    "JobRuns": 7,
+    "P95": "6.0",
+    "P99": "6.0",
+    "P75": "5.5",
+    "P50": "4.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13580,9 +23858,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "5.55",
-    "P99": "30.26"
+    "JobRuns": 87,
+    "P95": "1.0",
+    "P99": "30.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13593,9 +23873,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "790.5",
-    "P99": "1031.7"
+    "JobRuns": 17,
+    "P95": "770.4",
+    "P99": "1027.68",
+    "P75": "3.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13606,9 +23888,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "423.0",
-    "P99": "428.6"
+    "JobRuns": 19,
+    "P95": "388.6",
+    "P99": "421.72",
+    "P75": "214.5",
+    "P50": "125.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13619,9 +23903,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 242,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13633,8 +23919,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "617.6",
-    "P99": "669.12"
+    "P95": "619.0",
+    "P99": "669.4",
+    "P75": "499.0",
+    "P50": "376.5"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13645,9 +23933,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
     "P95": "1.0",
-    "P99": "2.06"
+    "P99": "3.18",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13658,74 +23948,86 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 496,
-    "P95": "5.0",
-    "P99": "9.05"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
+    "JobRuns": 458,
     "P95": "3.0",
-    "P99": "4.98"
+    "P99": "6.43",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 979,
-    "P95": "1.0",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "1.0",
-    "P99": "1.44"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.75",
-    "P99": "13.05"
-  },
-  {
-    "BackendName": "oauth-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
+    "Platform": "azure",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "11.7",
-    "P99": "12.54"
+    "P95": "2.0",
+    "P99": "3.54",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 850,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 47,
+    "P95": "1.0",
+    "P99": "1.54",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "8.85",
+    "P99": "12.56",
+    "P75": "3.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "12.25",
+    "P99": "14.3",
+    "P75": "8.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13736,9 +24038,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
     "P95": "1.0",
-    "P99": "26.72"
+    "P99": "26.64",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "4104.35",
+    "P99": "4223.3",
+    "P75": "3858.0",
+    "P50": "2978.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "0.94",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "129.55",
+    "P99": "225.27",
+    "P75": "123.0",
+    "P50": "99.5"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "3.0",
+    "P99": "6.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "1.0",
+    "P99": "6.05",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.05",
+    "P99": "1.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.3",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "6.63",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "3.0",
+    "P99": "13.76",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "1.6",
+    "P99": "10.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "26.44",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "879.85",
+    "P99": "1301.53",
+    "P75": "675.75",
+    "P50": "472.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "20.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "1.0",
+    "P99": "24.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.65",
+    "P99": "3.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "30.35",
+    "P99": "71.21",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "320.4",
+    "P99": "700.73",
+    "P75": "136.0",
+    "P50": "62.5"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13749,9 +24503,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13764,7 +24520,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13775,9 +24533,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "17.6",
-    "P99": "49.59"
+    "JobRuns": 38,
+    "P95": "33.95",
+    "P99": "50.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13788,9 +24548,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13803,7 +24565,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13814,9 +24578,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13827,9 +24593,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13842,7 +24610,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13854,8 +24624,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "135.0",
-    "P99": "151.65"
+    "P95": "239.0",
+    "P99": "271.0",
+    "P75": "129.25",
+    "P50": "3.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13866,9 +24638,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13880,8 +24654,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.85",
-    "P99": "0.97"
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13894,7 +24670,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "2.15",
-    "P99": "2.83"
+    "P99": "2.83",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13905,9 +24683,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13920,7 +24700,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13933,7 +24715,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13946,7 +24730,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13957,9 +24743,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13972,7 +24775,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13983,9 +24788,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
+    "JobRuns": 32,
     "P95": "8.0",
-    "P99": "10.1"
+    "P99": "10.07",
+    "P75": "5.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -13996,9 +24803,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "2.0",
-    "P99": "13.71"
+    "JobRuns": 93,
+    "P95": "1.0",
+    "P99": "2.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -14011,7 +24820,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "22.0",
-    "P99": "22.0"
+    "P99": "22.0",
+    "P75": "22.0",
+    "P50": "22.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -14024,7 +24835,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "901.0",
-    "P99": "905.0"
+    "P99": "905.0",
+    "P75": "785.0",
+    "P50": "475.5"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -14035,9 +24848,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "10.4"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -14048,9 +24863,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
+    "JobRuns": 72,
     "P95": "0.0",
-    "P99": "17.25"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -14063,7 +24880,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -14074,9 +24893,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "5.5",
-    "P99": "542.81"
+    "JobRuns": 87,
+    "P95": "17.8",
+    "P99": "71.76",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "oauth-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "oauth-api-reused-connections",
@@ -14087,9 +24923,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "250.3",
-    "P99": "789.28"
+    "JobRuns": 145,
+    "P95": "188.2",
+    "P99": "767.32",
+    "P75": "49.0",
+    "P50": "15.0"
+  },
+  {
+    "BackendName": "openshift-api-http2-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14100,9 +24953,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1000,
+    "JobRuns": 1033,
     "P95": "1.0",
-    "P99": "4.0"
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14114,8 +24969,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "537.0",
-    "P99": "538.6"
+    "P95": "527.1",
+    "P99": "527.82",
+    "P75": "523.5",
+    "P50": "519.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14126,9 +24983,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 163,
     "P95": "1.0",
-    "P99": "2.99"
+    "P99": "6.14",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14140,8 +24999,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "1.85",
-    "P99": "1.97"
+    "P95": "3.4",
+    "P99": "3.88",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14152,9 +25013,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 921,
+    "JobRuns": 858,
     "P95": "5.0",
-    "P99": "9.0"
+    "P99": "8.0",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14165,9 +25028,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 575,
+    "JobRuns": 594,
     "P95": "4.0",
-    "P99": "8.26"
+    "P99": "9.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14178,9 +25043,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "3.4",
-    "P99": "4.0"
+    "JobRuns": 40,
+    "P95": "2.05",
+    "P99": "3.61",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14191,9 +25058,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "16.9",
-    "P99": "19.0"
+    "JobRuns": 64,
+    "P95": "15.55",
+    "P99": "18.37",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14204,9 +25073,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "11.0",
-    "P99": "11.49"
+    "JobRuns": 49,
+    "P95": "10.6",
+    "P99": "11.52",
+    "P75": "8.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14217,9 +25088,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.9",
+    "P99": "1.98",
+    "P75": "1.5",
+    "P50": "1.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14230,9 +25103,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "12.25",
-    "P99": "12.85"
+    "JobRuns": 7,
+    "P95": "7.7",
+    "P99": "7.94",
+    "P75": "6.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14243,9 +25118,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "5.7",
+    "P99": "5.94",
+    "P75": "5.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14256,9 +25133,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "8.15",
-    "P99": "35.13"
+    "JobRuns": 87,
+    "P95": "1.0",
+    "P99": "35.14",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14269,9 +25148,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "886.5",
-    "P99": "1062.9"
+    "JobRuns": 17,
+    "P95": "984.6",
+    "P99": "1082.52",
+    "P75": "33.0",
+    "P50": "15.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14282,9 +25163,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "1032.5",
-    "P99": "1063.3"
+    "JobRuns": 19,
+    "P95": "1001.7",
+    "P99": "1057.14",
+    "P75": "524.0",
+    "P50": "438.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14295,9 +25178,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 238,
     "P95": "0.0",
-    "P99": "1.34"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14309,8 +25194,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "444.2",
-    "P99": "446.44"
+    "P95": "441.75",
+    "P99": "445.95",
+    "P75": "402.75",
+    "P50": "382.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14321,9 +25208,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "1.0",
-    "P99": "2.0"
+    "JobRuns": 465,
+    "P95": "0.8",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14334,9 +25223,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 499,
-    "P95": "3.0",
-    "P99": "10.02"
+    "JobRuns": 444,
+    "P95": "2.0",
+    "P99": "5.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14347,9 +25238,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "1.0",
-    "P99": "17.19"
+    "JobRuns": 45,
+    "P95": "2.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14360,9 +25253,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 983,
-    "P95": "3.0",
-    "P99": "5.18"
+    "JobRuns": 826,
+    "P95": "4.0",
+    "P99": "7.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14373,9 +25268,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "3.0",
-    "P99": "3.44"
+    "JobRuns": 45,
+    "P95": "3.8",
+    "P99": "25.72",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14386,9 +25283,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.0",
-    "P99": "12.0"
+    "JobRuns": 61,
+    "P95": "9.0",
+    "P99": "12.0",
+    "P75": "4.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14399,9 +25298,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "9.7",
-    "P99": "10.54"
+    "JobRuns": 36,
+    "P95": "11.25",
+    "P99": "12.0",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14412,9 +25313,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "0.95",
-    "P99": "27.44"
+    "JobRuns": 43,
+    "P95": "0.9",
+    "P99": "27.28",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14425,9 +25328,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14440,7 +25345,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14451,9 +25358,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "8.25",
-    "P99": "57.59"
+    "JobRuns": 38,
+    "P95": "20.7",
+    "P99": "58.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14464,9 +25373,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14479,7 +25390,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14490,9 +25403,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14503,9 +25418,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14518,7 +25435,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14529,9 +25448,11 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 136,
-    "P95": "151.75",
-    "P99": "168.55"
+    "JobRuns": 132,
+    "P95": "243.45",
+    "P99": "254.14",
+    "P75": "147.0",
+    "P50": "88.5"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14542,9 +25463,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 519,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14557,7 +25480,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.85",
-    "P99": "0.97"
+    "P99": "0.97",
+    "P75": "0.25",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14570,7 +25495,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14581,9 +25508,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.95",
-    "P99": "0.99"
+    "JobRuns": 3,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14596,7 +25525,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.2",
-    "P99": "1.64"
+    "P99": "1.64",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14609,7 +25540,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14622,7 +25555,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14635,7 +25570,24 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 69,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-http2-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14648,7 +25600,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14659,9 +25613,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "33.5",
-    "P99": "94.6"
+    "JobRuns": 32,
+    "P95": "31.45",
+    "P99": "94.02",
+    "P75": "5.25",
+    "P50": "3.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14672,9 +25628,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "12.55",
-    "P99": "2071.55"
+    "JobRuns": 90,
+    "P95": "1.55",
+    "P99": "39.98",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14687,7 +25645,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "22.0",
-    "P99": "22.0"
+    "P99": "22.0",
+    "P75": "22.0",
+    "P50": "22.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14700,7 +25660,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "931.75",
-    "P99": "958.35"
+    "P99": "958.35",
+    "P75": "747.5",
+    "P50": "488.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14711,9 +25673,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "13.35"
+    "P99": "2.42",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14724,9 +25688,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "0.5",
-    "P99": "22.25"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "0.58",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14739,7 +25705,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "7.0",
-    "P99": "7.0"
+    "P99": "7.0",
+    "P75": "7.0",
+    "P50": "7.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14750,9 +25718,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "15.55",
-    "P99": "585.58"
+    "JobRuns": 87,
+    "P95": "95.9",
+    "P99": "413.64",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-http2-external-lb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-new-connections",
@@ -14763,9 +25748,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "521.6",
-    "P99": "1291.46"
+    "JobRuns": 145,
+    "P95": "520.0",
+    "P99": "1517.2",
+    "P75": "197.0",
+    "P50": "77.0"
+  },
+  {
+    "BackendName": "openshift-api-http2-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "4.95",
+    "P99": "4.99",
+    "P75": "4.75",
+    "P50": "4.5"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14776,9 +25778,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1009,
-    "P95": "5.0",
-    "P99": "7.0"
+    "JobRuns": 1042,
+    "P95": "6.0",
+    "P99": "8.0",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14790,8 +25794,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "537.0",
-    "P99": "538.6"
+    "P95": "528.0",
+    "P99": "528.8",
+    "P75": "524.0",
+    "P50": "519.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14802,9 +25808,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "6.0",
-    "P99": "16.94"
+    "JobRuns": 163,
+    "P95": "5.0",
+    "P99": "7.38",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14816,8 +25824,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "39.25",
-    "P99": "44.65"
+    "P95": "42.7",
+    "P99": "45.34",
+    "P75": "29.5",
+    "P50": "12.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14828,9 +25838,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 924,
-    "P95": "90.0",
-    "P99": "129.08"
+    "JobRuns": 861,
+    "P95": "74.0",
+    "P99": "109.6",
+    "P75": "45.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14841,9 +25853,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 582,
+    "JobRuns": 601,
     "P95": "5.0",
-    "P99": "12.38"
+    "P99": "11.0",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14854,9 +25868,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "5.0",
-    "P99": "6.92"
+    "JobRuns": 40,
+    "P95": "4.0",
+    "P99": "4.61",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14867,9 +25883,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "12.9",
-    "P99": "15.38"
+    "JobRuns": 64,
+    "P95": "11.85",
+    "P99": "16.0",
+    "P75": "9.0",
+    "P50": "6.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14880,9 +25898,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "16.0",
-    "P99": "17.49"
+    "JobRuns": 49,
+    "P95": "14.6",
+    "P99": "17.0",
+    "P75": "12.0",
+    "P50": "8.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14893,9 +25913,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "2.0",
-    "P99": "2.0"
+    "JobRuns": 3,
+    "P95": "3.9",
+    "P99": "3.98",
+    "P75": "3.5",
+    "P50": "3.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14906,9 +25928,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "15.0",
-    "P99": "15.8"
+    "JobRuns": 7,
+    "P95": "9.4",
+    "P99": "9.88",
+    "P75": "7.0",
+    "P50": "6.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14919,9 +25943,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "11.85",
-    "P99": "11.97"
+    "JobRuns": 7,
+    "P95": "7.0",
+    "P99": "7.0",
+    "P75": "6.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14932,9 +25958,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "13.9",
-    "P99": "38.34"
+    "JobRuns": 87,
+    "P95": "5.7",
+    "P99": "29.92",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14945,9 +25973,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "818.5",
-    "P99": "1038.1"
+    "JobRuns": 17,
+    "P95": "800.2",
+    "P99": "1034.44",
+    "P75": "5.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14958,9 +25988,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "337.5",
-    "P99": "382.7"
+    "JobRuns": 19,
+    "P95": "292.3",
+    "P99": "373.66",
+    "P75": "166.5",
+    "P50": "92.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14971,9 +26003,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "4.65",
-    "P99": "5.33"
+    "JobRuns": 239,
+    "P95": "5.0",
+    "P99": "6.0",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14985,8 +26019,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "445.25",
-    "P99": "446.65"
+    "P95": "441.75",
+    "P99": "445.95",
+    "P75": "402.75",
+    "P50": "382.5"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -14997,9 +26033,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 465,
     "P95": "5.0",
-    "P99": "5.53"
+    "P99": "6.0",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15010,9 +26048,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 499,
-    "P95": "90.0",
-    "P99": "114.1"
+    "JobRuns": 444,
+    "P95": "62.2",
+    "P99": "91.0",
+    "P75": "2.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15023,9 +26063,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "70.0",
-    "P99": "137.5"
+    "JobRuns": 44,
+    "P95": "71.4",
+    "P99": "121.79",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15036,9 +26078,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 985,
+    "JobRuns": 828,
     "P95": "5.0",
-    "P99": "9.16"
+    "P99": "9.0",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15049,9 +26093,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "4.0",
-    "P99": "4.44"
+    "JobRuns": 45,
+    "P95": "3.0",
+    "P99": "12.52",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15062,9 +26108,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "12.75",
-    "P99": "15.35"
+    "JobRuns": 61,
+    "P95": "11.0",
+    "P99": "13.8",
+    "P75": "4.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15075,9 +26123,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 47,
-    "P95": "13.7",
-    "P99": "14.54"
+    "JobRuns": 36,
+    "P95": "14.25",
+    "P99": "16.95",
+    "P75": "10.25",
+    "P50": "3.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15088,9 +26138,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "18.25",
-    "P99": "41.26"
+    "JobRuns": 43,
+    "P95": "17.6",
+    "P99": "41.12",
+    "P75": "4.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15101,9 +26153,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15116,7 +26170,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15127,9 +26183,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "8.25",
-    "P99": "57.59"
+    "JobRuns": 38,
+    "P95": "20.7",
+    "P99": "58.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15140,9 +26198,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15155,7 +26215,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15166,9 +26228,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15179,9 +26243,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 527,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15194,7 +26260,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "3.0",
-    "P99": "3.0"
+    "P99": "3.0",
+    "P75": "3.0",
+    "P50": "2.5"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15205,9 +26273,11 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 136,
-    "P95": "151.5",
-    "P99": "170.55"
+    "JobRuns": 132,
+    "P95": "243.45",
+    "P99": "254.45",
+    "P75": "147.0",
+    "P50": "88.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15218,9 +26288,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 520,
-    "P95": "4.0",
-    "P99": "5.81"
+    "JobRuns": 528,
+    "P95": "5.0",
+    "P99": "6.0",
+    "P75": "3.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15232,8 +26304,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "37.85",
-    "P99": "42.77"
+    "P95": "37.55",
+    "P99": "42.71",
+    "P75": "11.75",
+    "P50": "0.5"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15246,7 +26320,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "107.2",
-    "P99": "153.44"
+    "P99": "153.44",
+    "P75": "49.75",
+    "P50": "0.5"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15257,9 +26333,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "1.95",
-    "P99": "1.99"
+    "JobRuns": 3,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15272,7 +26350,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "7.2",
-    "P99": "8.64"
+    "P99": "8.64",
+    "P75": "2.5",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15285,7 +26365,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15298,7 +26380,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15311,7 +26395,24 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 69,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-http2-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15324,7 +26425,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15335,9 +26438,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "48.0",
-    "P99": "61.6"
+    "JobRuns": 32,
+    "P95": "47.9",
+    "P99": "61.42",
+    "P75": "6.25",
+    "P50": "3.5"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15348,9 +26453,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "11.95",
-    "P99": "45.63"
+    "JobRuns": 90,
+    "P95": "2.0",
+    "P99": "45.11",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15363,7 +26470,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "27.0",
-    "P99": "27.0"
+    "P99": "27.0",
+    "P75": "27.0",
+    "P50": "27.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15376,7 +26485,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "931.5",
-    "P99": "958.3"
+    "P99": "958.3",
+    "P75": "746.75",
+    "P50": "488.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15387,9 +26498,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "5.0",
-    "P99": "13.8"
+    "P99": "6.71",
+    "P75": "4.0",
+    "P50": "3.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15400,9 +26513,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
+    "JobRuns": 72,
     "P95": "0.0",
-    "P99": "23.5"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15415,7 +26530,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15426,9 +26543,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "3.7",
-    "P99": "541.77"
+    "JobRuns": 87,
+    "P95": "21.7",
+    "P99": "55.64",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-http2-external-lb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-http2-external-lb-reused-connections",
@@ -15439,9 +26573,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "190.1",
-    "P99": "666.96"
+    "JobRuns": 145,
+    "P95": "192.4",
+    "P99": "673.52",
+    "P75": "44.0",
+    "P50": "11.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15452,9 +26603,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1001,
+    "JobRuns": 1063,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15466,8 +26619,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "537.0",
-    "P99": "538.6"
+    "P95": "527.1",
+    "P99": "527.82",
+    "P75": "523.5",
+    "P50": "519.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15478,9 +26633,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "1.0",
-    "P99": "2.99"
+    "JobRuns": 167,
+    "P95": "0.7",
+    "P99": "5.34",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15492,8 +26649,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "1.0",
-    "P99": "1.0"
+    "P95": "2.7",
+    "P99": "2.94",
+    "P75": "1.5",
+    "P50": "0.5"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15504,22 +26663,26 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 915,
-    "P95": "4.0",
-    "P99": "8.0"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.13",
-    "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 576,
+    "JobRuns": 879,
     "P95": "3.0",
-    "P99": "6.25"
+    "P99": "7.22",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.13",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 615,
+    "P95": "2.0",
+    "P99": "7.86",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15530,9 +26693,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "2.0",
-    "P99": "4.0"
+    "P99": "3.2",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15543,9 +26708,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "17.0",
-    "P99": "19.38"
+    "JobRuns": 65,
+    "P95": "14.0",
+    "P99": "17.36",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15556,9 +26723,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "11.0",
-    "P99": "11.49"
+    "JobRuns": 50,
+    "P95": "10.55",
+    "P99": "11.51",
+    "P75": "7.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15569,9 +26738,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "1.8",
+    "P99": "1.96",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15582,9 +26753,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "12.25",
-    "P99": "12.85"
+    "JobRuns": 7,
+    "P95": "7.7",
+    "P99": "7.94",
+    "P75": "6.5",
+    "P50": "5.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15595,9 +26768,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "5.7",
+    "P99": "5.94",
+    "P75": "5.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15608,9 +26783,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "8.8",
-    "P99": "32.78"
+    "JobRuns": 87,
+    "P95": "1.0",
+    "P99": "32.84",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15621,9 +26798,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "798.0",
-    "P99": "1045.2"
+    "JobRuns": 17,
+    "P95": "777.4",
+    "P99": "1041.08",
+    "P75": "16.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15634,9 +26813,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "670.5",
-    "P99": "672.5"
+    "JobRuns": 19,
+    "P95": "668.5",
+    "P99": "672.1",
+    "P75": "331.5",
+    "P50": "244.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15647,9 +26828,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 167,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15661,8 +26844,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "443.25",
-    "P99": "444.65"
+    "P95": "440.45",
+    "P99": "444.09",
+    "P75": "402.75",
+    "P50": "382.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15673,22 +26858,26 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
+    "JobRuns": 483,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 458,
     "P95": "1.0",
-    "P99": "1.53"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 496,
-    "P95": "4.0",
-    "P99": "10.05"
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15699,9 +26888,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "5.0",
-    "P99": "14.0"
+    "JobRuns": 46,
+    "P95": "1.0",
+    "P99": "2.55",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15712,48 +26903,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 981,
-    "P95": "2.0",
-    "P99": "4.0"
+    "JobRuns": 852,
+    "P95": "3.0",
+    "P99": "7.49",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "2.0",
-    "P99": "2.44"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.0",
-    "P99": "11.0"
-  },
-  {
-    "BackendName": "openshift-api-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "9.7",
-    "P99": "10.54"
+    "P95": "2.7",
+    "P99": "10.4",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "11.0",
+    "P99": "15.56",
+    "P75": "4.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "10.25",
+    "P99": "11.65",
+    "P75": "6.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15764,9 +26963,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
+    "P95": "0.0",
+    "P99": "28.9",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "4104.35",
+    "P99": "4223.3",
+    "P75": "3858.0",
+    "P50": "2978.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "2.82",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "148.55",
+    "P99": "236.84",
+    "P75": "142.0",
+    "P50": "133.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.2",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "2.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
     "P95": "1.0",
-    "P99": "28.95"
+    "P99": "11.1",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "2.0",
+    "P99": "4.37",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "3.0",
+    "P99": "6.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.05",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "7.44",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "7.14",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "8.4",
+    "P99": "21.28",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "3.0",
+    "P99": "10.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "1.4",
+    "P99": "23.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "893.7",
+    "P99": "1317.13",
+    "P75": "676.75",
+    "P50": "472.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "24.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.6",
+    "P99": "18.92",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "17.0",
+    "P99": "24.0",
+    "P75": "9.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "41.35",
+    "P99": "88.36",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "454.0",
+    "P99": "776.8",
+    "P75": "188.75",
+    "P50": "84.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15777,9 +27428,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15792,7 +27445,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15803,9 +27458,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "4.95",
-    "P99": "51.59"
+    "JobRuns": 38,
+    "P95": "14.7",
+    "P99": "52.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15816,9 +27473,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15831,7 +27490,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15842,9 +27503,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15855,9 +27518,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15870,7 +27535,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15882,8 +27549,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "151.75",
-    "P99": "168.55"
+    "P95": "244.25",
+    "P99": "273.25",
+    "P75": "147.5",
+    "P50": "96.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15894,9 +27563,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15909,7 +27580,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15922,7 +27595,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15933,9 +27608,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15948,7 +27625,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "2.1",
-    "P99": "2.82"
+    "P99": "2.82",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15961,7 +27640,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15974,7 +27655,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -15985,9 +27668,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16000,7 +27700,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16011,9 +27713,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "18.5",
-    "P99": "43.2"
+    "JobRuns": 32,
+    "P95": "17.85",
+    "P99": "42.94",
+    "P75": "5.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16024,9 +27728,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "8.7",
-    "P99": "1158.74"
+    "JobRuns": 93,
+    "P95": "1.0",
+    "P99": "30.8",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16039,7 +27745,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "26.0",
-    "P99": "26.0"
+    "P99": "26.0",
+    "P75": "26.0",
+    "P50": "26.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16052,7 +27760,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "931.75",
-    "P99": "958.35"
+    "P99": "958.35",
+    "P75": "747.5",
+    "P50": "488.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16063,9 +27773,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "8.8"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16076,9 +27788,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "0.5",
-    "P99": "19.5"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "0.58",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16091,7 +27805,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "10.0",
-    "P99": "10.0"
+    "P99": "10.0",
+    "P75": "10.0",
+    "P50": "10.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16102,9 +27818,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "11.35",
-    "P99": "556.2"
+    "JobRuns": 87,
+    "P95": "47.1",
+    "P99": "200.5",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.35",
+    "P99": "0.87",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-new-connections",
@@ -16115,9 +27848,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "352.2",
-    "P99": "1056.78"
+    "JobRuns": 145,
+    "P95": "317.8",
+    "P99": "1021.32",
+    "P75": "100.0",
+    "P50": "33.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16128,9 +27878,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1001,
+    "JobRuns": 1063,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16142,8 +27894,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 3,
-    "P95": "537.0",
-    "P99": "538.6"
+    "P95": "528.0",
+    "P99": "528.8",
+    "P75": "524.0",
+    "P50": "519.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16154,9 +27908,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
+    "JobRuns": 167,
     "P95": "0.0",
-    "P99": "1.33"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16168,8 +27924,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "4.25",
-    "P99": "4.85"
+    "P95": "2.55",
+    "P99": "2.91",
+    "P75": "0.75",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16180,9 +27938,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 919,
+    "JobRuns": 883,
     "P95": "4.0",
-    "P99": "8.0"
+    "P99": "7.18",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16193,9 +27953,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 573,
+    "JobRuns": 612,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16206,9 +27968,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16219,9 +27983,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 63,
-    "P95": "10.0",
-    "P99": "13.0"
+    "JobRuns": 65,
+    "P95": "9.8",
+    "P99": "13.0",
+    "P75": "7.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16232,9 +27998,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 52,
-    "P95": "13.0",
-    "P99": "14.49"
+    "JobRuns": 50,
+    "P95": "12.55",
+    "P99": "14.0",
+    "P75": "10.0",
+    "P50": "6.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16245,9 +28013,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
-    "P95": "0.0",
-    "P99": "0.0"
+    "JobRuns": 3,
+    "P95": "2.8",
+    "P99": "2.96",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16258,9 +28028,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 6,
-    "P95": "12.5",
-    "P99": "12.9"
+    "JobRuns": 7,
+    "P95": "7.1",
+    "P99": "7.82",
+    "P75": "5.0",
+    "P50": "5.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16271,9 +28043,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 4,
-    "P95": "9.85",
-    "P99": "9.97"
+    "JobRuns": 7,
+    "P95": "5.7",
+    "P99": "5.94",
+    "P75": "5.0",
+    "P50": "4.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16284,9 +28058,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "6.85",
-    "P99": "27.04"
+    "JobRuns": 87,
+    "P95": "1.0",
+    "P99": "21.1",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16297,9 +28073,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 16,
-    "P95": "790.25",
-    "P99": "1030.85"
+    "JobRuns": 17,
+    "P95": "770.2",
+    "P99": "1026.84",
+    "P75": "3.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16310,9 +28088,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 11,
-    "P95": "416.0",
-    "P99": "417.6"
+    "JobRuns": 19,
+    "P95": "383.4",
+    "P99": "407.88",
+    "P75": "210.0",
+    "P50": "127.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16323,9 +28103,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 242,
+    "P95": "0.95",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16337,8 +28119,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "Y",
     "JobRuns": 8,
-    "P95": "443.95",
-    "P99": "444.79"
+    "P95": "440.45",
+    "P99": "444.09",
+    "P75": "402.75",
+    "P50": "383.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16349,9 +28133,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "1.0",
-    "P99": "1.0"
+    "JobRuns": 483,
+    "P95": "0.9",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16362,9 +28148,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 497,
-    "P95": "4.0",
-    "P99": "10.0"
+    "JobRuns": 459,
+    "P95": "2.0",
+    "P99": "3.42",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16375,9 +28163,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "3.0",
-    "P99": "3.5"
+    "JobRuns": 46,
+    "P95": "2.75",
+    "P99": "3.55",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16388,48 +28178,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 980,
+    "JobRuns": 851,
     "P95": "1.0",
-    "P99": "1.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
     "Release": "4.14",
     "FromRelease": "4.14",
     "Platform": "gcp",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
-    "P95": "0.2",
-    "P99": "1.0"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 66,
-    "P95": "10.75",
-    "P99": "12.35"
-  },
-  {
-    "BackendName": "openshift-api-reused-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "metal",
     "Architecture": "amd64",
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 47,
-    "P95": "12.0",
-    "P99": "12.54"
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 62,
+    "P95": "8.95",
+    "P99": "11.78",
+    "P75": "3.75",
+    "P50": "1.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 36,
+    "P95": "12.25",
+    "P99": "14.3",
+    "P75": "8.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16440,9 +28238,461 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
+    "P95": "0.9",
+    "P99": "26.44",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 21,
     "P95": "0.0",
-    "P99": "26.62"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 27,
+    "P95": "0.7",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 45,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 152,
+    "P95": "4104.35",
+    "P99": "4223.3",
+    "P75": "3858.0",
+    "P50": "2978.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 54,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "alibaba",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 753,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 110,
+    "P95": "148.0",
+    "P99": "475.42",
+    "P75": "142.0",
+    "P50": "107.5"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 481,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "3.3",
+    "P99": "5.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 296,
+    "P95": "2.0",
+    "P99": "5.15",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 264,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 304,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 276,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "3.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": null,
+    "JobRuns": 22,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 155,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 29,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "ovirt",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 150,
+    "P95": "0.0",
+    "P99": "6.63",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 313,
+    "P95": "3.0",
+    "P99": "13.88",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "vsphere",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 55,
+    "P95": "3.0",
+    "P99": "11.46",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 327,
+    "P95": "0.0",
+    "P99": "24.22",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "single",
+    "MasterNodesUpdated": null,
+    "JobRuns": 74,
+    "P95": "894.7",
+    "P99": "1317.13",
+    "P75": "676.75",
+    "P50": "472.5"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 193,
+    "P95": "0.0",
+    "P99": "24.24",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 69,
+    "P95": "0.6",
+    "P99": "22.56",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 128,
+    "P95": "0.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 80,
+    "P95": "29.2",
+    "P99": "71.21",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.13",
+    "FromRelease": "",
+    "Platform": "libvirt",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": null,
+    "JobRuns": 58,
+    "P95": "321.25",
+    "P99": "700.73",
+    "P75": "136.0",
+    "P50": "67.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16453,9 +28703,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 14,
+    "JobRuns": 18,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16468,7 +28720,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16479,9 +28733,11 @@
     "Network": "sdn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 50,
-    "P95": "4.95",
-    "P99": "51.59"
+    "JobRuns": 38,
+    "P95": "14.7",
+    "P99": "52.67",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16492,9 +28748,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16507,7 +28765,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16518,9 +28778,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16531,9 +28793,11 @@
     "Network": "ovn",
     "Topology": "external",
     "MasterNodesUpdated": "N",
-    "JobRuns": 338,
+    "JobRuns": 531,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16546,7 +28810,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16558,8 +28824,10 @@
     "Topology": "single",
     "MasterNodesUpdated": "N",
     "JobRuns": 136,
-    "P95": "151.5",
-    "P99": "170.55"
+    "P95": "244.25",
+    "P99": "274.6",
+    "P75": "148.25",
+    "P50": "96.5"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16570,9 +28838,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 521,
+    "JobRuns": 541,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16584,8 +28854,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "0.85",
-    "P99": "0.97"
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "1.0",
+    "P50": "0.5"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16598,7 +28870,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 18,
     "P95": "3.15",
-    "P99": "3.83"
+    "P99": "3.83",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16609,9 +28883,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 2,
+    "JobRuns": 3,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16624,7 +28900,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 19,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16637,7 +28915,9 @@
     "MasterNodesUpdated": "N",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16650,7 +28930,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 11,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16661,9 +28943,26 @@
     "Network": "ovn",
     "Topology": "single",
     "MasterNodesUpdated": "N",
-    "JobRuns": 69,
+    "JobRuns": 70,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "metal",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 1,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16676,7 +28975,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 13,
     "P95": "0.4",
-    "P99": "0.88"
+    "P99": "0.88",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16687,9 +28988,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 31,
-    "P95": "8.5",
-    "P99": "9.7"
+    "JobRuns": 32,
+    "P95": "8.45",
+    "P99": "9.69",
+    "P75": "5.25",
+    "P50": "2.5"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16700,9 +29003,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 138,
-    "P95": "2.15",
-    "P99": "27.78"
+    "JobRuns": 93,
+    "P95": "1.0",
+    "P99": "2.76",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16715,7 +29020,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "22.0",
-    "P99": "22.0"
+    "P99": "22.0",
+    "P75": "22.0",
+    "P50": "22.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16728,7 +29035,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 6,
     "P95": "931.5",
-    "P99": "958.3"
+    "P99": "958.3",
+    "P75": "746.75",
+    "P50": "488.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16739,9 +29048,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 236,
+    "JobRuns": 230,
     "P95": "0.0",
-    "P99": "9.1"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16752,9 +29063,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 76,
-    "P95": "0.25",
-    "P99": "18.75"
+    "JobRuns": 72,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16767,7 +29080,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 1,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16778,9 +29093,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 114,
-    "P95": "5.5",
-    "P99": "542.81"
+    "JobRuns": 87,
+    "P95": "17.8",
+    "P99": "71.62",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "openshift-api-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 14,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "openshift-api-reused-connections",
@@ -16791,9 +29123,26 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "N",
-    "JobRuns": 127,
-    "P95": "245.6",
-    "P99": "781.98"
+    "JobRuns": 145,
+    "P95": "199.4",
+    "P99": "760.0",
+    "P75": "50.0",
+    "P50": "14.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16804,9 +29153,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1009,
+    "JobRuns": 1077,
     "P95": "1.0",
-    "P99": "8.92"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16819,7 +29170,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 168,
     "P95": "1.0",
-    "P99": "4.0"
+    "P99": "1.66",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16832,7 +29185,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
     "P95": "0.0",
-    "P99": "0.0"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16843,9 +29198,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 924,
+    "JobRuns": 896,
     "P95": "0.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16856,9 +29213,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 582,
+    "JobRuns": 621,
     "P95": "2.0",
-    "P99": "5.0"
+    "P99": "4.8",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16869,9 +29228,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
-    "P95": "2.0",
-    "P99": "15.48"
+    "JobRuns": 41,
+    "P95": "1.0",
+    "P99": "18.2",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16882,9 +29243,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
-    "P95": "3.65",
-    "P99": "17.13"
+    "JobRuns": 87,
+    "P95": "1.0",
+    "P99": "4.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16895,48 +29258,56 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "1.0",
-    "P99": "5.64"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "aws",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "1.0",
-    "P99": "6.0"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "ovn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 497,
-    "P95": "1.0",
-    "P99": "4.0"
-  },
-  {
-    "BackendName": "service-load-balancer-with-pdb-new-connections",
-    "Release": "4.14",
-    "FromRelease": "4.14",
-    "Platform": "azure",
-    "Architecture": "amd64",
-    "Network": "sdn",
-    "Topology": "ha",
-    "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
+    "JobRuns": 241,
     "P95": "0.0",
-    "P99": "10.5"
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 483,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 463,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "4.14",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 46,
+    "P95": "0.0",
+    "P99": "1.1",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16947,9 +29318,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 987,
-    "P95": "1.7",
-    "P99": "3.0"
+    "JobRuns": 868,
+    "P95": "2.0",
+    "P99": "7.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16960,9 +29333,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
+    "JobRuns": 47,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "3.08",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-new-connections",
@@ -16973,9 +29348,206 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
-    "P95": "2.95",
-    "P99": "5.77"
+    "JobRuns": 43,
+    "P95": "0.0",
+    "P99": "2.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 103,
+    "P95": "0.0",
+    "P99": "1.98",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 125,
+    "P95": "0.8",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 101,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 71,
+    "P95": "0.0",
+    "P99": "8.1",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "3.46",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 37,
+    "P95": "0.2",
+    "P99": "1.64",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 80,
+    "P95": "0.05",
+    "P99": "1.21",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 30,
+    "P95": "5.2",
+    "P99": "8.42",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 19,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 7,
+    "P95": "18.5",
+    "P99": "19.7",
+    "P75": "15.0",
+    "P50": "13.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 5,
+    "P95": "1305.0",
+    "P99": "1318.6",
+    "P75": "1237.0",
+    "P50": "1229.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-new-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 4,
+    "P95": "149.35",
+    "P99": "153.07",
+    "P75": "130.75",
+    "P50": "92.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "4.12",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "Y",
+    "JobRuns": 2,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -16986,9 +29558,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 1009,
+    "JobRuns": 1077,
     "P95": "1.0",
-    "P99": "3.0"
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17001,7 +29575,9 @@
     "MasterNodesUpdated": "Y",
     "JobRuns": 168,
     "P95": "1.0",
-    "P99": "1.33"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17013,8 +29589,10 @@
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
     "JobRuns": 4,
-    "P95": "2.0",
-    "P99": "2.0"
+    "P95": "2.85",
+    "P99": "2.97",
+    "P75": "2.25",
+    "P50": "2.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17025,9 +29603,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 924,
+    "JobRuns": 896,
     "P95": "2.0",
-    "P99": "2.0"
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17038,9 +29618,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 582,
+    "JobRuns": 621,
     "P95": "4.0",
-    "P99": "4.0"
+    "P99": "4.0",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17051,9 +29633,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 53,
+    "JobRuns": 41,
     "P95": "4.0",
-    "P99": "5.0"
+    "P99": "4.6",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17064,9 +29648,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 88,
+    "JobRuns": 87,
     "P95": "1.0",
-    "P99": "2.0"
+    "P99": "3.14",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17077,9 +29663,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 168,
-    "P95": "1.0",
-    "P99": "3.33"
+    "JobRuns": 241,
+    "P95": "0.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17090,9 +29678,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 548,
-    "P95": "1.0",
-    "P99": "2.0"
+    "JobRuns": 483,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17103,9 +29693,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 497,
+    "JobRuns": 463,
     "P95": "2.0",
-    "P99": "3.0"
+    "P99": "3.0",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17116,9 +29708,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 51,
-    "P95": "1.0",
-    "P99": "3.0"
+    "JobRuns": 46,
+    "P95": "2.0",
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17129,9 +29723,11 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 987,
+    "JobRuns": 868,
     "P95": "3.0",
-    "P99": "4.0"
+    "P99": "4.0",
+    "P75": "2.0",
+    "P50": "1.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17142,9 +29738,11 @@
     "Network": "sdn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 57,
+    "JobRuns": 47,
     "P95": "4.0",
-    "P99": "4.0"
+    "P99": "4.0",
+    "P75": "3.0",
+    "P50": "2.0"
   },
   {
     "BackendName": "service-load-balancer-with-pdb-reused-connections",
@@ -17155,8 +29753,190 @@
     "Network": "ovn",
     "Topology": "ha",
     "MasterNodesUpdated": "Y",
-    "JobRuns": 42,
+    "JobRuns": 43,
+    "P95": "0.9",
+    "P99": "2.74",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "external",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 103,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 125,
+    "P95": "0.8",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 101,
     "P95": "1.0",
-    "P99": "2.77"
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 71,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 60,
+    "P95": "0.0",
+    "P99": "0.41",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 37,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "gcp",
+    "Architecture": "amd64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 80,
+    "P95": "1.0",
+    "P99": "2.0",
+    "P75": "1.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 30,
+    "P95": "2.0",
+    "P99": "2.71",
+    "P75": "0.75",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "aws",
+    "Architecture": "arm64",
+    "Network": "sdn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 19,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.0",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "azure",
+    "Architecture": "arm64",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 7,
+    "P95": "1.0",
+    "P99": "1.0",
+    "P75": "0.5",
+    "P50": "0.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "",
+    "Architecture": "ppc64le",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 5,
+    "P95": "184.6",
+    "P99": "218.52",
+    "P75": "15.0",
+    "P50": "9.0"
+  },
+  {
+    "BackendName": "service-load-balancer-with-pdb-reused-connections",
+    "Release": "4.14",
+    "FromRelease": "",
+    "Platform": "ibmcloud",
+    "Architecture": "s390x",
+    "Network": "ovn",
+    "Topology": "ha",
+    "MasterNodesUpdated": "N",
+    "JobRuns": 4,
+    "P95": "0.0",
+    "P99": "0.0",
+    "P75": "0.0",
+    "P50": "0.0"
   }
 ]

--- a/pkg/monitortestlibrary/historicaldata/next_best_guess.go
+++ b/pkg/monitortestlibrary/historicaldata/next_best_guess.go
@@ -2,6 +2,7 @@ package historicaldata
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -14,6 +15,7 @@ var nextBestGuessers = []NextBestKey{
 	MicroReleaseUpgrade,
 	//	MinorReleaseUpgrade,
 	PreviousReleaseUpgrade,
+
 	combine(PreviousReleaseUpgrade, MicroReleaseUpgrade),
 	//	combine(PreviousReleaseUpgrade, MinorReleaseUpgrade),
 
@@ -188,4 +190,39 @@ func combine(nextBestKeys ...NextBestKey) NextBestKey {
 		}
 		return curr, true
 	}
+}
+
+func CurrentReleaseFromMap(releasesInQueryResults map[string]bool) string {
+	var releaseSlice []struct {
+		Key   string
+		Value bool
+	}
+	for key, value := range releasesInQueryResults {
+		releaseSlice = append(releaseSlice, struct {
+			Key   string
+			Value bool
+		}{Key: key, Value: value})
+	}
+
+	// Sort the slice in descending order
+	sort.Slice(releaseSlice, func(i, j int) bool {
+		return compareReleaseString(releaseSlice[i].Key, releaseSlice[j].Key)
+	})
+	var firstKey string
+	// Access the first key from the sorted slice
+	if len(releaseSlice) > 0 {
+		firstKey = releaseSlice[0].Key
+	}
+	return firstKey
+}
+
+func compareReleaseString(one, two string) bool {
+	major1 := getMajor(one)
+	major2 := getMajor(two)
+	if major1 == major2 {
+		minor1 := getMinor(one)
+		minor2 := getMinor(two)
+		return minor1 > minor2
+	}
+	return major1 > major2
 }

--- a/pkg/monitortestlibrary/historicaldata/next_best_guess_test.go
+++ b/pkg/monitortestlibrary/historicaldata/next_best_guess_test.go
@@ -1,0 +1,44 @@
+package historicaldata
+
+import "testing"
+
+func TestCurrentReleaseFromMap(t *testing.T) {
+	// Test case: Empty input map
+	releasesInQueryResults := make(map[string]bool)
+	result := CurrentReleaseFromMap(releasesInQueryResults)
+	if result != "" {
+		t.Errorf("Expected empty string, but got %s", result)
+	}
+
+	// Test case: Non-empty input map
+	releasesInQueryResults = map[string]bool{
+		"4.10.0": true,
+		"4.11.1": false,
+		"4.14.0": true,
+		"4.12.4": true,
+	}
+	result = CurrentReleaseFromMap(releasesInQueryResults)
+	if result != "4.14.0" {
+		t.Errorf("Expected '4.14.0', but got %s", result)
+	}
+}
+
+func TestCompareReleaseString(t *testing.T) {
+	// Test case: Same major version, different minor version (4.11 > 4.10)
+	result := compareReleaseString("4.11.0", "4.10.0")
+	if !result {
+		t.Errorf("Expected true, but got false")
+	}
+
+	// Test case: Same major and minor versions (4.12 == 4.12)
+	result = compareReleaseString("4.12.0", "4.12.0")
+	if result {
+		t.Errorf("Expected false, but got true")
+	}
+
+	// Test case: Different major versions (5.0 > 4.11)
+	result = compareReleaseString("5.0.0", "4.11.0")
+	if !result {
+		t.Errorf("Expected true, but got false")
+	}
+}


### PR DESCRIPTION
This is the second part to https://github.com/openshift/ci-tools/pull/3562 PR for origin test to support both releases .
Both alerts and disruption tests are updated along with query_results.json.
/cc @dgoodwin @neisw 