### PR TITLE
allow failures for tests intentionally producing failures

### DIFF
--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -87,6 +87,11 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 			// https://github.com/kubernetes/kubernetes/blob/70ca1dbb81d8b8c6a2ac88d62480008780d4db79/test/e2e/apimachinery/garbage_collector.go#L735
 			continue
 		}
+		if strings.Contains(event.Locator, "ns/e2e-test-tuning-") &&
+			strings.Contains(event.Message, "IFNAME") {
+			// These tests are trying to cause pod sandbox failures, so the errors are intended.
+			continue
+		}
 		if strings.Contains(event.Message, "Multus") &&
 			strings.Contains(event.Message, "error getting pod") &&
 			(strings.Contains(event.Message, "connection refused") || strings.Contains(event.Message, "i/o timeout")) {


### PR DESCRIPTION
I found tests in https://github.com/openshift/origin/blob/master/test/extended/networking/tuning.go that are trying to cause permission failures.  If it should result in pod sandbox creation failures, this is good to merge. If it should fail *prior* to pod sandbox creation, then that needs to be checked.