### PR TITLE
AUTH-428: add PSa labelsyncer managed labels e2e tests

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -307,6 +307,10 @@ var Annotations = map[string]string{
 
 	"[sig-auth][Feature:PodSecurity] restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-auth][Feature:PodSecurity][Feature:LabelSyncer] updating PSa labels": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-auth][Feature:PodSecurity][Feature:LabelSyncer][Feature:ForceHistoricalOwnership] forcing PSa label historical ownership": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-auth][Feature:PodSecurity][Feature:SCC] SCC admission fails for incorrect/non-existent required-scc annotation": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-auth][Feature:PodSecurity][Feature:SCC] creating pod controllers": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Adds e2e tests for the behavior added here:
- https://github.com/openshift/cluster-policy-controller/pull/127