### PR TITLE
TRT-1244: Bump aws-ovn upgradeDurationLimits to 130

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -378,7 +378,7 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 		// Due to well-known reasons (https://issues.redhat.com/browse/SDN-4042), these numbers are increased to
 		// 100 minutes only for the 4.13->4.14 upgrades - same as OVNAzurePlatformType. These numbers will be brought
 		// down to their original values in OCP 4.15 (https://issues.redhat.com/browse/OTA-999)
-		{configv1.AWSPlatformType, OVN}:       100,
+		{configv1.AWSPlatformType, OVN}:       130,
 		{configv1.AWSPlatformType, SDN}:       95,
 		{configv1.AzurePlatformType, OVN}:     100,
 		{configv1.AzurePlatformType, SDN}:     100,


### PR DESCRIPTION
Data analysis shows that p99 for this variant is just below 125min.
Allow some additional variance but not much.

We have plans to revert values to pre-4.14 values tracked via
https://issues.redhat.com/browse/OTA-999