### PR TITLE
OCPBUGS-18129: Ignore timeout and connection refused errors during upgrade tests for 4.11

### DIFF
--- a/pkg/synthetictests/duplicated_events.go
+++ b/pkg/synthetictests/duplicated_events.go
@@ -137,6 +137,10 @@ var allowedUpgradeRepeatedEventPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`ns/openshift-etcd-operator deployment/etcd-operator - reason/RequiredInstallerResourcesMissing configmaps: etcd-endpoints-[0-9]+`),
 	// There is a separate test to catch this specific case
 	regexp.MustCompile(requiredResourcesMissingRegEx),
+	// Ingore the timeouts because cluster maybe not be ready yet
+	regexp.MustCompile(`reason/ProbeError.Readiness.probe.error:.Get.+net/http:.request.canceled.while.waiting.for.connection.\(Client.Timeout.exceeded.while.awaiting.headers\)`),
+	// Ignore the connection refused error because cluster may not be ready yet
+	regexp.MustCompile(`reason/.*dial tcp.*connection refused`),
 }
 
 var knownEventsBugs = []knownProblem{

--- a/pkg/synthetictests/duplicated_events_test.go
+++ b/pkg/synthetictests/duplicated_events_test.go
@@ -153,6 +153,14 @@ func TestUpgradeEventRegexExcluder(t *testing.T) {
 			name:    "etcd-member",
 			message: `ns/openshift-etcd-operator deployment/etcd-operator - reason/UnhealthyEtcdMember unhealthy members: ip-10-0-198-128.ec2.internal`,
 		},
+		{
+			name:    "readiness-notready",
+			message: `ns/openshift-machine-api pod/machine-api-controllers-6665d45fd-blbbp node/ip-1-2-3-4.ec2.internal - reason/ProbeError Readiness probe error: Get "http://1.2.3.4:9441/healthz": dial tcp 1.2.3.4:9441: connect: connection refused`,
+		},
+		{
+			name:    "readiness-timeout",
+			message: `ns/openshift-monitoring pod/thanos-querier-d89745c9-xttvz node/ip-1-2-3-4.us-west-2.compute.internal - reason/ProbeError Readiness probe error: Get "https://1.2.3.4:9091/-/ready": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Ignore timeout and connection refused errors during upgrade tests for 4.11