### PR TITLE
OCPVE-295: rteval

### DIFF
--- a/test/extended/kernel/kernel_rt_latency.go
+++ b/test/extended/kernel/kernel_rt_latency.go
@@ -42,6 +42,11 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime/latency][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running cyclictest")
 	})
 
+	g.It("rteval", func() {
+		err := runRteval(oc)
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running rteval")
+	})
+
 	g.AfterEach(func() {
 		cleanupRtTestPod(oc)
 	})

--- a/test/extended/kernel/tools.go
+++ b/test/extended/kernel/tools.go
@@ -2,17 +2,20 @@ package kernel
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"strconv"
+	"time"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/pkg/errors"
 )
 
 const (
-	hwlatdetectThresholdusec = 5000
-	oslatThresholdusec       = 5000
-	cyclictestThresholdusec  = 5000
+	hwlatdetectThresholdusec = 7500
+	oslatThresholdusec       = 7500
+	cyclictestThresholdusec  = 7500
+	rtevalThresholdusec      = 7500
 )
 
 func runPiStressFifo(oc *exutil.CLI) error {
@@ -184,4 +187,56 @@ func getProcessorCount(oc *exutil.CLI) (int, error) {
 	}
 
 	return count, nil
+}
+
+type rtevalOutput struct {
+	XMLName    xml.Name `xml:"rteval"`
+	Statistics struct {
+		XMLName               xml.Name `xml:"statistics"`
+		Samples               int      `xml:"samples"`
+		Minimum               int      `xml:"minimum"`
+		Maximum               int      `xml:"maximum"`
+		Median                float32  `xml:"median"`
+		Mode                  int      `xml:"mode"`
+		Range                 int      `xml:"range"`
+		Mean                  float32  `xml:"mean"`
+		MeanAbsoluteDeviation float32  `xml:"mean_absolute_deviation"`
+		StandardDeviation     float32  `xml:"standard_deviation"`
+	} `xml:"Measurements>Profile>cyclictest>system>statistics"`
+}
+
+func runRteval(oc *exutil.CLI) error {
+	// The working directory for the pod under test
+	// This is where rteval will create a directory and write results
+	rtevalWorkDir := "/tmp"
+
+	// Run the test
+	args := []string{rtPodName, "--", "rteval", "--duration=10m", fmt.Sprintf("--workdir=%s", rtevalWorkDir)}
+	_, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
+	if err != nil {
+		return errors.Wrap(err, "error running rteval")
+	}
+
+	// rteval-YYYYMMDD-S This is a directory created by rteval to hold the summary.xml file where S is the Sequence this has been run (should be 1 for this test)
+	today := time.Now().Format("20060102") // YYYYMMDD
+	summaryFile := fmt.Sprintf("%s/rteval-%s-%d/summary.xml", rtevalWorkDir, today, 1)
+
+	// Gather the results
+	args = []string{rtPodName, "--", "cat", summaryFile}
+	report, err := oc.SetNamespace(rtNamespace).Run("exec").Args(args...).Output()
+	if err != nil {
+		return errors.Wrap(err, "error retrieving rteval results")
+	}
+
+	var res rtevalOutput
+	if err := xml.Unmarshal([]byte(report), &res); err != nil {
+		return errors.Wrap(err, "Unable to parse rteval xml report")
+	}
+
+	// Verify we meet the threshold value
+	if res.Statistics.Maximum > rtevalThresholdusec {
+		return fmt.Errorf("maximum rteval latency of %d usec exceeded maximum allowed of %d usec", res.Statistics.Maximum, rtevalThresholdusec)
+	}
+
+	return nil
 }

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1423,6 +1423,8 @@ var Annotations = map[string]string{
 
 	"[sig-node][Suite:openshift/nodes/realtime/latency][Disruptive] Real time kernel should meet latency requirements when tested with oslat": " [Serial]",
 
+	"[sig-node][Suite:openshift/nodes/realtime/latency][Disruptive] Real time kernel should meet latency requirements when tested with rteval": " [Serial]",
+
 	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow deadline_test to run successfully": " [Serial]",
 
 	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the fifo algorithm": " [Serial]",


### PR DESCRIPTION
This implements rteval as a realtime kernel test and updates the latency thresholds to be a little more forgiving