### PR TITLE
[release-4.11] OCPBUGS-18424: Add missing watch permission for console users

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -126,7 +126,7 @@ var (
 
 			// HelmChartRepository instances keep Helm chart repository configuration
 			// By default users are able to browse charts from all configured repositories through console UI
-			rbacv1helpers.NewRule("get", "list").Groups("helm.openshift.io").Resources("helmchartrepositories").RuleOrDie(),
+			rbacv1helpers.NewRule(read...).Groups("helm.openshift.io").Resources("helmchartrepositories").RuleOrDie(),
 
 			// TODO: remove when openshift-apiserver has removed these
 			rbacv1helpers.NewRule("get").URLs(


### PR DESCRIPTION
This is a manual backport of #28234

It will be required to backport a similar change as https://github.com/openshift/console-operator/pull/775 to 4.11.

It adds a missing watch permission to users that have already get and list permission. The missing permission results in unnecessary error logs and network failures because the console UI tries automatically to watch `helmchartrepositories`.

This results in performance issues customers report with the UI on OpenShift 4.10. I started this backport before the 4.11 PR was merged so that the tests could get green... :man_shrugging: 

/kind bug
/cc @bparees