### PR TITLE
disruptionpodnetwork: skip test if imagepullspec can not be determined

### DIFF
--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -87,10 +87,10 @@ func NewPodNetworkAvalibilityInvariant(initializationInfo monitortestframework.M
 func (pna *podNetworkAvalibility) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
 	openshiftTestsImagePullSpec, notSupportedReason, err := pna.getImagePullSpec(ctx, adminRESTConfig)
 	if err != nil {
-		return err
+		notSupportedReason = "Failed to find test image pullspec"
+		return nil
 	}
 	if len(notSupportedReason) > 0 {
-		pna.notSupportedReason = notSupportedReason
 		return nil
 	}
 


### PR DESCRIPTION
This is required for disconnected jobs where image pullspec cannot be figured out, similar to https://github.com/openshift/origin/pull/28231