### PR TITLE
fix *-to-host sampler failure calculation

### DIFF
--- a/pkg/cmd/openshift-tests/disruption/watch-endpointslice/watch_endpointslice_flags.go
+++ b/pkg/cmd/openshift-tests/disruption/watch-endpointslice/watch_endpointslice_flags.go
@@ -18,14 +18,15 @@ import (
 // WatchEndpointSliceFlags is used to run a monitoring process against the provided server as
 // a command line interaction.
 type WatchEndpointSliceFlags struct {
-	ConfigFlags       *genericclioptions.ConfigFlags
-	OutputFlags       *iooptions.OutputFlags
-	ServiceName       string
-	BackendPrefix     string
-	Scheme            string
-	Path              string
-	MyNodeName        string
-	StopConfigMapName string
+	ConfigFlags        *genericclioptions.ConfigFlags
+	OutputFlags        *iooptions.OutputFlags
+	ServiceName        string
+	BackendPrefix      string
+	Scheme             string
+	Path               string
+	ExpectedStatusCode int
+	MyNodeName         string
+	StopConfigMapName  string
 
 	genericclioptions.IOStreams
 }
@@ -90,6 +91,7 @@ func (f *WatchEndpointSliceFlags) BindOptions(flags *pflag.FlagSet) {
 	flags.StringVar(&f.StopConfigMapName, "stop-configmap", f.StopConfigMapName, "the name of the configmap that indicates that this pod should stop all watchers.")
 	flags.StringVar(&f.Scheme, "request-scheme", f.Scheme, "http or https")
 	flags.StringVar(&f.Path, "request-path", f.Path, "path to request, like /healthz")
+	flags.IntVar(&f.ExpectedStatusCode, "expected-status-code", f.ExpectedStatusCode, "status code to expect from the sampler")
 	f.ConfigFlags.AddFlags(flags)
 	f.OutputFlags.BindFlags(flags)
 }
@@ -137,17 +139,18 @@ func (f *WatchEndpointSliceFlags) ToOptions() (*WatchEndpointSliceOptions, error
 	}
 
 	return &WatchEndpointSliceOptions{
-		KubeClient:        kubeClient,
-		Namespace:         namespace,
-		OutputFile:        f.OutputFlags.OutFile,
-		ServiceName:       f.ServiceName,
-		StopConfigMapName: f.StopConfigMapName,
-		Scheme:            f.Scheme,
-		Path:              f.Path,
-		MyNodeName:        f.MyNodeName,
-		BackendPrefix:     f.BackendPrefix,
-		CloseFn:           closeFn,
-		OriginalOutFile:   originalOutStream,
-		IOStreams:         f.IOStreams,
+		KubeClient:         kubeClient,
+		Namespace:          namespace,
+		OutputFile:         f.OutputFlags.OutFile,
+		ServiceName:        f.ServiceName,
+		StopConfigMapName:  f.StopConfigMapName,
+		Scheme:             f.Scheme,
+		Path:               f.Path,
+		MyNodeName:         f.MyNodeName,
+		BackendPrefix:      f.BackendPrefix,
+		ExpectedStatusCode: f.ExpectedStatusCode,
+		CloseFn:            closeFn,
+		OriginalOutFile:    originalOutStream,
+		IOStreams:          f.IOStreams,
 	}, nil
 }

--- a/pkg/cmd/openshift-tests/disruption/watch-endpointslice/watch_endpointslice_options.go
+++ b/pkg/cmd/openshift-tests/disruption/watch-endpointslice/watch_endpointslice_options.go
@@ -23,13 +23,14 @@ type WatchEndpointSliceOptions struct {
 	KubeClient kubernetes.Interface
 	Namespace  string
 
-	OutputFile        string
-	BackendPrefix     string
-	ServiceName       string
-	MyNodeName        string
-	Scheme            string
-	Path              string
-	StopConfigMapName string
+	OutputFile         string
+	BackendPrefix      string
+	ServiceName        string
+	MyNodeName         string
+	Scheme             string
+	Path               string
+	ExpectedStatusCode int
+	StopConfigMapName  string
 
 	OriginalOutFile io.Writer
 	CloseFn         iooptions.CloseFunc
@@ -63,6 +64,7 @@ func (o *WatchEndpointSliceOptions) Run(ctx context.Context) error {
 		o.MyNodeName,
 		o.Scheme,
 		o.Path,
+		o.ExpectedStatusCode,
 		recorder,
 		o.IOStreams.Out,
 		namespaceScopedEndpointSliceInformers.EndpointSlices(),

--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-to-host-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-to-host-network-poller-deployment.yaml
@@ -32,7 +32,8 @@ spec:
             - --my-node-name=$(MY_NODE_NAME)
             - --request-scheme=https
             - --request-path=/healthz
-          image: docker.io/deads2k/openshift-tests:latest
+            - --expected-status-code=401
+          image: image-to-be-replaced
           imagePullPolicy: IfNotPresent
           name: disruption-poller
           terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-to-pod-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-to-pod-network-poller-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - --stop-configmap=stop-collecting
             - --my-node-name=$(MY_NODE_NAME)
             - --request-scheme=http
-          image: docker.io/deads2k/openshift-tests:latest
+          image: image-to-be-replaced
           imagePullPolicy: IfNotPresent
           name: disruption-poller
           terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-host-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-host-network-poller-deployment.yaml
@@ -32,7 +32,8 @@ spec:
             - --my-node-name=$(MY_NODE_NAME)
             - --request-scheme=https
             - --request-path=/healthz
-          image: docker.io/deads2k/openshift-tests:latest
+            - --expected-status-code=401
+          image: image-to-be-replaced
           imagePullPolicy: IfNotPresent
           name: disruption-poller
           terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
This fixes teh current pattern which doesn't cause failure, but does count disruption improperly: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/28191/pull-ci-openshift-origin-master-e2e-gcp-ovn-rt-upgrade/1692509054028484608