### PR TITLE
migrate some watching code to monitortests

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
-
-	"github.com/openshift/origin/pkg/monitortests/network/disruptionpodnetwork"
-
 	"github.com/openshift/origin/pkg/monitortests/authentication/legacyauthenticationmonitortests"
 	"github.com/openshift/origin/pkg/monitortests/clusterversionoperator/legacycvomonitortests"
 	"github.com/openshift/origin/pkg/monitortests/clusterversionoperator/operatorstateanalyzer"
@@ -18,11 +15,13 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/disruptionnewapiserver"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests"
 	"github.com/openshift/origin/pkg/monitortests/network/disruptioningress"
+	"github.com/openshift/origin/pkg/monitortests/network/disruptionpodnetwork"
 	"github.com/openshift/origin/pkg/monitortests/network/disruptionserviceloadbalancer"
 	"github.com/openshift/origin/pkg/monitortests/network/legacynetworkmonitortests"
 	"github.com/openshift/origin/pkg/monitortests/node/kubeletlogcollector"
 	"github.com/openshift/origin/pkg/monitortests/node/legacynodemonitortests"
 	"github.com/openshift/origin/pkg/monitortests/node/nodestateanalyzer"
+	"github.com/openshift/origin/pkg/monitortests/node/watchnodes"
 	"github.com/openshift/origin/pkg/monitortests/node/watchpods"
 	"github.com/openshift/origin/pkg/monitortests/storage/legacystoragemonitortests"
 	"github.com/openshift/origin/pkg/monitortests/testframework/additionaleventscollector"
@@ -38,6 +37,8 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/testframework/timelineserializer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/trackedresourcesserializer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/uploadtolokiserializer"
+	"github.com/openshift/origin/pkg/monitortests/testframework/watchclusteroperators"
+	"github.com/openshift/origin/pkg/monitortests/testframework/watchevents"
 )
 
 type ClusterStabilityDuringTest string
@@ -119,6 +120,7 @@ func newUniversalMonitorTests() monitortestframework.MonitorTestRegistry {
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-node-invariants", "Node", legacynodemonitortests.NewLegacyTests())
 	monitorTestRegistry.AddMonitorTestOrDie("node-state-analyzer", "Node", nodestateanalyzer.NewAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("pod-lifecycle", "Node", watchpods.NewPodWatcher())
+	monitorTestRegistry.AddMonitorTestOrDie("node-lifecycle", "Node", watchnodes.NewNodeWatcher())
 
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-storage-invariants", "Storage", legacystoragemonitortests.NewLegacyTests())
 
@@ -134,6 +136,8 @@ func newUniversalMonitorTests() monitortestframework.MonitorTestRegistry {
 	monitorTestRegistry.AddMonitorTestOrDie("known-image-checker", "Test Framework", knownimagechecker.NewEnsureValidImages())
 	monitorTestRegistry.AddMonitorTestOrDie("upload-to-loki-serializer", "Test Framework", uploadtolokiserializer.NewUploadSerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("e2e-test-analyzer", "Test Framework", e2etestanalyzer.NewAnalyzer())
+	monitorTestRegistry.AddMonitorTestOrDie("event-collector", "Test Framework", watchevents.NewEventWatcher())
+	monitorTestRegistry.AddMonitorTestOrDie("clusteroperator-collector", "Test Framework", watchclusteroperators.NewOperatorWatcher())
 
 	return monitorTestRegistry
 }

--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -2,14 +2,8 @@ package monitor
 
 import (
 	"fmt"
-	"sync"
 
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -21,49 +15,4 @@ func GetMonitorRESTConfig() (*rest.Config, error) {
 	}
 
 	return clusterConfig, nil
-}
-
-type errorRecordingListWatcher struct {
-	lw cache.ListerWatcher
-
-	recorder monitorapi.Recorder
-
-	lock          sync.Mutex
-	receivedError bool
-}
-
-func NewErrorRecordingListWatcher(recorder monitorapi.Recorder, lw cache.ListerWatcher) cache.ListerWatcher {
-	return &errorRecordingListWatcher{
-		lw:       lw,
-		recorder: recorder,
-	}
-}
-
-func (w *errorRecordingListWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
-	obj, err := w.lw.List(options)
-	w.handle(err)
-	return obj, err
-}
-
-func (w *errorRecordingListWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
-	obj, err := w.lw.Watch(options)
-	w.handle(err)
-	return obj, err
-}
-
-func (w *errorRecordingListWatcher) handle(err error) {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-	if err != nil {
-		if !w.receivedError {
-			w.recorder.Record(monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: "kube-apiserver",
-				Message: fmt.Sprintf("failed contacting the API: %v", err),
-			})
-		}
-		w.receivedError = true
-	} else {
-		w.receivedError = false
-	}
 }

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/origin/pkg/test"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 
-	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitor/shutdown"
 	"k8s.io/client-go/kubernetes"
@@ -76,17 +75,9 @@ func (m *Monitor) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	configClient, err := configclientset.NewForConfig(m.adminKubeConfig)
-	if err != nil {
-		return err
-	}
 
-	startNodeMonitoring(ctx, m.recorder, client)
-	startEventMonitoring(ctx, m.recorder, client)
 	shutdown.StartMonitoringGracefulShutdownEvents(ctx, m.recorder, client)
 
-	// add interval creation at the same point where we add the monitors
-	startClusterOperatorMonitoring(ctx, m.recorder, configClient)
 	return nil
 }
 

--- a/pkg/monitortests/node/watchnodes/monitortest.go
+++ b/pkg/monitortests/node/watchnodes/monitortest.go
@@ -1,0 +1,55 @@
+package watchnodes
+
+import (
+	"context"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitortestframework"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type nodeWatcher struct {
+}
+
+func NewNodeWatcher() monitortestframework.MonitorTest {
+	return &nodeWatcher{}
+}
+
+func (w *nodeWatcher) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	startNodeMonitoring(ctx, recorder, kubeClient)
+
+	return nil
+}
+
+func (w *nodeWatcher) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	// because we are sharing a recorder that we're streaming into, we don't need to have a separate data collection step.
+	return nil, nil, nil
+}
+
+func (*nodeWatcher) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	constructedIntervals := monitorapi.Intervals{}
+
+	return constructedIntervals, nil
+}
+
+func (*nodeWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (*nodeWatcher) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*nodeWatcher) Cleanup(ctx context.Context) error {
+	// TODO wire up the start to a context we can kill here
+	return nil
+}

--- a/pkg/monitortests/node/watchnodes/node.go
+++ b/pkg/monitortests/node/watchnodes/node.go
@@ -1,4 +1,4 @@
-package monitor
+package watchnodes
 
 import (
 	"context"
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func startNodeMonitoring(ctx context.Context, m monitorapi.Recorder, client kubernetes.Interface) {
+func startNodeMonitoring(ctx context.Context, m monitorapi.RecorderWriter, client kubernetes.Interface) {
 	nodeReadyFn := func(node, oldNode *corev1.Node) []monitorapi.Condition {
 		isCreate := false
 		if oldNode == nil {

--- a/pkg/monitortests/node/watchnodes/node_test.go
+++ b/pkg/monitortests/node/watchnodes/node_test.go
@@ -1,4 +1,4 @@
-package monitor
+package watchnodes
 
 import (
 	"testing"

--- a/pkg/monitortests/testframework/watchclusteroperators/monitortest.go
+++ b/pkg/monitortests/testframework/watchclusteroperators/monitortest.go
@@ -1,0 +1,56 @@
+package watchclusteroperators
+
+import (
+	"context"
+	"time"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+
+	"github.com/openshift/origin/pkg/monitortestframework"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/rest"
+)
+
+type operatorWatcher struct {
+}
+
+func NewOperatorWatcher() monitortestframework.MonitorTest {
+	return &operatorWatcher{}
+}
+
+func (w *operatorWatcher) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	configClient, err := configclient.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	startClusterOperatorMonitoring(ctx, recorder, configClient)
+
+	return nil
+}
+
+func (w *operatorWatcher) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	// because we are sharing a recorder that we're streaming into, we don't need to have a separate data collection step.
+	return nil, nil, nil
+}
+
+func (*operatorWatcher) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	constructedIntervals := monitorapi.Intervals{}
+
+	return constructedIntervals, nil
+}
+
+func (*operatorWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (*operatorWatcher) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*operatorWatcher) Cleanup(ctx context.Context) error {
+	// TODO wire up the start to a context we can kill here
+	return nil
+}

--- a/pkg/monitortests/testframework/watchclusteroperators/operator.go
+++ b/pkg/monitortests/testframework/watchclusteroperators/operator.go
@@ -1,4 +1,4 @@
-package monitor
+package watchclusteroperators
 
 import (
 	"context"
@@ -17,9 +17,9 @@ import (
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 )
 
-func startClusterOperatorMonitoring(ctx context.Context, m monitorapi.Recorder, client configclientset.Interface) {
+func startClusterOperatorMonitoring(ctx context.Context, m monitorapi.RecorderWriter, client configclientset.Interface) {
 	coInformer := cache.NewSharedIndexInformer(
-		NewErrorRecordingListWatcher(m, &cache.ListWatch{
+		newErrorRecordingListWatcher(m, &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				return client.ConfigV1().ClusterOperators().List(ctx, options)
 			},
@@ -133,7 +133,7 @@ func startClusterOperatorMonitoring(ctx context.Context, m monitorapi.Recorder, 
 	go coInformer.Run(ctx.Done())
 
 	cvInformer := cache.NewSharedIndexInformer(
-		NewErrorRecordingListWatcher(m, &cache.ListWatch{
+		newErrorRecordingListWatcher(m, &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector = "metadata.name=version"
 				return client.ConfigV1().ClusterVersions().List(ctx, options)

--- a/pkg/monitortests/testframework/watchclusteroperators/operator_test.go
+++ b/pkg/monitortests/testframework/watchclusteroperators/operator_test.go
@@ -1,4 +1,4 @@
-package monitor
+package watchclusteroperators
 
 import (
 	"reflect"

--- a/pkg/monitortests/testframework/watchclusteroperators/watcher.go
+++ b/pkg/monitortests/testframework/watchclusteroperators/watcher.go
@@ -1,0 +1,57 @@
+package watchclusteroperators
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+type errorRecordingListWatcher struct {
+	lw cache.ListerWatcher
+
+	recorder monitorapi.RecorderWriter
+
+	lock          sync.Mutex
+	receivedError bool
+}
+
+func newErrorRecordingListWatcher(recorder monitorapi.RecorderWriter, lw cache.ListerWatcher) cache.ListerWatcher {
+	return &errorRecordingListWatcher{
+		lw:       lw,
+		recorder: recorder,
+	}
+}
+
+func (w *errorRecordingListWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
+	obj, err := w.lw.List(options)
+	w.handle(err)
+	return obj, err
+}
+
+func (w *errorRecordingListWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	obj, err := w.lw.Watch(options)
+	w.handle(err)
+	return obj, err
+}
+
+func (w *errorRecordingListWatcher) handle(err error) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	if err != nil {
+		if !w.receivedError {
+			w.recorder.Record(monitorapi.Condition{
+				Level:   monitorapi.Error,
+				Locator: "kube-apiserver",
+				Message: fmt.Sprintf("failed contacting the API: %v", err),
+			})
+		}
+		w.receivedError = true
+	} else {
+		w.receivedError = false
+	}
+}

--- a/pkg/monitortests/testframework/watchevents/event.go
+++ b/pkg/monitortests/testframework/watchevents/event.go
@@ -1,10 +1,11 @@
-package monitor
+package watchevents
 
 import (
 	"context"
 	"crypto/sha256"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,12 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
 
 var reMatchFirstQuote = regexp.MustCompile(`"([^"]+)"( in (\d+(\.\d+)?(s|ms)$))?`)
 
-func startEventMonitoring(ctx context.Context, m monitorapi.Recorder, client kubernetes.Interface) {
+func startEventMonitoring(ctx context.Context, m monitorapi.RecorderWriter, adminRESTConfig *rest.Config, client kubernetes.Interface) {
 
 	// filter out events written "now" but with significantly older start times (events
 	// created in test jobs are the most common)
@@ -54,7 +56,7 @@ func startEventMonitoring(ctx context.Context, m monitorapi.Recorder, client kub
 				return nil
 			}
 			if processedEventUIDs[event.UID] != event.ResourceVersion {
-				recordAddOrUpdateEvent(ctx, m, client, significantlyBeforeNow, event)
+				recordAddOrUpdateEvent(ctx, m, adminRESTConfig, client, significantlyBeforeNow, event)
 				processedEventUIDs[event.UID] = event.ResourceVersion
 			}
 			return nil
@@ -65,7 +67,7 @@ func startEventMonitoring(ctx context.Context, m monitorapi.Recorder, client kub
 				return nil
 			}
 			if processedEventUIDs[event.UID] != event.ResourceVersion {
-				recordAddOrUpdateEvent(ctx, m, client, significantlyBeforeNow, event)
+				recordAddOrUpdateEvent(ctx, m, adminRESTConfig, client, significantlyBeforeNow, event)
 				processedEventUIDs[event.UID] = event.ResourceVersion
 			}
 			return nil
@@ -104,18 +106,10 @@ func combinedDuplicateEventPatterns() *regexp.Regexp {
 // and returns true if this event is an event we already know about.  Some functions
 // require a kubeconfig, but also handle the kubeconfig being nil (in case we cannot
 // successfully get a kubeconfig).
-func checkAllowedRepeatedEventOKFns(event monitorapi.Interval, times int32) bool {
-
-	kubeClient, err := GetMonitorRESTConfig()
-	if err != nil {
-		// If we couldn't get a kube client, we won't be able to run functions that require a kube config
-		// but we can still pass a nil so that the rest of the functions can run.
-		fmt.Printf("error getting kubeclient: [%v] when processing event %s - %s\n", err, event.Locator, event.Message)
-		kubeClient = nil
-	}
+func checkAllowedRepeatedEventOKFns(adminRESTConfig *rest.Config, event monitorapi.Interval, times int32) bool {
 	for _, isRepeatedEventOKFuncList := range [][]pathologicaleventlibrary.IsRepeatedEventOKFunc{pathologicaleventlibrary.AllowedRepeatedEventFns, pathologicaleventlibrary.AllowedSingleNodeRepeatedEventFns} {
 		for _, allowRepeatedEventFn := range isRepeatedEventOKFuncList {
-			allowed, err := allowRepeatedEventFn(event, kubeClient, int(times))
+			allowed, err := allowRepeatedEventFn(event, adminRESTConfig, int(times))
 			if err != nil {
 				// for errors, we'll default to no match.
 				fmt.Printf("Error processing pathological event: %v\n", err)
@@ -131,7 +125,8 @@ func checkAllowedRepeatedEventOKFns(event monitorapi.Interval, times int32) bool
 
 func recordAddOrUpdateEvent(
 	ctx context.Context,
-	recorder monitorapi.Recorder,
+	recorder monitorapi.RecorderWriter,
+	adminRESTConfig *rest.Config,
 	client kubernetes.Interface,
 	significantlyBeforeNow time.Time,
 	obj *corev1.Event) {
@@ -237,7 +232,7 @@ func recordAddOrUpdateEvent(
 		eventDisplayMessage := fmt.Sprintf("%s - %s", event.Locator, event.Message)
 
 		updatedMessage := event.Message
-		if allRepeatedEventPatterns.MatchString(eventDisplayMessage) || checkAllowedRepeatedEventOKFns(event, obj.Count) {
+		if allRepeatedEventPatterns.MatchString(eventDisplayMessage) || checkAllowedRepeatedEventOKFns(adminRESTConfig, event, obj.Count) {
 			// This is a repeated event that we know about
 			updatedMessage = fmt.Sprintf("%s %s", pathologicaleventlibrary.InterestingMark, updatedMessage)
 		}
@@ -299,4 +294,17 @@ func locateEvent(event *corev1.Event) string {
 		return fmt.Sprintf("%s/%s node/%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.Source.Host)
 	}
 	return fmt.Sprintf("%s/%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name)
+}
+
+func nodeRoles(node *corev1.Node) string {
+	const roleLabel = "node-role.kubernetes.io"
+	var roles []string
+	for label := range node.Labels {
+		if strings.Contains(label, roleLabel) {
+			roles = append(roles, label[len(roleLabel)+1:])
+		}
+	}
+
+	sort.Strings(roles)
+	return strings.Join(roles, ",")
 }

--- a/pkg/monitortests/testframework/watchevents/event_test.go
+++ b/pkg/monitortests/testframework/watchevents/event_test.go
@@ -1,10 +1,12 @@
-package monitor
+package watchevents
 
 import (
 	"context"
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/openshift/origin/pkg/monitor"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +40,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 			name: "simple event",
 			args: args{
 				ctx: context.TODO(),
-				m:   NewRecorder(),
+				m:   monitor.NewRecorder(),
 				kubeEvent: &corev1.Event{
 					Count:  2,
 					Reason: "SomethingHappened",
@@ -58,7 +60,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 			name: "unknown pathological event",
 			args: args{
 				ctx: context.TODO(),
-				m:   NewRecorder(),
+				m:   monitor.NewRecorder(),
 				kubeEvent: &corev1.Event{
 					Count:  40,
 					Reason: "SomethingHappened",
@@ -78,7 +80,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 			name: "allowed pathological event",
 			args: args{
 				ctx: context.TODO(),
-				m:   NewRecorder(),
+				m:   monitor.NewRecorder(),
 				kubeEvent: &corev1.Event{
 					Count:  40,
 					Reason: "SomethingHappened",
@@ -99,7 +101,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 			name: "allowed pathological event with known bug",
 			args: args{
 				ctx: context.TODO(),
-				m:   NewRecorder(),
+				m:   monitor.NewRecorder(),
 				kubeEvent: &corev1.Event{
 					Count:  40,
 					Reason: "TopologyAwareHintsDisabled",
@@ -123,7 +125,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			significantlyBeforeNow := now.UTC().Add(-15 * time.Minute)
-			recordAddOrUpdateEvent(tt.args.ctx, tt.args.m, nil, significantlyBeforeNow, tt.args.kubeEvent)
+			recordAddOrUpdateEvent(tt.args.ctx, tt.args.m, nil, nil, significantlyBeforeNow, tt.args.kubeEvent)
 			intervals := tt.args.m.Intervals(now.Add(-10*time.Minute), now.Add(10*time.Minute))
 			assert.Equal(t, 1, len(intervals))
 			interval := intervals[0]

--- a/pkg/monitortests/testframework/watchevents/monitortest.go
+++ b/pkg/monitortests/testframework/watchevents/monitortest.go
@@ -1,0 +1,55 @@
+package watchevents
+
+import (
+	"context"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitortestframework"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type eventWatcher struct {
+}
+
+func NewEventWatcher() monitortestframework.MonitorTest {
+	return &eventWatcher{}
+}
+
+func (w *eventWatcher) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	startEventMonitoring(ctx, recorder, adminRESTConfig, kubeClient)
+
+	return nil
+}
+
+func (w *eventWatcher) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	// because we are sharing a recorder that we're streaming into, we don't need to have a separate data collection step.
+	return nil, nil, nil
+}
+
+func (*eventWatcher) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	constructedIntervals := monitorapi.Intervals{}
+
+	return constructedIntervals, nil
+}
+
+func (*eventWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (*eventWatcher) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*eventWatcher) Cleanup(ctx context.Context) error {
+	// TODO wire up the start to a context we can kill here
+	return nil
+}


### PR DESCRIPTION
Just moves.  Be sure that the timeline shows node upgrades, pathological events, and cluster operator progression.