### PR TITLE
Properly default --from-repository in run-monitor

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -14,14 +14,14 @@ import (
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/disruption"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/images"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/monitor"
-	run2 "github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/run"
+	run_monitor "github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/run"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/timeline"
 	risk_analysis "github.com/openshift/origin/pkg/cmd/openshift-tests/risk-analysis"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/run"
 	run_disruption "github.com/openshift/origin/pkg/cmd/openshift-tests/run-disruption"
 	run_test "github.com/openshift/origin/pkg/cmd/openshift-tests/run-test"
 	run_upgrade "github.com/openshift/origin/pkg/cmd/openshift-tests/run-upgrade"
-	"github.com/openshift/origin/pkg/resourcewatch/cmd"
+	run_resourcewatch "github.com/openshift/origin/pkg/resourcewatch/cmd"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/sirupsen/logrus"
@@ -79,11 +79,11 @@ func main() {
 		images.NewImagesCommand(),
 		run_test.NewRunTestCommand(ioStreams),
 		dev.NewDevCommand(),
-		run2.NewRunMonitorCommand(ioStreams),
+		run_monitor.NewRunMonitorCommand(ioStreams),
 		monitor.NewMonitorCommand(ioStreams),
 		disruption.NewDisruptionCommand(ioStreams),
 		risk_analysis.NewTestFailureRiskAnalysisCommand(),
-		cmd.NewRunResourceWatchCommand(),
+		run_resourcewatch.NewRunResourceWatchCommand(),
 		timeline.NewTimelineCommand(ioStreams),
 		run_disruption.NewRunInClusterDisruptionMonitorCommand(ioStreams),
 	)

--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/clioptions/imagesetup"
 	"github.com/openshift/origin/pkg/monitortestframework"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -34,10 +35,11 @@ type RunMonitorFlags struct {
 	genericclioptions.IOStreams
 }
 
-func NewRunMonitorOptions(streams genericclioptions.IOStreams) *RunMonitorFlags {
+func NewRunMonitorOptions(streams genericclioptions.IOStreams, fromRepository string) *RunMonitorFlags {
 	return &RunMonitorFlags{
 		DisplayFromNow: true,
 		IOStreams:      streams,
+		FromRepository: fromRepository,
 	}
 }
 
@@ -51,7 +53,7 @@ func NewRunCommand(streams genericclioptions.IOStreams) *cobra.Command {
 }
 
 func newRunCommand(name string, streams genericclioptions.IOStreams) *cobra.Command {
-	f := NewRunMonitorOptions(streams)
+	f := NewRunMonitorOptions(streams, imagesetup.DefaultTestImageMirrorLocation)
 
 	cmd := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/openshift/origin/pkg/monitortestframework"
 
-	"github.com/openshift/origin/pkg/clioptions/imagesetup"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/test/extended/util/image"
 
@@ -30,6 +29,7 @@ type RunMonitorFlags struct {
 	DisplayFromNow      bool
 	ExactMonitorTests   []string
 	DisableMonitorTests []string
+	FromRepository      string
 
 	genericclioptions.IOStreams
 }
@@ -89,6 +89,7 @@ func (f *RunMonitorFlags) BindFlags(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&f.ExactMonitorTests, "monitor", f.ExactMonitorTests,
 		fmt.Sprintf("list of exactly which monitors to enable. All others will be disabled.  Current monitors are: [%s]", strings.Join(monitorNames, ", ")))
 	flags.StringSliceVar(&f.DisableMonitorTests, "disable-monitor", f.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored.")
+	flags.StringVar(&f.FromRepository, "from-repository", f.FromRepository, "A container image repository to retrieve test images from.")
 }
 
 func (f *RunMonitorFlags) ToOptions() (*RunMonitorOptions, error) {
@@ -113,6 +114,7 @@ func (f *RunMonitorFlags) ToOptions() (*RunMonitorOptions, error) {
 		DisplayFilterFn: displayFilterFn,
 		MonitorTests:    monitorTestRegistry,
 		IOStreams:       f.IOStreams,
+		FromRepository:  f.FromRepository,
 	}, nil
 }
 
@@ -140,6 +142,7 @@ type RunMonitorOptions struct {
 	ArtifactDir     string
 	DisplayFilterFn monitorapi.EventIntervalMatchesFunc
 	MonitorTests    monitortestframework.MonitorTestRegistry
+	FromRepository  string
 
 	genericclioptions.IOStreams
 }
@@ -148,9 +151,11 @@ type RunMonitorOptions struct {
 // events accumulated to Out. When the user hits CTRL+C or signals termination the
 // condition intervals (all non-instantaneous events) are reported to Out.
 func (o *RunMonitorOptions) Run() error {
+	// set globals so that helpers will create pods with the mapped images if we create them from this process.
+	image.InitializeImages(o.FromRepository)
+
 	fmt.Fprintf(o.Out, "Starting the monitor.\n")
 
-	image.InitializeImages(imagesetup.DefaultTestImageMirrorLocation)
 	restConfig, err := monitor.GetMonitorRESTConfig()
 	if err != nil {
 		return err
@@ -176,12 +181,15 @@ func (o *RunMonitorOptions) Run() error {
 	}()
 	signal.Notify(abortCh, syscall.SIGINT, syscall.SIGTERM)
 
+	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
+		ClusterStabilityDuringTest: monitortestframework.Stable,
+	}
 	recorder := monitor.WrapWithJSONLRecorder(monitor.NewRecorder(), o.Out, o.DisplayFilterFn)
 	m := monitor.NewMonitor(
 		recorder,
 		restConfig,
 		o.ArtifactDir,
-		o.MonitorTests,
+		defaultmonitortests.NewMonitorTestsFor(monitorTestInfo),
 	)
 	if err := m.Start(ctx); err != nil {
 		return err


### PR DESCRIPTION
~Followup to https://github.com/openshift/origin/pull/28258~

Brings back #28258 and adds a fix to the problem found in 
Found in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-aws-ovn-upgrade/1706913500141457408

/assign @dgoodwin 