### PR TITLE
AUTH-365: add PodSecurityViolation to watched alerts

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/all.go
+++ b/pkg/monitortestlibrary/allowedalerts/all.go
@@ -69,5 +69,7 @@ func AllAlertTests(jobType *platformidentification.JobType, etcdAllowance AlertT
 	ret = append(ret, newAlert("samples", "SamplesImagestreamImportFailing", jobType).pending().neverFail().toTests()...)
 	ret = append(ret, newAlert("samples", "SamplesImagestreamImportFailing", jobType).firing().toTests()...)
 
+	ret = append(ret, newAlert("apiserver-auth", "PodSecurityViolation", jobType).firing().toTests()...)
+
 	return ret
 }

--- a/test/extended/apiserver/apply.go
+++ b/test/extended/apiserver/apply.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ServerSideApply] Server-Side App
 	defer g.GinkgoRecover()
 
 	oc := exutil.NewCLIWithoutNamespace("server-side-apply")
-	oc.KubeFramework().NamespacePodSecurityEnforceLevel = psapi.LevelBaseline
+	oc.KubeFramework().NamespacePodSecurityLevel = psapi.LevelBaseline
 
 	g.BeforeEach(func() {
 		// Only init once per worker

--- a/test/extended/kubevirt/services.go
+++ b/test/extended/kubevirt/services.go
@@ -3,6 +3,7 @@ package kubevirt
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -17,7 +18,7 @@ var _ = Describe("[sig-kubevirt] services", func() {
 		mgmtFramework.SkipNamespaceCreation = true
 
 		f1 := e2e.NewDefaultFramework("server-framework")
-		f1.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		It("should allow connections to pods from infra cluster pod via NodePort across different infra nodes", func() {
 			oc = setMgmtFramework(mgmtFramework)

--- a/test/extended/networking/internal_ports.go
+++ b/test/extended/networking/internal_ports.go
@@ -38,7 +38,7 @@ const (
 var _ = ginkgo.Describe("[sig-network] Internal connectivity", func() {
 	f := framework.NewDefaultFramework("nettest")
 	// TODO(sur): verify if privileged is really necessary in a follow-up
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	oc := exutil.NewCLIWithoutNamespace("nettest").AsAdmin()
 
 	ginkgo.It("for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]", func() {

--- a/test/extended/networking/isolation.go
+++ b/test/extended/networking/isolation.go
@@ -1,12 +1,12 @@
 package networking
 
 import (
-	admissionapi "k8s.io/pod-security-admission/api"
-
-	e2e "k8s.io/kubernetes/test/e2e/framework"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -16,10 +16,10 @@ var _ = Describe("[sig-network] network isolation", func() {
 	InNonIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-isolation1")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f1.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 		f2 := e2e.NewDefaultFramework("net-isolation2")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f2.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f2.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		It("should allow communication between pods in different namespaces on the same node", func() {
 			Expect(checkPodIsolation(f1, f2, SAME_NODE)).To(Succeed())
@@ -33,10 +33,10 @@ var _ = Describe("[sig-network] network isolation", func() {
 	InIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-isolation1")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f1.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 		f2 := e2e.NewDefaultFramework("net-isolation2")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f2.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f2.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		It("should prevent communication between pods in different namespaces on the same node", func() {
 			Expect(checkPodIsolation(f1, f2, SAME_NODE)).NotTo(Succeed())

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -21,7 +21,7 @@ var _ = Describe("[sig-network] services", func() {
 	Context("basic functionality", func() {
 		f1 := e2e.NewDefaultFramework("net-services1")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f1.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		It("should allow connections to another pod on the same node via a service IP", func() {
 			Expect(checkServiceConnectivity(f1, f1, SAME_NODE)).To(Succeed())
@@ -35,10 +35,10 @@ var _ = Describe("[sig-network] services", func() {
 	InNonIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-services1")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f1.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 		f2 := e2e.NewDefaultFramework("net-services2")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f2.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f2.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		It("should allow connections to pods in different namespaces on the same node via service IPs", func() {
 			Expect(checkServiceConnectivity(f1, f2, SAME_NODE)).To(Succeed())
@@ -54,10 +54,10 @@ var _ = Describe("[sig-network] services", func() {
 	InIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-services1")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f1.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 		f2 := e2e.NewDefaultFramework("net-services2")
 		// TODO(sur): verify if privileged is really necessary in a follow-up
-		f2.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+		f2.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		It("should prevent connections to pods in different namespaces on the same node via service IPs", func() {
 			Expect(checkServiceConnectivity(f1, f2, SAME_NODE)).NotTo(Succeed())

--- a/test/extended/pods/liveness_override.go
+++ b/test/extended/pods/liveness_override.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-node]", func() {
 
 	f := framework.NewDefaultFramework("liveness-probe-override")
 	// TODO(sur): verify if privileged is really necessary in a follow-up
-	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	// upstream e2e will test normal grace period on shutdown
 	g.It("should override timeoutGracePeriodSeconds when annotation is set", func() {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -30960,6 +30960,8 @@ oc new-project "${namespace}"
 
 oc label namespace ${namespace} --overwrite \
   pod-security.kubernetes.io/enforce=baseline \
+  pod-security.kubernetes.io/warn=baseline \
+  pod-security.kubernetes.io/audit=baseline \
   security.openshift.io/scc.podSecurityLabelSync=false
 `)
 

--- a/test/extended/testdata/cmd/hack/lib/init.sh
+++ b/test/extended/testdata/cmd/hack/lib/init.sh
@@ -83,4 +83,6 @@ oc new-project "${namespace}"
 
 oc label namespace ${namespace} --overwrite \
   pod-security.kubernetes.io/enforce=baseline \
+  pod-security.kubernetes.io/warn=baseline \
+  pod-security.kubernetes.io/audit=baseline \
   security.openshift.io/scc.podSecurityLabelSync=false

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -26,7 +26,6 @@ import (
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/openshift/api/annotations"
 	kubeauthorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -55,6 +54,7 @@ import (
 	e2edebug "k8s.io/kubernetes/test/e2e/framework/debug"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	"github.com/openshift/api/annotations"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	userv1 "github.com/openshift/api/user/v1"
@@ -131,7 +131,7 @@ func NewCLIWithFramework(kubeFramework *framework.Framework) *CLI {
 // but the given pod security level is applied to the created e2e test namespace.
 func NewCLIWithPodSecurityLevel(project string, level admissionapi.Level) *CLI {
 	cli := NewCLI(project)
-	cli.kubeFramework.NamespacePodSecurityEnforceLevel = level
+	cli.kubeFramework.NamespacePodSecurityLevel = level
 	return cli
 }
 
@@ -557,17 +557,17 @@ func (c *CLI) setupNamespacePodSecurity(ns string) error {
 			return err
 		}
 
-		if len(c.kubeFramework.NamespacePodSecurityEnforceLevel) == 0 {
-			c.kubeFramework.NamespacePodSecurityEnforceLevel = admissionapi.LevelRestricted
+		if len(c.kubeFramework.NamespacePodSecurityLevel) == 0 {
+			c.kubeFramework.NamespacePodSecurityLevel = admissionapi.LevelRestricted
 		}
 		if ns.Labels == nil {
 			ns.Labels = make(map[string]string)
 		}
-		ns.Labels[admissionapi.EnforceLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
+		ns.Labels[admissionapi.EnforceLevelLabel] = string(c.kubeFramework.NamespacePodSecurityLevel)
 		// In contrast to upstream, OpenShift sets a global default on warn and audit pod security levels.
 		// Since this would cause unwanted audit log and warning entries, we are setting the same level as for enforcement.
-		ns.Labels[admissionapi.WarnLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
-		ns.Labels[admissionapi.AuditLevelLabel] = string(c.kubeFramework.NamespacePodSecurityEnforceLevel)
+		ns.Labels[admissionapi.WarnLevelLabel] = string(c.kubeFramework.NamespacePodSecurityLevel)
+		ns.Labels[admissionapi.AuditLevelLabel] = string(c.kubeFramework.NamespacePodSecurityLevel)
 		ns.Labels["security.openshift.io/scc.podSecurityLabelSync"] = "false"
 
 		_, err = c.AdminKubeClient().CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -18,15 +18,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openshift/origin/pkg/riskanalysis"
-	"github.com/openshift/origin/pkg/test"
-	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
-
 	g "github.com/onsi/ginkgo/v2"
+
 	"k8s.io/kubernetes/test/e2e/chaosmonkey"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/openshift/origin/pkg/riskanalysis"
+	"github.com/openshift/origin/pkg/test"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 )
 
 const (
@@ -319,7 +320,7 @@ func createTestFrameworks(tests []upgrades.Test) map[string]*framework.Framework
 			Timeouts: framework.NewTimeoutContext(),
 			// This is similar to https://github.com/kubernetes/kubernetes/blob/f33ca2306548719e5116b53fccfc278bffb809a8/test/e2e/upgrades/upgrade_suite.go#L106,
 			// where centrally all upgrade tests are being instantiated.
-			NamespacePodSecurityEnforceLevel: admissionapi.LevelPrivileged,
+			NamespacePodSecurityLevel: admissionapi.LevelPrivileged,
 		}
 	}
 	return testFrameworks


### PR DESCRIPTION
We don't want this to be firing in vanilla OpenShift clusters.

Supersedes #27634