### PR TITLE
run start and collect in parallel

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -456,6 +456,7 @@ func (b *BackendSampler) Stop() {
 		fmt.Printf("waiting for consumer to finish %v...\n", b.locator)
 		select {
 		case <-b.consumptionFinished:
+			fmt.Printf("consumer finished %v\n", b.locator)
 			return
 		case <-time.After(10 * time.Second):
 		}


### PR DESCRIPTION
it's painful on the CLI without this because we have several waits.  Yes the waits shoudl be cleaned up, but htis helps easily.