### PR TITLE
Revert "Disable EgressIP test temporarily due to OVN-K bug"

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1319,7 +1319,7 @@ var Annotations = map[string]string{
 
 	"[sig-network][Feature:EgressIP][apigroup:operator.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should have the assigned EgressIPs and EgressIPs can be updated [Skipped:Network/OpenShiftSDN]": " [Serial] [Suite:openshift/conformance/serial]",
 
-	"[sig-network][Feature:EgressIP][apigroup:operator.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should keep the assigned EgressIPs when being rescheduled to another node": " [Serial] [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/serial]",
+	"[sig-network][Feature:EgressIP][apigroup:operator.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should keep the assigned EgressIPs when being rescheduled to another node": " [Serial] [Suite:openshift/conformance/serial]",
 
 	"[sig-network][Feature:EgressIP][apigroup:operator.openshift.io] [internal-targets] EgressIP pods should query hostNetwork pods with the local node's SNAT": " [Disabled:Broken] [Serial]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -222,11 +222,6 @@ var (
 			`\[sig-storage\]\[Late\] Metrics should report short attach times`,
 			`\[sig-storage\]\[Late\] Metrics should report short mount times`,
 		},
-		// tests that don't pass under OVN Kubernetes
-		"[Skipped:Network/OVNKubernetes]": {
-			// https://issues.redhat.com/browse/OCPBUGS-17455: OVN-K bug in IC mode
-			`\[sig-network\]\[Feature:EgressIP\]\[apigroup:operator.openshift.io\] \[external-targets\]\[apigroup:user.openshift.io\]\[apigroup:security.openshift.io\] pods should keep the assigned EgressIPs when being rescheduled to another node`,
-		},
 		"[Skipped:ibmroks]": {
 			// skip Gluster tests (not supported on ROKS worker nodes)
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1825009 - e2e: skip Glusterfs-related tests upstream for rhel7 worker nodes


### PR DESCRIPTION
Reverts openshift/origin#28146
this is fixed via https://issues.redhat.com/browse/OCPBUGS-17455
we should no longer fail on these tests in serial jobs.
once aws-serial passes we can merge this PR
cc @jcaamano 