### PR TITLE
When --from-repository use built-in tests only

### DIFF
--- a/pkg/cmd/openshift-tests/run-upgrade/flags.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/flags.go
@@ -92,6 +92,7 @@ func (f *RunUpgradeSuiteFlags) ToOptions(args []string) (*RunUpgradeSuiteOptions
 		return nil, err
 	}
 
+	ginkgoOptions.FromRepository = f.FromRepository
 	o := &RunUpgradeSuiteOptions{
 		GinkgoRunSuiteOptions: ginkgoOptions,
 		Suite:                 suite,

--- a/pkg/cmd/openshift-tests/run/flags.go
+++ b/pkg/cmd/openshift-tests/run/flags.go
@@ -109,6 +109,7 @@ func (f *RunSuiteFlags) ToOptions(args []string) (*RunSuiteOptions, error) {
 		return nil, err
 	}
 
+	ginkgoOptions.FromRepository = f.FromRepository
 	o := &RunSuiteOptions{
 		GinkgoRunSuiteOptions: ginkgoOptions,
 		Suite:                 suite,

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -61,6 +61,8 @@ type GinkgoRunSuiteOptions struct {
 	PrintCommands bool
 	genericclioptions.IOStreams
 
+	FromRepository string
+
 	StartTime time.Time
 }
 
@@ -119,7 +121,14 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 	}
 
 	var fallbackSyntheticTestResult []*junitapi.JUnitTestCase
-	if len(os.Getenv("OPENSHIFT_SKIP_EXTERNAL_TESTS")) == 0 {
+	// OPENSHIFT_SKIP_EXTERNAL_TESTS env variable allows to skip using external binary
+	// in a similar fashion when --from-repository flag is specified when invoking tests
+	// this means that images are very likely mirrored so for the time being we cannot
+	// use external binary for tests
+	// TODO (soltysh): when using external binary we should also consult that binary
+	// for the list of tests it might require to run them
+	if len(os.Getenv("OPENSHIFT_SKIP_EXTERNAL_TESTS")) == 0 &&
+		strings.EqualFold(o.FromRepository, "quay.io/openshift/community-e2e-images") {
 		buf := &bytes.Buffer{}
 		fmt.Fprintf(buf, "Attempting to pull tests from external binary...\n")
 		externalTests, err := externalTestsForSuite(ctx)
@@ -156,7 +165,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 			SystemOut: buf.String(),
 		})
 	} else {
-		fmt.Fprintf(o.Out, "Using built-in tests only due to OPENSHIFT_SKIP_EXTERNAL_TESTS being set\n")
+		fmt.Fprintf(o.Out, "Using built-in tests only due to OPENSHIFT_SKIP_EXTERNAL_TESTS being set or --from-repository=%s not being the default\n", o.FromRepository)
 	}
 
 	// this ensures the tests are always run in random order to avoid


### PR DESCRIPTION
Alternative to https://github.com/openshift/release/pull/43229

When we're invoking tests with `--from-repository` it means we needed to mirror the images, which is problematic when we're bumping k8s, since the new images are not mirrored, yet. The long term goal would be to read the additional images from the external binary, but we don't have that functionality there, yet. This is a temporary solution to allow landing k8s bump.

/assign @bertinatto 