### PR TITLE
ignore stale condition challenge events

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -148,6 +148,9 @@ var AllowedRepeatedEventPatterns = []*regexp.Regexp{
 
 	// Separated out in testMarketplaceStartupProbeFailure
 	regexp.MustCompile(MarketplaceStartupProbeFailureRegExpStr),
+
+	// stale condition challenge reset
+	regexp.MustCompile(`message changed from "\x{FEFF}`),
 }
 
 // AllowedUpgradeRepeatedEventPatterns are patterns of events that we should only allow during upgrades, not during normal execution.


### PR DESCRIPTION
Proposed https://github.com/openshift/cluster-kube-apiserver-operator/pull/1423:
1. Prefixes condition messages with a zero-width non-breaking space (ZWNBSP).
2. Expects operators to quickly (within 1 min) update the condition message, removing the ZWNBSP.

Many operators emit an event when they are updating conditions (thanks to common code in libary-go) , these will trigger the pathological events tests.

This PR configured the pathological events tests to ignore these "challenge response" events. 