### PR TITLE
OCPBUGS-20024: Revert "OCPBUGS-13366: ignore repeated TopologyAwareHintsDisabled events"

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -224,10 +224,6 @@ var KnownEventsBugs = []KnownProblem{
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
 	},
 	{
-		Regexp: regexp.MustCompile("reason/TopologyAwareHintsDisabled"),
-		BZ:     "https://issues.redhat.com/browse/OCPBUGS-13366",
-	},
-	{
 		Regexp:   regexp.MustCompile("ns/.*reason/.*APICheckFailed.*503.*"),
 		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
 		Topology: TopologyPointer(v1.SingleReplicaTopologyMode),

--- a/pkg/monitortests/testframework/watchevents/event_test.go
+++ b/pkg/monitortests/testframework/watchevents/event_test.go
@@ -98,25 +98,26 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 			expectedMessage: "pathological/true interesting/true reason/SomethingHappened Readiness probe failed (40 times)",
 		},
 		{
-			name: "allowed pathological event with known bug",
+			name: "allowed pathological event with known bug (BZ 2000234)",
 			args: args{
 				ctx: context.TODO(),
 				m:   monitor.NewRecorder(),
 				kubeEvent: &corev1.Event{
 					Count:  40,
-					Reason: "TopologyAwareHintsDisabled",
+					Reason: "ns/openshift-etcd pod/etcd-quorum-guard-42 node/worker-42 - reason/Unhealthy",
 					InvolvedObject: corev1.ObjectReference{
 						Kind:      "Pod",
-						Namespace: "any",
-						Name:      "any",
+						Namespace: "openshift-etcd",
+						Name:      "etcd-quorum-guard-42",
 					},
-					Message:       "irrelevant",
+					Message:       "Readiness probe failed:",
 					LastTimestamp: metav1.Now(),
 				},
 				significantlyBeforeNow: now.UTC().Add(-15 * time.Minute),
 			},
-			expectedLocator: "ns/any pod/any hmsg/e13faa98ab",
-			expectedMessage: "pathological/true interesting/true reason/TopologyAwareHintsDisabled irrelevant (40 times)",
+			// hmsg in expectedLocator is the hash of the entire expectedMessage except the number of times
+			expectedLocator: "ns/openshift-etcd pod/etcd-quorum-guard-42 hmsg/9100aa725d",
+			expectedMessage: "pathological/true interesting/true reason/ns/openshift-etcd pod/etcd-quorum-guard-42 node/worker-42 - reason/Unhealthy Readiness probe failed: (40 times)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Revert the status of TopologyAwareHintsDisabled as a known issue, and fix the
unit test that relied on TopologyAwareHintsDisabled being a known issue.
    
Revert "OCPBUGS-13366: ignore repeated TopologyAwareHintsDisabled events"
This reverts commit 34fce4f11d0ec8554d9f356c1d72c075ea7ccb5a.
    
Add a reference to a known bug that can be considered pathological and interesting.