### PR TITLE
Fix kubevirt test flake caused by pod name collision

### DIFF
--- a/test/extended/kubevirt/util.go
+++ b/test/extended/kubevirt/util.go
@@ -112,6 +112,10 @@ func checkConnectivityToHostWithCLI(f *e2e.Framework, oc *exutil.CLI, nodeName s
 
 	e2e.Logf("Creating an exec pod on node %v", nodeName)
 	execPod := exutil.CreateExecPodOrFail(f.ClientSet, namespace, fmt.Sprintf("execpod-sourceip-%s", nodeName), func(pod *corev1.Pod) {
+		if pod.GenerateName == "" {
+			pod.GenerateName = pod.Name
+			pod.Name = ""
+		}
 		pod.Spec.NodeName = nodeName
 		pod.Spec.HostNetwork = hostNetwork
 	})
@@ -174,6 +178,10 @@ func platformType(configClient configv1client.Interface) (configv1.PlatformType,
 func checkConnectivityToHost(f *e2e.Framework, nodeName string, podName string, host string, timeout time.Duration, hostNetwork bool) error {
 	e2e.Logf("Creating an exec pod on node %v", nodeName)
 	execPod := exutil.CreateExecPodOrFail(f.ClientSet, f.Namespace.Name, fmt.Sprintf("execpod-sourceip-%s", nodeName), func(pod *corev1.Pod) {
+		if pod.GenerateName == "" {
+			pod.GenerateName = pod.Name
+			pod.Name = ""
+		}
 		pod.Spec.NodeName = nodeName
 		pod.Spec.HostNetwork = hostNetwork
 	})


### PR DESCRIPTION

When running tests in parallel, it's possible to get a failure when creating our exec pods due to naming collisions between tests. By using the GenerateName for our exec pod, we avoid the collision


below is an example failure
```
fail [k8s.io/kubernetes@v1.27.1/test/e2e/framework/pod/resource.go:367]: failed to create new exec pod in namespace: clusters-vossel2
Unexpected error:
    <*errors.StatusError | 0xc0067bf900>: 
    pods "execpod-sourceip-ip-10-0-0-126.us-west-1.compute.internal" already exists
    {
        ErrStatus: 
            code: 409
            details:
              kind: pods
              name: execpod-sourceip-ip-10-0-0-126.us-west-1.compute.internal
            message: pods "execpod-sourceip-ip-10-0-0-126.us-west-1.compute.internal" already
              exists
            metadata: {}
            reason: AlreadyExists
            status: Failure,
    }
occurred
```