### PR TITLE
Revert "Force using mirrored images in disruption tests"

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -14,14 +14,14 @@ import (
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/disruption"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/images"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/monitor"
-	run_monitor "github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/run"
+	run2 "github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/run"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/monitor/timeline"
 	risk_analysis "github.com/openshift/origin/pkg/cmd/openshift-tests/risk-analysis"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/run"
 	run_disruption "github.com/openshift/origin/pkg/cmd/openshift-tests/run-disruption"
 	run_test "github.com/openshift/origin/pkg/cmd/openshift-tests/run-test"
 	run_upgrade "github.com/openshift/origin/pkg/cmd/openshift-tests/run-upgrade"
-	run_resourcewatch "github.com/openshift/origin/pkg/resourcewatch/cmd"
+	"github.com/openshift/origin/pkg/resourcewatch/cmd"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/sirupsen/logrus"
@@ -79,11 +79,11 @@ func main() {
 		images.NewImagesCommand(),
 		run_test.NewRunTestCommand(ioStreams),
 		dev.NewDevCommand(),
-		run_monitor.NewRunMonitorCommand(ioStreams),
+		run2.NewRunMonitorCommand(ioStreams),
 		monitor.NewMonitorCommand(ioStreams),
 		disruption.NewDisruptionCommand(ioStreams),
 		risk_analysis.NewTestFailureRiskAnalysisCommand(),
-		run_resourcewatch.NewRunResourceWatchCommand(),
+		cmd.NewRunResourceWatchCommand(),
 		timeline.NewTimelineCommand(ioStreams),
 		run_disruption.NewRunInClusterDisruptionMonitorCommand(ioStreams),
 	)

--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/origin/pkg/monitortestframework"
 
+	"github.com/openshift/origin/pkg/clioptions/imagesetup"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/test/extended/util/image"
 
@@ -26,7 +27,6 @@ import (
 type RunMonitorFlags struct {
 	ArtifactDir    string
 	DisplayFromNow bool
-	FromRepository string
 
 	genericclioptions.IOStreams
 }
@@ -77,7 +77,6 @@ func newRunCommand(name string, streams genericclioptions.IOStreams) *cobra.Comm
 func (f *RunMonitorFlags) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&f.ArtifactDir, "artifact-dir", f.ArtifactDir, "The directory where monitor events will be stored.")
 	flags.BoolVar(&f.DisplayFromNow, "display-from-now", f.DisplayFromNow, "Only display intervals from at or after this comand was started.")
-	flags.StringVar(&f.FromRepository, "from-repository", f.FromRepository, "A container image repository to retrieve test images from.")
 }
 
 func (f *RunMonitorFlags) ToOptions() (*RunMonitorOptions, error) {
@@ -96,14 +95,12 @@ func (f *RunMonitorFlags) ToOptions() (*RunMonitorOptions, error) {
 		ArtifactDir:     f.ArtifactDir,
 		DisplayFilterFn: displayFilterFn,
 		IOStreams:       f.IOStreams,
-		FromRepository:  f.FromRepository,
 	}, nil
 }
 
 type RunMonitorOptions struct {
 	ArtifactDir     string
 	DisplayFilterFn monitorapi.EventIntervalMatchesFunc
-	FromRepository  string
 
 	genericclioptions.IOStreams
 }
@@ -111,12 +108,10 @@ type RunMonitorOptions struct {
 // Run starts monitoring the cluster by invoking Start, periodically printing the
 // events accumulated to Out. When the user hits CTRL+C or signals termination the
 // condition intervals (all non-instantaneous events) are reported to Out.
-func (o *RunMonitorOptions) Run() error {
-	// set globals so that helpers will create pods with the mapped images if we create them from this process.
-	image.InitializeImages(o.FromRepository)
+func (f *RunMonitorOptions) Run() error {
+	fmt.Fprintf(f.Out, "Starting the monitor.\n")
 
-	fmt.Fprintf(o.Out, "Starting the monitor.\n")
-
+	image.InitializeImages(imagesetup.DefaultTestImageMirrorLocation)
 	restConfig, err := monitor.GetMonitorRESTConfig()
 	if err != nil {
 		return err
@@ -127,12 +122,12 @@ func (o *RunMonitorOptions) Run() error {
 	abortCh := make(chan os.Signal, 2)
 	go func() {
 		<-abortCh
-		fmt.Fprintf(o.ErrOut, "Interrupted, terminating\n")
+		fmt.Fprintf(f.ErrOut, "Interrupted, terminating\n")
 		sampler.TearDownInClusterMonitors(restConfig)
 		cancelFn()
 
 		sig := <-abortCh
-		fmt.Fprintf(o.ErrOut, "Interrupted twice, exiting (%s)\n", sig)
+		fmt.Fprintf(f.ErrOut, "Interrupted twice, exiting (%s)\n", sig)
 		switch sig {
 		case syscall.SIGINT:
 			os.Exit(130)
@@ -145,21 +140,21 @@ func (o *RunMonitorOptions) Run() error {
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest: monitortestframework.Stable,
 	}
-	recorder := monitor.WrapWithJSONLRecorder(monitor.NewRecorder(), o.Out, o.DisplayFilterFn)
+	recorder := monitor.WrapWithJSONLRecorder(monitor.NewRecorder(), f.Out, f.DisplayFilterFn)
 	m := monitor.NewMonitor(
 		recorder,
 		restConfig,
-		o.ArtifactDir,
+		f.ArtifactDir,
 		defaultmonitortests.NewMonitorTestsFor(monitorTestInfo),
 	)
 	if err := m.Start(ctx); err != nil {
 		return err
 	}
-	fmt.Fprintf(o.Out, "Monitor started, waiting for ctrl+C to stop...\n")
+	fmt.Fprintf(f.Out, "Monitor started, waiting for ctrl+C to stop...\n")
 
 	<-ctx.Done()
 
-	fmt.Fprintf(o.Out, "Monitor shutting down, this may take up to five minutes...\n")
+	fmt.Fprintf(f.Out, "Monitor shutting down, this may take up to five minutes...\n")
 
 	cleanupContext, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cleanupCancel()


### PR DESCRIPTION
Reverts openshift/origin#28258