### PR TITLE
Revert "Fail on APIs removed in the next release"

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -14,20 +13,11 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	apiserverclientv1 "github.com/openshift/client-go/apiserver/clientset/versioned/typed/apiserver/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
+	"github.com/openshift/origin/pkg/test/ginkgo/result"
 	exutil "github.com/openshift/origin/test/extended/util"
-)
-
-const unknownUser = "<unknown>"
-
-var (
-	// allowedUsers is a list of users who are allowed to make API calls to deprecated APIs
-	allowedUsers = sets.NewString("system:serviceaccount:openshift-kube-storage-version-migrator:kube-storage-version-migrator-sa")
-	// allowedUsersRE is a regular expression for a user being added in test/extended/etcd/etcd_test_runner.go
-	allowedUsersRE = regexp.MustCompile(`test-etcd-storage-path\w+`)
 )
 
 var _ = g.Describe("[sig-arch][Late]", func() {
@@ -51,7 +41,9 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				apiRequestCount.Status.RemovedInRelease != "2.0" { // 2.0 is a current placeholder for not-slated for removal. It will be fixed before 4.8.
 				deprecatedAPIRequestCounts = append(deprecatedAPIRequestCounts, apiRequestCount)
 
-				framework.Logf("api %v, removed in release %s, was accessed %d times", apiRequestCount.Name, apiRequestCount.Status.RemovedInRelease, apiRequestCount.Status.RequestCount)
+				details := fmt.Sprintf("api %v, removed in release %s, was accessed %d times", apiRequestCount.Name, apiRequestCount.Status.RemovedInRelease, apiRequestCount.Status.RequestCount)
+				failureOutput = append(failureOutput, details)
+				framework.Logf(details)
 			}
 		}
 
@@ -81,22 +73,9 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 					}
 				}
 			}
-
-			// in case we didn't have the last 24h detailed data, at least log as a general API being accessed
-			if len(apiRequestCount.Status.Last24h) == 0 {
-				resourceToRequestCount := userToResourceToRequestCount[unknownUser]
-				if resourceToRequestCount == nil {
-					resourceToRequestCount = map[string]requestCount{}
-					userToResourceToRequestCount[unknownUser] = resourceToRequestCount
-				}
-				resourceToRequestCount[apiRequestCount.Name] = requestCount{count: apiRequestCount.Status.RequestCount}
-			}
 		}
 
 		for user, resourceToRequestCount := range userToResourceToRequestCount {
-			if allowedUsers.Has(user) || allowedUsersRE.MatchString(user) {
-				continue
-			}
 			for resource, requestCount := range resourceToRequestCount {
 				details := fmt.Sprintf("user/%v accessed %v %d times", user, resource, requestCount.count)
 				failureOutput = append(failureOutput, details)
@@ -107,7 +86,8 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 		sort.Strings(failureOutput)
 
 		if len(failureOutput) > 0 {
-			framework.Failf(strings.Join(failureOutput, "\n"))
+			// don't insta-fail all of CI
+			result.Flakef(strings.Join(failureOutput, "\n"))
 		}
 	})
 

--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -229,7 +229,7 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, oc *exutil.CLI, etcdClient3Fn fu
 
 	var tt *testing.T // will cause nil panics that make it easy enough to find where things went wrong
 
-	kubeConfig := restclient.CopyConfig(oc.UserConfig())
+	kubeConfig := restclient.CopyConfig(oc.AdminConfig())
 	kubeConfig.QPS = 99999
 	kubeConfig.Burst = 9999
 	kubeClient := kclientset.NewForConfigOrDie(kubeConfig)

--- a/test/extended/etcd/etcd_test_runner.go
+++ b/test/extended/etcd/etcd_test_runner.go
@@ -23,36 +23,24 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = g.Describe("[sig-api-machinery] API data in etcd", func() {
 	defer g.GinkgoRecover()
 
-	cli := exutil.NewCLIWithPodSecurityLevel("etcd-storage-path", psapi.LevelBaseline)
-	adminCLI := cli.AsAdmin()
+	oc := exutil.NewCLIWithPodSecurityLevel("etcd-storage-path", psapi.LevelBaseline).AsAdmin()
 
-	g.It("should be stored at the correct location and version for all resources [Serial]", func() {
-		controlPlaneTopology, err := exutil.GetControlPlaneTopology(adminCLI)
+	_ = g.It("should be stored at the correct location and version for all resources [Serial]", func() {
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
 			e2eskipper.Skipf("External clusters run etcd outside of the cluster. Etcd cannot be accessed directly from within the cluster")
 		}
 
-		etcdClientCreater := &etcdPortForwardClient{kubeClient: adminCLI.AdminKubeClient()}
+		etcdClientCreater := &etcdPortForwardClient{kubeClient: oc.AdminKubeClient()}
 		defer etcdClientCreater.closeAll()
-
-		// for the cleaning mechanism (cli.TeardownProject being invoked in g.AfterEach)
-		// we need to use the original client, AsAdmin replaces the instaces and thus
-		// the newely created objects won't get pruned afte the test finishes
-		etcdUser := cli.CreateUser("test-etcd-storage-path")
-		err = adminCLI.Run("adm", "policy", "add-cluster-role-to-user").Args("cluster-admin", etcdUser.Name, "--rolebinding-name", etcdUser.Name).Execute()
-		// make sure the clusterrolebinding also gets removed
-		cli.AddExplicitResourceToDelete(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), "", etcdUser.Name)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		adminCLI.ChangeUser(etcdUser.Name)
-		testEtcd3StoragePath(g.GinkgoT(2), adminCLI, etcdClientCreater.getEtcdClient)
+		testEtcd3StoragePath(g.GinkgoT(2), oc, etcdClientCreater.getEtcdClient)
 	})
 })
 


### PR DESCRIPTION
Reverts #27561 , tracked by [TRT-1209](https://issues.redhat.com//browse/TRT-1209)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of a minor upgrade.

CC: @soltysh