### PR TITLE
STOR-1425: Add images coming in k8s 1.28

### DIFF
--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -56,3 +56,14 @@ registry.k8s.io/sig-storage/hostpathplugin:v1.9.0 quay.io/openshift/community-e2
 registry.k8s.io/sig-storage/livenessprobe:v2.7.0 quay.io/openshift/community-e2e-images:e2e-52-registry-k8s-io-sig-storage-livenessprobe-v2-7-0-xUaqxY48BuQF81pK
 registry.k8s.io/sig-storage/nfs-provisioner:v3.0.1 quay.io/openshift/community-e2e-images:e2e-20-registry-k8s-io-sig-storage-nfs-provisioner-v3-0-1-eS192wx22gGKMh2M
 registry.k8s.io/sig-storage/volume-data-source-validator:v1.0.0 quay.io/openshift/community-e2e-images:e2e-42-registry-k8s-io-sig-storage-volume-data-source-validator-v1-0-0-pJwTeQGTDmAV8753
+registry.k8s.io/e2e-test-images/agnhost:2.45 quay.io/openshift/community-e2e-images:e2e-1-registry-k8s-io-e2e-test-images-agnhost-2-45-0axvGMNNN4BHiZi2
+registry.k8s.io/e2e-test-images/busybox:1.29-2 quay.io/openshift/community-e2e-images:e2e-54-registry-k8s-io-e2e-test-images-busybox-1-29-2-ZYWRth-o9U_JR2ZE
+registry.k8s.io/e2e-test-images/volume/nfs:1.3 quay.io/openshift/community-e2e-images:e2e-35-registry-k8s-io-e2e-test-images-volume-nfs-1-3-nwYqCusKEqAgWvkm
+registry.k8s.io/sig-storage/csi-attacher:v4.0.0 quay.io/openshift/community-e2e-images:e2e-43-registry-k8s-io-sig-storage-csi-attacher-v4-0-0-_44HoCYLoY8K1SpA
+registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1 quay.io/openshift/community-e2e-images:e2e-46-registry-k8s-io-sig-storage-csi-node-driver-registrar-v2-5-1-PNOgzdxTQbWunm33
+registry.k8s.io/sig-storage/csi-provisioner:v3.4.0 quay.io/openshift/community-e2e-images:e2e-42-registry-k8s-io-sig-storage-csi-provisioner-v3-4-0-dnf_qBCVrsdzJ1cy
+registry.k8s.io/sig-storage/csi-resizer:v1.6.0 quay.io/openshift/community-e2e-images:e2e-44-registry-k8s-io-sig-storage-csi-resizer-v1-6-0-ac5QBbSGDDDGpuyI
+registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0 quay.io/openshift/community-e2e-images:e2e-51-registry-k8s-io-sig-storage-csi-snapshotter-v6-1-0-VHjLoFuxMj90NLA8
+registry.k8s.io/sig-storage/hostpathplugin:v1.11.0 quay.io/openshift/community-e2e-images:e2e-48-registry-k8s-io-sig-storage-hostpathplugin-v1-11-0-Y1NYRRqpFRryDXNv
+registry.k8s.io/sig-storage/hostpathplugin:v1.9.0  quay.io/openshift/community-e2e-images:e2e-53-registry-k8s-io-sig-storage-hostpathplugin-v1-9-0-4xsLPL7j4yiDKNiL
+registry.k8s.io/sig-storage/nfs-provisioner:v3.0.1 quay.io/openshift/community-e2e-images:e2e-19-registry-k8s-io-sig-storage-nfs-provisioner-v3-0-1-eS192wx22gGKMh2M


### PR DESCRIPTION
Some of the metal jobs rely on information which images need to be mirrored, this information is coming in https://github.com/openshift/origin/pull/28097/ but to properly assess correctness we need those information sooner. 

This PR injects that image information directly into `./openshift-tests images` command.

/hold
Until master branch opens for OCP 4.15.

/assign @bertinatto 