### PR TITLE
[release-4.12] OCPBUGS-18309: Add missing watch permission for console users

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -129,7 +129,7 @@ var (
 
 			// HelmChartRepository instances keep Helm chart repository configuration
 			// By default users are able to browse charts from all configured repositories through console UI
-			rbacv1helpers.NewRule("get", "list").Groups("helm.openshift.io").Resources("helmchartrepositories").RuleOrDie(),
+			rbacv1helpers.NewRule(read...).Groups("helm.openshift.io").Resources("helmchartrepositories").RuleOrDie(),
 
 			// TODO: remove when openshift-apiserver has removed these
 			rbacv1helpers.NewRule("get").URLs(


### PR DESCRIPTION
This is a manual backport of #28054

It is required to merge https://github.com/openshift/console-operator/pull/789 to add a missing watch permission to users that have already get and list permission. The missing permission results in unnecessary error logs and network failures because the console UI tries automatically to watch `helmchartrepositories`.

This then results in performance issues customers report with the UI.

The console-operator e2e tests fails with errors like this:

```
[AfterEach] [sig-auth][Feature:OpenShiftAuthorization] The default cluster RBAC policy
  github.com/openshift/origin/test/extended/util/client.go:159
STEP: Destroying namespace "e2e-test-default-rbac-policy-zb8gj" for this suite. 08/31/23 06:58:39.292
fail [github.com/openshift/origin/test/extended/authorization/rbac/groups_default_rules.go:229]: Aug 31 06:58:38.991: system:authenticated has extra permissions in namespace "":
{APIGroups:["helm.openshift.io"], Resources:["helmchartrepositories"], Verbs:["watch"]}
Ginkgo exit error 1: exit with code 1
```

From https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console-operator/789/pull-ci-openshift-console-operator-release-4.12-e2e-gcp-ovn/1697116204835016704: