### PR TITLE
OCPBUGS-17477: requestheader: wait for only 3 oauth-servers to be available

### DIFF
--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -411,6 +411,20 @@ func generateCert(caCert *x509.Certificate, caKey *rsa.PrivateKey, cn string, ek
 func waitForNewOAuthConfig(oc *exutil.CLI) {
 	waitForAuthenticationProgressing(oc, configv1.ConditionTrue)
 	waitForAuthenticationProgressing(oc, configv1.ConditionFalse)
+
+	wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := oc.AdminKubeClient().CoreV1().Pods("openshift-authentication").List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(pods.Items) > 3 {
+			e2e.Logf("Waiting for old pods to be cleaned up from the openshift-authentication ns. Current no. of pods: %d", len(pods.Items))
+			return false, nil
+		}
+
+		return true, nil
+	})
 }
 
 // oauthHTTPRequestOrFail wraps oauthHTTPRequest and fails the test if the request failed


### PR DESCRIPTION
It seems that some of the old servers might be picking new requests even though they're shutting down. This commit should either prove or disprove that theory.

Another possibility is that the authn operator is not reporting the deployment status properly, or a revision rollout is borked.