### PR TITLE
Bug OCPBUGS-18718 Remove duplicate connection type from disruption name

### DIFF
--- a/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
@@ -175,9 +175,7 @@ func (w *Availability) junitForReusedConnections(ctx context.Context, finalInter
 }
 
 func historicalAllowedDisruption(ctx context.Context, backend *backenddisruption.BackendSampler, jobType *platformidentification.JobType) (*time.Duration, string, error) {
-	backendName := backend.GetDisruptionBackendName() + "-" + string(backend.GetConnectionType()) + "-connections"
-
-	return allowedbackenddisruption.GetAllowedDisruption(backendName, *jobType)
+	return allowedbackenddisruption.GetAllowedDisruption(backend.GetDisruptionBackendName(), *jobType)
 }
 
 func (w *Availability) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {


### PR DESCRIPTION
[TRT-1219](https://issues.redhat.com/browse/TRT-1219)
[OCPBUGS-18718](https://issues.redhat.com/browse/OCPBUGS-18718)

With the refactor, we are adding connection types twice to the backend name. This PR removes the duplicate. 