### PR TITLE
OCP-66086-Automate PSAP NTO Prevent from stalld continually restarting

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/kubevirt"
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
+	_ "github.com/openshift/origin/test/extended/node_tuning"
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/olm"
 	_ "github.com/openshift/origin/test/extended/operators"

--- a/test/extended/node_tuning/OWNERS
+++ b/test/extended/node_tuning/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - liqcui
+  - shahsahil264
+  - jmencak
+approvers:
+  - liqcui
+  - shahsahil264
+  - jmencak

--- a/test/extended/node_tuning/node_tuning.go
+++ b/test/extended/node_tuning/node_tuning.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-node-tuning] NTO should", func() {
 	// author: liqcui@redhat.com
 	// OCP Bugs: https://issues.redhat.com/browse/OCPBUGS-11150
 
-	g.It("OCP-66086 NTO Prevent from stalld continually restarting [slow]", func() {
+	g.It("OCP-66086 NTO Prevent from stalld continually restarting [Slow]", func() {
 		e2e.Logf("get the first rhcos worker nodes as label node")
 		firstCoreOSWorkerNodes, err := exutil.GetFirstCoreOsWorkerNode(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/node_tuning/node_tuning.go
+++ b/test/extended/node_tuning/node_tuning.go
@@ -1,0 +1,116 @@
+package node_tuning
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-node-tuning] NTO should", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		ntoNamespace        = "openshift-cluster-node-tuning-operator"
+		oc                  = exutil.NewCLIWithoutNamespace("nto")
+		buildPruningBaseDir = exutil.FixturePath("testdata", "node_tuning")
+		ntoStalldFile       = filepath.Join(buildPruningBaseDir, "nto-stalld.yaml")
+		stalldCurrentPID    string
+	)
+
+	// OCP-66086 - [OCPBUGS-11150] Node Tuning Operator - NTO Prevent from stalld continually restarting
+	// author: liqcui@redhat.com
+	// OCP Bugs: https://issues.redhat.com/browse/OCPBUGS-11150
+
+	g.It("OCP-66086 NTO Prevent from stalld continually restarting [slow]", func() {
+		e2e.Logf("get the first rhcos worker nodes as label node")
+		firstCoreOSWorkerNodes, err := exutil.GetFirstCoreOsWorkerNode(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if len(firstCoreOSWorkerNodes) == 0 {
+			g.Skip("no rhcos worker node was found - skipping test ...")
+		}
+		e2e.Logf("the firstCoreOSWorkerNodes is:%v", firstCoreOSWorkerNodes)
+
+		defer oc.AsAdmin().WithoutNamespace().Run("label").Args("node", firstCoreOSWorkerNodes, "node-role.kubernetes.io/worker-stalld-", "--overwrite").Execute()
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-stalld", "-n", ntoNamespace, "--ignore-not-found").Execute()
+
+		e2e.Logf("label the first rhcos node with node-role.kubernetes.io/worker-stalld=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", firstCoreOSWorkerNodes, "node-role.kubernetes.io/worker-stalld=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		e2e.Logf("create custom profile openshift-stalld")
+		err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", ntoStalldFile, "-n", ntoNamespace).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		e2e.Logf("assert if the tuned openshift-stalld created successfully")
+		tunedStdOut, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "-n", ntoNamespace).Output()
+		e2e.Logf("current tuned status is:\n%s,", tunedStdOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedStdOut).NotTo(o.BeEmpty())
+		o.Expect(tunedStdOut).To(o.ContainSubstring("openshift-stalld"))
+
+		// Assert if profile applied to label node with re-try
+		o.Eventually(func() bool {
+			appliedStatus, err1 := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profile", firstCoreOSWorkerNodes, `-ojsonpath='{.status.conditions[?(@.type=="Applied")].status}'`).Output()
+			tunedProfile, err2 := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profile", firstCoreOSWorkerNodes, "-ojsonpath={.status.tunedProfile}").Output()
+			if err1 != nil || err2 != nil || strings.Contains(appliedStatus, "False") || strings.Contains(appliedStatus, "Unknown") || tunedProfile != "openshift-stalld" {
+				e2e.Logf("failed to apply custom profile to nodes, the status is %s and profile is %s, check again", appliedStatus, tunedProfile)
+			}
+			return strings.Contains(appliedStatus, "True") && tunedProfile == "openshift-stalld"
+		}, 5*time.Second, time.Second).Should(o.BeTrue())
+
+		e2e.Logf("assert if the custom profile openshift-stalld applied to label node")
+		profileStdOut, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profile", firstCoreOSWorkerNodes, "-ojsonpath={.status.tunedProfile}").Output()
+		e2e.Logf("current profile status is [ %s ] on [ %s ]", profileStdOut, firstCoreOSWorkerNodes)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileStdOut).NotTo(o.BeEmpty())
+		o.Expect(profileStdOut).To(o.ContainSubstring("openshift-stalld"))
+
+		e2e.Logf("check if stalld service is running ...")
+		stalldStatus, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, firstCoreOSWorkerNodes, ntoNamespace, "systemctl", "status", "stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stalldStatus).To(o.ContainSubstring("active (running)"))
+
+		e2e.Logf("assert if stalld service restart ...")
+		stalldPreviousPID, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, firstCoreOSWorkerNodes, ntoNamespace, "pidof", "stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stalldPreviousPID).NotTo(o.BeEmpty())
+		e2e.Logf("record the previous stalld PID is <stalldPreviousPID: %v>", stalldPreviousPID)
+
+		e2e.Logf("start to periodically check stalld PID and compare if stalld pid change")
+		// Wait for 10 minutes and check stalld pid in the meantime and exit if we found stalld restarted
+		errWait := wait.Poll(2*time.Minute, 10*time.Minute, func() (bool, error) {
+			stalldCurrentPID, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, firstCoreOSWorkerNodes, ntoNamespace, "pidof", "stalld")
+			e2e.Logf("the current PID of stalld is < %v >", stalldCurrentPID)
+			// the wait poll will exit if stalld restart or anbonrmal
+			if err != nil || stalldCurrentPID != stalldPreviousPID {
+				e2e.Logf("[ NOTE ] <stalldPreviousPID: %v stalldCurrentPID: %v > The PID of stalld has been changed due to stalld service restarted.", stalldPreviousPID, stalldCurrentPID)
+				return true, nil
+			}
+			e2e.Logf("no restart of stalld process as expected, the stalld PID still is %v", stalldCurrentPID)
+			return false, nil
+		})
+
+		e2e.Logf("get how many minutes stalld process keep up and running ...")
+		stalldRuntimeDuration, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, firstCoreOSWorkerNodes, ntoNamespace, "/bin/bash", "-c", "ps -o etime= -p "+stalldCurrentPID)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stalldRuntimeDuration).NotTo(o.BeEmpty())
+		e2e.Logf("the the stalld process keep running for %v", stalldRuntimeDuration)
+
+		if errWait != nil {
+			e2e.Logf("%v", errWait)
+			return
+		}
+
+		err = fmt.Errorf("case: %v\nexpected error got because of %v", g.CurrentSpecReport().FullText(), fmt.Sprintf("stalld service restarted : %v", errWait))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -420,6 +420,7 @@
 // test/extended/testdata/net-attach-defs/whereabouts-nad.yml
 // test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml
 // test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml
+// test/extended/testdata/node_tuning/nto-stalld.yaml
 // test/extended/testdata/oauthserver/cabundle-cm.yaml
 // test/extended/testdata/oauthserver/oauth-network.yaml
 // test/extended/testdata/oauthserver/oauth-pod.yaml
@@ -48821,6 +48822,46 @@ func testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml() (*asset, error)
 	return a, nil
 }
 
+var _testExtendedTestdataNode_tuningNtoStalldYaml = []byte(`apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-stalld
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift profile
+      include=openshift-node,realtime
+      
+      [sysctl]
+      kernel.sched_rt_runtime_us = -1
+      
+      [service]
+      service.stalld=start,enable
+    name: openshift-stalld
+  recommend:
+  - match:
+    - label: node-role.kubernetes.io/worker-stalld
+    priority: 20
+    profile: openshift-stalld
+`)
+
+func testExtendedTestdataNode_tuningNtoStalldYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataNode_tuningNtoStalldYaml, nil
+}
+
+func testExtendedTestdataNode_tuningNtoStalldYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataNode_tuningNtoStalldYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/node_tuning/nto-stalld.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataOauthserverCabundleCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -54611,6 +54652,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/net-attach-defs/whereabouts-nad.yml":                                             testExtendedTestdataNetAttachDefsWhereaboutsNadYml,
 	"test/extended/testdata/net-attach-defs/whereabouts-race-awake.yml":                                      testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml,
 	"test/extended/testdata/net-attach-defs/whereabouts-race-sleepy.yml":                                     testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml,
+	"test/extended/testdata/node_tuning/nto-stalld.yaml":                                                     testExtendedTestdataNode_tuningNtoStalldYaml,
 	"test/extended/testdata/oauthserver/cabundle-cm.yaml":                                                    testExtendedTestdataOauthserverCabundleCmYaml,
 	"test/extended/testdata/oauthserver/oauth-network.yaml":                                                  testExtendedTestdataOauthserverOauthNetworkYaml,
 	"test/extended/testdata/oauthserver/oauth-pod.yaml":                                                      testExtendedTestdataOauthserverOauthPodYaml,
@@ -55343,6 +55385,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"whereabouts-nad.yml":         {testExtendedTestdataNetAttachDefsWhereaboutsNadYml, map[string]*bintree{}},
 					"whereabouts-race-awake.yml":  {testExtendedTestdataNetAttachDefsWhereaboutsRaceAwakeYml, map[string]*bintree{}},
 					"whereabouts-race-sleepy.yml": {testExtendedTestdataNetAttachDefsWhereaboutsRaceSleepyYml, map[string]*bintree{}},
+				}},
+				"node_tuning": {nil, map[string]*bintree{
+					"nto-stalld.yaml": {testExtendedTestdataNode_tuningNtoStalldYaml, map[string]*bintree{}},
 				}},
 				"oauthserver": {nil, map[string]*bintree{
 					"cabundle-cm.yaml":   {testExtendedTestdataOauthserverCabundleCmYaml, map[string]*bintree{}},

--- a/test/extended/testdata/node_tuning/OWNERS
+++ b/test/extended/testdata/node_tuning/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - liqcui
+  - shahsahil264
+  - jmencak
+approvers:
+  - liqcui
+  - shahsahil264
+  - jmencak

--- a/test/extended/testdata/node_tuning/nto-stalld.yaml
+++ b/test/extended/testdata/node_tuning/nto-stalld.yaml
@@ -1,0 +1,23 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-stalld
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift profile
+      include=openshift-node,realtime
+      
+      [sysctl]
+      kernel.sched_rt_runtime_us = -1
+      
+      [service]
+      service.stalld=start,enable
+    name: openshift-stalld
+  recommend:
+  - match:
+    - label: node-role.kubernetes.io/worker-stalld
+    priority: 20
+    profile: openshift-stalld

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1401,7 +1401,7 @@ var Annotations = map[string]string{
 
 	"[sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of Endpoints pointing to the cluster or service network": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-node-tuning] NTO should OCP-66086 NTO Prevent from stalld continually restarting [slow]": " [Suite:openshift/conformance/parallel]",
+	"[sig-node-tuning] NTO should OCP-66086 NTO Prevent from stalld continually restarting [Slow]": "",
 
 	"[sig-node] Managed cluster record the number of nodes at the beginning of the tests [Early]": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1401,6 +1401,8 @@ var Annotations = map[string]string{
 
 	"[sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of Endpoints pointing to the cluster or service network": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-node-tuning] NTO should OCP-66086 NTO Prevent from stalld continually restarting [slow]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node] Managed cluster record the number of nodes at the beginning of the tests [Early]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-node] Managed cluster should report ready nodes the entire duration of the test run [Late][apigroup:monitoring.coreos.com]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/nodes.go
+++ b/test/extended/util/nodes.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// GetClusterNodesBy returns the cluster nodes by role
+func GetClusterNodesBy(oc *CLI, role string) ([]string, error) {
+	nodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", "-l", "node-role.kubernetes.io/"+role, "-o", "jsonpath='{.items[*].metadata.name}'").Output()
+	return strings.Split(strings.Trim(nodes, "'"), " "), err
+}
+
+// GetFirstCoreOsWorkerNode returns the first CoreOS worker node
+func GetFirstCoreOsWorkerNode(oc *CLI) (string, error) {
+	return getFirstNodeByOsID(oc, "worker", "rhcos")
+}
+
+// getFirstNodeByOsID returns the cluster node by role and os id
+func getFirstNodeByOsID(oc *CLI, role string, osID string) (string, error) {
+	nodes, err := GetClusterNodesBy(oc, role)
+	for _, node := range nodes {
+		stdout, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node/"+node, "-o", "jsonpath=\"{.metadata.labels.node\\.openshift\\.io/os_id}\"").Output()
+		if strings.Trim(stdout, "\"") == osID {
+			return node, err
+		}
+	}
+	return "", err
+}
+
+// DebugNodeRetryWithOptionsAndChroot launches debug container using chroot with options
+// and waitPoll to avoid "error: unable to create the debug pod" and do retry
+func DebugNodeRetryWithOptionsAndChroot(oc *CLI, nodeName string, debugNodeNamespace string, cmd ...string) (string, error) {
+	var (
+		cargs  []string
+		stdOut string
+		err    error
+	)
+	cargs = []string{"node/" + nodeName, "-n" + debugNodeNamespace, "--", "chroot", "/host"}
+	cargs = append(cargs, cmd...)
+	wait.Poll(3*time.Second, 30*time.Second, func() (bool, error) {
+		stdOut, _, err = oc.AsAdmin().WithoutNamespace().Run("debug").Args(cargs...).Outputs()
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	return stdOut, err
+}

--- a/test/extended/util/nodes.go
+++ b/test/extended/util/nodes.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// GetClusterNodesBy returns the cluster nodes by role
+// GetClusterNodesByRole returns the cluster nodes by role
 func GetClusterNodesByRole(oc *CLI, role string) ([]string, error) {
 	nodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", "-l", "node-role.kubernetes.io/"+role, "-o", "jsonpath='{.items[*].metadata.name}'").Output()
 	return strings.Split(strings.Trim(nodes, "'"), " "), err

--- a/test/extended/util/nodes.go
+++ b/test/extended/util/nodes.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetClusterNodesBy returns the cluster nodes by role
-func GetClusterNodesBy(oc *CLI, role string) ([]string, error) {
+func GetClusterNodesByRole(oc *CLI, role string) ([]string, error) {
 	nodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", "-l", "node-role.kubernetes.io/"+role, "-o", "jsonpath='{.items[*].metadata.name}'").Output()
 	return strings.Split(strings.Trim(nodes, "'"), " "), err
 }

--- a/test/extended/util/nodes.go
+++ b/test/extended/util/nodes.go
@@ -20,7 +20,7 @@ func GetFirstCoreOsWorkerNode(oc *CLI) (string, error) {
 
 // getFirstNodeByOsID returns the cluster node by role and os id
 func getFirstNodeByOsID(oc *CLI, role string, osID string) (string, error) {
-	nodes, err := GetClusterNodesBy(oc, role)
+	nodes, err := GetClusterNodesByRole(oc, role)
 	for _, node := range nodes {
 		stdout, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node/"+node, "-o", "jsonpath=\"{.metadata.labels.node\\.openshift\\.io/os_id}\"").Output()
 		if strings.Trim(stdout, "\"") == osID {


### PR DESCRIPTION
Automate PSAP NTO Prevent from stalld continually restarting

**How to execute the test case in local**
1. Clone the origin code
2. make WHAT=cmd/openshift-tests
3. openshift-tests run-test "[sig-node-tuning] NTO should [Conformance][Serial]OCP-66086 NTO Prevent from stalld continually restarting [Slow]"


**The Test Case Logs:**
openshift-tests run-test "[sig-node-tuning] NTO should OCP-66086 NTO Prevent from stalld continually restarting [Slow]"
  Aug 17 14:42:51.951: INFO: Enabling in-tree volume drivers
  Aug 17 14:42:52.616: INFO: get the first rhcos worker nodes as label node
  Aug 17 14:42:52.616: INFO: Running 'oc --kubeconfig=/root/.kube/config get node -l node-role.kubernetes.io/worker -o jsonpath='{.items[*].metadata.name}''
  Aug 17 14:42:52.848: INFO: Running 'oc --kubeconfig=/root/.kube/config get node/liqcui-oc413z9-9mhk8-master-0 -o jsonpath="{.metadata.labels.node\.openshift\.io/os_id}"'
  Aug 17 14:42:53.007: INFO: the firstCoreOSWorkerNodes is:liqcui-oc413z9-9mhk8-master-0
  Aug 17 14:42:53.007: INFO: label the first rhcos node with node-role.kubernetes.io/worker-stalld=
  Aug 17 14:42:53.007: INFO: Running 'oc --kubeconfig=/root/.kube/config label node liqcui-oc413z9-9mhk8-master-0 node-role.kubernetes.io/worker-stalld= --overwrite'
  node/liqcui-oc413z9-9mhk8-master-0 labeled
  Aug 17 14:42:53.213: INFO: create custom profile openshift-stalld
  Aug 17 14:42:53.213: INFO: Running 'oc --kubeconfig=/root/.kube/config apply -f /tmp/fixture-testdata-dir3089254525/test/extended/testdata/psap/nto-stalld.yaml -n openshift-cluster-node-tuning-operator'
  tuned.tuned.openshift.io/openshift-stalld created
  Aug 17 14:42:53.772: INFO: assert if the tuned openshift-stalld created successfully
  Aug 17 14:42:53.772: INFO: Running 'oc --kubeconfig=/root/.kube/config get tuned -n openshift-cluster-node-tuning-operator'
  Aug 17 14:42:53.932: INFO: current tuned status is:
  NAME               AGE
  default            5h55m
  openshift-stalld   0s
  rendered           5h55m,
  Aug 17 14:42:53.932: INFO: Running 'oc --kubeconfig=/root/.kube/config get -n openshift-cluster-node-tuning-operator profile liqcui-oc413z9-9mhk8-master-0 -ojsonpath='{.status.conditions[?(@.type=="Applied")].status}''
  Aug 17 14:42:54.080: INFO: failed to apply custom profile to nodes, the status is 'Unknown' and <nil>, check again
  Aug 17 14:42:55.080: INFO: Running 'oc --kubeconfig=/root/.kube/config get -n openshift-cluster-node-tuning-operator profile liqcui-oc413z9-9mhk8-master-0 -ojsonpath='{.status.conditions[?(@.type=="Applied")].status}''
  Aug 17 14:42:55.223: INFO: failed to apply custom profile to nodes, the status is 'Unknown' and <nil>, check again
  Aug 17 14:42:56.223: INFO: Running 'oc --kubeconfig=/root/.kube/config get -n openshift-cluster-node-tuning-operator profile liqcui-oc413z9-9mhk8-master-0 -ojsonpath='{.status.conditions[?(@.type=="Applied")].status}''
  Aug 17 14:42:56.363: INFO: assert if the custom profile openshift-stalld applied to label node
  Aug 17 14:42:56.363: INFO: Running 'oc --kubeconfig=/root/.kube/config get -n openshift-cluster-node-tuning-operator profile liqcui-oc413z9-9mhk8-master-0 -ojsonpath={.status.tunedProfile}'
  Aug 17 14:42:56.509: INFO: current profile status is [ openshift-stalld ] on [ liqcui-oc413z9-9mhk8-master-0 ]
  Aug 17 14:42:56.509: INFO: check if stalld service is running ...
  Aug 17 14:42:59.509: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host systemctl status stalld'
  Aug 17 14:43:00.942: INFO: assert if stalld service restart ...
  Aug 17 14:43:03.944: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host pidof stalld'
  Aug 17 14:43:04.967: INFO: record the previous stalld PID is <stalldPreviousPID: 906413>
  Aug 17 14:43:04.967: INFO: start to periodically check stalld PID and compare if stalld pid change
  Aug 17 14:45:07.970: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host pidof stalld'
  Aug 17 14:45:09.200: INFO: the current PID of stalld is < 906413 >
  Aug 17 14:45:09.200: INFO: no restart of stalld process as expected, the stalld PID still is 906413
  Aug 17 14:47:07.970: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host pidof stalld'
  Aug 17 14:47:09.158: INFO: the current PID of stalld is < 906413 >
  Aug 17 14:47:09.158: INFO: no restart of stalld process as expected, the stalld PID still is 906413
  Aug 17 14:49:07.968: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host pidof stalld'
  Aug 17 14:49:09.434: INFO: the current PID of stalld is < 906413 >
  Aug 17 14:49:09.434: INFO: no restart of stalld process as expected, the stalld PID still is 906413
  Aug 17 14:51:07.968: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host pidof stalld'
  Aug 17 14:51:09.606: INFO: the current PID of stalld is < 906413 >
  Aug 17 14:51:09.606: INFO: no restart of stalld process as expected, the stalld PID still is 906413
  Aug 17 14:53:07.970: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host pidof stalld'
  Aug 17 14:53:09.771: INFO: the current PID of stalld is < 906413 >
  Aug 17 14:53:09.771: INFO: no restart of stalld process as expected, the stalld PID still is 906413
  Aug 17 14:53:12.772: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host pidof stalld'
  Aug 17 14:53:14.791: INFO: the current PID of stalld is < 906413 >
  Aug 17 14:53:14.791: INFO: no restart of stalld process as expected, the stalld PID still is 906413
  Aug 17 14:53:14.791: INFO: get how many minutes stalld process keep up and running ...
  Aug 17 14:53:17.792: INFO: Running 'oc --kubeconfig=/root/.kube/config debug node/liqcui-oc413z9-9mhk8-master-0 -nopenshift-cluster-node-tuning-operator -- chroot /host /bin/bash -c ps -o etime= -p 906413'
  Aug 17 14:53:18.838: INFO: the the stalld process keep running for 10:21
  Aug 17 14:53:18.838: INFO: timed out waiting for the condition
  Aug 17 14:53:18.838: INFO: Running 'oc --kubeconfig=/root/.kube/config delete tuned openshift-stalld -n openshift-cluster-node-tuning-operator --ignore-not-found'
  tuned.tuned.openshift.io "openshift-stalld" deleted
  Aug 17 14:53:19.018: INFO: Running 'oc --kubeconfig=/root/.kube/config label node liqcui-oc413z9-9mhk8-master-0 node-role.kubernetes.io/worker-stalld- --overwrite'
  node/liqcui-oc413z9-9mhk8-master-0 labeled