### PR TITLE
[WIP] Add ginkgo.By strings

### DIFF
--- a/pkg/test/ginkgo/cmd_runtest.go
+++ b/pkg/test/ginkgo/cmd_runtest.go
@@ -3,6 +3,7 @@ package ginkgo
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -96,18 +97,20 @@ func (o *TestOptions) Run(args []string) error {
 
 	// These settings are matched to upstream's ginkgo configuration. See:
 	// https://github.com/kubernetes/kubernetes/blob/v1.25.0/test/e2e/framework/test_context.go#L354-L355
-	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)
-	suiteConfig.EmitSpecProgress = true
 	// Randomize specs as well as suites
 	suiteConfig.RandomizeAllSpecs = true
-	// turn off stdout/stderr capture see https://github.com/kubernetes/kubernetes/pull/111240
-	suiteConfig.OutputInterceptorMode = "none"
 	// https://github.com/kubernetes/kubernetes/blob/v1.25.0/hack/ginkgo-e2e.sh#L172-L173
 	suiteConfig.Timeout = 24 * time.Hour
 	reporterConfig.NoColor = true
+	reporterConfig.Verbose = true
 
 	ginkgo.SetReporterConfig(reporterConfig)
-	ginkgo.GetSuite().RunSpec(test.spec, ginkgo.Labels{}, "", ginkgo.GetFailer(), ginkgo.GetWriter(), suiteConfig)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	ginkgo.GetSuite().RunSpec(test.spec, ginkgo.Labels{}, "OpenShift e2e suite", cwd, ginkgo.GetFailer(), ginkgo.GetWriter(), suiteConfig, reporterConfig)
 
 	if m != nil {
 		// ignore the resultstate of the monitor tests because we're only focused on a single one.

--- a/test/extended/jobs/jobs.go
+++ b/test/extended/jobs/jobs.go
@@ -44,7 +44,7 @@ var _ = g.Describe("[sig-apps][Feature:Jobs]", func() {
 
 		o.Expect(len(jobs.Items)).Should(o.Equal(1))
 		job := jobs.Items[0]
-		o.Expect(len(job.Status.Conditions)).Should(o.Equal(1))
+		o.Expect(len(job.Status.Conditions)).Should(o.Equal(10))
 		o.Expect(job.Status.Conditions[0].Type).Should(o.Equal(batchv1.JobComplete))
 
 		g.By("removing a job...")

--- a/vendor/github.com/onsi/ginkgo/v2/internal/suite_patch.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/suite_patch.go
@@ -48,7 +48,7 @@ func (suite *Suite) ClearBeforeAndAfterSuiteNodes() {
 	suite.suiteNodes = newNodes
 }
 
-func (suite *Suite) RunSpec(spec types.TestSpec, suiteLabels Labels, suitePath string, failer *Failer, writer WriterInterface, suiteConfig types.SuiteConfig) (bool, bool) {
+func (suite *Suite) RunSpec(spec types.TestSpec, suiteLabels Labels, suiteDescription, suitePath string, failer *Failer, writer WriterInterface, suiteConfig types.SuiteConfig, reporterConfig types.ReporterConfig) (bool, bool) {
 	if suite.phase != PhaseBuildTree {
 		panic("cannot run before building the tree = call suite.BuildTree() first")
 	}
@@ -56,7 +56,7 @@ func (suite *Suite) RunSpec(spec types.TestSpec, suiteLabels Labels, suitePath s
 	suite.phase = PhaseRun
 	suite.client = nil
 	suite.failer = failer
-	suite.reporter = reporters.NoopReporter{}
+	suite.reporter = reporters.NewDefaultReporter(reporterConfig, writer)
 	suite.writer = writer
 	suite.outputInterceptor = NoopOutputInterceptor{}
 	if suite.config.Timeout > 0 {
@@ -65,7 +65,7 @@ func (suite *Suite) RunSpec(spec types.TestSpec, suiteLabels Labels, suitePath s
 	suite.interruptHandler = interrupt_handler.NewInterruptHandler(nil)
 	suite.config = suiteConfig
 
-	success := suite.runSpecs("", suiteLabels, suitePath, false, []Spec{spec.(Spec)})
+	success := suite.runSpecs(suiteDescription, suiteLabels, suitePath, false, []Spec{spec.(Spec)})
 
 	return success, false
 }


### PR DESCRIPTION
This is to show the result of https://github.com/openshift/onsi-ginkgo/pull/12.

In general, currently if a test fails we'll see something like:
```
  Aug 11 13:00:54.301: INFO: About to run a Kube e2e test, ensuring namespace/e2e-job-8336 is privileged
  W0811 13:00:56.024021   45371 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "c" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "c" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "c" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "c" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  Aug 11 13:01:04.504: INFO: At 0001-01-01 00:00:00 +0000 UTC - event for all-succeed-57wl4: { } Scheduled: Successfully assigned e2e-job-8336/all-succeed-57wl4 to ip-10-0-5-67.ec2.internal
...
  Aug 11 13:01:04.864: INFO: skipping dumping cluster info - cluster too large
fail [k8s.io/kubernetes@v1.27.1/test/e2e/apps/job.go:101]: expected 5 successful job pods, but got  4
Expected
    <int32>: 4
to equal
    <int32>: 5
Ginkgo exit error 1: exit with code 1
```

the improved version will look like this:
```
  Running Suite: OpenShift e2e suite - /home/maszulik/workspace/origin/src/github.com/openshift/origin
  ====================================================================================================
  Random Seed: 1691750682 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-apps] Job should run a job to completion when tasks succeed [Suite:openshift/conformance/parallel] [Suite:k8s]
  k8s.io/kubernetes@v1.27.1/test/e2e/apps/job.go:82
    STEP: Creating a kubernetes client @ 08/11/23 12:44:43.265
    STEP: Building a namespace api object, basename job @ 08/11/23 12:44:43.267
  Aug 11 12:44:43.884: INFO: About to run a Kube e2e test, ensuring namespace/e2e-job-3248 is privileged
    STEP: Waiting for a default service account to be provisioned in namespace @ 08/11/23 12:44:44.983
    STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 08/11/23 12:44:45.223
    STEP: Creating a job @ 08/11/23 12:44:45.463
  W0811 12:44:45.588001   41387 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "c" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "c" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "c" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "c" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
    STEP: Ensuring job reaches completions @ 08/11/23 12:44:45.588
    STEP: Ensuring pods for job exist @ 08/11/23 12:44:53.708
    [FAILED] in [It] - k8s.io/kubernetes@v1.27.1/test/e2e/apps/job.go:101 @ 08/11/23 12:44:53.946
    STEP: dump namespace information after failure @ 08/11/23 12:44:53.946
    STEP: Collecting events from namespace "e2e-job-3248". @ 08/11/23 12:44:53.946
    STEP: Found 25 events. @ 08/11/23 12:44:54.068
  Aug 11 12:44:54.068: INFO: At 0001-01-01 00:00:00 +0000 UTC - event for all-succeed-86zxc: { } Scheduled: Successfully assigned e2e-job-3248/all-succeed-86zxc to ip-10-0-5-67.ec2.internal
  ...
  Aug 11 12:44:54.430: INFO: skipping dumping cluster info - cluster too large
    STEP: Destroying namespace "e2e-job-3248" for this suite. @ 08/11/23 12:44:54.43
  • [FAILED] [11.295 seconds]
  [sig-apps] Job [It] should run a job to completion when tasks succeed [Suite:openshift/conformance/parallel] [Suite:k8s]
  k8s.io/kubernetes@v1.27.1/test/e2e/apps/job.go:82

    [FAILED] expected 5 successful job pods, but got  4
    Expected
        <int32>: 4
    to equal
        <int32>: 5
    In [It] at: k8s.io/kubernetes@v1.27.1/test/e2e/apps/job.go:101 @ 08/11/23 12:44:53.946
  ------------------------------

  Summarizing 1 Failure:
    [FAIL] [sig-apps] Job [It] should run a job to completion when tasks succeed [Suite:openshift/conformance/parallel] [Suite:k8s]
    k8s.io/kubernetes@v1.27.1/test/e2e/apps/job.go:101

  Ran 1 of 1 Specs in 11.295 seconds
  FAIL! -- 0 Passed | 1 Failed | 0 Pending | 0 Skipped
fail [k8s.io/kubernetes@v1.27.1/test/e2e/apps/job.go:101]: expected 5 successful job pods, but got  4
Expected
    <int32>: 4
to equal
    <int32>: 5
Ginkgo exit error 1: exit with code 1
```

In this PR I've intentionally put a failure in `[sig-apps][Feature:Jobs] Users should be able to create and run a job in a user project` to see the additional output. 

/assign @bparees @bertinatto 