### PR TITLE
[WIP] Refactor `test/extended/util/client.go`

### DIFF
--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -81,7 +81,7 @@ func InitializeTestFramework(context *e2e.TestContextType, config *ClusterConfig
 	// As an extra precaution for now, we do not run this check on all tests since some might fail to pull
 	// release payload information
 	if config.HasNoOptionalCapabilities && !isMicroShift {
-		imageStreamString, _, err := exutil.NewCLIWithoutNamespace("").AsAdmin().Run("adm", "release", "info", `-ojsonpath={.references}`).Outputs()
+		imageStreamString, _, err := exutil.NewCLI("default", exutil.WithoutNamespace()).AsAdmin().Run("adm", "release", "info", `-ojsonpath={.references}`).Outputs()
 		if err != nil {
 			return err
 		}

--- a/pkg/monitortests/network/disruptionpodnetwork/utils.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/utils.go
@@ -47,7 +47,7 @@ func GetOpenshiftTestsImagePullSpec(ctx context.Context, adminRESTConfig *rest.C
 		logrus.WithError(err).Errorf("unable to determine openshift-tests image through exec: %v", errOut.String())
 		// Now try the wrapper to see if it makes a difference
 		if oc == nil {
-			oc = exutil.NewCLIWithoutNamespace("openshift-tests")
+			oc = exutil.NewCLI("openshift-tests", exutil.WithoutNamespace())
 		}
 		outStr, err = oc.Run("adm", "release", "info", suggestedPayloadImage).Args("--image-for=tests").Output()
 		if err != nil {

--- a/pkg/monitortests/testframework/watchrequestcountscollector/monitortest.go
+++ b/pkg/monitortests/testframework/watchrequestcountscollector/monitortest.go
@@ -47,7 +47,7 @@ func (w *watchRequestCountSerializer) EvaluateTestsFromConstructedIntervals(ctx 
 }
 
 func (w *watchRequestCountSerializer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	oc := exutil.NewCLIWithoutNamespace("api-requests")
+	oc := exutil.NewCLI("api-requests", exutil.WithoutNamespace())
 
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	if err != nil {

--- a/pkg/test/ginkgo/external.go
+++ b/pkg/test/ginkgo/external.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imagev1 "github.com/openshift/api/image/v1"
-	"github.com/openshift/origin/test/extended/util"
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 type serializedTest struct {
@@ -73,8 +72,8 @@ func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
 		return "", fmt.Errorf("cannot create temporary directory for extracted binary: %w", err)
 	}
 
-	oc := util.NewCLIWithoutNamespace("default")
-	cv, err := util.GetClusterVersion(context.Background(), oc.AdminConfig())
+	oc := exutil.NewCLI("default", exutil.WithoutNamespace())
+	cv, err := exutil.GetClusterVersion(context.Background(), oc.AdminConfig())
 	if err != nil {
 		return "", fmt.Errorf("failed reading ClusterVersion/version: %w", err)
 	}
@@ -91,7 +90,7 @@ func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
 		return "", fmt.Errorf("failed reading image-references: %w", err)
 	}
 	defer jsonFile.Close()
-	data, err := ioutil.ReadAll(jsonFile)
+	data, err := io.ReadAll(jsonFile)
 	if err != nil {
 		return "", fmt.Errorf("unable to load release image-references: %w", err)
 	}
@@ -146,7 +145,7 @@ func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
 
 // runImageExtract extracts src from specified image to dst
 func runImageExtract(image, src, dst string, dockerConfigJsonPath string) error {
-	args := []string{"--kubeconfig=" + util.KubeConfigPath(), "image", "extract", image, fmt.Sprintf("--path=%s:%s", src, dst), "--confirm"}
+	args := []string{"--kubeconfig=" + exutil.KubeConfigPath(), "image", "extract", image, fmt.Sprintf("--path=%s:%s", src, dst), "--confirm"}
 	if len(dockerConfigJsonPath) > 0 {
 		args = append(args, fmt.Sprintf("--registry-config=%s", dockerConfigJsonPath))
 	}

--- a/pkg/test/ginkgo/external.go
+++ b/pkg/test/ginkgo/external.go
@@ -74,7 +74,7 @@ func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
 	}
 
 	oc := util.NewCLIWithoutNamespace("default")
-	cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+	cv, err := util.GetClusterVersion(context.Background(), oc.AdminConfig())
 	if err != nil {
 		return "", fmt.Errorf("failed reading ClusterVersion/version: %w", err)
 	}

--- a/test/e2e/upgrade/adminack/adminack.go
+++ b/test/e2e/upgrade/adminack/adminack.go
@@ -29,7 +29,7 @@ func (UpgradeTest) DisplayName() string {
 // Setup creates artifacts to be used by Test
 func (t *UpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	g.By("Setting up admin ack test")
-	oc := exutil.NewCLIWithFramework(f)
+	oc := exutil.NewCLI("", exutil.WithFramework(f))
 	t.oc = oc
 	config, err := framework.LoadConfig()
 	o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/e2e/upgrade/manifestdelete/manifest-delete.go
+++ b/test/e2e/upgrade/manifestdelete/manifest-delete.go
@@ -95,7 +95,7 @@ func (UpgradeTest) DisplayName() string {
 // Setup creates artifacts to be used by Test
 func (t *UpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	g.By("Setting up upgrade delete test")
-	oc := exutil.NewCLIWithFramework(f)
+	oc := exutil.NewCLI("", exutil.WithFramework(f))
 	t.oc = oc
 	config, err := framework.LoadConfig()
 	o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -39,7 +39,7 @@ var (
 var _ = g.Describe("[sig-arch][Late]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("api-requests")
+	oc := exutil.NewCLI("api-requests", exutil.WithoutNamespace())
 
 	g.It("clients should not use APIs that are removed in upcoming releases [apigroup:apiserver.openshift.io]", func() {
 		ctx := context.Background()

--- a/test/extended/apiserver/apply.go
+++ b/test/extended/apiserver/apply.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ServerSideApply] Server-Side App
 
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("server-side-apply")
+	oc := exutil.NewCLI("server-side-apply", exutil.WithoutNamespace())
 	oc.KubeFramework().NamespacePodSecurityLevel = psapi.LevelBaseline
 
 	g.BeforeEach(func() {

--- a/test/extended/apiserver/apply.go
+++ b/test/extended/apiserver/apply.go
@@ -68,7 +68,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ServerSideApply] Server-Side App
 
 		g.It(fmt.Sprintf("should work for %s [apigroup:%s]", gvr, gvr.Group), func() {
 			// create the testing namespace
-			testNamespace := oc.SetupProject()
+			testNamespace := oc.NewProject()
 
 			exist, err := exutil.DoesApiResourceExist(oc.AdminConfig(), gvr.Resource, gvr.GroupVersion().String())
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -28,7 +28,7 @@ import (
 var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("terminating-kube-apiserver")
+	oc := exutil.NewCLI("terminating-kube-apiserver", exutil.WithoutNamespace())
 
 	// This test checks whether the apiserver reports any events that may indicate a problem at any time,
 	// not just when the suite is running. We already have invariant tests that fail if these are violated
@@ -154,7 +154,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 		results := map[string]int{}
 
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			mgmtClusterOC := exutil.NewHypershiftManagementCLI("default").AsAdmin().WithoutNamespace()
+			mgmtClusterOC := exutil.NewCLI("default", exutil.WithoutNamespace()).AsAdmin()
 			pods, err := mgmtClusterOC.KubeClient().CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{LabelSelector: "hypershift.openshift.io/control-plane-component=kube-apiserver"})
 			o.Expect(err).To(o.BeNil())
 			for _, pod := range pods.Items {

--- a/test/extended/apiserver/kubeconfigs.go
+++ b/test/extended/apiserver/kubeconfigs.go
@@ -22,7 +22,7 @@ import (
 
 var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("apiserver", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("apiserver", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 
 	for _, kc := range []string{
 		"localhost.kubeconfig",

--- a/test/extended/apiserver/openapiv3.go
+++ b/test/extended/apiserver/openapiv3.go
@@ -25,7 +25,7 @@ import (
 var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("apiserver-openapi")
+	oc := exutil.NewCLI("apiserver-openapi", exutil.WithoutNamespace())
 
 	g.It("should serve openapi v3 discovery", func() {
 		transport, err := rest.TransportFor(oc.AdminConfig())

--- a/test/extended/apiserver/resiliency.go
+++ b/test/extended/apiserver/resiliency.go
@@ -32,7 +32,8 @@ var _ = ginkgo.Describe("[Conformance][sig-sno][Serial] Cluster", func() {
 	f := framework.NewDefaultFramework("cluster-resiliency")
 	f.SkipNamespaceCreation = true
 
-	oc := exutil.NewCLIWithoutNamespace("cluster-resiliency")
+	// TODO (soltysh): why we're using two frameworks: one created above, and another in NewCLI
+	oc := exutil.NewCLI("cluster-resiliency", exutil.WithoutNamespace())
 
 	ginkgo.It("should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]", func() {
 		controlPlaneTopology, _ := single_node.GetTopologies(f)

--- a/test/extended/apiserver/root_403.go
+++ b/test/extended/apiserver/root_403.go
@@ -20,7 +20,7 @@ import (
 var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("apiserver")
+	oc := exutil.NewCLI("apiserver", exutil.WithoutNamespace())
 
 	g.It("anonymous browsers should get a 403 from /", func() {
 		transport, err := anonymousHttpTransport(oc.AdminConfig())

--- a/test/extended/authorization/podsecurity_admission.go
+++ b/test/extended/authorization/podsecurity_admission.go
@@ -33,7 +33,7 @@ var sleeperContainer = corev1.Container{
 var _ = g.Describe("[sig-auth][Feature:PodSecurity]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithPodSecurityLevel("pod-security", psapi.LevelRestricted)
+	oc := exutil.NewCLI("pod-security", exutil.WithPSALevel(psapi.LevelRestricted))
 
 	g.It("restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile", func() {
 		pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(context.Background(), &corev1.Pod{
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-auth][Feature:PodSecurity]", func() {
 var _ = g.Describe("[sig-auth][Feature:PodSecurity][Feature:SCC]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithPodSecurityLevel("pod-security-scc-mutation", psapi.LevelRestricted)
+	oc := exutil.NewCLI("pod-security-scc-mutation", exutil.WithPSALevel(psapi.LevelRestricted))
 
 	g.It("creating pod controllers", func() {
 		ns, err := oc.AdminKubeClient().CoreV1().Namespaces().Get(context.Background(), oc.Namespace(), metav1.GetOptions{})

--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -240,12 +240,12 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] The default clust
 			kubeInformers.Rbac().V1().Roles().Informer().HasSynced,
 			kubeInformers.Rbac().V1().RoleBindings().Informer().HasSynced,
 		); !ok {
-			exutil.FatalErr("failed to sync RBAC cache")
+			e2e.Failf("failed to sync RBAC cache")
 		}
 
 		namespaces, err := oc.AdminKubeClient().CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 		if err != nil {
-			exutil.FatalErr(err)
+			e2e.Failf("%v", err)
 		}
 
 		g.By("should only allow the system:authenticated group to access certain policy rules", func() {

--- a/test/extended/authorization/scc.go
+++ b/test/extended/authorization/scc.go
@@ -23,7 +23,7 @@ import (
 var _ = g.Describe("[sig-auth][Feature:SCC][Early]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("working-scc-during-install")
+	oc := exutil.NewCLI("working-scc-during-install", exutil.WithoutNamespace())
 
 	g.It("should not have pod creation failures during install", func() {
 		kubeClient := oc.AdminKubeClient()
@@ -86,7 +86,7 @@ var _ = g.Describe("[sig-auth][Feature:SCC][Early]", func() {
 var _ = g.Describe("[sig-auth][Feature:PodSecurity][Feature:SCC]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithPodSecurityLevel("required-scc", psapi.LevelPrivileged)
+	oc := exutil.NewCLI("required-scc", exutil.WithPSALevel(psapi.LevelPrivileged))
 
 	g.It("required-scc annotation is being applied to workloads", func() {
 		sccRole, err := oc.AdminKubeClient().RbacV1().ClusterRoles().Create(context.Background(),

--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 		failedBuildConfig     = filepath.Join(buildPruningBaseDir, "failed-build-config.yaml")
 		erroredBuildConfig    = filepath.Join(buildPruningBaseDir, "errored-build-config.yaml")
 		groupBuildConfig      = filepath.Join(buildPruningBaseDir, "default-group-build-config.yaml")
-		oc                    = exutil.NewCLIWithPodSecurityLevel("build-pruning", admissionapi.LevelBaseline)
+		oc                    = exutil.NewCLI("build-pruning", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		pollingInterval       = time.Second
 		timeout               = time.Minute
 	)

--- a/test/extended/builds/build_timing.go
+++ b/test/extended/builds/build_timing.go
@@ -39,7 +39,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][timing] capture build stages an
 		dockerBuildDockerfile = filepath.Join(buildTimingBaseDir, "Dockerfile")
 		sourceBuildFixture    = filepath.Join(buildTimingBaseDir, "test-s2i-build.json")
 		sourceBuildBinDir     = filepath.Join(buildTimingBaseDir, "s2i-binary-dir")
-		oc                    = exutil.NewCLIWithPodSecurityLevel("build-timing", admissionapi.LevelBaseline)
+		oc                    = exutil.NewCLI("build-timing", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds with a context dir
 	defer g.GinkgoRecover()
 	var (
 		appFixture            = exutil.FixturePath("testdata", "builds", "test-context-build.json")
-		oc                    = exutil.NewCLIWithPodSecurityLevel("contextdir", admissionapi.LevelBaseline)
+		oc                    = exutil.NewCLI("contextdir", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		s2iBuildConfigName    = "s2icontext"
 		s2iBuildName          = "s2icontext-1"
 		dcName                = "frontend"

--- a/test/extended/builds/custom_build.go
+++ b/test/extended/builds/custom_build.go
@@ -14,7 +14,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] custom build with buildah", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                 = exutil.NewCLIWithPodSecurityLevel("custom-build", admissionapi.LevelBaseline)
+		oc                 = exutil.NewCLI("custom-build", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		customBuildAdd     = exutil.FixturePath("testdata", "builds", "custom-build")
 		customBuildFixture = exutil.FixturePath("testdata", "builds", "test-custom-build.yaml")
 	)

--- a/test/extended/builds/docker_pullsearch.go
+++ b/test/extended/builds/docker_pullsearch.go
@@ -13,7 +13,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][pullsearch] docker build where 
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-build-search-registries.yaml")
-		oc           = exutil.NewCLIWithPodSecurityLevel("docker-build-pullsearch", api.LevelPrivileged)
+		oc           = exutil.NewCLI("docker-build-pullsearch", exutil.WithPSALevel(api.LevelPrivileged))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/docker_pullsecret.go
+++ b/test/extended/builds/docker_pullsecret.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][pullsecret] docker build using 
 
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-docker-build-pullsecret.json")
-		oc           = exutil.NewCLIWithPodSecurityLevel("docker-build-pullsecret", admissionapi.LevelBaseline)
+		oc           = exutil.NewCLI("docker-build-pullsecret", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/hooks.go
+++ b/test/extended/builds/hooks.go
@@ -21,7 +21,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] testing build configurati
 		dockerBuildFixture = exutil.FixturePath("testdata", "builds", "build-postcommit", "docker.yaml")
 		s2iBuildFixture    = exutil.FixturePath("testdata", "builds", "build-postcommit", "sti.yaml")
 		imagestreamFixture = exutil.FixturePath("testdata", "builds", "build-postcommit", "imagestreams.yaml")
-		oc                 = exutil.NewCLIWithPodSecurityLevel("cli-test-hooks", admissionapi.LevelBaseline)
+		oc                 = exutil.NewCLI("cli-test-hooks", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -47,7 +47,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 		s2iBuildFixture    = exutil.FixturePath("testdata", "builds", "test-imageresolution-s2i-build.yaml")
 		dockerBuildFixture = exutil.FixturePath("testdata", "builds", "test-imageresolution-docker-build.yaml")
 		customBuildFixture = exutil.FixturePath("testdata", "builds", "test-imageresolution-custom-build.yaml")
-		oc                 = exutil.NewCLIWithPodSecurityLevel("build-image-source", admissionapi.LevelRestricted)
+		oc                 = exutil.NewCLI("build-image-source", exutil.WithPSALevel(admissionapi.LevelRestricted))
 		imageSourceLabel   = exutil.ParseLabelsOrDie("app=imagesourceapp")
 		imageDockerLabel   = exutil.ParseLabelsOrDie("app=imagedockerapp")
 		sourceBuildLabel   = exutil.ParseLabelsOrDie("openshift.io/build.name=imagesourcebuild")

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] result image should have proper
 		imageStreamFixture = exutil.FixturePath("testdata", "builds", "test-image-stream.json")
 		stiBuildFixture    = exutil.FixturePath("testdata", "builds", "test-s2i-build.json")
 		dockerBuildFixture = exutil.FixturePath("testdata", "builds", "test-docker-build.json")
-		oc                 = exutil.NewCLIWithPodSecurityLevel("build-sti-labels", admissionapi.LevelBaseline)
+		oc                 = exutil.NewCLI("build-sti-labels", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -24,7 +24,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] Multi-stage image builds", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc             = exutil.NewCLIWithPodSecurityLevel("build-multistage", admissionapi.LevelBaseline)
+		oc             = exutil.NewCLI("build-multistage", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		testDockerfile = fmt.Sprintf(`
 FROM scratch as test
 USER 1001

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 	// whose name itself includes the app name.  Ensure we can create and fully
 	// deploy an app with a 58 character name [63 maximum - len('-9999' suffix)].
 
-	oc := exutil.NewCLIWithPodSecurityLevel("new-app", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("new-app", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.Context("", func() {
 

--- a/test/extended/builds/no_outputname.go
+++ b/test/extended/builds/no_outputname.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build without output image", fu
 	var (
 		dockerImageFixture = exutil.FixturePath("testdata", "builds", "test-docker-no-outputname.json")
 		s2iImageFixture    = exutil.FixturePath("testdata", "builds", "test-s2i-no-outputname.json")
-		oc                 = exutil.NewCLIWithPodSecurityLevel("build-no-outputname", admissionapi.LevelBaseline)
+		oc                 = exutil.NewCLI("build-no-outputname", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/nosrc.go
+++ b/test/extended/builds/nosrc.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build with empty source", func(
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-nosrc-build.json")
-		oc           = exutil.NewCLIWithPodSecurityLevel("cli-build-nosrc", admissionapi.LevelBaseline)
+		oc           = exutil.NewCLI("cli-build-nosrc", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		exampleBuild = exutil.FixturePath("testdata", "builds", "test-build-app")
 	)
 

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -22,7 +22,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] Optimized image builds", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc             = exutil.NewCLIWithPodSecurityLevel("build-dockerfile-env", admissionapi.LevelBaseline)
+		oc             = exutil.NewCLI("build-dockerfile-env", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		skipLayers     = buildv1.ImageOptimizationSkipLayers
 		testDockerfile = fmt.Sprintf(`
 FROM %s

--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-builds][Feature:JenkinsRHELImagesOnly][Feature:Jenkins]
 	defer g.GinkgoRecover()
 
 	var (
-		oc               = exutil.NewCLIWithPodSecurityLevel("jenkins-pipeline", admissionapi.LevelBaseline)
+		oc               = exutil.NewCLI("jenkins-pipeline", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		j                *jenkins.JenkinsRef
 		simplePipelineBC = exutil.FixturePath("testdata", "builds", "simple-pipeline-bc.yaml")
 

--- a/test/extended/builds/revision.go
+++ b/test/extended/builds/revision.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build have source revision meta
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-build-revision.json")
-		oc           = exutil.NewCLIWithPodSecurityLevel("cli-build-revision", admissionapi.LevelBaseline)
+		oc           = exutil.NewCLI("cli-build-revision", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/run_fs_verification.go
+++ b/test/extended/builds/run_fs_verification.go
@@ -16,7 +16,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] verify /run filesystem contents", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                                      = exutil.NewCLIWithPodSecurityLevel("verify-run-fs", admissionapi.LevelBaseline)
+		oc                                      = exutil.NewCLI("verify-run-fs", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		testVerityRunFSWriteableBuildConfigYaml = fmt.Sprintf(`
 apiVersion: build.openshift.io/v1
 kind: BuildConfig

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] s2i build with environmen
 		imageStreamFixture   = exutil.FixturePath("testdata", "builds", "test-image-stream.json")
 		stiEnvBuildFixture   = exutil.FixturePath("testdata", "builds", "test-env-build.json")
 		podAndServiceFixture = exutil.FixturePath("testdata", "builds", "test-build-podsvc.json")
-		oc                   = exutil.NewCLIWithPodSecurityLevel("build-sti-env", admissionapi.LevelBaseline)
+		oc                   = exutil.NewCLI("build-sti-env", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] incremental s2i build", f
 	var (
 		templateFixture      = exutil.FixturePath("testdata", "builds", "incremental-auth-build.json")
 		podAndServiceFixture = exutil.FixturePath("testdata", "builds", "test-build-podsvc.json")
-		oc                   = exutil.NewCLIWithPodSecurityLevel("build-sti-inc", admissionapi.LevelBaseline)
+		oc                   = exutil.NewCLI("build-sti-inc", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a quota", func()
 
 	var (
 		buildFixture = exutil.FixturePath("testdata", "builds", "test-s2i-build-quota.json")
-		oc           = exutil.NewCLIWithPodSecurityLevel("s2i-build-quota", api.LevelPrivileged)
+		oc           = exutil.NewCLI("s2i-build-quota", exutil.WithPSALevel(api.LevelPrivileged))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -32,7 +32,7 @@ func After(oc *exutil.CLI) {
 
 var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user image", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("s2i-build-root", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("s2i-build-root", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("should create a root build and fail without a privileged SCC [apigroup:build.openshift.io]", func() {
 		g.Skip("TODO: figure out why we aren't properly denying this, also consider whether we still need to deny it")

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use build secrets", f
 		dockerBuildDockerfile  = filepath.Join(buildSecretBaseDir, "Dockerfile")
 		sourceBuildFixture     = filepath.Join(buildSecretBaseDir, "test-s2i-build.json")
 		sourceBuildBinDir      = filepath.Join(buildSecretBaseDir, "s2i-binary-dir")
-		oc                     = exutil.NewCLIWithPodSecurityLevel("build-secrets", admissionapi.LevelBaseline)
+		oc                     = exutil.NewCLI("build-secrets", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/service.go
+++ b/test/extended/builds/service.go
@@ -19,7 +19,7 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds] build can reference a cluster service", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc             = exutil.NewCLIWithPodSecurityLevel("build-service", admissionapi.LevelBaseline)
+		oc             = exutil.NewCLI("build-service", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		testDockerfile = fmt.Sprintf(`
 FROM %s
 RUN cat /etc/resolv.conf

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 		symlinkFixture     = exutil.FixturePath("testdata", "builds", "test-symlink-build.yaml")
 		exampleGemfileURL  = "https://raw.githubusercontent.com/openshift/ruby-hello-world/master/Gemfile"
 		exampleArchiveURL  = "https://github.com/openshift/ruby-hello-world/archive/master.zip"
-		oc                 = exutil.NewCLIWithPodSecurityLevel("cli-start-build", admissionapi.LevelBaseline)
+		oc                 = exutil.NewCLI("cli-start-build", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		verifyNodeSelector = func(oc *exutil.CLI, name string) {
 			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), name+"-build", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/subscription_content.go
+++ b/test/extended/builds/subscription_content.go
@@ -18,7 +18,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][subscription-content] builds in
 	defer g.GinkgoRecover()
 
 	var (
-		oc               = exutil.NewCLIWithPodSecurityLevel("build-subscription-content", admissionapi.LevelBaseline)
+		oc               = exutil.NewCLI("build-subscription-content", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		baseDir          = exutil.FixturePath("testdata", "builds", "subscription-content")
 		secretTemplate   = filepath.Join(baseDir, "secret-template.txt")
 		imageStream      = filepath.Join(baseDir, "build-imagestream.yaml")

--- a/test/extended/builds/valuefrom.go
+++ b/test/extended/builds/valuefrom.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 		successfulDockerBuildValueFrom = filepath.Join(valueFromBaseDir, "successful-docker-build-value-from-config.yaml")
 		failedSTIBuildValueFrom        = filepath.Join(valueFromBaseDir, "failed-sti-build-value-from-config.yaml")
 		failedDockerBuildValueFrom     = filepath.Join(valueFromBaseDir, "failed-docker-build-value-from-config.yaml")
-		oc                             = exutil.NewCLIWithPodSecurityLevel("build-valuefrom", admissionapi.LevelBaseline)
+		oc                             = exutil.NewCLI("build-valuefrom", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.Context("", func() {

--- a/test/extended/builds/volumes.go
+++ b/test/extended/builds/volumes.go
@@ -17,7 +17,7 @@ import (
 
 var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func() {
 	var (
-		oc                     = exutil.NewCLIWithPodSecurityLevel("build-volumes", admissionapi.LevelBaseline)
+		oc                     = exutil.NewCLI("build-volumes", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		baseDir                = exutil.FixturePath("testdata", "builds", "volumes")
 		secret                 = filepath.Join(baseDir, "secret.yaml")
 		configmap              = filepath.Join(baseDir, "configmap.yaml")
@@ -134,7 +134,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func()
 var _ = g.Describe("[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                     = exutil.NewCLIWithPodSecurityLevel("build-volumes-csi", admissionapi.LevelBaseline)
+		oc                     = exutil.NewCLI("build-volumes-csi", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		baseDir                = exutil.FixturePath("testdata", "builds", "volumes")
 		secret                 = filepath.Join(baseDir, "secret.yaml")
 		s2iDeploymentConfig    = filepath.Join(baseDir, "s2i-deploymentconfig.yaml")

--- a/test/extended/builds/webhook.go
+++ b/test/extended/builds/webhook.go
@@ -29,10 +29,7 @@ import (
 
 var _ = g.Describe("[sig-builds][Feature:Builds][webhook]", func() {
 	defer g.GinkgoRecover()
-
-	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("build-webhooks", admissionapi.LevelBaseline)
-	)
+	oc := exutil.NewCLI("build-webhooks", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
 		TestWebhook(g.GinkgoT(), oc)

--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -32,8 +32,8 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 	f := framework.NewDefaultFramework("oc-adm")
 	f.SkipNamespaceCreation = true
 
-	oc := exutil.NewCLIWithoutNamespace("oc-adm").AsAdmin()
-	ocns := exutil.NewCLI("oc-adm-ns").AsAdmin()
+	oc := exutil.NewCLI("oc-adm", exutil.WithoutNamespace()).AsAdmin()
+	ocns := exutil.NewCLI("oc-adn-ns").AsAdmin()
 	policyRolesPath := exutil.FixturePath("testdata", "roles", "policy-roles.yaml")
 	policyClusterRolesPath := exutil.FixturePath("testdata", "roles", "policy-clusterroles.yaml")
 	gen := names.SimpleNameGenerator

--- a/test/extended/cli/annotation.go
+++ b/test/extended/cli/annotation.go
@@ -18,7 +18,7 @@ var _ = g.Describe("[sig-cli] oc annotate", func() {
 		podAnnotationTemplate = `{{index .metadata.annotations "new-anno"}}`
 	)
 
-	var oc = exutil.NewCLIWithPodSecurityLevel("oc-annotation", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("oc-annotation", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("pod", func() {
 		g.By("creating hello-openshift pod")

--- a/test/extended/cli/basics.go
+++ b/test/extended/cli/basics.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc                   = exutil.NewCLIWithPodSecurityLevel("oc-basics", admissionapi.LevelBaseline)
+		oc                   = exutil.NewCLI("oc-basics", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		cmdTestData          = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata")
 		mixedAPIVersionsFile = exutil.FixturePath("testdata", "mixed-api-versions.yaml")
 		oauthAccessTokenFile = filepath.Join(cmdTestData, "oauthaccesstoken.yaml")

--- a/test/extended/cli/compat.go
+++ b/test/extended/cli/compat.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-cli] oc", func() {
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("cli", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("cli", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("can run inside of a busybox container [apigroup:image.openshift.io]", func() {
 		ns := oc.Namespace()

--- a/test/extended/cli/debug.go
+++ b/test/extended/cli/debug.go
@@ -22,7 +22,7 @@ var (
 var _ = g.Describe("[sig-cli] oc debug", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithPodSecurityLevel("oc-debug", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("oc-debug", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	testCLIDebug := exutil.FixturePath("testdata", "test-cli-debug.yaml")
 	testDeploymentConfig := exutil.FixturePath("testdata", "test-deployment-config.yaml")
 	testReplicationController := exutil.FixturePath("testdata", "test-replication-controller.yaml")

--- a/test/extended/cli/help.go
+++ b/test/extended/cli/help.go
@@ -12,7 +12,7 @@ import (
 var _ = g.Describe("[sig-cli] oc help", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("oc-help")
+	oc := exutil.NewCLI("oc-help", exutil.WithoutNamespace())
 
 	g.It("works as expected", func() {
 		err := exec.Command("kubectl").Run()

--- a/test/extended/cli/idle.go
+++ b/test/extended/cli/idle.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 	defer g.GinkgoRecover()
 
 	var (
-		oc                   = exutil.NewCLIWithPodSecurityLevel("oc-idle", admissionapi.LevelBaseline)
+		oc                   = exutil.NewCLI("oc-idle", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		cmdTestData          = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata")
 		idleSVCRoute         = filepath.Join(cmdTestData, "idling-svc-route.yaml")
 		idleDeploymentConfig = filepath.Join(cmdTestData, "idling-dc.yaml")

--- a/test/extended/cli/label.go
+++ b/test/extended/cli/label.go
@@ -18,7 +18,7 @@ const (
 var _ = g.Describe("[sig-cli] oc label", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithPodSecurityLevel("oc-label", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("oc-label", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("pod", func() {
 		g.By("creating hello-openshift pod")

--- a/test/extended/cli/observe.go
+++ b/test/extended/cli/observe.go
@@ -14,7 +14,7 @@ import (
 var _ = g.Describe("[sig-cli] oc observe", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("oc-observe").AsAdmin()
+	oc := exutil.NewCLI("oc-observe", exutil.WithoutNamespace()).AsAdmin()
 
 	g.It("works as expected", func() {
 		g.By("Find out the clusterIP of the kubernetes.default service")

--- a/test/extended/cli/policy.go
+++ b/test/extended/cli/policy.go
@@ -13,7 +13,7 @@ var _ = g.Describe("[sig-cli] policy", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc               = exutil.NewCLIWithPodSecurityLevel("oc-policy", api.LevelRestricted)
+		oc               = exutil.NewCLI("oc-policy", exutil.WithPSALevel(api.LevelRestricted))
 		simpleDeployment = exutil.FixturePath("testdata", "deployments", "deployment-simple-sleep.yaml")
 	)
 

--- a/test/extended/cli/probe.go
+++ b/test/extended/cli/probe.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-cli] oc probe", func() {
 
 	var (
 		deploymentConfig = exutil.FixturePath("testdata", "test-deployment-config.yaml")
-		oc               = exutil.NewCLIWithPodSecurityLevel("oc-probe", admissionapi.LevelBaseline)
+		oc               = exutil.NewCLI("oc-probe", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.It("can ensure the probe command is functioning as expected on pods", func() {

--- a/test/extended/cli/routes.go
+++ b/test/extended/cli/routes.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-cli] oc", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc          = exutil.NewCLIWithPodSecurityLevel("oc-routes", admissionapi.LevelBaseline)
+		oc          = exutil.NewCLI("oc-routes", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		cmdTestData = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata")
 		testRoute   = filepath.Join(cmdTestData, "test-route.json")
 		testService = filepath.Join(cmdTestData, "test-service.json")

--- a/test/extended/cli/rsh.go
+++ b/test/extended/cli/rsh.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-cli] oc rsh", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc        = exutil.NewCLIWithPodSecurityLevel("oc-rsh", admissionapi.LevelBaseline)
+		oc        = exutil.NewCLI("oc-rsh", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		podsLabel = exutil.ParseLabelsOrDie("name=hello-busybox")
 	)
 

--- a/test/extended/cli/run.go
+++ b/test/extended/cli/run.go
@@ -12,7 +12,7 @@ import (
 var _ = g.Describe("[sig-cli] oc run", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithPodSecurityLevel("oc-run", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("oc-run", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("can use --image flag correctly [apigroup:apps.openshift.io]", func() {
 		_, err := oc.Run("create").Args("deploymentconfig", "newdcforimage", "--image=validimagevalue").Output()

--- a/test/extended/cli/setimage.go
+++ b/test/extended/cli/setimage.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 	var (
 		deploymentConfig = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "test-deployment-config.yaml")
 		imageStream      = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "image-streams", "image-streams-centos7.json")
-		oc               = exutil.NewCLIWithPodSecurityLevel("oc-set-image", admissionapi.LevelBaseline)
+		oc               = exutil.NewCLI("oc-set-image", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.It("can set images for pods and deployments [apigroup:image.openshift.io][apigroup:apps.openshift.io][Skipped:Disconnected]", func() {

--- a/test/extended/cli/statefulset.go
+++ b/test/extended/cli/statefulset.go
@@ -15,7 +15,7 @@ import (
 var _ = g.Describe("[sig-cli] oc statefulset", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithPodSecurityLevel("oc-statefulset", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("oc-statefulset", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("creates and deletes statefulsets", func() {
 		g.By("creating a new service for the statefulset")

--- a/test/extended/cli/template.go
+++ b/test/extended/cli/template.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[sig-cli] templates", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc                           = exutil.NewCLIWithPodSecurityLevel("oc-templates", admissionapi.LevelPrivileged)
+		oc                           = exutil.NewCLI("oc-templates", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		testDataPath                 = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata")
 		appTemplatePath              = filepath.Join(testDataPath, "application-template-dockerbuild.json")
 		appTemplateStiPath           = filepath.Join(testDataPath, "application-template-stibuild.json")

--- a/test/extended/cluster/cl.go
+++ b/test/extended/cluster/cl.go
@@ -38,7 +38,7 @@ var rootDir string
 var _ = g.Describe("[sig-scalability][Feature:Performance] Load cluster", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                = exutil.NewCLIWithoutNamespace("cl")
+		oc                = exutil.NewCLI("cl", exutil.WithoutNamespace())
 		masterVertFixture = exutil.FixturePath("testdata", "cluster", "master-vert.yaml")
 		_                 = exutil.FixturePath("testdata", "cluster", "quickstarts", "cakephp-mysql.json")
 		_                 = exutil.FixturePath("testdata", "cluster", "quickstarts", "dancer-mysql.json")

--- a/test/extended/cluster/clt.go
+++ b/test/extended/cluster/clt.go
@@ -18,7 +18,8 @@ const (
 
 var _ = g.Describe("[sig-scalability][Feature:Performance][Serial][Slow] Load cluster", func() {
 	defer g.GinkgoRecover()
-	var oc = exutil.NewCLIWithoutNamespace("cl")
+
+	oc := exutil.NewCLI("cl", exutil.WithoutNamespace())
 
 	g.It("concurrently with templates", func() {
 		var namespaces []string

--- a/test/extended/cmd/cmd.go
+++ b/test/extended/cmd/cmd.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] te
 	hacklibDir := exutil.FixturePath("testdata", "cmd", "hack")
 	keys := exutil.FixturePaths("testdata", "cmd", "test", "cmd")
 
-	oc := exutil.NewCLIWithPodSecurityLevel("test-cmd", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("test-cmd", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	for _, filename := range keys {
 		// only make tests for the bash files

--- a/test/extended/coreos/coreos.go
+++ b/test/extended/coreos/coreos.go
@@ -27,7 +27,7 @@ type stream struct {
 var _ = g.Describe("[sig-coreos] [Conformance] CoreOS bootimages", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("coreos")
+	oc := exutil.NewCLI("coreos", exutil.WithoutNamespace())
 
 	g.It("TestBootimagesPresent [apigroup:machineconfiguration.openshift.io]", func() {
 		client := oc.AdminKubeClient()

--- a/test/extended/cpu_partitioning/crio.go
+++ b/test/extended/cpu_partitioning/crio.go
@@ -37,8 +37,8 @@ container_ids=$(sudo crictl ps -q)
 container_data=$(sudo crictl inspect $container_ids)
 
 # Filter down CRIO data to relevant information only
-workload_containers=$(echo $container_data | jq -rs '[ 
-	.[] | select(.info.runtimeSpec.annotations["target.workload.openshift.io/management"]) | 
+workload_containers=$(echo $container_data | jq -rs '[
+	.[] | select(.info.runtimeSpec.annotations["target.workload.openshift.io/management"]) |
 	{
 		cpuSet: (.info.runtimeSpec.linux.resources.cpu.cpus // ""),
         cpuShares: .info.runtimeSpec.linux.resources.cpu.shares,
@@ -48,8 +48,8 @@ workload_containers=$(echo $container_data | jq -rs '[
         podNamespace: .info.runtimeSpec.annotations["io.kubernetes.pod.namespace"],
         podName: .info.runtimeSpec.annotations["io.kubernetes.pod.name"],
 		name: .status.metadata.name,
-		pid: .info.pid, 
-		hostname: .info.runtimeSpec.hostname 
+		pid: .info.pid,
+		hostname: .info.runtimeSpec.hostname
 	}
 	]')
 
@@ -117,7 +117,7 @@ func (c *crioContainerData) getAnnotationCPUResources() (crioCPUResource, error)
 var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning node validation", func() {
 
 	var (
-		oc                      = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		oc                      = exutil.NewCLI("cpu-partitioning", exutil.WithoutNamespace()).AsAdmin()
 		managedNamespace        = exutil.NewCLI("managed-namespace").SetManagedNamespace().AsAdmin()
 		ctx                     = context.Background()
 		isClusterCPUPartitioned = false

--- a/test/extended/cpu_partitioning/managed.go
+++ b/test/extended/cpu_partitioning/managed.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 	defer g.GinkgoRecover()
 
 	var (
-		oc                      = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		oc                      = exutil.NewCLI("cpu-partitioning", exutil.WithoutNamespace()).AsAdmin()
 		ctx                     = context.Background()
 		isClusterCPUPartitioned = false
 	)

--- a/test/extended/cpu_partitioning/platform.go
+++ b/test/extended/cpu_partitioning/platform.go
@@ -18,7 +18,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 	defer g.GinkgoRecover()
 
 	var (
-		oc                      = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		oc                      = exutil.NewCLI("cpu-partitioning", exutil.WithoutNamespace()).AsAdmin()
 		ctx                     = context.Background()
 		isClusterCPUPartitioned = false
 

--- a/test/extended/cpu_partitioning/pods.go
+++ b/test/extended/cpu_partitioning/pods.go
@@ -51,7 +51,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 	defer g.GinkgoRecover()
 
 	var (
-		oc                      = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		oc                      = exutil.NewCLI("cpu-partitioning", exutil.WithoutNamespace()).AsAdmin()
 		ctx                     = context.Background()
 		isClusterCPUPartitioned = false
 

--- a/test/extended/csrapprover/csrapprover.go
+++ b/test/extended/csrapprover/csrapprover.go
@@ -34,7 +34,7 @@ import (
 )
 
 var _ = g.Describe("[sig-cluster-lifecycle]", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel("cluster-client-cert", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("cluster-client-cert", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	defer g.GinkgoRecover()
 
 	g.It("Pods cannot access the /config/master API endpoint", func() {

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -85,7 +85,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 		entry.dic.Wait()
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("cli-deployment", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("cli-deployment", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	var (
 		deploymentFixture               = exutil.FixturePath("testdata", "deployments", "test-deployment-test.yaml")

--- a/test/extended/dr/cert_rotation.go
+++ b/test/extended/dr/cert_rotation.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certro
 	defer g.GinkgoRecover()
 
 	ctx := context.TODO()
-	oc := exutil.NewCLIWithoutNamespace("etcd-certs").AsAdmin()
+	oc := exutil.NewCLI("etcd-certs", exutil.WithoutNamespace()).AsAdmin()
 
 	g.BeforeEach(func() {
 		// we need to ensure this test always begins with a stable revision for api and etcd

--- a/test/extended/dr/recovery.go
+++ b/test/extended/dr/recovery.go
@@ -18,7 +18,8 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/re
 
 	f := framework.NewDefaultFramework("recovery")
 	f.SkipNamespaceCreation = true
-	oc := exutil.NewCLIWithoutNamespace("recovery")
+	// TODO (soltysh): why we're using two frameworks: one created above, and another in NewCLI
+	oc := exutil.NewCLI("recovery", exutil.WithoutNamespace())
 
 	g.AfterEach(func() {
 		g.GinkgoT().Log("waiting to delete post backup resources....")
@@ -78,7 +79,8 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/re
 
 	f := framework.NewDefaultFramework("recovery")
 	f.SkipNamespaceCreation = true
-	oc := exutil.NewCLIWithoutNamespace("recovery")
+	// TODO (soltysh): why we're using two frameworks: one created above, and another in NewCLI
+	oc := exutil.NewCLI("recovery", exutil.WithoutNamespace())
 
 	g.AfterEach(func() {
 		// we need to ensure this test also ends with a stable revision for api and etcd

--- a/test/extended/etcd/etcd_test_runner.go
+++ b/test/extended/etcd/etcd_test_runner.go
@@ -29,7 +29,7 @@ import (
 var _ = g.Describe("[sig-api-machinery] API data in etcd", func() {
 	defer g.GinkgoRecover()
 
-	cli := exutil.NewCLIWithPodSecurityLevel("etcd-storage-path", psapi.LevelBaseline)
+	cli := exutil.NewCLI("etcd-storage-path", exutil.WithPSALevel(psapi.LevelBaseline))
 	adminCLI := cli.AsAdmin()
 
 	g.It("should be stored at the correct location and version for all resources [Serial]", func() {

--- a/test/extended/etcd/hardware_speed.go
+++ b/test/extended/etcd/hardware_speed.go
@@ -21,7 +21,7 @@ import (
 
 var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithoutNamespace("etcd-hardware-speed").AsAdmin()
+	oc := exutil.NewCLI("etcd-hardware-speed", exutil.WithoutNamespace()).AsAdmin()
 
 	g.BeforeEach(func() {
 		isSingleNode, err := exutil.IsSingleNode(context.Background(), oc.AdminConfigClient())

--- a/test/extended/etcd/invariants.go
+++ b/test/extended/etcd/invariants.go
@@ -20,7 +20,8 @@ import (
 
 var _ = g.Describe("[sig-etcd] etcd", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithoutNamespace("etcd-invariants").AsAdmin()
+
+	oc := exutil.NewCLI("etcd-invariants", exutil.WithoutNamespace()).AsAdmin()
 
 	g.It("cluster has the same number of master nodes and voting members from the endpoints configmap [Early][apigroup:config.openshift.io]", func() {
 		exutil.SkipIfExternalControlplaneTopology(oc, "clusters with external controlplane topology don't have master nodes")

--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -18,7 +18,7 @@ import (
 
 var _ = g.Describe("[sig-etcd] etcd", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithoutNamespace("etcd-leader-change").AsAdmin()
+	oc := exutil.NewCLI("etcd-leader-change", exutil.WithoutNamespace()).AsAdmin()
 
 	var earlyTimeStamp time.Time
 	g.It("record the start revision of the etcd-operator [Early]", func() {
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			oc = exutil.NewHypershiftManagementCLI("default").AsAdmin().WithoutNamespace()
+			oc = exutil.NewCLI("default", exutil.WithoutNamespace()).AsAdmin()
 		}
 
 		prometheus, err := client.NewE2EPrometheusRouterClient(ctx, oc)

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -19,7 +19,8 @@ import (
 
 var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling] etcd", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithoutNamespace("etcd-scaling").AsAdmin()
+
+	oc := exutil.NewCLI("etcd-scaling", exutil.WithoutNamespace()).AsAdmin()
 
 	cleanupPlatformSpecificConfiguration := func() { /*noop*/ }
 

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -162,7 +162,7 @@ func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]s
 var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc                  = exutil.NewCLIWithPodSecurityLevel("cli-idling", admissionapi.LevelBaseline).Verbose()
+		oc                  = exutil.NewCLI("cli-idling", exutil.WithPSALevel(admissionapi.LevelBaseline)).Verbose()
 		echoServerFixture   = exutil.FixturePath("testdata", "idling-echo-server.yaml")
 		echoServerRcFixture = exutil.FixturePath("testdata", "idling-echo-server-rc.yaml")
 		framework           = oc.KubeFramework()

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -80,7 +80,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageAppend] Image append", func
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("image-append", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("image-append", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("should create images by appending them [apigroup:image.openshift.io]", func() {
 		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})

--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("image-extract", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("image-extract", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("should extract content from an image [apigroup:image.openshift.io]", func() {
 		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)

--- a/test/extended/images/imagestreamimport.go
+++ b/test/extended/images/imagestreamimport.go
@@ -34,7 +34,7 @@ import (
 
 var _ = g.Describe("[sig-imageregistry][Feature:ImageStreamImport][Serial][Slow] ImageStream API [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("imagestream-api", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("imagestream-api", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	g.BeforeEach(func() {
 		if err := deployEphemeralImageRegistry(oc); err != nil {
 			g.GinkgoT().Fatalf("error deploying ephemeral registry: %s", err)

--- a/test/extended/images/info.go
+++ b/test/extended/images/info.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageInfo] Image info", func() {
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("image-info", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("image-info", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("should display information about images [apigroup:image.openshift.io]", func() {
 		ns = oc.Namespace()

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("image-layers", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("image-layers", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("should identify a deleted image as missing [apigroup:image.openshift.io]", func() {
 		client := oc.AdminImageClient().ImageV1()

--- a/test/extended/images/mirror.go
+++ b/test/extended/images/mirror.go
@@ -205,7 +205,7 @@ RUN echo %[3]s > /3
 var _ = g.Describe("[sig-imageregistry][Feature:ImageMirror][Slow] Image mirror", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithPodSecurityLevel("image-mirror", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("image-mirror", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("mirror image from integrated registry to external registry [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
 		g.By("get user credentials")

--- a/test/extended/images/oc_tag.go
+++ b/test/extended/images/oc_tag.go
@@ -21,7 +21,7 @@ import (
 
 var _ = g.Describe("[sig-imageregistry][Feature:Image] oc tag", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("image-oc-tag", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("image-oc-tag", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	ctx := context.Background()
 
 	g.It("should preserve image reference for external images [apigroup:image.openshift.io]", func() {

--- a/test/extended/images/resolve.go
+++ b/test/extended/images/resolve.go
@@ -24,7 +24,7 @@ import (
 
 var _ = g.Describe("[sig-imageregistry][Feature:ImageLookup] Image policy", func() {
 	defer g.GinkgoRecover()
-	var oc = exutil.NewCLIWithPodSecurityLevel("resolve-local-names", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("resolve-local-names", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	one := int64(0)
 	ctx := context.Background()
 

--- a/test/extended/images/signatures.go
+++ b/test/extended/images/signatures.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-imageregistry][Serial] Image signature workflow", func(
 	defer g.GinkgoRecover()
 
 	var (
-		oc                 = exutil.NewCLIWithPodSecurityLevel("registry-signing", admissionapi.LevelBaseline)
+		oc                 = exutil.NewCLI("registry-signing", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		signerBuildFixture = exutil.FixturePath("testdata", "signer-buildconfig.yaml")
 	)
 

--- a/test/extended/jobs/jobs.go
+++ b/test/extended/jobs/jobs.go
@@ -18,7 +18,7 @@ import (
 
 var _ = g.Describe("[sig-apps][Feature:Jobs]", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("job-controller", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("job-controller", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("Users should be able to create and run a job in a user project", func() {
 

--- a/test/extended/kubevirt/migration.go
+++ b/test/extended/kubevirt/migration.go
@@ -17,7 +17,7 @@ import (
 )
 
 var _ = Describe("[sig-kubevirt] migration", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel("ns-global", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("ns-global", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	InKubeVirtClusterContext(oc, func() {
 		mgmtFramework := e2e.NewDefaultFramework("mgmt-framework")
 		mgmtFramework.SkipNamespaceCreation = true

--- a/test/extended/kubevirt/services.go
+++ b/test/extended/kubevirt/services.go
@@ -11,7 +11,7 @@ import (
 )
 
 var _ = Describe("[sig-kubevirt] services", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel("ns-global", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("ns-global", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	InKubeVirtClusterContext(oc, func() {
 		mgmtFramework := e2e.NewDefaultFramework("mgmt-framework")

--- a/test/extended/kubevirt/util.go
+++ b/test/extended/kubevirt/util.go
@@ -368,7 +368,9 @@ func SetMgmtFramework(mgmtFramework *e2e.Framework) *exutil.CLI {
 	_, hcpNamespace, err := exutil.GetHypershiftManagementClusterConfigAndNamespace()
 	Expect(err).NotTo(HaveOccurred())
 
-	oc := exutil.NewHypershiftManagementCLI(hcpNamespace).AsAdmin()
+	// TODO (soltysh): this is wrong, since the hcpNamespace here is only a prefix
+	// not an actually used namespace
+	oc := exutil.NewCLI(hcpNamespace).AsAdmin()
 
 	mgmtFramework.Namespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -78,7 +78,7 @@ var (
 var _ = g.Describe("[sig-node] Managed cluster", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("managed-cluster-node", psapi.LevelPrivileged).AsAdmin()
+		oc = exutil.NewCLI("managed-cluster-node", exutil.WithPSALevel(psapi.LevelPrivileged)).AsAdmin()
 	)
 
 	var staticNodeNames []string

--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -36,7 +36,7 @@ const (
 
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster should", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithoutNamespace("control-plane-machines").AsAdmin()
+	oc := exutil.NewCLI("control-plane-machines", exutil.WithoutNamespace()).AsAdmin()
 
 	var cfg *rest.Config
 	var c *kubernetes.Clientset

--- a/test/extended/networking/acl_audit_log.go
+++ b/test/extended/networking/acl_audit_log.go
@@ -37,7 +37,7 @@ var _ = Describe("[sig-network][Feature:Network Policy Audit logging]", func() {
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("acl-logging", psapi.LevelBaseline)
+	oc = exutil.NewCLI("acl-logging", exutil.WithPSALevel(psapi.LevelBaseline))
 
 	// The OVNKubernetes subnet plugin should allow acl_logging for network policy.
 	// For Openshift SDN and third party plugins, the behavior is unspecified and we should not run either test.

--- a/test/extended/networking/acl_audit_log.go
+++ b/test/extended/networking/acl_audit_log.go
@@ -49,7 +49,7 @@ var _ = Describe("[sig-network][Feature:Network Policy Audit logging]", func() {
 				makeNamespaceScheduleToAllNodes(f)
 				makeNamespaceACLLoggingEnabled(oc)
 
-				nsNoACLLog := oc.SetupProject()
+				nsNoACLLog := oc.NewProject()
 				By("making namespace " + nsNoACLLog + " with acl-logging disabled")
 				ns = append(ns, nsNoACLLog)
 

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -33,7 +33,7 @@ const (
 
 var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 
-	egFwoc := exutil.NewCLIWithPodSecurityLevel(egressFWE2E, admissionapi.LevelPrivileged)
+	egFwoc := exutil.NewCLI(egressFWE2E, exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	egFwf := egFwoc.KubeFramework()
 	mgmtFw := e2e.NewDefaultFramework("mgmt-framework")
 	mgmtFw.SkipNamespaceCreation = true
@@ -54,8 +54,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 			})
 		},
 	)
-
-	noegFwoc := exutil.NewCLIWithPodSecurityLevel(noEgressFWE2E, admissionapi.LevelBaseline)
+	noegFwoc := exutil.NewCLI(noEgressFWE2E, exutil.WithPSALevel(admissionapi.LevelBaseline))
 	noegFwf := noegFwoc.KubeFramework()
 	g.It("egressFirewall should have no impact outside its namespace", func() {
 		g.By("creating test pod")
@@ -94,7 +93,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:DNSNameResolver][Feature:Egress
 	// - Merge this section with main section when feature is GA.
 	// - Merge oVNKManifest & oVNKWCManifest contents.
 	// - Update doEgressFwTest and sendEgressFwTraffic functions.
-	wcEgFwOc := exutil.NewCLIWithPodSecurityLevel(wcEgressFWE2E, admissionapi.LevelPrivileged)
+	wcEgFwOc := exutil.NewCLI(wcEgressFWE2E, exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	wcEgFwF := wcEgFwOc.KubeFramework()
 	mgmtFramework := e2e.NewDefaultFramework("mgmt-framework")
 	mgmtFramework.SkipNamespaceCreation = true

--- a/test/extended/networking/egress_router_cni.go
+++ b/test/extended/networking/egress_router_cni.go
@@ -34,7 +34,7 @@ const (
 )
 
 var _ = g.Describe("[sig-network][Feature:EgressRouterCNI]", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel(egressRouterCNIE2E, admissionapi.LevelPrivileged).SetManagedNamespace()
+	oc := exutil.NewCLI(egressRouterCNIE2E, exutil.WithPSALevel(admissionapi.LevelPrivileged)).SetManagedNamespace()
 
 	g.It("should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io]", func() {
 		doEgressRouterCNI(egressRouterCNIV4Manifest, oc, ipv4MatchPattern)

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -44,7 +44,7 @@ const (
 )
 
 var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.io]", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel(namespacePrefix, admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI(namespacePrefix, exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	portAllocator := NewPortAllocator(egressIPTargetHostPortMin, egressIPTargetHostPortMax)
 
 	var (

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -158,7 +158,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 		// Create a target project and assign source and target namespace
 		// to variables for later use.
 		egressIPNamespace = f.Namespace.Name
-		externalNamespace = oc.SetupProject()
+		externalNamespace = oc.NewProject()
 
 		g.By("Selecting the EgressIP nodes and a non-EgressIP node")
 		nonEgressIPNodeName = workerNodesOrderedNames[0]

--- a/test/extended/networking/external_gateway.go
+++ b/test/extended/networking/external_gateway.go
@@ -9,7 +9,7 @@ import (
 )
 
 var _ = g.Describe("[sig-network] external gateway address", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel("ns-global", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("ns-global", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 
 	InOVNKubernetesContext(func() {
 		f := oc.KubeFramework()

--- a/test/extended/networking/internal_ports.go
+++ b/test/extended/networking/internal_ports.go
@@ -35,8 +35,9 @@ const (
 var _ = ginkgo.Describe("[sig-network] Internal connectivity", func() {
 	f := framework.NewDefaultFramework("nettest")
 	// TODO(sur): verify if privileged is really necessary in a follow-up
-	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-	oc := exutil.NewCLIWithoutNamespace("nettest").AsAdmin()
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	// TODO (soltysh): why we're using two frameworks: one created above, and another in NewCLI
+	oc := exutil.NewCLI("nettest", exutil.WithoutNamespace()).AsAdmin()
 
 	ginkgo.It("for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]", func() {
 		e2eskipper.SkipUnlessNodeCountIsAtLeast(2)

--- a/test/extended/networking/ipsec.go
+++ b/test/extended/networking/ipsec.go
@@ -208,7 +208,7 @@ func ensureIPsecDisabled(oc *exutil.CLI) error {
 
 var _ = g.Describe("[sig-network][Feature:IPsec]", g.Ordered, func() {
 
-	oc := exutil.NewCLIWithPodSecurityLevel("ipsec", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("ipsec", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	f := oc.KubeFramework()
 
 	waitForIPsecNSConfigApplied := func() {

--- a/test/extended/networking/load_balancer.go
+++ b/test/extended/networking/load_balancer.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-network] load balancer", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("load-balancer", admissionapi.LevelPrivileged)
+		oc = exutil.NewCLI("load-balancer", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	)
 
 	g.It("should be managed by OpenShift", func() {

--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -25,7 +25,7 @@ import (
 )
 
 var _ = Describe("[sig-network] multicast", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel("multicast", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("multicast", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	// The subnet plugin should block all multicast. The multitenant and networkpolicy
 	// plugins should implement multicast in the way that we test. For third-party

--- a/test/extended/networking/multinetpolicy.go
+++ b/test/extended/networking/multinetpolicy.go
@@ -29,7 +29,7 @@ type podAddressSet struct {
 
 var _ = g.Describe("[sig-network][Feature:MultiNetworkPolicy][Serial][apigroup:operator.openshift.io]", func() {
 
-	oc := exutil.NewCLIWithPodSecurityLevel("multinetpol-e2e", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("multinetpol-e2e", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	f := oc.KubeFramework()
 
 	g.DescribeTable("should enforce a network policies on secondary network", func(ctx context.Context, addrs podAddressSet) {
@@ -47,7 +47,7 @@ var _ = g.Describe("[sig-network][Feature:MultiNetworkPolicy][Serial][apigroup:o
 
 		networksTemplate := `[
 			  {
-				"name": "macvlan1-nad",		
+				"name": "macvlan1-nad",
 				"ips": ["%s"]
 			  }
 			]`

--- a/test/extended/networking/multus.go
+++ b/test/extended/networking/multus.go
@@ -18,7 +18,7 @@ var _ = g.Describe("[sig-network][Feature:Multus]", func() {
 	var oc *exutil.CLI
 	var ns string // namespace
 
-	oc = exutil.NewCLIWithPodSecurityLevel("multus-e2e", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("multus-e2e", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	f := oc.KubeFramework()
 	podName := "multus-test-pod-"

--- a/test/extended/networking/network_diagnostics.go
+++ b/test/extended/networking/network_diagnostics.go
@@ -28,7 +28,7 @@ const (
 // This is [Serial] because it modifies the cluster/network.config.openshift.io object in each test.
 var _ = g.Describe("[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Serial]", g.Ordered, func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithoutNamespace("network-diagnostics")
+	oc := exutil.NewCLI("network-diagnostics", exutil.WithoutNamespace())
 
 	g.BeforeAll(func(ctx context.Context) {
 		// Reset and take ownership of the network diagnostics config

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -49,7 +49,7 @@ var _ = Describe("[sig-network] services", func() {
 		})
 	})
 
-	oc := exutil.NewCLIWithPodSecurityLevel("ns-global", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("ns-global", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	InIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-services1")

--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -57,7 +57,7 @@ func getPodNodeName(client clientset.Interface, namespace, name string) string {
 }
 
 var _ = g.Describe("[sig-network][Feature:tuning]", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel("tuning", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("tuning", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	f := oc.KubeFramework()
 
 	g.It("pod should start with all sysctl on whitelist [apigroup:k8s.cni.cncf.io]", func() {

--- a/test/extended/networking/whereabouts.go
+++ b/test/extended/networking/whereabouts.go
@@ -20,7 +20,7 @@ import (
 
 var _ = g.Describe("[sig-network][Feature:Whereabouts]", func() {
 
-	oc := exutil.NewCLIWithPodSecurityLevel("whereabouts-e2e", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("whereabouts-e2e", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	// Whereabouts is already installed in Origin. These tests aims to verify the integrity of the installation.
 

--- a/test/extended/node_tuning/node_tuning.go
+++ b/test/extended/node_tuning/node_tuning.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-node-tuning] NTO should", func() {
 
 	var (
 		ntoNamespace        = "openshift-cluster-node-tuning-operator"
-		oc                  = exutil.NewCLIWithoutNamespace("nto").AsAdmin()
+		oc                  = exutil.NewCLI("nto", exutil.WithoutNamespace()).AsAdmin()
 		buildPruningBaseDir = exutil.FixturePath("testdata", "node_tuning")
 		ntoStalldFile       = filepath.Join(buildPruningBaseDir, "nto-stalld.yaml")
 		stalldCurrentPID    string

--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() {
-	var oc = exutil.NewCLIWithPodSecurityLevel("oauth-expiration", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("oauth-expiration", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	var newRequestTokenOptions oauthserver.NewRequestTokenOptionsFunc
 	var oauthServerCleanup func()
 

--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -33,7 +33,7 @@ import (
 var _ = g.Describe("[sig-auth][Feature:LDAP][Serial] ldap group sync", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("ldap-group-sync", admissionapi.LevelPrivileged).AsAdmin()
+		oc = exutil.NewCLI("ldap-group-sync", exutil.WithPSALevel(admissionapi.LevelPrivileged)).AsAdmin()
 	)
 
 	g.It("can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", func() {

--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 var _ = g.Describe("[sig-auth][Feature:HTPasswdAuth] HTPasswd IDP", func() {
-	var oc = exutil.NewCLIWithPodSecurityLevel("htpasswd-idp", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("htpasswd-idp", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io]", func() {
 		newTokenReqOpts, cleanup, err := deployOAuthServer(oc)

--- a/test/extended/oauth/ldap.go
+++ b/test/extended/oauth/ldap.go
@@ -12,7 +12,7 @@ import (
 var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("oauth-ldap", admissionapi.LevelPrivileged)
+		oc = exutil.NewCLI("oauth-ldap", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	)
 
 	g.It("should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io]", func() {

--- a/test/extended/oauth/oauth_ldap.go
+++ b/test/extended/oauth/oauth_ldap.go
@@ -26,7 +26,7 @@ import (
 var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP IDP", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("oauth-ldap-idp", admissionapi.LevelPrivileged)
+		oc = exutil.NewCLI("oauth-ldap-idp", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 
 		bindDN         = "cn=Manager,dc=example,dc=com"
 		bindPassword   = "admin"

--- a/test/extended/oauth/server_headers.go
+++ b/test/extended/oauth/server_headers.go
@@ -17,7 +17,7 @@ import (
 )
 
 var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers][apigroup:route.openshift.io][apigroup:config.openshift.io][apigroup:oauth.openshift.io]", func() {
-	var oc = exutil.NewCLIWithPodSecurityLevel("oauth-server-headers", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("oauth-server-headers", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	var transport http.RoundTripper
 	var oauthServerAddr string
 	var oauthServerCleanup func()

--- a/test/extended/olm/olm.go
+++ b/test/extended/olm/olm.go
@@ -25,7 +25,7 @@ const (
 var _ = g.Describe("[sig-operator] OLM should", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithoutNamespace("default")
+	oc := exutil.NewCLI("default", exutil.WithoutNamespace())
 
 	providedAPIs := []struct {
 		fromAPIService bool
@@ -93,10 +93,11 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			_, namespace, err = exutil.GetHypershiftManagementClusterConfigAndNamespace()
+			var kubeConfig string
+			kubeConfig, namespace, err = exutil.GetHypershiftManagementClusterConfigAndNamespace()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			oc = exutil.NewHypershiftManagementCLI("default").AsAdmin().WithoutNamespace()
+			oc = exutil.NewCLI("default", exutil.WithoutNamespace(), exutil.WithKubeConfig(kubeConfig)).AsAdmin()
 		}
 
 		deploymentResource := []string{"catalog-operator", "olm-operator", "packageserver"}
@@ -137,7 +138,7 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 var _ = g.Describe("[sig-arch] ocp payload should be based on existing source", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithoutNamespace("default")
+	oc := exutil.NewCLI("default", exutil.WithoutNamespace())
 
 	// TODO: This test should be more generic and across components
 	// OCP-20981, [BZ 1626434]The olm/catalog binary should output the exact version info
@@ -150,9 +151,10 @@ var _ = g.Describe("[sig-arch] ocp payload should be based on existing source", 
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			_, namespace, err = exutil.GetHypershiftManagementClusterConfigAndNamespace()
+			var kubeConfig string
+			kubeConfig, namespace, err = exutil.GetHypershiftManagementClusterConfigAndNamespace()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			oc = exutil.NewHypershiftManagementCLI("default").AsAdmin().WithoutNamespace()
+			oc = exutil.NewCLI("default", exutil.WithoutNamespace(), exutil.WithKubeConfig(kubeConfig)).AsAdmin()
 		}
 		sameCommit := ""
 		subPods := []string{"catalog-operator", "olm-operator", "packageserver"}
@@ -261,7 +263,7 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc = exutil.NewCLI("olm-23440")
+		oc = exutil.NewCLI("olm-23440", exutil.WithoutNamespace())
 
 		buildPruningBaseDir = exutil.FixturePath("testdata", "olm")
 		operatorGroup       = filepath.Join(buildPruningBaseDir, "operatorgroup.yaml")

--- a/test/extended/operators/certs.go
+++ b/test/extended/operators/certs.go
@@ -87,7 +87,7 @@ func gatherCertsFromPlatformNamespaces(ctx context.Context, kubeClient kubernete
 var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g.Ordered, func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("certificate-checker")
+	oc := exutil.NewCLI("certificate-checker", exutil.WithoutNamespace())
 	ctx := context.Background()
 
 	g.BeforeAll(func() {

--- a/test/extended/operators/clusteroperators.go
+++ b/test/extended/operators/clusteroperators.go
@@ -43,7 +43,7 @@ var _ = g.Describe("[sig-arch] ClusterOperators [apigroup:config.openshift.io]",
 		"support",
 	)
 
-	oc := exutil.NewCLIWithoutNamespace("clusteroperators")
+	oc := exutil.NewCLI("clusteroperators", exutil.WithoutNamespace())
 
 	g.BeforeEach(func() {
 		clusterOperatorsList, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().List(context.Background(), metav1.ListOptions{})

--- a/test/extended/operators/daemon_set.go
+++ b/test/extended/operators/daemon_set.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = g.Describe("[sig-arch] Managed cluster", func() {
-	oc := exutil.NewCLIWithoutNamespace("operator-daemonsets")
+	oc := exutil.NewCLI("operator-daemonsets", exutil.WithoutNamespace())
 
 	// Daemonsets shipped with the platform must be able to upgrade without disruption to workloads.
 	// Daemonsets that are in the data path must gracefully shutdown and redirect workload traffic, or

--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("[sig-arch] Managed cluster", func() {
-	oc := exutil.NewCLIWithoutNamespace("operators")
+	oc := exutil.NewCLI("operators", exutil.WithoutNamespace())
 	It("should ensure pods use downstream images from our release image with proper ImagePullPolicy [apigroup:config.openshift.io]", func() {
 		imagePullSecret, err := oc.KubeFramework().ClientSet.CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
 		if err != nil {

--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -15,7 +15,7 @@ import (
 )
 
 var _ = Describe("[sig-arch] Managed cluster should", func() {
-	oc := exutil.NewCLIWithoutNamespace("operators")
+	oc := exutil.NewCLI("operators", exutil.WithoutNamespace())
 
 	It("ensure control plane pods do not run in best-effort QoS", func() {
 		// iterate over the references to find valid images

--- a/test/extended/operators/resources.go
+++ b/test/extended/operators/resources.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = g.Describe("[sig-arch] Managed cluster", func() {
-	oc := exutil.NewCLIWithoutNamespace("operator-resources")
+	oc := exutil.NewCLI("operator-resources", exutil.WithoutNamespace())
 
 	// Pods that are part of the control plane should set both cpu and memory requests, but require an exception
 	// to set limits on memory (CPU limits are generally not allowed). This enforces the rules described in

--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("operators-routable", admissionapi.LevelBaseline)
+		oc = exutil.NewCLI("operators-routable", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 		// routeHostWait is how long to wait for routes to be assigned a host
 		routeHostWait = 30 * time.Second

--- a/test/extended/operators/server_side_apply_examples.go
+++ b/test/extended/operators/server_side_apply_examples.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-apimachinery]", func() {
 
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithPodSecurityLevel("server-side-apply-examples", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("server-side-apply-examples", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	fieldManager := metav1.ApplyOptions{
 		FieldManager: "e2e=test",
 	}

--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -15,7 +15,7 @@ import (
 )
 
 var _ = Describe("[sig-arch] Managed cluster should", func() {
-	oc := exutil.NewCLIWithoutNamespace("operators")
+	oc := exutil.NewCLI("operators", exutil.WithoutNamespace())
 
 	It("ensure control plane operators do not make themselves unevictable", func() {
 		// iterate over the references to find valid images

--- a/test/extended/poddisruptionbudget/poddisruptionbudget.go
+++ b/test/extended/poddisruptionbudget/poddisruptionbudget.go
@@ -27,7 +27,7 @@ import (
 
 var _ = g.Describe("[sig-apps] poddisruptionbudgets", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("poddisruptionbudgets", admissionapi.LevelRestricted)
+	oc := exutil.NewCLI("poddisruptionbudgets", exutil.WithPSALevel(admissionapi.LevelRestricted))
 
 	const (
 		// should be higher than the pod start time, so first pod is still not ready when a seconds one starts with a big delay (might take a long time to pull image)

--- a/test/extended/pods/graceful-shutdown.go
+++ b/test/extended/pods/graceful-shutdown.go
@@ -78,7 +78,7 @@ ls /host/$hostPath
 var _ = Describe("[sig-node][Disruptive][Feature:KubeletGracefulShutdown]", func() {
 
 	var (
-		oc           = exutil.NewCLIWithoutNamespace("pod").AsAdmin()
+		oc           = exutil.NewCLI("pod", exutil.WithoutNamespace()).AsAdmin()
 		node         *corev1.Node
 		successPod   *corev1.Pod
 		errorPod     *corev1.Pod

--- a/test/extended/pods/priorityclasses.go
+++ b/test/extended/pods/priorityclasses.go
@@ -14,7 +14,7 @@ import (
 )
 
 var _ = Describe("[sig-arch] Managed cluster should", func() {
-	oc := exutil.NewCLIWithoutNamespace("pod")
+	oc := exutil.NewCLI("pod", exutil.WithoutNamespace())
 
 	It("ensure platform components have system-* priority class associated", func() {
 		// iterate over the references to find valid images

--- a/test/extended/pods/systemd.go
+++ b/test/extended/pods/systemd.go
@@ -14,7 +14,7 @@ import (
 var _ = g.Describe("[sig-node][Late]", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithoutNamespace("no-systemd-timeouts")
+	oc := exutil.NewCLI("no-systemd-timeouts", exutil.WithoutNamespace())
 
 	g.It("should not have pod creation failures due to systemd timeouts", func() {
 		kubeClient := oc.AdminKubeClient()

--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -102,13 +102,13 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			w, err := bobProjectClient.Projects().Watch(ctx, metav1.ListOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			ns01Name := oc.SetupProject()
+			ns01Name := oc.NewProject()
 			authorization.AddUserAdminToProject(oc, ns01Name, bobName)
 			waitForAdd(ns01Name, w)
 
 			// TEST FOR ADD/REMOVE ACCESS
 			joeName := oc.CreateUser("joe-").Name
-			ns02Name := oc.SetupProject()
+			ns02Name := oc.NewProject()
 			authorization.AddUserAdminToProject(oc, ns02Name, joeName)
 			bobEditName := authorization.AddUserEditToProject(oc, ns02Name, bobName)
 			waitForAdd(ns02Name, w)
@@ -121,7 +121,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			waitForDelete(ns02Name, w)
 
 			// TEST FOR DELETE PROJECT
-			ns03Name := oc.SetupProject()
+			ns03Name := oc.NewProject()
 			authorization.AddUserAdminToProject(oc, ns03Name, bobName)
 			waitForAdd(ns03Name, w)
 
@@ -163,7 +163,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			bobConfig := oc.GetClientConfigForUser(bobName)
 			bobProjectClient := projectv1client.NewForConfigOrDie(bobConfig)
 
-			ns01Name := oc.SetupProject()
+			ns01Name := oc.NewProject()
 			w, err := bobProjectClient.Projects().Watch(ctx, metav1.ListOptions{
 				FieldSelector: "metadata.name=" + ns01Name,
 			})
@@ -173,7 +173,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			// we should be seeing an "ADD" watch event being emitted, since we are specifically watching this project via a field selector
 			waitForAdd(ns01Name, w)
 
-			ns03Name := oc.SetupProject()
+			ns03Name := oc.NewProject()
 			authorization.AddUserAdminToProject(oc, ns03Name, bobName)
 			// we are only watching ns-01, we should not receive events for other projects
 			waitForNoEvent(w, ns01Name)
@@ -347,10 +347,10 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			fullBobConfig := oc.GetClientConfigForUser(bobName)
 			fullBobClient := projectv1client.NewForConfigOrDie(fullBobConfig)
 
-			oneName := oc.SetupProject()
-			twoName := oc.SetupProject()
-			threeName := oc.SetupProject()
-			fourName := oc.SetupProject()
+			oneName := oc.NewProject()
+			twoName := oc.NewProject()
+			threeName := oc.NewProject()
+			fourName := oc.NewProject()
 
 			oneTwoBobConfig, err := GetScopedClientForUser(oc, bobName, []string{
 				scope.UserListScopedProjects,
@@ -468,9 +468,9 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			aliceName := oc.CreateUser("alice-").Name
 			aliceConfig := oc.GetClientConfigForUser(aliceName)
 
-			fooName := oc.SetupProject()
+			fooName := oc.NewProject()
 			authorization.AddUserAdminToProject(oc, fooName, bobName)
-			barName := oc.SetupProject()
+			barName := oc.NewProject()
 			authorization.AddUserAdminToProject(oc, barName, aliceName)
 
 			roleBinding := &rbacv1.RoleBinding{}

--- a/test/extended/prometheus/image_pulls.go
+++ b/test/extended/prometheus/image_pulls.go
@@ -39,7 +39,7 @@ func (t *ImagePullsAreFast) Test(ctx context.Context, f *framework.Framework, do
 
 	g.By(fmt.Sprintf("verifying that pull durations do not exceed %s", t.threshold))
 
-	oc := exutil.NewCLIWithFramework(f)
+	oc := exutil.NewCLI("default", exutil.WithFramework(f))
 
 	// we only consider samples since the beginning of the test
 	testDuration := exutil.DurationSinceStartInSeconds().String()

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -211,7 +211,7 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 	)
 
 	var alertingRules map[string][]promv1.AlertingRule
-	oc := exutil.NewCLIWithoutNamespace("prometheus")
+	oc := exutil.NewCLI("prometheus", exutil.WithoutNamespace())
 
 	g.BeforeEach(func(ctx context.Context) {
 		err := exutil.WaitForAnImageStream(
@@ -362,7 +362,7 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 	defer g.GinkgoRecover()
 	ctx := context.TODO()
-	oc := exutil.NewCLIWithoutNamespace("prometheus")
+	oc := exutil.NewCLI("prometheus", exutil.WithoutNamespace())
 
 	g.BeforeEach(func() {
 		kubeClient, err := kubernetes.NewForConfig(oc.AdminConfig())
@@ -415,11 +415,9 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	ctx := context.TODO()
-	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("prometheus", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("default", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
-		queryURL, prometheusURL, querySvcURL, prometheusSvcURL, bearerToken string
-	)
+	var queryURL, prometheusURL, querySvcURL, prometheusSvcURL, bearerToken string
 
 	g.BeforeEach(func(ctx g.SpecContext) {
 		err := exutil.WaitForAnImageStream(

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -722,7 +722,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 		})
 
 		g.It("should provide named network metrics [apigroup:project.openshift.io]", func() {
-			ns := oc.SetupProject()
+			ns := oc.NewProject()
 
 			cs, err := newDynClientSet()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -20,7 +20,7 @@ import (
 var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("prometheus", admissionapi.LevelBaseline)
+		oc = exutil.NewCLI("prometheus", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.AfterEach(func() {

--- a/test/extended/prometheus/storage.go
+++ b/test/extended/prometheus/storage.go
@@ -23,7 +23,7 @@ const (
 var _ = g.Describe("[sig-storage][Late] Metrics", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithoutNamespace("prometheus")
+		oc = exutil.NewCLI("prometheus", exutil.WithoutNamespace())
 
 		url, token string
 	)

--- a/test/extended/prometheus/upgrade.go
+++ b/test/extended/prometheus/upgrade.go
@@ -32,7 +32,7 @@ func (t *MetricsAvailableAfterUpgradeTest) DisplayName() string {
 }
 
 func (t *MetricsAvailableAfterUpgradeTest) Setup(ctx context.Context, f *e2e.Framework) {
-	oc := exutil.NewCLIWithFramework(f)
+	oc := exutil.NewCLI("default", exutil.WithFramework(f))
 
 	g.By("getting the prometheus_build_info metric before the upgrade")
 	preUpgradeQuery := `prometheus_build_info{pod="prometheus-k8s-0"}`
@@ -56,7 +56,7 @@ func (t *MetricsAvailableAfterUpgradeTest) Setup(ctx context.Context, f *e2e.Fra
 func (t *MetricsAvailableAfterUpgradeTest) Test(ctx context.Context, f *e2e.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	<-done
 
-	oc := exutil.NewCLIWithFramework(f)
+	oc := exutil.NewCLI("default", exutil.WithFramework(f))
 
 	g.By("verifying that the timeseries is queryable at the same timestamp after the upgrade")
 	postUpgradeQuery := `prometheus_build_info{pod="prometheus-k8s-0"}`

--- a/test/extended/quota/clusterquota.go
+++ b/test/extended/quota/clusterquota.go
@@ -85,8 +85,8 @@ var _ = g.Describe("[sig-api-machinery][Feature:ClusterResourceQuota]", func() {
 			}
 			oc.AddResourceToDelete(quotav1.GroupVersion.WithResource("clusterresourcequotas"), cq)
 
-			firstProjectName := oc.SetupProject()
-			secondProjectName := oc.SetupProject()
+			firstProjectName := oc.NewProject()
+			secondProjectName := oc.NewProject()
 
 			// Wait for the creation of the mandatory configmaps before performing checks of quota
 			// enforcement to ensure reliable test execution.

--- a/test/extended/quota/resourcequota.go
+++ b/test/extended/quota/resourcequota.go
@@ -87,7 +87,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 		})
 
 		g.It("should properly count the number of persistentvolumeclaims resources [Serial]", func() {
-			testProject := oc.SetupProject()
+			testProject := oc.NewProject()
 			testResourceQuotaName := "my-resource-quota-" + testProject
 			pvcName := "myclaim-" + testProject
 			clusterAdminKubeClient := oc.AdminKubeClient()
@@ -166,7 +166,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 		})
 
 		g.It("check the quota after import-image with --all option [Skipped:Disconnected]", func() {
-			testProject := oc.SetupProject()
+			testProject := oc.NewProject()
 			testResourceQuotaName := "my-imagestream-quota-" + testProject
 			clusterAdminKubeClient := oc.AdminKubeClient()
 

--- a/test/extended/quota/resourcequota.go
+++ b/test/extended/quota/resourcequota.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 		g.It(fmt.Sprintf("should properly count the number of imagestreams resources [apigroup:image.openshift.io]"), func() {
 			clusterAdminKubeClient := oc.AdminKubeClient()
 			clusterAdminImageClient := oc.AdminImageClient().ImageV1()
-			testProject := oc.SetupProject()
+			testProject := oc.NewProject()
 			testResourceQuotaName := "count-imagestreams"
 
 			rq := &corev1.ResourceQuota{

--- a/test/extended/router/certs.go
+++ b/test/extended/router/certs.go
@@ -141,7 +141,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("router-certs", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("router-certs", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -28,7 +28,7 @@ import (
 var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithPodSecurityLevel("grpc-interop", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("grpc-interop", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	// this hook must be registered before the framework namespace teardown
 	// hook

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -42,7 +42,7 @@ type h2specFailingTest struct {
 var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithPodSecurityLevel("router-h2spec", admissionapi.LevelBaseline)
+	var oc = exutil.NewCLI("router-h2spec", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	// this hook must be registered before the framework namespace teardown
 	// hook

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router", "router-http-echo-server.yaml")
-		oc         = exutil.NewCLIWithPodSecurityLevel("router-headers", admissionapi.LevelBaseline)
+		oc         = exutil.NewCLI("router-headers", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 		routerIP  string
 		metricsIP string

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -80,7 +80,7 @@ func makeHTTPClient(useHTTP2Transport bool, timeout time.Duration) *http.Client 
 var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router][apigroup:route.openshift.io][apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLIWithPodSecurityLevel("router-http2", api.LevelBaseline)
+	var oc = exutil.NewCLI("router-http2", exutil.WithPSALevel(api.LevelBaseline))
 
 	// this hook must be registered before the framework namespace teardown
 	// hook

--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -33,9 +33,7 @@ import (
 var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 
-	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("router-idling", admissionapi.LevelBaseline)
-	)
+	oc := exutil.NewCLI("router-idling", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	// this hook must be registered before the framework namespace teardown
 	// hook

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -34,7 +34,7 @@ import (
 var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("router-metrics", admissionapi.LevelBaseline)
+		oc = exutil.NewCLI("router-metrics", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 		username, password, bearerToken string
 		metricsPort                     int32

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][a
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("router-reencrypt", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("router-reencrypt", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.BeforeEach(func() {
 		var err error

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -47,7 +47,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("router-stress", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("router-stress", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.BeforeEach(func() {
 		var err error

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("router-scoped", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("router-scoped", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("router-stress", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("router-stress", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/subdomain.go
+++ b/test/extended/router/subdomain.go
@@ -43,7 +43,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("router-subdomain", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("router-subdomain", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -39,7 +39,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 		}
 	})
 
-	oc = exutil.NewCLIWithPodSecurityLevel("unprivileged-router", admissionapi.LevelBaseline)
+	oc = exutil.NewCLI("unprivileged-router", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -32,7 +32,7 @@ import (
 var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc = exutil.NewCLIWithPodSecurityLevel("weighted-router", admissionapi.LevelBaseline)
+		oc = exutil.NewCLI("weighted-router", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	)
 
 	g.BeforeEach(func() {

--- a/test/extended/security/fips.go
+++ b/test/extended/security/fips.go
@@ -50,7 +50,7 @@ func validateFIPSOnNode(oc *exutil.CLI, fipsExpected bool, node *corev1.Node) er
 
 var _ = g.Describe("[sig-arch] [Conformance] FIPS", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("fips", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("fips", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 
 	g.It("TestFIPS", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)

--- a/test/extended/security/labels.go
+++ b/test/extended/security/labels.go
@@ -42,7 +42,7 @@ func testOpenshiftNodeLabeling(oc *exutil.CLI, node *corev1.Node, forbiddenLabel
 
 var _ = g.Describe("[sig-node] [Conformance] Prevent openshift node labeling on update by the node", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("node-label-e2e", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("node-label-e2e", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 
 	g.It("TestOpenshiftNodeLabeling", func() {
 		clusterAdminKubeClientset := oc.AdminKubeClient()

--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -30,7 +30,7 @@ import (
 
 var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("scc", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	ctx := context.Background()
 
 	g.It("TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io]", func() {
@@ -106,7 +106,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 
 	defer g.GinkgoRecover()
 	// pods running as root are being started here
-	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("scc", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 
 	g.It("TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", func() {
 		t := g.GinkgoT()
@@ -357,7 +357,7 @@ func RunTestAllowedSCCViaRBAC(
 
 var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("ssc", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("ssc", exutil.WithPSALevel(admissionapi.LevelBaseline))
 
 	g.It("TestPodDefaultCapabilities", func() {
 		g.By("Running a restricted pod and getting it's inherited capabilities")

--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 		clusterAdminKubeClientset := oc.AdminKubeClient()
 
 		project1 := oc.Namespace()
-		project2 := oc.SetupProject()
+		project2 := oc.NewProject()
 		user1 := oc.CreateUser("user1-").Name
 		user2 := oc.CreateUser("user2-").Name
 

--- a/test/extended/security/supplemental_groups.go
+++ b/test/extended/security/supplemental_groups.go
@@ -32,7 +32,7 @@ const (
 var _ = g.Describe("[sig-node] supplemental groups", func() {
 	defer g.GinkgoRecover()
 
-	oc := exutil.NewCLIWithPodSecurityLevel("sup-groups", admissionapi.LevelBaseline)
+	oc := exutil.NewCLI("sup-groups", exutil.WithPSALevel(admissionapi.LevelBaseline))
 	ctx := context.Background()
 
 	g.Describe("Ensure supplemental groups propagate to docker", func() {

--- a/test/extended/security/sysctl.go
+++ b/test/extended/security/sysctl.go
@@ -17,7 +17,7 @@ import (
 )
 
 var _ = g.Describe("[sig-arch] [Conformance] sysctl", func() {
-	oc := exutil.NewCLIWithPodSecurityLevel("sysctl", admissionapi.LevelPrivileged)
+	oc := exutil.NewCLI("sysctl", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 	ctx := context.Background()
 	g.DescribeTable("whitelists", func(sysctl, value, path, defaultSysctlValue string) {
 		f := oc.KubeFramework()

--- a/test/extended/single_node/topology.go
+++ b/test/extended/single_node/topology.go
@@ -44,7 +44,7 @@ func getNamespaceStatefulSets(f *framework.Framework, namespace corev1.Namespace
 }
 
 func GetTopologies(f *framework.Framework) (controlPlaneTopology, infraTopology v1.TopologyMode) {
-	oc := exutil.NewCLIWithFramework(f)
+	oc := exutil.NewCLI("default", exutil.WithFramework(f))
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(),
 		"cluster", metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/extended/storage/csi_snapshot_controller_operator.go
+++ b/test/extended/storage/csi_snapshot_controller_operator.go
@@ -21,7 +21,7 @@ const (
 // This is [Serial] because it deletes the csi-snapshot-webhook-secret
 var _ = g.Describe("[sig-storage][Feature:Cluster-CSI-Snapshot-Controller-Operator][Serial][apigroup:operator.openshift.io]", func() {
 	defer g.GinkgoRecover()
-	var oc = exutil.NewCLIWithoutNamespace("storage-csi-snapshot-operator")
+	var oc = exutil.NewCLI("storage-csi-snapshot-operator", exutil.WithoutNamespace())
 
 	g.BeforeEach(func() {
 		// Skip if CSISnapshot CO is not enabled

--- a/test/extended/storage/inline.go
+++ b/test/extended/storage/inline.go
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 
 	g.Context("privileged namespace", func() {
 		var (
-			oc = exutil.NewCLIWithPodSecurityLevel("inline-vol-privileged-ns", admissionapi.LevelPrivileged)
+			oc = exutil.NewCLI("inline-vol-privileged-ns", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 		)
 
 		g.BeforeEach(func() {
@@ -120,7 +120,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 
 	g.Context("baseline namespace", func() {
 		var (
-			oc = exutil.NewCLIWithPodSecurityLevel("inline-vol-baseline-ns", admissionapi.LevelBaseline)
+			oc = exutil.NewCLI("inline-vol-baseline-ns", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		)
 
 		g.BeforeEach(func() {
@@ -177,7 +177,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 
 	g.Context("restricted namespace", func() {
 		var (
-			oc = exutil.NewCLIWithPodSecurityLevel("inline-vol-restricted-ns", admissionapi.LevelRestricted)
+			oc = exutil.NewCLI("inline-vol-restricted-ns", exutil.WithPSALevel(admissionapi.LevelRestricted))
 		)
 
 		g.BeforeEach(func() {

--- a/test/extended/storage/storageclass.go
+++ b/test/extended/storage/storageclass.go
@@ -32,7 +32,7 @@ const (
 var _ = g.Describe("[sig-storage][Feature:DisableStorageClass][Serial][apigroup:operator.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc           = exutil.NewCLIWithPodSecurityLevel("disable-sc-test", admissionapi.LevelPrivileged)
+		oc           = exutil.NewCLI("disable-sc-test", exutil.WithPSALevel(admissionapi.LevelPrivileged))
 		sctest       *DisableStorageClassTest
 		savedSCState operatorv1.StorageClassStateName
 	)

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 	defer g.GinkgoRecover()
 
 	var (
-		cli              = exutil.NewCLIWithPodSecurityLevel("templates", admissionapi.LevelBaseline)
+		cli              = exutil.NewCLI("templates", exutil.WithPSALevel(admissionapi.LevelBaseline))
 		template         *templatev1.Template
 		templateinstance *templatev1.TemplateInstance
 		templatefixture  = exutil.FixturePath("testdata", "templates", "templateinstance_readiness.yaml")

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -267,17 +267,17 @@ func (c *CLI) ChangeUser(name string) *CLI {
 
 	kubeConfig, err := createConfig(c.Namespace(), clientConfig)
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 
 	f, err := os.CreateTemp("", "configfile")
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	c.configPath = f.Name()
 	err = clientcmd.WriteToFile(*kubeConfig, c.configPath)
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 
 	c.username = name
@@ -798,7 +798,7 @@ func (c *CLI) NewPrometheusClient(ctx context.Context) prometheusv1.API {
 func (c *CLI) UserConfig() *rest.Config {
 	clientConfig, err := GetClientConfig(c.configPath)
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	return clientConfig
 }
@@ -806,7 +806,7 @@ func (c *CLI) UserConfig() *rest.Config {
 func (c *CLI) AdminConfig() *rest.Config {
 	clientConfig, err := GetClientConfig(c.adminConfigPath)
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	return clientConfig
 }
@@ -965,7 +965,7 @@ func (c *CLI) outputs(stdOutBuff, stdErrBuff *bytes.Buffer) (string, string, err
 		wrappedErr := fmt.Errorf("Error running %v:\nStdOut>\n%s\nStdErr>\n%s\n%w\n", cmd, stdOut[getStartingIndexForLastN(stdOutBytes, 4096):], stdErr[getStartingIndexForLastN(stdErrBytes, 4096):], err)
 		return stdOut, stdErr, wrappedErr
 	default:
-		FatalErr(fmt.Errorf("unable to execute %q: %v", c.execPath, err))
+		fatalErr(fmt.Errorf("unable to execute %q: %v", c.execPath, err))
 		// unreachable code
 		return "", "", nil
 	}
@@ -992,8 +992,7 @@ func (c *CLI) Execute() error {
 	return err
 }
 
-// FatalErr exits the test in case a fatal error has occurred.
-func FatalErr(msg interface{}) {
+func fatalErr(msg interface{}) {
 	// the path that leads to this being called isn't always clear...
 	fmt.Fprintln(g.GinkgoWriter, string(debug.Stack()))
 	framework.Failf("%v", msg)
@@ -1012,7 +1011,7 @@ func (c *CLI) CreateUser(prefix string) *userv1.User {
 		ObjectMeta: metav1.ObjectMeta{GenerateName: prefix + c.Namespace()},
 	}, metav1.CreateOptions{})
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	c.AddResourceToDelete(userv1.GroupVersion.WithResource("users"), user)
 
@@ -1020,16 +1019,15 @@ func (c *CLI) CreateUser(prefix string) *userv1.User {
 }
 
 func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
-
 	userAPIExists, err := DoesApiResourceExist(c.AdminConfig(), "users", "user.openshift.io")
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 
 	if !userAPIExists {
 		config, err := c.setupUserConfig(username)
 		if err != nil {
-			FatalErr(err)
+			fatalErr(err)
 		}
 		return config
 	}
@@ -1039,14 +1037,14 @@ func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
 
 	user, err := userClient.UserV1().Users().Get(ctx, username, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	if err != nil {
 		user, err = userClient.UserV1().Users().Create(ctx, &userv1.User{
 			ObjectMeta: metav1.ObjectMeta{Name: username},
 		}, metav1.CreateOptions{})
 		if err != nil {
-			FatalErr(err)
+			fatalErr(err)
 		}
 		c.AddResourceToDelete(userv1.GroupVersion.WithResource("users"), user)
 	}
@@ -1058,7 +1056,7 @@ func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
 		GrantMethod: oauthv1.GrantHandlerAuto,
 	}, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	if oauthClientObj != nil {
 		c.AddExplicitResourceToDelete(oauthv1.GroupVersion.WithResource("oauthclients"), "", oauthClientName)
@@ -1074,7 +1072,7 @@ func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
 		RedirectURI: "https://localhost:8443/oauth/token/implicit",
 	}, metav1.CreateOptions{})
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	c.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthaccesstokens"), token)
 
@@ -1114,7 +1112,7 @@ func (c *CLI) WaitForAccessAllowed(review *kubeauthorizationv1.SelfSubjectAccess
 
 	kubeClient, err := kubernetes.NewForConfig(c.GetClientConfigForUser(user))
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	return WaitForAccess(kubeClient, true, review)
 }
@@ -1126,7 +1124,7 @@ func (c *CLI) WaitForAccessDenied(review *kubeauthorizationv1.SelfSubjectAccessR
 
 	kubeClient, err := kubernetes.NewForConfig(c.GetClientConfigForUser(user))
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 	return WaitForAccess(kubeClient, false, review)
 }

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -24,7 +24,6 @@ import (
 	o "github.com/onsi/gomega"
 	"github.com/pborman/uuid"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	yaml "gopkg.in/yaml.v2"
 
 	kubeauthorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -42,7 +41,6 @@ import (
 	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
@@ -1145,38 +1143,4 @@ func GetClientConfig(kubeConfigFile string) (*rest.Config, error) {
 	}
 
 	return clientConfig, nil
-}
-
-const (
-	installConfigName = "cluster-config-v1"
-)
-
-// installConfig The subset of openshift-install's InstallConfig we parse for this test
-type installConfig struct {
-	FIPS bool `json:"fips,omitempty"`
-}
-
-func IsFIPS(client clientcorev1.ConfigMapsGetter) (bool, error) {
-	// this currently uses an install config because it has a lower dependency threshold than going directly to the node.
-	installConfig, err := installConfigFromCluster(client)
-	if err != nil {
-		return false, err
-	}
-	return installConfig.FIPS, nil
-}
-
-func installConfigFromCluster(client clientcorev1.ConfigMapsGetter) (*installConfig, error) {
-	cm, err := client.ConfigMaps("kube-system").Get(context.Background(), installConfigName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	data, ok := cm.Data["install-config"]
-	if !ok {
-		return nil, fmt.Errorf("no install-config found in kube-system/%s", installConfigName)
-	}
-	config := &installConfig{}
-	if err := yaml.Unmarshal([]byte(data), config); err != nil {
-		return nil, err
-	}
-	return config, nil
 }

--- a/test/extended/util/fips.go
+++ b/test/extended/util/fips.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	installConfigName = "cluster-config-v1"
+)
+
+// installConfig The subset of openshift-install's InstallConfig we parse for this test
+type installConfig struct {
+	FIPS bool `json:"fips,omitempty"`
+}
+
+func IsFIPS(client corev1client.ConfigMapsGetter) (bool, error) {
+	// this currently uses an install config because it has a lower dependency threshold than going directly to the node.
+	installConfig, err := installConfigFromCluster(client)
+	if err != nil {
+		return false, err
+	}
+	return installConfig.FIPS, nil
+}
+
+func installConfigFromCluster(client corev1client.ConfigMapsGetter) (*installConfig, error) {
+	cm, err := client.ConfigMaps("kube-system").Get(context.Background(), installConfigName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	data, ok := cm.Data["install-config"]
+	if !ok {
+		return nil, fmt.Errorf("no install-config found in kube-system/%s", installConfigName)
+	}
+	config := &installConfig{}
+	if err := yaml.Unmarshal([]byte(data), config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2122,36 +2122,6 @@ func GetControlPlaneTopologyFromConfigClient(client *configclient.ConfigV1Client
 	return ControlPlaneTopology, nil
 }
 
-const (
-	hypershiftManagementClusterKubeconfigEnvVar = "HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG"
-	hypershiftManagementClusterNamespaceEnvVar  = "HYPERSHIFT_MANAGEMENT_CLUSTER_NAMESPACE"
-)
-
-var (
-	hypershiftManagementClusterKubeconfig string
-	hypershiftManagementClusterNamespace  string
-	hypershiftMutex                       sync.Mutex
-)
-
-func GetHypershiftManagementClusterConfigAndNamespace() (string, string, error) {
-	hypershiftMutex.Lock()
-	defer hypershiftMutex.Unlock()
-
-	if hypershiftManagementClusterKubeconfig == "" && hypershiftManagementClusterNamespace != "" {
-		return hypershiftManagementClusterKubeconfig, hypershiftManagementClusterNamespace, nil
-	}
-
-	kubeconfig, namespace := os.Getenv(hypershiftManagementClusterKubeconfigEnvVar), os.Getenv(hypershiftManagementClusterNamespaceEnvVar)
-	if kubeconfig == "" || namespace == "" {
-		return "", "", fmt.Errorf("both the %s and the %s env var must be set", hypershiftManagementClusterKubeconfigEnvVar, hypershiftManagementClusterNamespaceEnvVar)
-	}
-
-	hypershiftManagementClusterKubeconfig = kubeconfig
-	hypershiftManagementClusterNamespace = namespace
-
-	return hypershiftManagementClusterKubeconfig, hypershiftManagementClusterNamespace, nil
-}
-
 func SkipIfExternalControlplaneTopology(oc *CLI, reason string) {
 	controlPlaneTopology, err := GetControlPlaneTopology(oc)
 	o.ExpectWithOffset(1, err).NotTo(o.HaveOccurred())

--- a/test/extended/util/hypershift.go
+++ b/test/extended/util/hypershift.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+const (
+	hypershiftManagementClusterKubeconfigEnvVar = "HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG"
+	hypershiftManagementClusterNamespaceEnvVar  = "HYPERSHIFT_MANAGEMENT_CLUSTER_NAMESPACE"
+)
+
+var (
+	hypershiftManagementClusterKubeconfig string
+	hypershiftManagementClusterNamespace  string
+	hypershiftMutex                       sync.Mutex
+)
+
+// GetHypershiftManagementClusterConfigAndNamespace retrieves the management cluster
+// kubeconfig and namespace, or an error in case of a failure
+func GetHypershiftManagementClusterConfigAndNamespace() (string, string, error) {
+	hypershiftMutex.Lock()
+	defer hypershiftMutex.Unlock()
+
+	if hypershiftManagementClusterKubeconfig == "" && hypershiftManagementClusterNamespace != "" {
+		return hypershiftManagementClusterKubeconfig, hypershiftManagementClusterNamespace, nil
+	}
+
+	kubeconfig, namespace := os.Getenv(hypershiftManagementClusterKubeconfigEnvVar), os.Getenv(hypershiftManagementClusterNamespaceEnvVar)
+	if kubeconfig == "" || namespace == "" {
+		return "", "", fmt.Errorf("both the %s and the %s env var must be set", hypershiftManagementClusterKubeconfigEnvVar, hypershiftManagementClusterNamespaceEnvVar)
+	}
+
+	hypershiftManagementClusterKubeconfig = kubeconfig
+	hypershiftManagementClusterNamespace = namespace
+
+	return hypershiftManagementClusterKubeconfig, hypershiftManagementClusterNamespace, nil
+}

--- a/test/extended/util/test_setup.go
+++ b/test/extended/util/test_setup.go
@@ -174,7 +174,7 @@ func allowAllNodeScheduling(c kclientset.Interface, namespace string) {
 		return err
 	})
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 }
 
@@ -199,7 +199,7 @@ func addE2EServiceAccountsToSCC(securityClient securityv1client.Interface, names
 		return nil
 	})
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 }
 
@@ -225,6 +225,6 @@ func addRoleToE2EServiceAccounts(rbacClient rbacv1client.RbacV1Interface, namesp
 		return nil
 	})
 	if err != nil {
-		FatalErr(err)
+		fatalErr(err)
 	}
 }


### PR DESCRIPTION
This PR does the following things at a high level:
- cleans up `test/extended/util/client.go` to get rid of duplicate code and ensure all creation goes through the exact same path - single `NewCLI` method with a structure that allows you to configure the necessary variant
- keep explicit separation between admin and user config files to allow easily switching users, without creating new copies of the same resources, which then leads to resources not being cleaned up
- moves non-CLI helpers to their own files

