### PR TITLE
Bug OCPBUGS-17483: Skip invariant load balancer test for OpenStack

### DIFF
--- a/pkg/invariants/network/disruptionserviceloadbalancer/invariant.go
+++ b/pkg/invariants/network/disruptionserviceloadbalancer/invariant.go
@@ -89,7 +89,8 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 		infra.Status.PlatformStatus.Type == configv1.LibvirtPlatformType ||
 		infra.Status.PlatformStatus.Type == configv1.NutanixPlatformType ||
 		infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType ||
-		infra.Status.PlatformStatus.Type == configv1.BareMetalPlatformType {
+		infra.Status.PlatformStatus.Type == configv1.BareMetalPlatformType ||
+		infra.Status.PlatformStatus.Type == configv1.OpenStackPlatformType {
 		w.notSupportedReason = fmt.Sprintf("platform %q is not supported", infra.Status.PlatformStatus.Type)
 	}
 	// single node clusters are not supported because the replication controller has 2 replicas with anti-affinity for running on the same node.


### PR DESCRIPTION
The disruption Service tests that were previously run and skipped for OpenStack on upgrades jobs, are now run on various jobs unrelated to upgrades. This can cause the job run to fail when proxy installations are run with OpenStack given floating ip is not supported in this scenario. This commit fixes the issue by continue to skips those tests for OpenStack.