### PR TITLE
always flake on non-zero disruption for pod network communication so …

### DIFF
--- a/pkg/monitortestframework/panic.go
+++ b/pkg/monitortestframework/panic.go
@@ -3,6 +3,7 @@ package monitortestframework
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"k8s.io/client-go/rest"
@@ -14,7 +15,7 @@ import (
 func startCollectionWithPanicProtection(ctx context.Context, monitortest MonitorTest, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("caught panic: %v", r)
+			err = fmt.Errorf("caught panic: %v\n%v", r, string(debug.Stack()))
 		}
 	}()
 
@@ -25,7 +26,7 @@ func startCollectionWithPanicProtection(ctx context.Context, monitortest Monitor
 func collectDataWithPanicProtection(ctx context.Context, monitortest MonitorTest, storageDir string, beginning, end time.Time) (intervals monitorapi.Intervals, junit []*junitapi.JUnitTestCase, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("caught panic: %v", r)
+			err = fmt.Errorf("caught panic: %v\n%v", r, string(debug.Stack()))
 		}
 	}()
 
@@ -36,7 +37,7 @@ func collectDataWithPanicProtection(ctx context.Context, monitortest MonitorTest
 func constructComputedIntervalsWithPanicProtection(ctx context.Context, monitortest MonitorTest, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (intervals monitorapi.Intervals, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("caught panic: %v", r)
+			err = fmt.Errorf("caught panic: %v\n%v", r, string(debug.Stack()))
 		}
 	}()
 
@@ -47,7 +48,7 @@ func constructComputedIntervalsWithPanicProtection(ctx context.Context, monitort
 func evaluateTestsFromConstructedIntervalsWithPanicProtection(ctx context.Context, monitortest MonitorTest, finalIntervals monitorapi.Intervals) (junits []*junitapi.JUnitTestCase, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("caught panic: %v", r)
+			err = fmt.Errorf("caught panic: %v\n%v", r, string(debug.Stack()))
 		}
 	}()
 
@@ -58,7 +59,7 @@ func evaluateTestsFromConstructedIntervalsWithPanicProtection(ctx context.Contex
 func writeContentToStorageWithPanicProtection(ctx context.Context, monitortest MonitorTest, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("caught panic: %v", r)
+			err = fmt.Errorf("caught panic: %v\n%v", r, string(debug.Stack()))
 		}
 	}()
 
@@ -69,7 +70,7 @@ func writeContentToStorageWithPanicProtection(ctx context.Context, monitortest M
 func cleanupWithPanicProtection(ctx context.Context, monitortest MonitorTest) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("caught panic: %v", r)
+			err = fmt.Errorf("caught panic: %v\n%v", r, string(debug.Stack()))
 		}
 	}()
 

--- a/pkg/monitortestlibrary/disruptionlibrary/disruption_test_evaluator.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/disruption_test_evaluator.go
@@ -1,0 +1,156 @@
+package disruptionlibrary
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitortestlibrary/allowedbackenddisruption"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+type AvailabilityTestEvaluator struct {
+	newConnectionTestName       string
+	reusedConnectionTestName    string
+	jobType                     platformidentification.JobType
+	alwaysAtLeastFlakeOnNonZero bool
+
+	newConnectionHistoricalBackendName    string
+	reusedConnectionHistoricalBackendName string
+}
+
+func NewAvailabilityTestEvaluatorInvariant(
+	newConnectionTestName, reusedConnectionTestName string,
+	newConnectionHistoricalBackendName, reusedConnectionHistoricalBackendName string,
+	jobType platformidentification.JobType) *AvailabilityTestEvaluator {
+	return &AvailabilityTestEvaluator{
+		newConnectionTestName:                 newConnectionTestName,
+		reusedConnectionTestName:              reusedConnectionTestName,
+		newConnectionHistoricalBackendName:    newConnectionHistoricalBackendName,
+		reusedConnectionHistoricalBackendName: reusedConnectionHistoricalBackendName,
+		jobType:                               jobType,
+	}
+}
+
+func (w *AvailabilityTestEvaluator) AlwaysAtLeastFlakeOnNonZero() *AvailabilityTestEvaluator {
+	w.alwaysAtLeastFlakeOnNonZero = true
+	return w
+}
+
+func (w *AvailabilityTestEvaluator) createDisruptionJunit(testName string, allowedDisruption *time.Duration, disruptionDetails string, backendName string, finalIntervals monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	// Indicates there is no entry in the query_results.json data file, nor a valid fallback,
+	// we do not wish to run the test. (this likely implies we do not have the required number of
+	// runs in 3 weeks to do a reliable P99)
+	if allowedDisruption == nil {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				SkipMessage: &junitapi.SkipMessage{
+					Message: "No historical data to calculate allowedDisruption",
+				},
+			},
+		}
+	}
+
+	if *allowedDisruption < 1*time.Second {
+		t := 1 * time.Second
+		allowedDisruption = &t
+		disruptionDetails = "always allow at least one second"
+	}
+
+	roundedAllowedDisruption := allowedDisruption.Round(time.Second)
+	roundedDisruptionDuration, describe := monitorapi.BackendDisruptionSeconds(backendName, finalIntervals)
+
+	failureReason := fmt.Sprintf("%v was unreachable during disruption: %v", backendName, disruptionDetails)
+	failureMessage := fmt.Sprintf("%s for at least %s (maxAllowed=%s):\n\n%s", failureReason, roundedDisruptionDuration, roundedAllowedDisruption, strings.Join(describe, "\n"))
+	ret := []*junitapi.JUnitTestCase{}
+
+	if w.alwaysAtLeastFlakeOnNonZero && roundedDisruptionDuration > 0 {
+		ret = append(ret,
+			&junitapi.JUnitTestCase{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Output: failureMessage,
+				},
+				SystemOut: failureMessage,
+			})
+	}
+
+	if roundedDisruptionDuration <= roundedAllowedDisruption {
+		return append(ret,
+			&junitapi.JUnitTestCase{
+				Name: testName,
+			})
+	}
+
+	return []*junitapi.JUnitTestCase{
+		{
+			Name: testName,
+			FailureOutput: &junitapi.FailureOutput{
+				Output: failureMessage,
+			},
+			SystemOut: failureMessage,
+		},
+	}
+}
+
+func (w *AvailabilityTestEvaluator) junitForNewConnections(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	newConnectionAllowed, newConnectionDisruptionDetails, err := historicalAllowedDisruption(ctx, w.newConnectionHistoricalBackendName, w.jobType)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get new allowed disruption: %w", err)
+	}
+
+	return w.createDisruptionJunit(
+			w.newConnectionTestName,
+			newConnectionAllowed,
+			newConnectionDisruptionDetails,
+			w.newConnectionHistoricalBackendName,
+			finalIntervals,
+		),
+		nil
+}
+
+func (w *AvailabilityTestEvaluator) junitForReusedConnections(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	reusedConnectionAllowed, reusedConnectionDisruptionDetails, err := historicalAllowedDisruption(ctx, w.reusedConnectionHistoricalBackendName, w.jobType)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get reused allowed disruption: %w", err)
+	}
+	return w.createDisruptionJunit(
+			w.reusedConnectionTestName,
+			reusedConnectionAllowed,
+			reusedConnectionDisruptionDetails,
+			w.reusedConnectionHistoricalBackendName,
+			finalIntervals,
+		),
+		nil
+}
+
+func historicalAllowedDisruption(ctx context.Context, backendName string, jobType platformidentification.JobType) (*time.Duration, string, error) {
+	return allowedbackenddisruption.GetAllowedDisruption(backendName, jobType)
+}
+
+func (w *AvailabilityTestEvaluator) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	if w == nil {
+		return nil, fmt.Errorf("unable to evaluate tests because instance is nil")
+	}
+
+	newConnectionJunit, err := w.junitForNewConnections(ctx, finalIntervals)
+	if err != nil {
+		return nil, err
+	}
+
+	reusedConnectionJunit, err := w.junitForReusedConnections(ctx, finalIntervals)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []*junitapi.JUnitTestCase{}
+	ret = append(ret, newConnectionJunit...)
+	ret = append(ret, reusedConnectionJunit...)
+	return ret, nil
+}


### PR DESCRIPTION
…we can find it in CI

not the easiest thing to do, but this kept the code paths unified.