### PR TITLE
Force using mirrored images in disruption tests

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -14,14 +14,14 @@ import (
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/disruption"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/images"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/monitor"
-	run2 "github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/run"
+	run_monitor "github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/run"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/timeline"
 	risk_analysis "github.com/openshift/origin/pkg/cmd/openshift-tests/risk-analysis"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/run"
 	run_disruption "github.com/openshift/origin/pkg/cmd/openshift-tests/run-disruption"
 	run_test "github.com/openshift/origin/pkg/cmd/openshift-tests/run-test"
 	run_upgrade "github.com/openshift/origin/pkg/cmd/openshift-tests/run-upgrade"
-	"github.com/openshift/origin/pkg/resourcewatch/cmd"
+	run_resourcewatch "github.com/openshift/origin/pkg/resourcewatch/cmd"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/sirupsen/logrus"
@@ -79,11 +79,11 @@ func main() {
 		images.NewImagesCommand(),
 		run_test.NewRunTestCommand(ioStreams),
 		dev.NewDevCommand(),
-		run2.NewRunMonitorCommand(ioStreams),
+		run_monitor.NewRunMonitorCommand(ioStreams),
 		monitor.NewMonitorCommand(ioStreams),
 		disruption.NewDisruptionCommand(ioStreams),
 		risk_analysis.NewTestFailureRiskAnalysisCommand(),
-		cmd.NewRunResourceWatchCommand(),
+		run_resourcewatch.NewRunResourceWatchCommand(),
 		timeline.NewTimelineCommand(ioStreams),
 		run_disruption.NewRunInClusterDisruptionMonitorCommand(ioStreams),
 	)


### PR DESCRIPTION
Noticed in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-kubernetes-1646-nightly-4.15-e2e-metal-ipi-sdn-serial-ipv4/1701752788494585856

/assign @deads2k 