### PR TITLE
prevent secondary errors reported in prior steps

### DIFF
--- a/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
+++ b/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
@@ -107,6 +107,11 @@ func (w *availability) CollectData(ctx context.Context, storageDir string, begin
 	if len(w.notSupportedReason) > 0 {
 		return nil, nil, nil
 	}
+	// we failed and indicated it during setup.
+	if w.disruptionChecker == nil {
+		return nil, nil, nil
+	}
+
 	return w.disruptionChecker.CollectData(ctx)
 }
 
@@ -119,6 +124,10 @@ func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 		return nil, nil
 	}
 	if w.suppressJunit {
+		return nil, nil
+	}
+	// we failed and indicated it during setup.
+	if w.disruptionChecker == nil {
 		return nil, nil
 	}
 

--- a/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers/monitortest.go
@@ -222,6 +222,11 @@ func (w *availability) CollectData(ctx context.Context, storageDir string, begin
 	errs := []error{}
 
 	for i := range w.disruptionCheckers {
+		// we failed and indicated it during setup.
+		if w.disruptionCheckers[i] == nil {
+			continue
+		}
+
 		localIntervals, localJunits, localErr := w.disruptionCheckers[i].CollectData(ctx)
 		intervals = append(intervals, localIntervals...)
 		junits = append(junits, localJunits...)
@@ -246,6 +251,11 @@ func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 	errs := []error{}
 
 	for i := range w.disruptionCheckers {
+		// we failed and indicated it during setup.
+		if w.disruptionCheckers[i] == nil {
+			continue
+		}
+
 		localJunits, localErr := w.disruptionCheckers[i].EvaluateTestsFromConstructedIntervals(ctx, finalIntervals)
 		junits = append(junits, localJunits...)
 		if localErr != nil {

--- a/pkg/monitortests/network/disruptioningress/monitortest.go
+++ b/pkg/monitortests/network/disruptioningress/monitortest.go
@@ -116,6 +116,11 @@ func (w *availability) CollectData(ctx context.Context, storageDir string, begin
 	errs := []error{}
 
 	for i := range w.disruptionCheckers {
+		// we failed and indicated it during setup.
+		if w.disruptionCheckers[i] == nil {
+			continue
+		}
+
 		localIntervals, localJunits, localErr := w.disruptionCheckers[i].CollectData(ctx)
 		intervals = append(intervals, localIntervals...)
 		junits = append(junits, localJunits...)
@@ -140,6 +145,11 @@ func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 	errs := []error{}
 
 	for i := range w.disruptionCheckers {
+		// we failed and indicated it during setup.
+		if w.disruptionCheckers[i] == nil {
+			continue
+		}
+
 		localJunits, localErr := w.disruptionCheckers[i].EvaluateTestsFromConstructedIntervals(ctx, finalIntervals)
 		junits = append(junits, localJunits...)
 		if localErr != nil {

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -234,6 +234,10 @@ func (w *availability) CollectData(ctx context.Context, storageDir string, begin
 	if len(w.notSupportedReason) > 0 {
 		return nil, nil, nil
 	}
+	// we failed and indicated it during setup.
+	if w.disruptionChecker == nil {
+		return nil, nil, nil
+	}
 
 	return w.disruptionChecker.CollectData(ctx)
 }
@@ -247,6 +251,10 @@ func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 		return nil, nil
 	}
 	if w.suppressJunit {
+		return nil, nil
+	}
+	// we failed and indicated it during setup.
+	if w.disruptionChecker == nil {
 		return nil, nil
 	}
 


### PR DESCRIPTION
/assign @stbenjam 

this eliminates the secondary errors when setup fails on building samplers and the apiserver is unreliable.