### PR TITLE
OPRUN-3014: Introduce OLM V1 Tests

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -1,0 +1,114 @@
+package operators
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("[sig-operator] OLM V1", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = exutil.NewCLI("default")
+
+		buildPruningBaseDir = exutil.FixturePath("testdata", "olm")
+		catalog             = filepath.Join(buildPruningBaseDir, "catalog.yaml")
+		operator            = filepath.Join(buildPruningBaseDir, "operator.yaml")
+	)
+
+	//TODO remove this check once OLM V1 has graduated
+	if !exutil.IsTechPreviewNoUpgrade(oc) {
+		g.Skip("the test is not expected to work within Tech Preview disabled clusters")
+	}
+
+	g.It("should unpack a catalog successfully", func() {
+		oc := oc
+
+		// configure Catalog before tests
+		// TODO: Build a catalog for CI purposes
+		configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", catalog, "-p", "NAME=test-catalog", "IMAGE=quay.io/operatorhubio/catalog:latest").OutputToFile("config.json")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Eventually(func() string {
+			output, err := oc.AsAdmin().Run("get").Args("catalog", "test-catalog", "-o=json").Output()
+			if err != nil {
+				e2e.Logf("Failed to get valid catalog, error:%v", err)
+				return ""
+			}
+			type catalogStatus struct {
+				Phase string `json:"phase"`
+			}
+			type catalog struct {
+				Status catalogStatus `json:"status"`
+			}
+			parsed := catalog{
+				Status: catalogStatus{
+					Phase: "",
+				},
+			}
+			if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+				e2e.Logf("Failed to parse catalog, error:%v", err)
+				return ""
+			}
+			return parsed.Status.Phase
+			// Check every 30 seconds as it takes awhile for the catalog to unpack
+		}, 5*time.Minute, 30*time.Second).Should(o.Equal("Unpacked"))
+
+	})
+
+	g.It("should install an operator successfully", func() {
+		oc := oc
+
+		configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", operator, "-p", "NAME=test-operator", "VERSION=0.6.0", "PACKAGE_NAME=argocd-operator").OutputToFile("config.json")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Eventually(func() bool {
+			output, err := oc.AsAdmin().Run("get").Args("operators.operators.operatorframework.io", "test-operator", "-o=json").Output()
+			if err != nil {
+				e2e.Logf("Failed to get valid operator, error:%v", err)
+				return false
+			}
+			type operatorStatus struct {
+				Conditions []metav1.Condition `json:"conditions"`
+			}
+			type operator struct {
+				Status operatorStatus `json:"status"`
+			}
+			parsed := operator{
+				Status: operatorStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+			if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+				e2e.Logf("Failed to parse operator, error:%v", err)
+				return false
+			}
+
+			if !apimeta.IsStatusConditionTrue(parsed.Status.Conditions, "Resolved") {
+				e2e.Logf("Operator is not resolved")
+				return false
+			}
+
+			if !apimeta.IsStatusConditionTrue(parsed.Status.Conditions, "Installed") {
+				e2e.Logf("Operator is not installed")
+				return false
+			}
+
+			return true
+		}, 5*time.Minute, time.Second).Should(o.BeTrue())
+	})
+
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -425,6 +425,8 @@
 // test/extended/testdata/oauthserver/oauth-network.yaml
 // test/extended/testdata/oauthserver/oauth-pod.yaml
 // test/extended/testdata/oauthserver/oauth-sa.yaml
+// test/extended/testdata/olm/catalog.yaml
+// test/extended/testdata/olm/operator.yaml
 // test/extended/testdata/olm/operatorgroup.yaml
 // test/extended/testdata/olm/subscription.yaml
 // test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml
@@ -49073,6 +49075,71 @@ func testExtendedTestdataOauthserverOauthSaYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataOlmCatalogYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: catalog-template
+objects:
+- apiVersion: catalogd.operatorframework.io/v1alpha1
+  kind: Catalog
+  metadata:
+    name: "${NAME}"
+  spec:
+    source:
+      type: image
+      image:
+        ref: "${IMAGE}"
+parameters:
+- name: NAME
+- name: IMAGE`)
+
+func testExtendedTestdataOlmCatalogYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmCatalogYaml, nil
+}
+
+func testExtendedTestdataOlmCatalogYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmCatalogYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olm/catalog.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmOperatorYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: operator-template
+objects:
+- apiVersion: operators.operatorframework.io/v1alpha1
+  kind: Operator
+  metadata:
+    name: "${NAME}"
+  spec:
+    packageName: "${PACKAGE_NAME}"
+    version: "${VERSION}"
+parameters:
+- name: NAME
+- name: VERSION
+- name: PACKAGE_NAME`)
+
+func testExtendedTestdataOlmOperatorYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmOperatorYaml, nil
+}
+
+func testExtendedTestdataOlmOperatorYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmOperatorYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olm/operator.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataOlmOperatorgroupYaml = []byte(`apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -54657,6 +54724,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/oauthserver/oauth-network.yaml":                                                  testExtendedTestdataOauthserverOauthNetworkYaml,
 	"test/extended/testdata/oauthserver/oauth-pod.yaml":                                                      testExtendedTestdataOauthserverOauthPodYaml,
 	"test/extended/testdata/oauthserver/oauth-sa.yaml":                                                       testExtendedTestdataOauthserverOauthSaYaml,
+	"test/extended/testdata/olm/catalog.yaml":                                                                testExtendedTestdataOlmCatalogYaml,
+	"test/extended/testdata/olm/operator.yaml":                                                               testExtendedTestdataOlmOperatorYaml,
 	"test/extended/testdata/olm/operatorgroup.yaml":                                                          testExtendedTestdataOlmOperatorgroupYaml,
 	"test/extended/testdata/olm/subscription.yaml":                                                           testExtendedTestdataOlmSubscriptionYaml,
 	"test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml":                               testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml,
@@ -55396,6 +55465,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"oauth-sa.yaml":      {testExtendedTestdataOauthserverOauthSaYaml, map[string]*bintree{}},
 				}},
 				"olm": {nil, map[string]*bintree{
+					"catalog.yaml":       {testExtendedTestdataOlmCatalogYaml, map[string]*bintree{}},
+					"operator.yaml":      {testExtendedTestdataOlmOperatorYaml, map[string]*bintree{}},
 					"operatorgroup.yaml": {testExtendedTestdataOlmOperatorgroupYaml, map[string]*bintree{}},
 					"subscription.yaml":  {testExtendedTestdataOlmSubscriptionYaml, map[string]*bintree{}},
 				}},

--- a/test/extended/testdata/olm/catalog.yaml
+++ b/test/extended/testdata/olm/catalog.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: catalog-template
+objects:
+- apiVersion: catalogd.operatorframework.io/v1alpha1
+  kind: Catalog
+  metadata:
+    name: "${NAME}"
+  spec:
+    source:
+      type: image
+      image:
+        ref: "${IMAGE}"
+parameters:
+- name: NAME
+- name: IMAGE

--- a/test/extended/testdata/olm/operator.yaml
+++ b/test/extended/testdata/olm/operator.yaml
@@ -1,0 +1,16 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: operator-template
+objects:
+- apiVersion: operators.operatorframework.io/v1alpha1
+  kind: Operator
+  metadata:
+    name: "${NAME}"
+  spec:
+    packageName: "${PACKAGE_NAME}"
+    version: "${VERSION}"
+parameters:
+- name: NAME
+- name: VERSION
+- name: PACKAGE_NAME

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1441,6 +1441,10 @@ var Annotations = map[string]string{
 
 	"[sig-node][apigroup:config.openshift.io] CPU Partitioning node validation should have correct cpuset and cpushare set in crio containers": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-operator] OLM V1 should install an operator successfully": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-operator] OLM V1 should unpack a catalog successfully": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-operator] OLM should be installed with catalogsources at version v1alpha1 [apigroup:operators.coreos.com]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This commit introduces a series of tests that ensure OLM V1 is behaving as expected on tech preview clusters.

The first test case ensures that Catalogd controller successfully reconciles a catalog CR and makes it's content available for install.

The second test ensures that the operator controller successfully reconciles an operator CR and installs the expected operator using RukPak.