### PR TITLE
Port Node and Pod State to Structured Intervals

### DIFF
--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -76,7 +76,7 @@ func (b *IntervalBuilder) BuildNow() Interval {
 }
 
 func (b *IntervalBuilder) Message(mb *MessageBuilder) *IntervalBuilder {
-	b.structuredMessage = mb.build()
+	b.structuredMessage = mb.Build()
 	return b
 }
 
@@ -414,8 +414,8 @@ func (m *MessageBuilder) HumanMessagef(messageFormat string, args ...interface{}
 	return m.HumanMessage(fmt.Sprintf(messageFormat, args...))
 }
 
-// build creates the final StructuredMessage with all data assembled by this builder.
-func (m *MessageBuilder) build() Message {
+// Build creates the final StructuredMessage with all data assembled by this builder.
+func (m *MessageBuilder) Build() Message {
 	ret := Message{
 		Annotations: map[AnnotationKey]string{},
 	}

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -61,6 +61,20 @@ func (b *IntervalBuilder) Build(from, to time.Time) Interval {
 	return ret
 }
 
+// BuildNow creates the final interval with a from/to timestamp of now.
+func (b *IntervalBuilder) BuildNow() Interval {
+	now := time.Now()
+	ret := Interval{
+		Condition: b.BuildCondition(),
+		Display:   b.display,
+		Source:    b.source,
+		From:      now,
+		To:        now,
+	}
+
+	return ret
+}
+
 func (b *IntervalBuilder) Message(mb *MessageBuilder) *IntervalBuilder {
 	b.structuredMessage = mb.build()
 	return b

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -370,26 +370,18 @@ type Intervals []Interval
 var _ sort.Interface = Intervals{}
 
 func (intervals Intervals) Less(i, j int) bool {
-	fmt.Printf("comparing\n")
-	fmt.Printf("    %+v\n", intervals[i])
-	fmt.Printf("    %+v\n", intervals[j])
 	switch d := intervals[i].From.Sub(intervals[j].From); {
 	case d < 0:
-		fmt.Println("    from less than, returning true")
 		return true
 	case d > 0:
-		fmt.Println("    from greater than, returning false")
 		return false
 	}
 	switch d := intervals[i].To.Sub(intervals[j].To); {
 	case d < 0:
-		fmt.Println("    to less than, returning true")
 		return true
 	case d > 0:
-		fmt.Println("    to greater than, returning false")
 		return false
 	}
-	fmt.Printf("    falling back to message comparison: %v\n", intervals[i].Message < intervals[j].Message)
 	return intervals[i].Message < intervals[j].Message
 }
 func (intervals Intervals) Len() int { return len(intervals) }

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -187,7 +187,7 @@ const (
 	NodeNotReadyReason IntervalReason = "NotReady"
 	NodeFailedLease    IntervalReason = "FailedToUpdateLease"
 
-	MachineConfigChangeReason  IntervalReason = "MachineConfigChanged"
+	MachineConfigChangeReason  IntervalReason = "MachineConfigChange"
 	MachineConfigReachedReason IntervalReason = "MachineConfigReached"
 
 	Timeout IntervalReason = "Timeout"

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -216,6 +216,13 @@ const (
 	AnnotationCondition      AnnotationKey = "condition"
 )
 
+// ConstructionOwner was originally meant to signify that an interval was derived from other intervals.
+// This allowed for the possibility of testing interval generation by feeding in only source intervals,
+// and checking what was generated.
+// TODO: likely want to drop this concept in favor of Source, plus a flag automatically applied to any
+// intervals coming back from the monitor test call to generate calculated intervals. Source
+// will replace the use of what constructed the interval, and the flag will allow us to see what is derived
+// and what isn't.
 type ConstructionOwner string
 
 const (
@@ -234,6 +241,9 @@ type Message struct {
 	Annotations map[AnnotationKey]string `json:"annotations"`
 }
 
+// IntervalSource is used to type/categorize all intervals based on what created them.
+// This is intended to be used to group, and when combined with the display flag, signal that
+// they should be visible by default in the UIs that render interval charts.
 type IntervalSource string
 
 const (
@@ -251,6 +261,8 @@ const (
 	SourcePathologicalEventMarker IntervalSource = "PathologicalEventMarker" // not sure if this is really helpful since the events all have a different origin
 	SourceClusterOperatorMonitor  IntervalSource = "ClusterOperatorMonitor"
 	SourceOperatorState           IntervalSource = "OperatorState"
+	SourceNodeState                              = "NodeState"
+	SourcePodState                               = "PodState"
 )
 
 type Interval struct {

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -184,6 +184,9 @@ const (
 	NodeNotReadyReason IntervalReason = "NotReady"
 	NodeFailedLease    IntervalReason = "FailedToUpdateLease"
 
+	MachineConfigChangeReason  IntervalReason = "MachineConfigChanged"
+	MachineConfigReachedReason IntervalReason = "MachineConfigReached"
+
 	Timeout IntervalReason = "Timeout"
 
 	E2ETestStarted  IntervalReason = "E2ETestStarted"
@@ -196,6 +199,7 @@ const (
 	AnnotationReason             AnnotationKey = "reason"
 	AnnotationContainerExitCode  AnnotationKey = "code"
 	AnnotationCause              AnnotationKey = "cause"
+	AnnotationConfig             AnnotationKey = "config"
 	AnnotationNode               AnnotationKey = "node"
 	AnnotationEtcdLocalMember    AnnotationKey = "local-member-id"
 	AnnotationEtcdTerm           AnnotationKey = "term"
@@ -207,6 +211,7 @@ const (
 	// TODO this looks wrong. seems like it ought to be set in the to/from
 	AnnotationDuration       AnnotationKey = "duration"
 	AnnotationRequestAuditID AnnotationKey = "request-audit-id"
+	AnnotationRoles          AnnotationKey = "roles"
 	AnnotationStatus         AnnotationKey = "status"
 	AnnotationCondition      AnnotationKey = "condition"
 )

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -165,6 +165,9 @@ const (
 	PodReasonForceDelete           IntervalReason = "ForceDelete"
 	PodReasonDeleted               IntervalReason = "Deleted"
 	PodReasonScheduled             IntervalReason = "Scheduled"
+	PodReasonEvicted               IntervalReason = "Evicted"
+	PodReasonPreempted             IntervalReason = "Preempted"
+	PodReasonFailed                IntervalReason = "Failed"
 
 	ContainerReasonContainerExit      IntervalReason = "ContainerExit"
 	ContainerReasonContainerStart     IntervalReason = "ContainerStart"

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -238,6 +238,7 @@ const (
 	SourceE2ETest                 IntervalSource = "E2ETest"
 	SourceNetworkManagerLog       IntervalSource = "NetworkMangerLog"
 	SourceNodeMonitor             IntervalSource = "NodeMonitor"
+	SourceSystemJournalScanner    IntervalSource = "KubeletLogScanner"
 	SourcePodLog                  IntervalSource = "PodLog"
 	SourcePodMonitor              IntervalSource = "PodMonitor"
 	SourceKubeEvent               IntervalSource = "KubeEvent"

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -370,18 +370,26 @@ type Intervals []Interval
 var _ sort.Interface = Intervals{}
 
 func (intervals Intervals) Less(i, j int) bool {
+	fmt.Printf("comparing\n")
+	fmt.Printf("    %+v\n", intervals[i])
+	fmt.Printf("    %+v\n", intervals[j])
 	switch d := intervals[i].From.Sub(intervals[j].From); {
 	case d < 0:
+		fmt.Println("    from less than, returning true")
 		return true
 	case d > 0:
+		fmt.Println("    from greater than, returning false")
 		return false
 	}
 	switch d := intervals[i].To.Sub(intervals[j].To); {
 	case d < 0:
+		fmt.Println("    to less than, returning true")
 		return true
 	case d > 0:
+		fmt.Println("    to greater than, returning false")
 		return false
 	}
+	fmt.Printf("    falling back to message comparison: %v\n", intervals[i].Message < intervals[j].Message)
 	return intervals[i].Message < intervals[j].Message
 }
 func (intervals Intervals) Len() int { return len(intervals) }

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -66,9 +66,11 @@ func EventsFromJSON(data []byte) (monitorapi.Intervals, error) {
 		events = append(events, monitorapi.Interval{
 			Source: monitorapi.IntervalSource(interval.Source),
 			Condition: monitorapi.Condition{
-				Level:   level,
-				Locator: interval.Locator,
-				Message: interval.Message,
+				Level:             level,
+				Locator:           interval.Locator,
+				Message:           interval.Message,
+				StructuredLocator: interval.StructuredLocator,
+				StructuredMessage: interval.StructuredMessage,
 			},
 
 			From: interval.From.Time,

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -178,8 +178,16 @@ func (intervals byTime) Less(i, j int) bool {
 	case d > 0:
 		return false
 	}
-	return intervals[i].Locator < intervals[j].Locator
+
+	switch d := intervals[i].To.Sub(intervals[j].To.Time); {
+	case d < 0:
+		return true
+	case d > 0:
+		return false
+	}
+	return intervals[i].Message < intervals[j].Message
 }
+
 func (intervals byTime) Len() int { return len(intervals) }
 func (intervals byTime) Swap(i, j int) {
 	intervals[i], intervals[j] = intervals[j], intervals[i]

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -29,7 +29,8 @@ type stateTracker struct {
 	intervalSource monitorapi.IntervalSource
 }
 
-type intervalCreationFunc func(locator monitorapi.Locator, from, to time.Time) (*monitorapi.IntervalBuilder, bool)
+type intervalCreationFunc func(locator monitorapi.Locator,
+	from, to time.Time) (*monitorapi.IntervalBuilder, bool)
 
 func SimpleInterval(constructedBy monitorapi.ConstructionOwner,
 	source monitorapi.IntervalSource, level monitorapi.IntervalLevel,

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -148,7 +148,6 @@ func (t *stateTracker) CloseInterval(locator monitorapi.Locator, state StateInfo
 	if !hasCondition {
 		return nil
 	}
-	// TODO: from/to and Build needed?
 	return []monitorapi.Interval{ib.Build(from, to)}
 }
 

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -15,6 +15,15 @@ type stateTracker struct {
 	locatorToStateMap        map[string]stateMap
 	locatorsToObservedStates map[string]sets.String
 
+	// locators is a hack due to the fact we cannot use Locator objects as map keys because they contain
+	// a non-comparable map within them. To work around, we serialize to strings to use as map keys. When closing
+	// all remaining intervals we need to actually use the Locator objects themselves, which we don't want to
+	// parse from strings lest we get into the troubles we're trying to avoid by using structured locators to begin
+	// with. (ex. e2e-test/"my big long test name" which has historically caused parsing problems)
+	// Track a map from locator string to Locator for every incoming locator, that we can use when closing remaining
+	// intervals.
+	locators map[string]monitorapi.Locator
+
 	constructedBy monitorapi.ConstructionOwner
 	// intervalSource is used to type/categorize intervals by where they were created.
 	intervalSource monitorapi.IntervalSource
@@ -40,6 +49,7 @@ func NewStateTracker(constructedBy monitorapi.ConstructionOwner,
 		beginning:                beginning,
 		locatorToStateMap:        map[string]stateMap{},
 		locatorsToObservedStates: map[string]sets.String{},
+		locators:                 map[string]monitorapi.Locator{},
 		constructedBy:            constructedBy,
 		intervalSource:           src,
 	}
@@ -53,26 +63,30 @@ type StateInfo struct {
 	reason    monitorapi.IntervalReason
 }
 
-func (t *stateTracker) getStates(locator string) stateMap {
-	if states, ok := t.locatorToStateMap[locator]; ok {
+func (t *stateTracker) getStates(locator monitorapi.Locator) stateMap {
+	locatorKey := locator.OldLocator()
+	if states, ok := t.locatorToStateMap[locatorKey]; ok {
 		return states
 	}
 
-	t.locatorToStateMap[locator] = stateMap{}
-	return t.locatorToStateMap[locator]
+	t.locatorToStateMap[locatorKey] = stateMap{}
+	t.locators[locatorKey] = locator
+	return t.locatorToStateMap[locatorKey]
 }
 
-func (t *stateTracker) getHasOpenedStates(locator string) sets.String {
-	if openedStates, ok := t.locatorsToObservedStates[locator]; ok {
+func (t *stateTracker) getHasOpenedStates(locator monitorapi.Locator) sets.String {
+	locatorKey := locator.OldLocator()
+	if openedStates, ok := t.locatorsToObservedStates[locatorKey]; ok {
 		return openedStates
 	}
 
-	t.locatorsToObservedStates[locator] = sets.String{}
-	return t.locatorsToObservedStates[locator]
+	t.locatorsToObservedStates[locatorKey] = sets.String{}
+	t.locators[locatorKey] = locator
+	return t.locatorsToObservedStates[locatorKey]
 }
 
-func (t *stateTracker) hasOpenedState(locator, stateName string) bool {
-	states, ok := t.locatorsToObservedStates[locator]
+func (t *stateTracker) hasOpenedState(locator monitorapi.Locator, stateName string) bool {
+	states, ok := t.locatorsToObservedStates[locator.OldLocator()]
 	if !ok {
 		return false
 	}
@@ -87,22 +101,24 @@ func State(stateName string, reason monitorapi.IntervalReason) StateInfo {
 	}
 }
 
-func (t *stateTracker) OpenInterval(locator string, state StateInfo, from time.Time) bool {
+func (t *stateTracker) OpenInterval(locator monitorapi.Locator, state StateInfo, from time.Time) bool {
 	states := t.getStates(locator)
 	if _, ok := states[state]; ok {
 		return true
 	}
 
 	states[state] = from
-	t.locatorToStateMap[locator] = states
+	locatorKey := locator.OldLocator()
+	t.locatorToStateMap[locatorKey] = states
+	t.locators[locatorKey] = locator
 
 	openedStates := t.getHasOpenedStates(locator)
 	openedStates.Insert(state.stateName)
-	t.locatorsToObservedStates[locator] = openedStates
+	t.locatorsToObservedStates[locatorKey] = openedStates
 
 	return false
 }
-func (t *stateTracker) CloseIfOpenedInterval(locator string, state StateInfo, intervalCreator intervalCreationFunc, to time.Time) []monitorapi.Interval {
+func (t *stateTracker) CloseIfOpenedInterval(locator monitorapi.Locator, state StateInfo, intervalCreator intervalCreationFunc, to time.Time) []monitorapi.Interval {
 	states := t.getStates(locator)
 	if _, ok := states[state]; !ok {
 		return nil
@@ -111,7 +127,7 @@ func (t *stateTracker) CloseIfOpenedInterval(locator string, state StateInfo, in
 	return t.CloseInterval(locator, state, intervalCreator, to)
 }
 
-func (t *stateTracker) CloseInterval(locator string, state StateInfo, intervalCreator intervalCreationFunc, to time.Time) []monitorapi.Interval {
+func (t *stateTracker) CloseInterval(locator monitorapi.Locator, state StateInfo, intervalCreator intervalCreationFunc, to time.Time) []monitorapi.Interval {
 	states := t.getStates(locator)
 
 	from, ok := states[state]
@@ -123,19 +139,16 @@ func (t *stateTracker) CloseInterval(locator string, state StateInfo, intervalCr
 		from = t.beginning
 	}
 	delete(states, state)
-	t.locatorToStateMap[locator] = states
+	locatorKey := locator.OldLocator()
+	t.locatorToStateMap[locatorKey] = states
+	t.locators[locatorKey] = locator
 
-	condition, hasCondition := intervalCreator(locator, from, to)
+	ib, hasCondition := intervalCreator(locator, from, to)
 	if !hasCondition {
 		return nil
 	}
-	return []monitorapi.Interval{
-		{
-			Condition: condition,
-			From:      from,
-			To:        to,
-		},
-	}
+	// TODO: from/to and Build needed?
+	return []monitorapi.Interval{ib.Build(from, to)}
 }
 
 func (t *stateTracker) CloseAllIntervals(locatorToMessageAnnotations map[string]map[string]string, end time.Time) []monitorapi.Interval {
@@ -146,9 +159,10 @@ func (t *stateTracker) CloseAllIntervals(locatorToMessageAnnotations map[string]
 			annotationStrings = append(annotationStrings, fmt.Sprintf("%v/%v", k, v))
 		}
 
+		l := t.locators[locator]
 		for stateName := range states {
 			message := fmt.Sprintf("%v state/%v never completed", strings.Join(annotationStrings, " "), stateName.stateName)
-			ret = append(ret, t.CloseInterval(locator, stateName, SimpleInterval(t.constructedBy, monitorapi.Warning, stateName.reason, message), end)...)
+			ret = append(ret, t.CloseInterval(l, stateName, SimpleInterval(t.constructedBy, t.intervalSource, monitorapi.Warning, stateName.reason, message), end)...)
 		}
 	}
 

--- a/pkg/monitortests/node/kubeletlogcollector/node.go
+++ b/pkg/monitortests/node/kubeletlogcollector/node.go
@@ -225,7 +225,7 @@ func readinessFailure(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceSystemJournalScanner, monitorapi.Info).
 				Locator(containerRef).
 				Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonReadinessFailed).Node(nodeName).HumanMessage(message)).
 				BuildCondition(),
@@ -255,7 +255,7 @@ func readinessError(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceSystemJournalScanner, monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
@@ -284,7 +284,7 @@ func errParsingSignature(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceSystemJournalScanner, monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
@@ -333,7 +333,7 @@ func startupProbeError(nodeName, logLine string) monitorapi.Intervals {
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceSystemJournalScanner, monitorapi.Info).
 				Locator(containerRef).
 				Message(
 					monitorapi.NewMessage().
@@ -441,7 +441,7 @@ func failedToDeleteCGroupsPath(nodeLocator monitorapi.Locator, logLine string) m
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Error).
+			Condition: monitorapi.NewInterval(monitorapi.SourceSystemJournalScanner, monitorapi.Error).
 				Locator(nodeLocator).
 				Message(monitorapi.NewMessage().Reason("FailedToDeleteCGroupsPath").HumanMessage(logLine)).
 				BuildCondition(),
@@ -460,7 +460,7 @@ func anonymousCertConnectionError(nodeLocator monitorapi.Locator, logLine string
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Error).
+			Condition: monitorapi.NewInterval(monitorapi.SourceSystemJournalScanner, monitorapi.Error).
 				Locator(nodeLocator).
 				Message(monitorapi.NewMessage().Reason("FailedToAuthenticateWithOpenShiftUser").HumanMessage(logLine)).
 				BuildCondition(),
@@ -514,7 +514,7 @@ func leaseUpdateError(nodeLocator monitorapi.Locator, logLine string) monitorapi
 
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceSystemJournalScanner, monitorapi.Info).
 				Locator(nodeLocator).
 				Message(
 					monitorapi.NewMessage().Reason(monitorapi.NodeFailedLease).HumanMessage(fmt.Sprintf("%s - %s", url, msg)),
@@ -559,7 +559,7 @@ func commonErrorInterval(nodeName, logLine string, messageExp *regexp.Regexp, re
 	failureTime := systemdJournalLogTime(logLine)
 	return monitorapi.Intervals{
 		{
-			Condition: monitorapi.NewInterval(monitorapi.SourceNodeMonitor, monitorapi.Info).
+			Condition: monitorapi.NewInterval(monitorapi.SourceSystemJournalScanner, monitorapi.Info).
 				Locator(locator()).
 				Message(
 					monitorapi.NewMessage().Reason(reason).Node(nodeName).HumanMessage(message),

--- a/pkg/monitortests/node/nodestateanalyzer/node.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node.go
@@ -18,7 +18,7 @@ const (
 
 func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.ResourcesMap, beginning, end time.Time) monitorapi.Intervals {
 	var intervals monitorapi.Intervals
-	nodeStateTracker := statetracker.NewStateTracker(monitorapi.ConstructionOwnerNodeLifecycle, beginning)
+	nodeStateTracker := statetracker.NewStateTracker(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, beginning)
 	locatorToMessageAnnotations := map[string]map[string]string{}
 
 	for _, event := range events {

--- a/pkg/monitortests/node/nodestateanalyzer/node.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node.go
@@ -32,11 +32,13 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 		}
 
 		roles := monitorapi.GetNodeRoles(event)
-		nodeLocator := monitorapi.NodeLocator(node)
-		if _, ok := locatorToMessageAnnotations[nodeLocator]; !ok {
-			locatorToMessageAnnotations[nodeLocator] = map[string]string{}
+
+		nodeLocator := monitorapi.NewLocator().NodeFromName(node)
+		nodeLocatorKey := nodeLocator.OldLocator()
+		if _, ok := locatorToMessageAnnotations[nodeLocatorKey]; !ok {
+			locatorToMessageAnnotations[nodeLocatorKey] = map[string]string{}
 		}
-		locatorToMessageAnnotations[nodeLocator]["role"] = roles
+		locatorToMessageAnnotations[nodeLocatorKey]["role"] = roles
 
 		notReadyState := statetracker.State("NotReady", monitorapi.NodeNotReadyReason)
 		updateState := statetracker.State("Update", monitorapi.NodeUpdateReason)
@@ -57,25 +59,25 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 			nodeStateTracker.OpenInterval(nodeLocator, notReadyState, event.From)
 		case "Ready":
 			message := monitorapi.NewMessage().Reason(monitorapi.NodeNotReadyReason).HumanMessagef("role/%v is not ready", roles).BuildString()
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, notReadyState, statetracker.SimpleCondition(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.Warning, monitorapi.NodeNotReadyReason, message), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, notReadyState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Warning, monitorapi.NodeNotReadyReason, message), event.From)...)
 		case "MachineConfigChange":
 			nodeStateTracker.OpenInterval(nodeLocator, updateState, event.From)
 		case "MachineConfigReached":
 			message := strings.ReplaceAll(event.Message, "reason/MachineConfigReached ", "phase/Update ") + " roles/" + roles
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, updateState, statetracker.SimpleCondition(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.Info, monitorapi.NodeUpdateReason, message), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, updateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, message), event.From)...)
 		case "Cordon", "Drain":
 			nodeStateTracker.OpenInterval(nodeLocator, drainState, event.From)
 		case "OSUpdateStarted":
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleCondition(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
 			nodeStateTracker.OpenInterval(nodeLocator, osUpdateState, event.From)
 		case "Reboot":
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleCondition(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleCondition(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles)), event.From)...)
 			nodeStateTracker.OpenInterval(nodeLocator, rebootState, event.From)
 		case "Starting":
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleCondition(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleCondition(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles)), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, rebootState, statetracker.SimpleCondition(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseReboot, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, rebootState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseReboot, roles)), event.From)...)
 		}
 	}
 	intervals = append(intervals, nodeStateTracker.CloseAllIntervals(locatorToMessageAnnotations, end)...)

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
@@ -4,15 +4,21 @@
             "level": "Info",
             "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate phase/Drain roles/worker drained node",
+            "tempSource": "NodeState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Node",
+                "keys": {
+                    "node": "ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NodeUpdate",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "phase/Drain roles/worker drained node",
+                "annotations": {
+                    "constructed": "node-lifecycle-constructor",
+                    "reason": "NodeUpdate"
+                }
             },
             "from": "2023-07-17T22:58:52Z",
             "to": "2023-07-17T23:00:24Z"
@@ -21,15 +27,21 @@
             "level": "Warning",
             "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate role/worker state/OperatingSystemUpdate never completed",
+            "tempSource": "NodeState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Node",
+                "keys": {
+                    "node": "ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NodeUpdate",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "role/worker state/OperatingSystemUpdate never completed",
+                "annotations": {
+                    "constructed": "node-lifecycle-constructor",
+                    "reason": "NodeUpdate"
+                }
             },
             "from": "2023-07-17T23:00:24Z",
             "to": "2023-07-17T23:58:52Z"

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/expected.json
@@ -4,15 +4,21 @@
             "level": "Info",
             "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate phase/Drain roles/worker drained node",
+            "tempSource": "NodeState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Node",
+                "keys": {
+                    "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NodeUpdate",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "phase/Drain roles/worker drained node",
+                "annotations": {
+                    "constructed": "node-lifecycle-constructor",
+                    "reason": "NodeUpdate"
+                }
             },
             "from": "2023-07-18T16:40:16Z",
             "to": "2023-07-18T16:41:49Z"
@@ -21,15 +27,21 @@
             "level": "Warning",
             "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate role/worker state/OperatingSystemUpdate never completed",
+            "tempSource": "NodeState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Node",
+                "keys": {
+                    "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NodeUpdate",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "role/worker state/OperatingSystemUpdate never completed",
+                "annotations": {
+                    "constructed": "node-lifecycle-constructor",
+                    "reason": "NodeUpdate"
+                }
             },
             "from": "2023-07-18T16:41:49Z",
             "to": "2023-07-19T23:58:52Z"

--- a/pkg/monitortests/node/watchpods/collection.go
+++ b/pkg/monitortests/node/watchpods/collection.go
@@ -197,7 +197,8 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(
-						monitorapi.NewMessage().Reason(monitorapi.TerminationStateCleared).HumanMessage("lastState.terminated was cleared on a pod (bug https://bugzilla.redhat.com/show_bug.cgi?id=1933760 or similar)"),
+						monitorapi.NewMessage().Reason(monitorapi.TerminationStateCleared).
+							HumanMessage("lastState.terminated was cleared on a pod (bug https://bugzilla.redhat.com/show_bug.cgi?id=1933760 or similar)"),
 					).BuildNow())
 			}
 

--- a/pkg/monitortests/node/watchpods/collection.go
+++ b/pkg/monitortests/node/watchpods/collection.go
@@ -14,29 +14,28 @@ import (
 )
 
 func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderWriter, client kubernetes.Interface) {
-	podPendingFn := func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
+	podPendingFn := func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
 		isCreate := oldPod == nil
 		oldPodIsPending := oldPod != nil && oldPod.Status.Phase == "Pending"
 		newPodIsPending := pod != nil && pod.Status.Phase == "Pending"
 
+		now := time.Now()
 		switch {
 		case !oldPodIsPending && newPodIsPending:
-			return []monitorapi.Condition{
-				{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.LocatePod(pod),
-					Message: monitorapi.NewMessage().Reason(monitorapi.PodPendingReason).BuildString(),
-				},
+			return []monitorapi.Interval{
+				monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.PodPendingReason)).
+					Build(now, now),
 			}
 
 		case !oldPodIsPending && !newPodIsPending:
 			if isCreate { // if we're creating, then our first state is not-pending.
-				return []monitorapi.Condition{
-					{
-						Level:   monitorapi.Info,
-						Locator: monitorapi.LocatePod(pod),
-						Message: monitorapi.NewMessage().Reason(monitorapi.PodNotPendingReason).BuildString(),
-					},
+				return []monitorapi.Interval{
+					monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+						Locator(monitorapi.NewLocator().PodFromPod(pod)).
+						Message(monitorapi.NewMessage().Reason(monitorapi.PodNotPendingReason)).
+						Build(now, now),
 				}
 			}
 			return nil
@@ -45,37 +44,36 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 			return nil
 
 		case oldPodIsPending && !newPodIsPending:
-			return []monitorapi.Condition{
-				{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.LocatePod(pod),
-					Message: monitorapi.NewMessage().Reason(monitorapi.PodNotPendingReason).BuildString(),
-				},
+			return []monitorapi.Interval{
+				monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.PodNotPendingReason)).
+					Build(now, now),
 			}
-
 		}
 		return nil
 	}
 
-	podScheduledFn := func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
+	podScheduledFn := func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
 		oldPodHasNode := oldPod != nil && len(oldPod.Spec.NodeName) > 0
 		newPodHasNode := pod != nil && len(pod.Spec.NodeName) > 0
+		now := time.Now()
 		if !oldPodHasNode && newPodHasNode {
-			return []monitorapi.Condition{
-				{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.LocatePod(pod),
-					Message: monitorapi.NewMessage().Reason(monitorapi.PodReasonScheduled).Node(pod.Spec.NodeName).BuildString(),
-				},
+			return []monitorapi.Interval{
+				monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonScheduled).Node(pod.Spec.NodeName)).
+					Build(now, now),
 			}
 		}
 		return nil
 	}
 
-	containerStatusesReadinessFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Condition {
+	containerStatusesReadinessFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Interval {
 		isCreate := oldContainerStatuses == nil
 
-		conditions := []monitorapi.Condition{}
+		intervals := []monitorapi.Interval{}
+		now := time.Now()
 		for i := range containerStatuses {
 			containerStatus := &containerStatuses[i]
 			containerName := containerStatus.Name
@@ -89,40 +87,40 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 
 			// always produce conditions during create
 			if (isCreate && !newContainerReady) || (oldContainerReady && !newContainerReady) {
-				conditions = append(conditions, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonNotReady)).
-					BuildCondition())
+					Build(now, now))
 			}
 			if (isCreate && newContainerReady) || (!oldContainerReady && newContainerReady) {
-				conditions = append(conditions, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(
 						monitorapi.NewMessage().Reason(monitorapi.ContainerReasonReady),
-					).BuildCondition())
+					).Build(now, now))
 			}
 		}
 
-		return conditions
+		return intervals
 	}
 
-	containerReadinessFn := func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
+	containerReadinessFn := func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
 		isCreate := oldPod == nil
 
-		conditions := []monitorapi.Condition{}
+		intervals := []monitorapi.Interval{}
 		if isCreate {
-			conditions = append(conditions, containerStatusesReadinessFn(pod, pod.Status.ContainerStatuses, nil)...)
-			conditions = append(conditions, containerStatusesReadinessFn(pod, pod.Status.InitContainerStatuses, nil)...)
+			intervals = append(intervals, containerStatusesReadinessFn(pod, pod.Status.ContainerStatuses, nil)...)
+			intervals = append(intervals, containerStatusesReadinessFn(pod, pod.Status.InitContainerStatuses, nil)...)
 		} else {
-			conditions = append(conditions, containerStatusesReadinessFn(pod, pod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses)...)
-			conditions = append(conditions, containerStatusesReadinessFn(pod, pod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses)...)
+			intervals = append(intervals, containerStatusesReadinessFn(pod, pod.Status.ContainerStatuses, oldPod.Status.ContainerStatuses)...)
+			intervals = append(intervals, containerStatusesReadinessFn(pod, pod.Status.InitContainerStatuses, oldPod.Status.InitContainerStatuses)...)
 		}
 
-		return conditions
+		return intervals
 	}
 
-	containerStatusContainerWaitFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Condition {
-		conditions := []monitorapi.Condition{}
+	containerStatusContainerWaitFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Interval {
+		intervals := []monitorapi.Interval{}
 		for i := range containerStatuses {
 			containerStatus := &containerStatuses[i]
 			containerName := containerStatus.Name
@@ -140,23 +138,23 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 			// always produce messages if we have no previous container status
 			// this happens on create and when a new container status appears as the kubelet starts working on it
 			case oldContainerStatus == nil:
-				conditions = append(conditions,
-					conditionsForTransitioningContainer(pod, containerStatus,
+				intervals = append(intervals,
+					intervalsForTransitioningContainer(pod, containerStatus,
 						monitorapi.ContainerReasonContainerWait, containerStatus.State.Waiting.Reason, " "+containerStatus.State.Waiting.Message)...)
 
 			case oldContainerStatus.State.Waiting == nil || // if the container wasn't previously waiting OR
 				containerStatus.State.Waiting.Reason != oldContainerStatus.State.Waiting.Reason: // the container was previously waiting for a different reason
-				conditions = append(conditions,
-					conditionsForTransitioningContainer(pod, containerStatus,
+				intervals = append(intervals,
+					intervalsForTransitioningContainer(pod, containerStatus,
 						monitorapi.ContainerReasonContainerWait, containerStatus.State.Waiting.Reason, " "+containerStatus.State.Waiting.Message)...)
 			}
 		}
 
-		return conditions
+		return intervals
 	}
 
-	containerStatusContainerStartFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Condition {
-		conditions := []monitorapi.Condition{}
+	containerStatusContainerStartFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Interval {
+		conditions := []monitorapi.Interval{}
 		for i := range containerStatuses {
 			containerStatus := &containerStatuses[i]
 			containerName := containerStatus.Name
@@ -175,12 +173,12 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 			// this happens on create and when a new container status appears as the kubelet starts working on it
 			case oldContainerStatus == nil:
 				conditions = append(conditions,
-					conditionsForTransitioningContainer(pod, containerStatus,
+					intervalsForTransitioningContainer(pod, containerStatus,
 						monitorapi.ContainerReasonContainerStart, "", "")...)
 
 			case oldContainerStatus.State.Running == nil: // the container was previously not running
 				conditions = append(conditions,
-					conditionsForTransitioningContainer(pod, containerStatus,
+					intervalsForTransitioningContainer(pod, containerStatus,
 						monitorapi.ContainerReasonContainerStart, "", "")...)
 			}
 		}
@@ -188,8 +186,9 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 		return conditions
 	}
 
-	containerStatusContainerExitFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Condition {
-		conditions := []monitorapi.Condition{}
+	containerStatusContainerExitFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Interval {
+		intervals := []monitorapi.Interval{}
+		now := time.Now()
 		for i := range containerStatuses {
 			containerStatus := &containerStatuses[i]
 			containerName := containerStatus.Name
@@ -199,11 +198,11 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 			}
 
 			if oldContainerStatus != nil && oldContainerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated == nil {
-				conditions = append(conditions, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(
 						monitorapi.NewMessage().Reason(monitorapi.TerminationStateCleared).HumanMessage("lastState.terminated was cleared on a pod (bug https://bugzilla.redhat.com/show_bug.cgi?id=1933760 or similar)"),
-					).BuildCondition())
+					).Build(now, now))
 			}
 
 			// if this container is not terminated, then we don't need to compute an event for it.
@@ -222,7 +221,7 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 			case lastTerminated && oldContainerStatus.LastTerminationState.Terminated == nil:
 				// if we are transitioning to a terminated state
 				if containerStatus.LastTerminationState.Terminated.ExitCode != 0 {
-					conditions = append(conditions,
+					intervals = append(intervals,
 						monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
 							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 							Message(monitorapi.NewMessage().
@@ -230,10 +229,10 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 								WithAnnotation(monitorapi.AnnotationContainerExitCode, fmt.Sprintf("%d", containerStatus.LastTerminationState.Terminated.ExitCode)).
 								Cause(containerStatus.LastTerminationState.Terminated.Reason).
 								HumanMessage(containerStatus.LastTerminationState.Terminated.Message),
-							).BuildCondition(),
+							).Build(now, now),
 					)
 				} else {
-					conditions = append(conditions,
+					intervals = append(intervals,
 						monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
 							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 							Message(monitorapi.NewMessage().
@@ -241,14 +240,14 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 								WithAnnotation(monitorapi.AnnotationContainerExitCode, "0").
 								Cause(containerStatus.LastTerminationState.Terminated.Reason).
 								HumanMessage(containerStatus.LastTerminationState.Terminated.Message)).
-							BuildCondition(),
+							Build(now, now),
 					)
 				}
 
 			case currentTerminated && oldContainerStatus.State.Terminated == nil:
 				// if we are transitioning to a terminated state
 				if containerStatus.State.Terminated.ExitCode != 0 {
-					conditions = append(conditions,
+					intervals = append(intervals,
 						monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
 							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 							Message(monitorapi.NewMessage().
@@ -257,10 +256,10 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 								Cause(containerStatus.State.Terminated.Reason).
 								HumanMessage(containerStatus.State.Terminated.Message),
 							).
-							BuildCondition(),
+							Build(now, now),
 					)
 				} else {
-					conditions = append(conditions,
+					intervals = append(intervals,
 						monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
 							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 							Message(monitorapi.NewMessage().
@@ -269,18 +268,19 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 								Cause(containerStatus.State.Terminated.Reason).
 								HumanMessage(containerStatus.State.Terminated.Message),
 							).
-							BuildCondition(),
+							Build(now, now),
 					)
 				}
 			}
 
 		}
 
-		return conditions
+		return intervals
 	}
 
-	containerStatusContainerRestartedFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Condition {
-		conditions := []monitorapi.Condition{}
+	containerStatusContainerRestartedFn := func(pod *corev1.Pod, containerStatuses, oldContainerStatuses []corev1.ContainerStatus) []monitorapi.Interval {
+		intervals := []monitorapi.Interval{}
+		now := time.Now()
 		for i := range containerStatuses {
 			containerStatus := &containerStatuses[i]
 			containerName := containerStatus.Name
@@ -300,18 +300,18 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 			}
 
 			if containerStatus.RestartCount != oldContainerStatus.RestartCount {
-				conditions = append(conditions, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
 					Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
 					Message(
 						monitorapi.NewMessage().Reason(monitorapi.ContainerReasonRestarted),
-					).BuildCondition())
+					).Build(now, now))
 			}
 		}
 
-		return conditions
+		return intervals
 	}
 
-	containerLifecycleStateFn := func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
+	containerLifecycleStateFn := func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
 		var oldContainerStatus []corev1.ContainerStatus
 		var oldInitContainerStatus []corev1.ContainerStatus
 		if oldPod != nil {
@@ -319,7 +319,7 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 			oldInitContainerStatus = oldPod.Status.InitContainerStatuses
 		}
 
-		conditions := []monitorapi.Condition{}
+		conditions := []monitorapi.Interval{}
 		conditions = append(conditions, containerStatusContainerWaitFn(pod, pod.Status.ContainerStatuses, oldContainerStatus)...)
 		conditions = append(conditions, containerStatusContainerStartFn(pod, pod.Status.ContainerStatuses, oldContainerStatus)...)
 		conditions = append(conditions, containerStatusContainerExitFn(pod, pod.Status.ContainerStatuses, oldContainerStatus)...)
@@ -333,31 +333,31 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 		return conditions
 	}
 
-	podCreatedFns := []func(pod *corev1.Pod) []monitorapi.Condition{
-		func(pod *corev1.Pod) []monitorapi.Condition {
-			return []monitorapi.Condition{
-				{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.LocatePod(pod),
-					Message: monitorapi.NewMessage().Reason(monitorapi.PodReasonCreated).BuildString(),
-				},
+	podCreatedFns := []func(pod *corev1.Pod) []monitorapi.Interval{
+		func(pod *corev1.Pod) []monitorapi.Interval {
+			now := time.Now()
+			return []monitorapi.Interval{
+				monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonCreated)).
+					Build(now, now),
 			}
 		},
-		func(pod *corev1.Pod) []monitorapi.Condition {
+		func(pod *corev1.Pod) []monitorapi.Interval {
 			return podScheduledFn(pod, nil)
 		},
-		func(pod *corev1.Pod) []monitorapi.Condition {
+		func(pod *corev1.Pod) []monitorapi.Interval {
 			return containerLifecycleStateFn(pod, nil)
 		},
-		func(pod *corev1.Pod) []monitorapi.Condition {
+		func(pod *corev1.Pod) []monitorapi.Interval {
 			return containerReadinessFn(pod, nil)
 		},
-		func(pod *corev1.Pod) []monitorapi.Condition {
+		func(pod *corev1.Pod) []monitorapi.Interval {
 			return podPendingFn(pod, nil)
 		},
 	}
 
-	podChangeFns := []func(pod, oldPod *corev1.Pod) []monitorapi.Condition{
+	podChangeFns := []func(pod, oldPod *corev1.Pod) []monitorapi.Interval{
 		podPendingFn,
 		// check if the pod was scheduled
 		podScheduledFn,
@@ -366,85 +366,78 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 		// check if readiness for containers changed
 		containerReadinessFn,
 		// check phase transitions
-		func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
+		func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
+			now := time.Now()
 			new, old := pod.Status.Phase, oldPod.Status.Phase
 			if new == old || len(old) == 0 {
 				return nil
 			}
-			var conditions []monitorapi.Condition
+			var intervals []monitorapi.Interval
 			switch {
 			case new == corev1.PodPending && old != corev1.PodUnknown:
 				switch {
 				case pod.DeletionTimestamp != nil:
-					conditions = append(conditions, monitorapi.Condition{
-						Level:   monitorapi.Warning,
-						Locator: monitorapi.LocatePod(pod),
-						Message: fmt.Sprintf("invariant violation (bug): pod should not transition %s->%s even when terminated", old, new),
-					})
+					intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
+						Locator(monitorapi.NewLocator().PodFromPod(pod)).
+						Message(monitorapi.NewMessage().HumanMessage("invariant violation (bug): pod should not transition %s->%s even when terminated")).
+						Build(now, now))
 				case isMirrorPod(pod):
-					conditions = append(conditions, monitorapi.Condition{
-						Level:   monitorapi.Warning,
-						Locator: monitorapi.LocatePod(pod),
-						Message: fmt.Sprintf("invariant violation (bug): static pod should not transition %s->%s with same UID", old, new),
-					})
+					intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
+						Locator(monitorapi.NewLocator().PodFromPod(pod)).
+						Message(monitorapi.NewMessage().HumanMessage("invariant violation (bug): static pod should not transition %s->%s with same UID")).
+						Build(now, now))
 				default:
-					conditions = append(conditions, monitorapi.Condition{
-						Level:   monitorapi.Warning,
-						Locator: monitorapi.LocatePod(pod),
-						Message: fmt.Sprintf("pod moved back to Pending"),
-					})
+					intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
+						Locator(monitorapi.NewLocator().PodFromPod(pod)).
+						Message(monitorapi.NewMessage().HumanMessage("pod moved back to Pending")).
+						Build(now, now))
 				}
 			case new == corev1.PodUnknown:
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Warning,
-					Locator: monitorapi.LocatePod(pod),
-					Message: fmt.Sprintf("pod moved to the Unknown phase"),
-				})
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().HumanMessage("pod moved to the Unknown phase")).
+					Build(now, now))
 			case new == corev1.PodFailed && old != corev1.PodFailed:
 				switch pod.Status.Reason {
 				case "Evicted":
-					conditions = append(conditions, monitorapi.Condition{
-						Level:   monitorapi.Error,
-						Locator: monitorapi.LocatePod(pod),
-						Message: fmt.Sprintf("reason/Evicted %s", pod.Status.Message),
-					})
+					intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
+						Locator(monitorapi.NewLocator().PodFromPod(pod)).
+						Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonEvicted).HumanMessage(pod.Status.Message)).
+						Build(now, now))
 				case "Preempting":
-					conditions = append(conditions, monitorapi.Condition{
-						Level:   monitorapi.Error,
-						Locator: monitorapi.LocatePod(pod),
-						Message: fmt.Sprintf("reason/Preempted %s", pod.Status.Message),
-					})
+					intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+						Locator(monitorapi.NewLocator().PodFromPod(pod)).
+						Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonPreempted).HumanMessage(pod.Status.Message)).
+						Build(now, now))
 				default:
-					conditions = append(conditions, monitorapi.Condition{
-						Level:   monitorapi.Error,
-						Locator: monitorapi.LocatePod(pod),
-						Message: fmt.Sprintf("reason/Failed (%s): %s", pod.Status.Reason, pod.Status.Message),
-					})
+					intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+						Locator(monitorapi.NewLocator().PodFromPod(pod)).
+						Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonFailed).
+							HumanMessagef("(%s): %s", pod.Status.Reason, pod.Status.Message)).
+						Build(now, now))
 				}
 				for _, s := range pod.Status.InitContainerStatuses {
 					if t := s.State.Terminated; t != nil && t.ExitCode != 0 {
-						conditions = append(conditions, monitorapi.Condition{
-							Level:   monitorapi.Error,
-							Locator: monitorapi.LocatePodContainer(pod, s.Name),
-							Message: fmt.Sprintf("init container exited with code %d (%s): %s", t.ExitCode, t.Reason, t.Message),
-						})
+						intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+							Locator(monitorapi.NewLocator().ContainerFromPod(pod, s.Name)).
+							Message(monitorapi.NewMessage().HumanMessagef("init container exited with code %d (%s): %s", t.ExitCode, t.Reason, t.Message)).
+							Build(now, now))
 					}
 				}
 				for _, s := range pod.Status.ContainerStatuses {
 					if t := s.State.Terminated; t != nil && t.ExitCode != 0 {
-						conditions = append(conditions, monitorapi.Condition{
-							Level:   monitorapi.Error,
-							Locator: monitorapi.LocatePodContainer(pod, s.Name),
-							Message: fmt.Sprintf("container exited with code %d (%s): %s", t.ExitCode, t.Reason, t.Message),
-						})
+						intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+							Locator(monitorapi.NewLocator().ContainerFromPod(pod, s.Name)).
+							Message(monitorapi.NewMessage().HumanMessagef("container exited with code %d (%s): %s", t.ExitCode, t.Reason, t.Message)).
+							BuildNow())
 					}
 				}
 			}
-			return conditions
+			return intervals
 		},
 		// check for transitions to being deleted
-		func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
-			var conditions []monitorapi.Condition
+		func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
+			var intervals []monitorapi.Interval
 			if pod.DeletionGracePeriodSeconds != nil && oldPod.DeletionGracePeriodSeconds == nil {
 				switch {
 				case len(pod.Spec.NodeName) == 0:
@@ -453,93 +446,87 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 					// terminal pods are immediately deleted (do not undergo graceful deletion)
 				default:
 					if *pod.DeletionGracePeriodSeconds == 0 {
-						conditions = append(conditions, monitorapi.Condition{
-							Level:   monitorapi.Info,
-							Locator: monitorapi.LocatePod(pod),
-							Message: monitorapi.NewMessage().Reason(monitorapi.PodReasonForceDelete).WithAnnotation(monitorapi.AnnotationIsStaticPod, fmt.Sprintf("%t", isMirrorPod(pod))).BuildString(),
-						})
+						intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+							Locator(monitorapi.NewLocator().PodFromPod(pod)).
+							Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonForceDelete).
+								WithAnnotation(monitorapi.AnnotationIsStaticPod, fmt.Sprintf("%t", isMirrorPod(pod)))).
+							BuildNow())
 					} else {
-						conditions = append(conditions, monitorapi.Condition{
-							Level:   monitorapi.Info,
-							Locator: monitorapi.LocatePod(pod),
-							Message: monitorapi.NewMessage().Reason(monitorapi.PodReasonGracefulDeleteStarted).WithAnnotation(monitorapi.AnnotationDuration, fmt.Sprintf("%ds", *pod.DeletionGracePeriodSeconds)).BuildString(),
-						})
+						intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+							Locator(monitorapi.NewLocator().PodFromPod(pod)).
+							Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonGracefulDeleteStarted).
+								WithAnnotation(monitorapi.AnnotationDuration, fmt.Sprintf("%ds", *pod.DeletionGracePeriodSeconds))).
+							BuildNow())
 					}
 				}
 			}
 			if pod.DeletionGracePeriodSeconds == nil && oldPod.DeletionGracePeriodSeconds != nil {
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Error,
-					Locator: monitorapi.LocatePod(pod),
-					Message: "invariant violation: pod was marked for deletion and then deletion grace period was cleared",
-				})
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().HumanMessage("invariant violation: pod was marked for deletion and then deletion grace period was cleared")).
+					BuildNow())
 			}
-			return conditions
+			return intervals
 		},
 		// check restarts, readiness drop outs, or other status changes
-		func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
-			var conditions []monitorapi.Condition
+		func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
+			var intervals []monitorapi.Interval
 
 			// container status should never be removed since the kubelet should be
 			// synthesizing status from the apiserver in order to determine what to
 			// run after a reboot (this is likely to be the result of a pod going back
 			// to pending status)
 			if len(pod.Status.ContainerStatuses) < len(oldPod.Status.ContainerStatuses) {
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Error,
-					Locator: monitorapi.LocatePod(pod),
-					Message: "invariant violation: container statuses were removed",
-				})
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().HumanMessage("invariant violation: container statuses were removed")).
+					BuildNow())
 			}
 			if len(pod.Status.InitContainerStatuses) < len(oldPod.Status.InitContainerStatuses) {
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Error,
-					Locator: monitorapi.LocatePod(pod),
-					Message: "invariant violation: init container statuses were removed",
-				})
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().HumanMessage("invariant violation: init container statuses were removed")).
+					BuildNow())
 			}
 
-			return conditions
+			return intervals
 		},
 		// inform when a pod gets reassigned to a new node
-		func(pod, oldPod *corev1.Pod) []monitorapi.Condition {
-			var conditions []monitorapi.Condition
+		func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
+			var intervals []monitorapi.Interval
 			if len(oldPod.Spec.NodeName) > 0 && pod.Spec.NodeName != oldPod.Spec.NodeName {
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Error,
-					Locator: monitorapi.LocatePod(pod),
-					Message: fmt.Sprintf("invariant violation, pod once assigned to a node must stay on it. The pod previously scheduled to %s, has just been assigned to a new node %s", oldPod.Spec.NodeName, pod.Spec.NodeName),
-				})
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().HumanMessagef(
+						"invariant violation, pod once assigned to a node must stay on it. The pod previously scheduled to %s, has just been assigned to a new node %s", oldPod.Spec.NodeName, pod.Spec.NodeName)).
+					BuildNow())
 			}
-			return conditions
+			return intervals
 		},
 	}
-	podDeleteFns := []func(pod *corev1.Pod) []monitorapi.Condition{
+	podDeleteFns := []func(pod *corev1.Pod) []monitorapi.Interval{
 		// check for transitions to being deleted
-		func(pod *corev1.Pod) []monitorapi.Condition {
-			conditions := []monitorapi.Condition{
-				{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.LocatePod(pod),
-					Message: monitorapi.NewMessage().Reason(monitorapi.PodReasonDeleted).BuildString(),
-				},
+		func(pod *corev1.Pod) []monitorapi.Interval {
+			intervals := []monitorapi.Interval{
+				monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonDeleted)).
+					BuildNow(),
 			}
 			switch {
 			case len(pod.Spec.NodeName) == 0:
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.LocatePod(pod),
-					Message: monitorapi.NewMessage().Reason(monitorapi.PodReasonDeletedBeforeScheduling).BuildString(),
-				})
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonDeletedBeforeScheduling)).
+					BuildNow())
 			case pod.Status.Phase == corev1.PodFailed, pod.Status.Phase == corev1.PodSucceeded:
-				conditions = append(conditions, monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: monitorapi.LocatePod(pod),
-					Message: monitorapi.NewMessage().Reason(monitorapi.PodReasonDeletedAfterCompletion).BuildString(),
-				})
+				intervals = append(intervals, monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().PodFromPod(pod)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.PodReasonDeletedAfterCompletion)).
+					BuildNow())
 			default:
 			}
-			return conditions
+			return intervals
 		},
 	}
 
@@ -563,16 +550,16 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 
 }
 
-type objCreateFunc func(obj interface{}) []monitorapi.Condition
-type objUpdateFunc func(obj, oldObj interface{}) []monitorapi.Condition
-type objDeleteFunc func(obj interface{}) []monitorapi.Condition
+type objCreateFunc func(obj interface{}) []monitorapi.Interval
+type objUpdateFunc func(obj, oldObj interface{}) []monitorapi.Interval
+type objDeleteFunc func(obj interface{}) []monitorapi.Interval
 
-func toCreateFns(podCreateFns []func(pod *corev1.Pod) []monitorapi.Condition) []objCreateFunc {
+func toCreateFns(podCreateFns []func(pod *corev1.Pod) []monitorapi.Interval) []objCreateFunc {
 	ret := []objCreateFunc{}
 
 	for i := range podCreateFns {
 		fn := podCreateFns[i]
-		ret = append(ret, func(obj interface{}) []monitorapi.Condition {
+		ret = append(ret, func(obj interface{}) []monitorapi.Interval {
 			return fn(obj.(*corev1.Pod))
 		})
 	}
@@ -580,12 +567,12 @@ func toCreateFns(podCreateFns []func(pod *corev1.Pod) []monitorapi.Condition) []
 	return ret
 }
 
-func toDeleteFns(podDeleteFns []func(pod *corev1.Pod) []monitorapi.Condition) []objDeleteFunc {
+func toDeleteFns(podDeleteFns []func(pod *corev1.Pod) []monitorapi.Interval) []objDeleteFunc {
 	ret := []objDeleteFunc{}
 
 	for i := range podDeleteFns {
 		fn := podDeleteFns[i]
-		ret = append(ret, func(obj interface{}) []monitorapi.Condition {
+		ret = append(ret, func(obj interface{}) []monitorapi.Interval {
 			return fn(obj.(*corev1.Pod))
 		})
 	}
@@ -593,12 +580,12 @@ func toDeleteFns(podDeleteFns []func(pod *corev1.Pod) []monitorapi.Condition) []
 	return ret
 }
 
-func toUpdateFns(podUpdateFns []func(pod, oldPod *corev1.Pod) []monitorapi.Condition) []objUpdateFunc {
+func toUpdateFns(podUpdateFns []func(pod, oldPod *corev1.Pod) []monitorapi.Interval) []objUpdateFunc {
 	ret := []objUpdateFunc{}
 
 	for i := range podUpdateFns {
 		fn := podUpdateFns[i]
-		ret = append(ret, func(obj, oldObj interface{}) []monitorapi.Condition {
+		ret = append(ret, func(obj, oldObj interface{}) []monitorapi.Interval {
 			if oldObj == nil {
 				return fn(obj.(*corev1.Pod), nil)
 			}
@@ -619,12 +606,12 @@ func lastContainerTimeFromStatus(current *corev1.ContainerStatus) time.Time {
 	return time.Time{}
 }
 
-func conditionsForTransitioningContainer(pod *corev1.Pod, current *corev1.ContainerStatus, reason monitorapi.IntervalReason, cause, message string) []monitorapi.Condition {
-	return []monitorapi.Condition{
+func intervalsForTransitioningContainer(pod *corev1.Pod, current *corev1.ContainerStatus, reason monitorapi.IntervalReason, cause, message string) []monitorapi.Interval {
+	return []monitorapi.Interval{
 		monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
 			Locator(monitorapi.NewLocator().ContainerFromPod(pod, current.Name)).
 			Message(monitorapi.NewMessage().Reason(reason).Cause(cause).HumanMessage(message)).
-			BuildCondition(),
+			BuildNow(),
 	}
 }
 

--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -14,7 +14,7 @@ import (
 
 func intervalsFromEvents_PodChanges(events monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals {
 	var intervals monitorapi.Intervals
-	podStateTracker := statetracker.NewStateTracker(monitorapi.ConstructionOwnerPodLifecycle, beginning)
+	podStateTracker := statetracker.NewStateTracker(monitorapi.ConstructionOwnerPodLifecycle, monitorapi.SourcePodState, beginning)
 	locatorToMessageAnnotations := map[string]map[string]string{}
 
 	for _, event := range events {

--- a/pkg/monitortests/node/watchpods/compute_intervals_test.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals_test.go
@@ -28,7 +28,6 @@ func TestPodIntervalCreation(t *testing.T) {
 		}
 		testName := file.Name()
 		events := podBytesOrDie(fmt.Sprintf("podTest/%s/startingEvents.json", testName))
-		fmt.Println(fmt.Sprintf("podTest/%s/startingEvents.json", testName))
 		expected := podStringOrDie(fmt.Sprintf("podTest/%s/expected.json", testName))
 		podData := podBytesOrDie(fmt.Sprintf("podTest/%s/podData.json", testName))
 		times := podStringOrDie(fmt.Sprintf("podTest/%s/times.txt", testName))

--- a/pkg/monitortests/node/watchpods/compute_intervals_test.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals_test.go
@@ -28,6 +28,7 @@ func TestPodIntervalCreation(t *testing.T) {
 		}
 		testName := file.Name()
 		events := podBytesOrDie(fmt.Sprintf("podTest/%s/startingEvents.json", testName))
+		fmt.Println(fmt.Sprintf("podTest/%s/startingEvents.json", testName))
 		expected := podStringOrDie(fmt.Sprintf("podTest/%s/expected.json", testName))
 		podData := podBytesOrDie(fmt.Sprintf("podTest/%s/podData.json", testName))
 		times := podStringOrDie(fmt.Sprintf("podTest/%s/times.txt", testName))

--- a/pkg/monitortests/node/watchpods/monitoring_reflector.go
+++ b/pkg/monitortests/node/watchpods/monitoring_reflector.go
@@ -18,8 +18,8 @@ type resourceTracker interface {
 	RecordResource(resourceType string, obj runtime.Object)
 }
 
-type conditionRecorder interface {
-	Record(conditions ...monitorapi.Condition)
+type intervalRecorder interface {
+	AddIntervals(intervals ...monitorapi.Interval)
 }
 
 type monitoringStore struct {
@@ -37,7 +37,7 @@ func newMonitoringStore(
 	updateHandlers []objUpdateFunc,
 	deleteHandlers []objDeleteFunc,
 	resourceTracker resourceTracker,
-	conditionRecorder conditionRecorder,
+	intervalRecorder intervalRecorder,
 ) *monitoringStore {
 	s := &monitoringStore{
 		FakeCustomStore:       &cache.FakeCustomStore{},
@@ -65,7 +65,7 @@ func newMonitoringStore(
 		}
 
 		for _, updateHandler := range updateHandlers {
-			conditionRecorder.Record(updateHandler(obj, oldObj)...)
+			intervalRecorder.AddIntervals(updateHandler(obj, oldObj)...)
 		}
 
 		return nil
@@ -86,7 +86,7 @@ func newMonitoringStore(
 		resourceTracker.RecordResource(resourceType, obj.(runtime.Object))
 
 		for _, createHandler := range createHandlers {
-			conditionRecorder.Record(createHandler(obj)...)
+			intervalRecorder.AddIntervals(createHandler(obj)...)
 		}
 
 		return nil
@@ -108,7 +108,7 @@ func newMonitoringStore(
 		resourceTracker.RecordResource(resourceType, obj.(runtime.Object))
 
 		for _, deleteHandler := range deleteHandlers {
-			conditionRecorder.Record(deleteHandler(obj)...)
+			intervalRecorder.AddIntervals(deleteHandler(obj)...)
 		}
 
 		return nil

--- a/pkg/monitortests/node/watchpods/podTest/container-life/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/container-life/expected.json
@@ -2,102 +2,157 @@
     "items": [
         {
             "level": "Info",
-            "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+            "locator": "namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "e2e-kubectl-3271",
+                    "pod": "without-label",
+                    "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Created",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Created"
+                }
             },
             "from": "2022-03-07T18:41:46Z",
             "to": "2022-03-07T18:41:46Z"
         },
         {
             "level": "Info",
-            "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
-            "message": "constructed/pod-lifecycle-constructor node/ip-10-0-141-9.us-west-2.compute.internal reason/Scheduled",
-            "tempStructuredLocator": {
-                "type": "",
-                "keys": null
-            },
-            "tempStructuredMessage": {
-                "reason": "",
-                "cause": "",
-                "humanMessage": "",
-                "annotations": null
-            },
-            "from": "2022-03-07T18:41:46Z",
-            "to": "2022-03-07T18:41:54Z"
-        },
-        {
-            "level": "Info",
-            "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
+            "locator": "container/without-label namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "without-label",
+                    "namespace": "e2e-kubectl-3271",
+                    "pod": "without-label",
+                    "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "ContainerWait",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "missed real \"ContainerWait\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "ContainerWait"
+                }
             },
             "from": "2022-03-07T18:41:46Z",
             "to": "2022-03-07T18:41:52Z"
         },
         {
             "level": "Info",
-            "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
-            "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "locator": "namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+            "message": "constructed/pod-lifecycle-constructor node/ip-10-0-141-9.us-west-2.compute.internal reason/Scheduled",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "e2e-kubectl-3271",
+                    "pod": "without-label",
+                    "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Scheduled",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "node": "ip-10-0-141-9.us-west-2.compute.internal",
+                    "reason": "Scheduled"
+                }
+            },
+            "from": "2022-03-07T18:41:46Z",
+            "to": "2022-03-07T18:41:54Z"
+        },
+        {
+            "level": "Info",
+            "locator": "container/without-label namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+            "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempSource": "PodState",
+            "tempStructuredLocator": {
+                "type": "Container",
+                "keys": {
+                    "container": "without-label",
+                    "namespace": "e2e-kubectl-3271",
+                    "pod": "without-label",
+                    "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+                }
+            },
+            "tempStructuredMessage": {
+                "reason": "NotReady",
+                "cause": "",
+                "humanMessage": "missed real \"NotReady\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-07T18:41:52Z",
             "to": "2022-03-07T18:41:52Z"
         },
         {
             "level": "Info",
-            "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
+            "locator": "container/without-label namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/6.00s reason/ContainerStart",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "without-label",
+                    "namespace": "e2e-kubectl-3271",
+                    "pod": "without-label",
+                    "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "ContainerStart",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "cause": "",
+                    "constructed": "pod-lifecycle-constructor",
+                    "duration": "6.00s",
+                    "reason": "ContainerStart"
+                }
             },
             "from": "2022-03-07T18:41:52Z",
             "to": "2022-03-07T18:41:54Z"
         },
         {
             "level": "Info",
-            "locator": "ns/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
+            "locator": "container/without-label namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "without-label",
+                    "namespace": "e2e-kubectl-3271",
+                    "pod": "without-label",
+                    "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Ready",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Ready"
+                }
             },
             "from": "2022-03-07T18:41:52Z",
             "to": "2022-03-07T18:41:54Z"

--- a/pkg/monitortests/node/watchpods/podTest/container-life/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/container-life/expected.json
@@ -27,7 +27,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/without-label namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+            "locator": "namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -79,7 +79,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/without-label namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+            "locator": "namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -105,7 +105,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/without-label namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+            "locator": "namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/6.00s reason/ContainerStart",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -133,7 +133,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/without-label namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+            "locator": "namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempSource": "PodState",
             "tempStructuredLocator": {

--- a/pkg/monitortests/node/watchpods/podTest/container-life/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/container-life/startingEvents.json
@@ -2,43 +2,141 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/e2e-kubectl-3271 pod/without-label node/ uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+      "locator": "namespace/e2e-kubectl-3271 pod/without-label node/ uid/e185b70c-ea3e-4600-850a-b2370a729a73",
       "message": "reason/Created ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "without-label",
+          "namespace": "e2e-kubectl-3271",
+          "node": "",
+          "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-07T18:41:46Z",
       "to": "2022-03-07T18:41:46Z"
     },
     {
       "level": "Warning",
-      "locator": "ns/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+      "locator": "namespace/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73",
       "message": "reason/Scheduled node/ip-10-0-141-9.us-west-2.compute.internal",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "without-label",
+          "namespace": "e2e-kubectl-3271",
+          "node": "ip-10-0-141-9.us-west-2.compute.internal",
+          "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Scheduled",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "node": "ip-10-0-141-9.us-west-2.compute.internal"
+        }
+      },
       "from": "2022-03-07T18:41:46Z",
       "to": "2022-03-07T18:41:46Z"
     },
     {
       "level": "Info",
-      "locator": "ns/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
+      "locator": "namespace/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
       "message": "reason/ContainerStart cause/ duration/6.00s",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "without-label",
+          "pod": "without-label",
+          "namespace": "e2e-kubectl-3271",
+          "node": "ip-10-0-141-9.us-west-2.compute.internal",
+          "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "ContainerStart",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "duration": "6.00s"
+        }
+      },
       "from": "2022-03-07T18:41:52Z",
       "to": "2022-03-07T18:41:52Z"
     },
     {
       "level": "Info",
-      "locator": "ns/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
+      "locator": "namespace/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
       "message": "reason/Ready ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "without-label",
+          "pod": "without-label",
+          "namespace": "e2e-kubectl-3271",
+          "node": "ip-10-0-141-9.us-west-2.compute.internal",
+          "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-07T18:41:52Z",
       "to": "2022-03-07T18:41:52Z"
     },
     {
       "level": "Info",
-      "locator": "ns/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+      "locator": "namespace/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73",
       "message": "reason/ForceDelete mirrored/false",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "without-label",
+          "namespace": "e2e-kubectl-3271",
+          "node": "ip-10-0-141-9.us-west-2.compute.internal",
+          "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "ForceDelete",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "mirrored": "false"
+        }
+      },
       "from": "2022-03-07T18:41:54Z",
       "to": "2022-03-07T18:41:54Z"
     },
     {
       "level": "Info",
-      "locator": "ns/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73",
+      "locator": "namespace/e2e-kubectl-3271 pod/without-label node/ip-10-0-141-9.us-west-2.compute.internal uid/e185b70c-ea3e-4600-850a-b2370a729a73",
       "message": "reason/Deleted ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "without-label",
+          "namespace": "e2e-kubectl-3271",
+          "node": "ip-10-0-141-9.us-west-2.compute.internal",
+          "uid": "e185b70c-ea3e-4600-850a-b2370a729a73"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Deleted",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-07T18:41:54Z",
       "to": "2022-03-07T18:41:54Z"
     }

--- a/pkg/monitortests/node/watchpods/podTest/end-before-begin/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/end-before-begin/expected.json
@@ -53,7 +53,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/pruner namespace/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
+            "locator": "namespace/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9 container/pruner",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
             "tempSource": "PodState",
             "tempStructuredLocator": {

--- a/pkg/monitortests/node/watchpods/podTest/end-before-begin/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/end-before-begin/expected.json
@@ -2,51 +2,77 @@
     "items": [
         {
             "level": "Info",
-            "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
+            "locator": "namespace/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-214-214.us-west-1.compute.internal reason/Scheduled",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-kube-apiserver",
+                    "pod": "revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal",
+                    "uid": "6a81964d-169c-47e0-a986-551429370ae9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Scheduled",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "node": "ip-10-0-214-214.us-west-1.compute.internal",
+                    "reason": "Scheduled"
+                }
             },
             "from": "2022-03-21T16:43:14Z",
             "to": "2022-03-21T16:43:14Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
+            "locator": "namespace/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-kube-apiserver",
+                    "pod": "revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal",
+                    "uid": "6a81964d-169c-47e0-a986-551429370ae9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Created",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Created"
+                }
             },
             "from": "2022-03-21T16:43:14Z",
             "to": "2022-03-21T16:43:14Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9 container/pruner",
+            "locator": "container/pruner namespace/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "pruner",
+                    "namespace": "openshift-kube-apiserver",
+                    "pod": "revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal",
+                    "uid": "6a81964d-169c-47e0-a986-551429370ae9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NotReady",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-21T16:43:14Z",
             "to": "2022-03-21T16:43:14Z"

--- a/pkg/monitortests/node/watchpods/podTest/end-before-begin/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/end-before-begin/startingEvents.json
@@ -2,22 +2,70 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal node/ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
+      "locator": "namespace/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal node/ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
       "message": "reason/Created ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal",
+          "namespace": "openshift-kube-apiserver",
+          "node": "ip-10-0-214-214.us-west-1.compute.internal",
+          "uid": "6a81964d-169c-47e0-a986-551429370ae9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-21T16:43:39Z",
       "to": "2022-03-21T16:43:39Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal node/ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
+      "locator": "namespace/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal node/ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9",
       "message": "reason/Scheduled node/ip-10-0-214-214.us-west-1.compute.internal",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal",
+          "namespace": "openshift-kube-apiserver",
+          "node": "ip-10-0-214-214.us-west-1.compute.internal",
+          "uid": "6a81964d-169c-47e0-a986-551429370ae9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "node": "ip-10-0-214-214.us-west-1.compute.internal"
+        }
+      },
       "from": "2022-03-21T16:43:39Z",
       "to": "2022-03-21T16:43:39Z"
     },
     {
       "level": "Warning",
-      "locator": "ns/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal node/ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9 container/pruner",
+      "locator": "namespace/openshift-kube-apiserver pod/revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal node/ip-10-0-214-214.us-west-1.compute.internal uid/6a81964d-169c-47e0-a986-551429370ae9 container/pruner",
       "message": "reason/NotReady ",
+      "tempStructuredLocator": {
+        "type": "Pruner",
+        "keys": {
+          "container": "pruner",
+          "pod": "revision-pruner-7-ip-10-0-214-214.us-west-1.compute.internal",
+          "namespace": "openshift-kube-apiserver",
+          "node": "ip-10-0-214-214.us-west-1.compute.internal",
+          "uid": "6a81964d-169c-47e0-a986-551429370ae9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-21T16:43:39Z",
       "to": "2022-03-21T16:43:39Z"
     }

--- a/pkg/monitortests/node/watchpods/podTest/installer-pod/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/installer-pod/expected.json
@@ -27,7 +27,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+            "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -79,7 +79,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+            "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -105,7 +105,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+            "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/3.00s reason/ContainerStart",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -133,7 +133,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+            "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -159,7 +159,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+            "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
             "tempSource": "PodState",
             "tempStructuredLocator": {

--- a/pkg/monitortests/node/watchpods/podTest/installer-pod/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/installer-pod/expected.json
@@ -2,119 +2,183 @@
     "items": [
         {
             "level": "Info",
-            "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+            "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-etcd",
+                    "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+                    "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Created",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Created"
+                }
             },
             "from": "2022-03-21T21:37:20Z",
             "to": "2022-03-21T21:37:20Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
-            "message": "constructed/pod-lifecycle-constructor node/ci-op-97t906zm-db044-bwrrn-master-0 reason/Scheduled",
-            "tempStructuredLocator": {
-                "type": "",
-                "keys": null
-            },
-            "tempStructuredMessage": {
-                "reason": "",
-                "cause": "",
-                "humanMessage": "",
-                "annotations": null
-            },
-            "from": "2022-03-21T21:37:20Z",
-            "to": "2022-03-21T21:37:56Z"
-        },
-        {
-            "level": "Info",
-            "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "installer",
+                    "namespace": "openshift-etcd",
+                    "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+                    "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "ContainerWait",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "missed real \"ContainerWait\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "ContainerWait"
+                }
             },
             "from": "2022-03-21T21:37:20Z",
             "to": "2022-03-21T21:37:23Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
-            "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+            "message": "constructed/pod-lifecycle-constructor node/ci-op-97t906zm-db044-bwrrn-master-0 reason/Scheduled",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-etcd",
+                    "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+                    "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Scheduled",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+                    "reason": "Scheduled"
+                }
+            },
+            "from": "2022-03-21T21:37:20Z",
+            "to": "2022-03-21T21:37:56Z"
+        },
+        {
+            "level": "Info",
+            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+            "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempSource": "PodState",
+            "tempStructuredLocator": {
+                "type": "Container",
+                "keys": {
+                    "container": "installer",
+                    "namespace": "openshift-etcd",
+                    "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+                    "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+                }
+            },
+            "tempStructuredMessage": {
+                "reason": "NotReady",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-21T21:37:23Z",
             "to": "2022-03-21T21:37:23Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/3.00s reason/ContainerStart",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "installer",
+                    "namespace": "openshift-etcd",
+                    "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+                    "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "ContainerStart",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "cause": "",
+                    "constructed": "pod-lifecycle-constructor",
+                    "duration": "3.00s",
+                    "reason": "ContainerStart"
+                }
             },
             "from": "2022-03-21T21:37:23Z",
             "to": "2022-03-21T21:37:56Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "installer",
+                    "namespace": "openshift-etcd",
+                    "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+                    "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Ready",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Ready"
+                }
             },
             "from": "2022-03-21T21:37:23Z",
             "to": "2022-03-21T21:37:56Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+            "locator": "container/installer namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "installer",
+                    "namespace": "openshift-etcd",
+                    "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+                    "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NotReady",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-21T21:37:56Z",
             "to": "2022-03-21T21:37:56Z"

--- a/pkg/monitortests/node/watchpods/podTest/installer-pod/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/installer-pod/startingEvents.json
@@ -2,64 +2,213 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
       "message": "reason/Created ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-21T21:37:20Z",
       "to": "2022-03-21T21:37:20Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
       "message": "reason/Scheduled node/ci-op-97t906zm-db044-bwrrn-master-0",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Scheduled",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0"
+        }
+      },
       "from": "2022-03-21T21:37:20Z",
       "to": "2022-03-21T21:37:20Z"
     },
     {
       "level": "Warning",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
       "message": "reason/NotReady ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "installer",
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-21T21:37:20Z",
       "to": "2022-03-21T21:37:20Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
       "message": "reason/Ready ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "installer",
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-21T21:37:23Z",
       "to": "2022-03-21T21:37:23Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
       "message": "reason/ContainerStart cause/ duration/3.00s",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "installer",
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "ContainerStart",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "cause": "",
+          "duration": "3.00s"
+        }
+      },
       "from": "2022-03-21T21:37:23Z",
       "to": "2022-03-21T21:37:23Z"
     },
     {
       "level": "Warning",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
       "message": "reason/NotReady ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "installer",
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-21T21:37:56Z",
       "to": "2022-03-21T21:37:56Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21 container/installer",
       "message": "reason/ContainerExit code/0 cause/Completed ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "installer",
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "ContainerExit",
+        "cause": "Completed",
+        "humanMessage": "",
+        "annotations": {
+          "cause": "Completed",
+          "code": "0"
+        }
+      },
       "from": "2022-03-21T21:37:56Z",
       "to": "2022-03-21T21:37:56Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
       "message": "reason/DeletedAfterCompletion ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "installer",
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "DeletedAfterCompletion",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-21T22:22:32Z",
       "to": "2022-03-21T22:22:32Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
+      "locator": "namespace/openshift-etcd pod/installer-9-ci-op-97t906zm-db044-bwrrn-master-0 node/ci-op-97t906zm-db044-bwrrn-master-0 uid/6fb10c53-7ed9-4f51-88db-f8a689050f21",
       "message": "reason/Deleted ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "installer-9-ci-op-97t906zm-db044-bwrrn-master-0",
+          "namespace": "openshift-etcd",
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "uid": "6fb10c53-7ed9-4f51-88db-f8a689050f21"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Deleted",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-21T22:22:32Z",
       "to": "2022-03-21T22:22:32Z"
     }

--- a/pkg/monitortests/node/watchpods/podTest/long-not-ready/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/long-not-ready/expected.json
@@ -2,136 +2,207 @@
     "items": [
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
-            "message": "constructed/pod-lifecycle-constructor reason/Created",
-            "tempStructuredLocator": {
-                "type": "",
-                "keys": null
-            },
-            "tempStructuredMessage": {
-                "reason": "",
-                "cause": "",
-                "humanMessage": "",
-                "annotations": null
-            },
-            "from": "2022-03-22T18:48:41Z",
-            "to": "2022-03-22T19:00:26Z"
-        },
-        {
-            "level": "Info",
-            "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/fix-audit-permissions",
+            "locator": "container/fix-audit-permissions namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "fix-audit-permissions",
+                    "namespace": "openshift-apiserver",
+                    "pod": "apiserver-5b9785f765-qk9hl",
+                    "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NotReady",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "missed real \"NotReady\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-22T18:48:41Z",
             "to": "2022-03-22T18:49:50Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver",
-            "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-apiserver",
+                    "pod": "apiserver-5b9785f765-qk9hl",
+                    "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Created",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Created"
+                }
             },
             "from": "2022-03-22T18:48:41Z",
             "to": "2022-03-22T19:00:26Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver-check-endpoints",
+            "locator": "container/openshift-apiserver namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "openshift-apiserver",
+                    "namespace": "openshift-apiserver",
+                    "pod": "apiserver-5b9785f765-qk9hl",
+                    "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NotReady",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "missed real \"NotReady\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-22T18:48:41Z",
             "to": "2022-03-22T19:00:26Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/fix-audit-permissions",
+            "locator": "container/openshift-apiserver-check-endpoints namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempSource": "PodState",
+            "tempStructuredLocator": {
+                "type": "Container",
+                "keys": {
+                    "container": "openshift-apiserver-check-endpoints",
+                    "namespace": "openshift-apiserver",
+                    "pod": "apiserver-5b9785f765-qk9hl",
+                    "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+                }
+            },
+            "tempStructuredMessage": {
+                "reason": "NotReady",
+                "cause": "",
+                "humanMessage": "missed real \"NotReady\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
+            },
+            "from": "2022-03-22T18:48:41Z",
+            "to": "2022-03-22T19:00:26Z"
+        },
+        {
+            "level": "Info",
+            "locator": "container/fix-audit-permissions namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "fix-audit-permissions",
+                    "namespace": "openshift-apiserver",
+                    "pod": "apiserver-5b9785f765-qk9hl",
+                    "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Ready",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Ready"
+                }
             },
             "from": "2022-03-22T18:49:50Z",
             "to": "2022-03-22T18:49:50Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-142-23.us-east-2.compute.internal reason/Scheduled",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-apiserver",
+                    "pod": "apiserver-5b9785f765-qk9hl",
+                    "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Scheduled",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "node": "ip-10-0-142-23.us-east-2.compute.internal",
+                    "reason": "Scheduled"
+                }
             },
             "from": "2022-03-22T19:00:26Z",
             "to": "2022-03-22T19:11:18Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver",
+            "locator": "container/openshift-apiserver namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "openshift-apiserver",
+                    "namespace": "openshift-apiserver",
+                    "pod": "apiserver-5b9785f765-qk9hl",
+                    "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Ready",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Ready"
+                }
             },
             "from": "2022-03-22T19:00:26Z",
             "to": "2022-03-22T19:11:18Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver-check-endpoints",
+            "locator": "container/openshift-apiserver-check-endpoints namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "openshift-apiserver-check-endpoints",
+                    "namespace": "openshift-apiserver",
+                    "pod": "apiserver-5b9785f765-qk9hl",
+                    "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Ready",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Ready"
+                }
             },
             "from": "2022-03-22T19:00:26Z",
             "to": "2022-03-22T19:11:18Z"

--- a/pkg/monitortests/node/watchpods/podTest/long-not-ready/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/long-not-ready/expected.json
@@ -2,7 +2,7 @@
     "items": [
         {
             "level": "Info",
-            "locator": "container/fix-audit-permissions namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/fix-audit-permissions",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -53,7 +53,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/openshift-apiserver namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -79,7 +79,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/openshift-apiserver-check-endpoints namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver-check-endpoints",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -105,7 +105,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/fix-audit-permissions namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/fix-audit-permissions",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -157,7 +157,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/openshift-apiserver namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -183,7 +183,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/openshift-apiserver-check-endpoints namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+            "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver-check-endpoints",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempSource": "PodState",
             "tempStructuredLocator": {

--- a/pkg/monitortests/node/watchpods/podTest/long-not-ready/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/long-not-ready/startingEvents.json
@@ -2,36 +2,116 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+      "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c",
       "message": "reason/Created ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "apiserver-5b9785f765-qk9hl",
+          "namespace": "openshift-apiserver",
+          "node": "ip-10-0-142-23.us-east-2.compute.internal",
+          "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c",
+      "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c",
       "message": "reason/Scheduled node/ip-10-0-142-23.us-east-2.compute.internal",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "apiserver-5b9785f765-qk9hl",
+          "namespace": "openshift-apiserver",
+          "node": "ip-10-0-142-23.us-east-2.compute.internal",
+          "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Scheduled",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "node": "ip-10-0-142-23.us-east-2.compute.internal"
+        }
+      },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c container/fix-audit-permissions",
+      "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c container/fix-audit-permissions",
       "message": "reason/Ready ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "fix-audit-permissions",
+          "pod": "apiserver-5b9785f765-qk9hl",
+          "namespace": "openshift-apiserver",
+          "node": "ip-10-0-142-23.us-east-2.compute.internal",
+          "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver",
+      "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver",
       "message": "reason/Ready ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "openshift-apiserver",
+          "pod": "apiserver-5b9785f765-qk9hl",
+          "namespace": "openshift-apiserver",
+          "node": "ip-10-0-142-23.us-east-2.compute.internal",
+          "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver-check-endpoints",
+      "locator": "namespace/openshift-apiserver pod/apiserver-5b9785f765-qk9hl node/ip-10-0-142-23.us-east-2.compute.internal uid/d5f66519-ca7a-4808-94a0-b889552d411c container/openshift-apiserver-check-endpoints",
       "message": "reason/Ready ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "openshift-apiserver-check-endpoints",
+          "pod": "apiserver-5b9785f765-qk9hl",
+          "namespace": "openshift-apiserver",
+          "node": "ip-10-0-142-23.us-east-2.compute.internal",
+          "uid": "d5f66519-ca7a-4808-94a0-b889552d411c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"
     }

--- a/pkg/monitortests/node/watchpods/podTest/run-once-done/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/run-once-done/expected.json
@@ -2,51 +2,77 @@
     "items": [
         {
             "level": "Info",
-            "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
+            "locator": "namespace/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-kube-scheduler",
+                    "pod": "installer-3-ip-10-0-136-132.us-west-2.compute.internal",
+                    "uid": "b7d89367-600a-49a3-95e1-a3ef2c91ecb9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Created",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Created"
+                }
             },
             "from": "2022-03-10T22:46:20Z",
             "to": "2022-03-10T22:46:20Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
+            "locator": "namespace/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
             "message": "constructed/pod-lifecycle-constructor node/ip-10-0-136-132.us-west-2.compute.internal reason/Scheduled",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-kube-scheduler",
+                    "pod": "installer-3-ip-10-0-136-132.us-west-2.compute.internal",
+                    "uid": "b7d89367-600a-49a3-95e1-a3ef2c91ecb9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Scheduled",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "node": "ip-10-0-136-132.us-west-2.compute.internal",
+                    "reason": "Scheduled"
+                }
             },
             "from": "2022-03-10T22:46:20Z",
             "to": "2022-03-14T15:00:00Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9 container/installer",
+            "locator": "container/installer namespace/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "installer",
+                    "namespace": "openshift-kube-scheduler",
+                    "pod": "installer-3-ip-10-0-136-132.us-west-2.compute.internal",
+                    "uid": "b7d89367-600a-49a3-95e1-a3ef2c91ecb9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NotReady",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-10T22:46:20Z",
             "to": "2022-03-14T15:00:00Z"

--- a/pkg/monitortests/node/watchpods/podTest/run-once-done/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/run-once-done/expected.json
@@ -53,7 +53,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/installer namespace/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
+            "locator": "namespace/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9 container/installer",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
             "tempSource": "PodState",
             "tempStructuredLocator": {

--- a/pkg/monitortests/node/watchpods/podTest/run-once-done/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/run-once-done/startingEvents.json
@@ -2,22 +2,70 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal node/ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
+      "locator": "namespace/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal node/ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
       "message": "reason/Created ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "installer-3-ip-10-0-136-132.us-west-2.compute.internal",
+          "namespace": "openshift-kube-scheduler",
+          "node": "ip-10-0-136-132.us-west-2.compute.internal",
+          "uid": "b7d89367-600a-49a3-95e1-a3ef2c91ecb9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-10T22:46:20Z",
       "to": "2022-03-10T22:46:20Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal node/ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
+      "locator": "namespace/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal node/ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9",
       "message": "reason/Scheduled node/ip-10-0-136-132.us-west-2.compute.internal",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "installer-3-ip-10-0-136-132.us-west-2.compute.internal",
+          "namespace": "openshift-kube-scheduler",
+          "node": "ip-10-0-136-132.us-west-2.compute.internal",
+          "uid": "b7d89367-600a-49a3-95e1-a3ef2c91ecb9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Scheduled",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "node": "ip-10-0-136-132.us-west-2.compute.internal"
+        }
+      },
       "from": "2022-03-10T22:46:20Z",
       "to": "2022-03-10T22:46:20Z"
     },
     {
       "level": "Warning",
-      "locator": "ns/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal node/ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9 container/installer",
+      "locator": "namespace/openshift-kube-scheduler pod/installer-3-ip-10-0-136-132.us-west-2.compute.internal node/ip-10-0-136-132.us-west-2.compute.internal uid/b7d89367-600a-49a3-95e1-a3ef2c91ecb9 container/installer",
       "message": "reason/NotReady ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "pod": "installer-3-ip-10-0-136-132.us-west-2.compute.internal",
+          "namespace": "openshift-kube-scheduler",
+          "node": "ip-10-0-136-132.us-west-2.compute.internal",
+          "container": "installer",
+          "uid": "b7d89367-600a-49a3-95e1-a3ef2c91ecb9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-10T22:46:20Z",
       "to": "2022-03-10T22:46:20Z"
     }

--- a/pkg/monitortests/node/watchpods/podTest/simple/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/simple/expected.json
@@ -2,7 +2,7 @@
     "items": [
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
             "tempStructuredLocator": {
                 "type": "",
@@ -19,7 +19,7 @@
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
             "tempStructuredLocator": {
                 "type": "",
@@ -36,7 +36,7 @@
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
             "tempStructuredLocator": {
                 "type": "",
@@ -53,7 +53,7 @@
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor node/ci-op-ckiwry67-db044-lzjpd-master-0 reason/Scheduled",
             "tempStructuredLocator": {
                 "type": "",
@@ -70,7 +70,7 @@
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempStructuredLocator": {
                 "type": "",
@@ -87,7 +87,7 @@
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor duration/30s reason/GracefulDelete",
             "tempStructuredLocator": {
                 "type": "",
@@ -104,7 +104,7 @@
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
             "tempStructuredLocator": {
                 "type": "",

--- a/pkg/monitortests/node/watchpods/podTest/simple/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/simple/expected.json
@@ -4,49 +4,75 @@
             "level": "Info",
             "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-apiserver-operator",
+                    "pod": "openshift-apiserver-operator-845779f5d-975gr",
+                    "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Created",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Created"
+                }
             },
             "from": "2022-03-22T21:41:54Z",
             "to": "2022-03-22T22:02:53Z"
         },
         {
             "level": "Info",
-            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+            "locator": "container/openshift-apiserver-operator namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "openshift-apiserver-operator",
+                    "namespace": "openshift-apiserver-operator",
+                    "pod": "openshift-apiserver-operator-845779f5d-975gr",
+                    "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NotReady",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "missed real \"NotReady\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-22T21:41:54Z",
             "to": "2022-03-22T22:02:53Z"
         },
         {
             "level": "Info",
-            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+            "locator": "container/openshift-apiserver-operator namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "openshift-apiserver-operator",
+                    "namespace": "openshift-apiserver-operator",
+                    "pod": "openshift-apiserver-operator-845779f5d-975gr",
+                    "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "ContainerWait",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "missed real \"ContainerWait\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "ContainerWait"
+                }
             },
             "from": "2022-03-22T21:41:54Z",
             "to": "2022-03-22T22:29:35Z"
@@ -55,69 +81,105 @@
             "level": "Info",
             "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor node/ci-op-ckiwry67-db044-lzjpd-master-0 reason/Scheduled",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-apiserver-operator",
+                    "pod": "openshift-apiserver-operator-845779f5d-975gr",
+                    "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Scheduled",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+                    "reason": "Scheduled"
+                }
             },
             "from": "2022-03-22T22:02:53Z",
             "to": "2022-03-22T22:29:35Z"
         },
         {
             "level": "Info",
-            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+            "locator": "container/openshift-apiserver-operator namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "openshift-apiserver-operator",
+                    "namespace": "openshift-apiserver-operator",
+                    "pod": "openshift-apiserver-operator-845779f5d-975gr",
+                    "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Ready",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Ready"
+                }
             },
             "from": "2022-03-22T22:02:53Z",
+            "to": "2022-03-22T22:29:35Z"
+        },
+        {
+            "level": "Info",
+            "locator": "container/openshift-apiserver-operator namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+            "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempSource": "PodState",
+            "tempStructuredLocator": {
+                "type": "Container",
+                "keys": {
+                    "container": "openshift-apiserver-operator",
+                    "namespace": "openshift-apiserver-operator",
+                    "pod": "openshift-apiserver-operator-845779f5d-975gr",
+                    "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+                }
+            },
+            "tempStructuredMessage": {
+                "reason": "NotReady",
+                "cause": "",
+                "humanMessage": "",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
+            },
+            "from": "2022-03-22T22:29:35Z",
             "to": "2022-03-22T22:29:35Z"
         },
         {
             "level": "Info",
             "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
             "message": "constructed/pod-lifecycle-constructor duration/30s reason/GracefulDelete",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-apiserver-operator",
+                    "pod": "openshift-apiserver-operator-845779f5d-975gr",
+                    "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "GracefulDelete",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "duration": "30s",
+                    "reason": "GracefulDelete"
+                }
             },
             "from": "2022-03-22T22:29:35Z",
             "to": "2022-03-22T22:29:36Z"
-        },
-        {
-            "level": "Info",
-            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
-            "message": "constructed/pod-lifecycle-constructor reason/NotReady",
-            "tempStructuredLocator": {
-                "type": "",
-                "keys": null
-            },
-            "tempStructuredMessage": {
-                "reason": "",
-                "cause": "",
-                "humanMessage": "",
-                "annotations": null
-            },
-            "from": "2022-03-22T22:29:35Z",
-            "to": "2022-03-22T22:29:35Z"
         }
     ]
 }

--- a/pkg/monitortests/node/watchpods/podTest/simple/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/simple/expected.json
@@ -27,7 +27,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/openshift-apiserver-operator namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -53,7 +53,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/openshift-apiserver-operator namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -105,7 +105,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/openshift-apiserver-operator namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -131,7 +131,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/openshift-apiserver-operator namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+            "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
             "tempSource": "PodState",
             "tempStructuredLocator": {

--- a/pkg/monitortests/node/watchpods/podTest/simple/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/simple/startingEvents.json
@@ -4,6 +4,21 @@
       "level": "Info",
       "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
       "message": "reason/Created ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "openshift-apiserver-operator-845779f5d-975gr",
+          "namespace": "openshift-apiserver-operator",
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-22T22:02:53Z",
       "to": "2022-03-22T22:02:53Z"
     },
@@ -11,6 +26,23 @@
       "level": "Info",
       "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
       "message": "reason/Scheduled node/ci-op-ckiwry67-db044-lzjpd-master-0",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "openshift-apiserver-operator-845779f5d-975gr",
+          "namespace": "openshift-apiserver-operator",
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Scheduled",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0"
+        }
+      },
       "from": "2022-03-22T22:02:53Z",
       "to": "2022-03-22T22:02:53Z"
     },
@@ -18,6 +50,22 @@
       "level": "Info",
       "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
       "message": "reason/Ready ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "pod": "openshift-apiserver-operator-845779f5d-975gr",
+          "namespace": "openshift-apiserver-operator",
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "container": "openshift-apiserver-operator",
+          "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-22T22:02:53Z",
       "to": "2022-03-22T22:02:53Z"
     },
@@ -25,6 +73,23 @@
       "level": "Info",
       "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
       "message": "reason/GracefulDelete duration/30s",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "openshift-apiserver-operator-845779f5d-975gr",
+          "namespace": "openshift-apiserver-operator",
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "duration": "30s"
+        }
+      },
       "from": "2022-03-22T22:29:35Z",
       "to": "2022-03-22T22:29:35Z"
     },
@@ -32,6 +97,22 @@
       "level": "Warning",
       "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
       "message": "reason/NotReady ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "pod": "openshift-apiserver-operator-845779f5d-975gr",
+          "namespace": "openshift-apiserver-operator",
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "container": "openshift-apiserver-operator",
+          "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-22T22:29:36Z",
       "to": "2022-03-22T22:29:36Z"
     },
@@ -39,6 +120,22 @@
       "level": "Error",
       "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
       "message": "reason/TerminationStateCleared lastState.terminated was cleared on a pod (bug https://bugzilla.redhat.com/show_bug.cgi?id=1933760 or similar)",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "pod": "openshift-apiserver-operator-845779f5d-975gr",
+          "namespace": "openshift-apiserver-operator",
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "container": "openshift-apiserver-operator",
+          "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "TerminationStateCleared",
+        "cause": "",
+        "humanMessage": "lastState.terminated was cleared on a pod (bug https://bugzilla.redhat.com/show_bug.cgi?id=1933760 or similar)",
+        "annotations": null
+      },
       "from": "2022-03-22T22:29:36Z",
       "to": "2022-03-22T22:29:36Z"
     },
@@ -46,6 +143,24 @@
       "level": "Info",
       "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
       "message": "reason/ContainerExit code/0 cause/Completed ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "pod": "openshift-apiserver-operator-845779f5d-975gr",
+          "namespace": "openshift-apiserver-operator",
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "container": "openshift-apiserver-operator",
+          "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "ContainerExit",
+        "cause": "Completed",
+        "humanMessage": "",
+        "annotations": {
+          "code": "0"
+        }
+      },
       "from": "2022-03-22T22:29:36Z",
       "to": "2022-03-22T22:29:36Z"
     },
@@ -53,6 +168,21 @@
       "level": "Info",
       "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
       "message": "reason/Deleted ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "openshift-apiserver-operator-845779f5d-975gr",
+          "namespace": "openshift-apiserver-operator",
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "uid": "d9a5b0ba-6958-44aa-bc32-03d62944f973"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Deleted",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-22T22:29:36Z",
       "to": "2022-03-22T22:29:36Z"
     }

--- a/pkg/monitortests/node/watchpods/podTest/simple/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/simple/startingEvents.json
@@ -83,7 +83,7 @@
         }
       },
       "tempStructuredMessage": {
-        "reason": "Ready",
+        "reason": "GracefulDelete",
         "cause": "",
         "humanMessage": "",
         "annotations": {

--- a/pkg/monitortests/node/watchpods/podTest/simple/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/simple/startingEvents.json
@@ -2,7 +2,7 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+      "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
       "message": "reason/Created ",
       "tempStructuredLocator": {
         "type": "Pod",
@@ -24,7 +24,7 @@
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+      "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
       "message": "reason/Scheduled node/ci-op-ckiwry67-db044-lzjpd-master-0",
       "tempStructuredLocator": {
         "type": "Pod",
@@ -48,7 +48,7 @@
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+      "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
       "message": "reason/Ready ",
       "tempStructuredLocator": {
         "type": "Container",
@@ -71,7 +71,7 @@
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+      "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
       "message": "reason/GracefulDelete duration/30s",
       "tempStructuredLocator": {
         "type": "Pod",
@@ -95,7 +95,7 @@
     },
     {
       "level": "Warning",
-      "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+      "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
       "message": "reason/NotReady ",
       "tempStructuredLocator": {
         "type": "Container",
@@ -118,7 +118,7 @@
     },
     {
       "level": "Error",
-      "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+      "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
       "message": "reason/TerminationStateCleared lastState.terminated was cleared on a pod (bug https://bugzilla.redhat.com/show_bug.cgi?id=1933760 or similar)",
       "tempStructuredLocator": {
         "type": "Container",
@@ -141,7 +141,7 @@
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
+      "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973 container/openshift-apiserver-operator",
       "message": "reason/ContainerExit code/0 cause/Completed ",
       "tempStructuredLocator": {
         "type": "Container",
@@ -166,7 +166,7 @@
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
+      "locator": "namespace/openshift-apiserver-operator pod/openshift-apiserver-operator-845779f5d-975gr node/ci-op-ckiwry67-db044-lzjpd-master-0 uid/d9a5b0ba-6958-44aa-bc32-03d62944f973",
       "message": "reason/Deleted ",
       "tempStructuredLocator": {
         "type": "Pod",

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready-2/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready-2/expected.json
@@ -2,68 +2,103 @@
     "items": [
         {
             "level": "Info",
-            "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
+            "locator": "namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-machine-config-operator",
+                    "pod": "machine-config-operator-7d5bf78cff-bbbwb",
+                    "uid": "27e57fd1-c8f9-4528-8a04-0054dad5d38f"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Created",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Created"
+                }
             },
             "from": "2022-03-08T23:17:18Z",
             "to": "2022-03-08T23:17:18Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
-            "message": "constructed/pod-lifecycle-constructor node/ip-10-0-231-18.us-east-2.compute.internal reason/Scheduled",
+            "locator": "container/machine-config-operator namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
+            "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "machine-config-operator",
+                    "namespace": "openshift-machine-config-operator",
+                    "pod": "machine-config-operator-7d5bf78cff-bbbwb",
+                    "uid": "27e57fd1-c8f9-4528-8a04-0054dad5d38f"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NotReady",
+                "cause": "",
+                "humanMessage": "missed real \"NotReady\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
+            },
+            "from": "2022-03-08T23:17:18Z",
+            "to": "2022-03-08T23:17:18Z"
+        },
+        {
+            "level": "Info",
+            "locator": "namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
+            "message": "constructed/pod-lifecycle-constructor node/ip-10-0-231-18.us-east-2.compute.internal reason/Scheduled",
+            "tempSource": "PodState",
+            "tempStructuredLocator": {
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-machine-config-operator",
+                    "pod": "machine-config-operator-7d5bf78cff-bbbwb",
+                    "uid": "27e57fd1-c8f9-4528-8a04-0054dad5d38f"
+                }
+            },
+            "tempStructuredMessage": {
+                "reason": "Scheduled",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "node": "ip-10-0-231-18.us-east-2.compute.internal",
+                    "reason": "Scheduled"
+                }
             },
             "from": "2022-03-08T23:17:18Z",
             "to": "2022-03-10T23:00:00Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f container/machine-config-operator",
-            "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
-            "tempStructuredLocator": {
-                "type": "",
-                "keys": null
-            },
-            "tempStructuredMessage": {
-                "reason": "",
-                "cause": "",
-                "humanMessage": "",
-                "annotations": null
-            },
-            "from": "2022-03-08T23:17:18Z",
-            "to": "2022-03-08T23:17:18Z"
-        },
-        {
-            "level": "Info",
-            "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f container/machine-config-operator",
+            "locator": "container/machine-config-operator namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "machine-config-operator",
+                    "namespace": "openshift-machine-config-operator",
+                    "pod": "machine-config-operator-7d5bf78cff-bbbwb",
+                    "uid": "27e57fd1-c8f9-4528-8a04-0054dad5d38f"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Ready",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Ready"
+                }
             },
             "from": "2022-03-08T23:17:18Z",
             "to": "2022-03-10T23:00:00Z"

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready-2/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready-2/expected.json
@@ -27,7 +27,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/machine-config-operator namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
+            "locator": "namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f container/machine-config-operator",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -79,7 +79,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/machine-config-operator namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
+            "locator": "namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f container/machine-config-operator",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempSource": "PodState",
             "tempStructuredLocator": {

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready-2/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready-2/startingEvents.json
@@ -2,22 +2,70 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb node/ip-10-0-231-18.us-east-2.compute.internal uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
+      "locator": "namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb node/ip-10-0-231-18.us-east-2.compute.internal uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
       "message": "reason/Created ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "machine-config-operator-7d5bf78cff-bbbwb",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ip-10-0-231-18.us-east-2.compute.internal",
+          "uid": "27e57fd1-c8f9-4528-8a04-0054dad5d38f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-08T23:17:18Z",
       "to": "2022-03-08T23:17:18Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb node/ip-10-0-231-18.us-east-2.compute.internal uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
+      "locator": "namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb node/ip-10-0-231-18.us-east-2.compute.internal uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f",
       "message": "reason/Scheduled node/ip-10-0-231-18.us-east-2.compute.internal",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "machine-config-operator-7d5bf78cff-bbbwb",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ip-10-0-231-18.us-east-2.compute.internal",
+          "uid": "27e57fd1-c8f9-4528-8a04-0054dad5d38f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Scheduled",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "node": "ip-10-0-231-18.us-east-2.compute.internal"
+        }
+      },
       "from": "2022-03-08T23:17:18Z",
       "to": "2022-03-08T23:17:18Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb node/ip-10-0-231-18.us-east-2.compute.internal uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f container/machine-config-operator",
+      "locator": "namespace/openshift-machine-config-operator pod/machine-config-operator-7d5bf78cff-bbbwb node/ip-10-0-231-18.us-east-2.compute.internal uid/27e57fd1-c8f9-4528-8a04-0054dad5d38f container/machine-config-operator",
       "message": "reason/Ready ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "machine-config-operator",
+          "pod": "machine-config-operator-7d5bf78cff-bbbwb",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ip-10-0-231-18.us-east-2.compute.internal",
+          "uid": "27e57fd1-c8f9-4528-8a04-0054dad5d38f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-08T23:17:18Z",
       "to": "2022-03-08T23:17:18Z"
     }

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready/expected.json
@@ -2,136 +2,209 @@
     "items": [
         {
             "level": "Info",
-            "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "constructed/pod-lifecycle-constructor reason/Created",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-marketplace",
+                    "pod": "community-operators-sp6lm",
+                    "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Created",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Created"
+                }
             },
             "from": "2022-03-07T22:47:04Z",
             "to": "2022-03-07T22:47:04Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
-            "message": "constructed/pod-lifecycle-constructor node/ip-10-0-154-151.ec2.internal reason/Scheduled",
-            "tempStructuredLocator": {
-                "type": "",
-                "keys": null
-            },
-            "tempStructuredMessage": {
-                "reason": "",
-                "cause": "",
-                "humanMessage": "",
-                "annotations": null
-            },
-            "from": "2022-03-07T22:47:04Z",
-            "to": "2022-03-07T22:47:14Z"
-        },
-        {
-            "level": "Info",
-            "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
+            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "registry-server",
+                    "namespace": "openshift-marketplace",
+                    "pod": "community-operators-sp6lm",
+                    "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "ContainerWait",
                 "cause": "",
-                "humanMessage": "",
-                "annotations": null
+                "humanMessage": "missed real \"ContainerWait\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "ContainerWait"
+                }
             },
             "from": "2022-03-07T22:47:04Z",
             "to": "2022-03-07T22:47:07Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
-            "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "message": "constructed/pod-lifecycle-constructor node/ip-10-0-154-151.ec2.internal reason/Scheduled",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-marketplace",
+                    "pod": "community-operators-sp6lm",
+                    "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Scheduled",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "node": "ip-10-0-154-151.ec2.internal",
+                    "reason": "Scheduled"
+                }
+            },
+            "from": "2022-03-07T22:47:04Z",
+            "to": "2022-03-07T22:47:14Z"
+        },
+        {
+            "level": "Info",
+            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
+            "tempSource": "PodState",
+            "tempStructuredLocator": {
+                "type": "Container",
+                "keys": {
+                    "container": "registry-server",
+                    "namespace": "openshift-marketplace",
+                    "pod": "community-operators-sp6lm",
+                    "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+                }
+            },
+            "tempStructuredMessage": {
+                "reason": "NotReady",
+                "cause": "",
+                "humanMessage": "missed real \"NotReady\"",
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-07T22:47:07Z",
             "to": "2022-03-07T22:47:14Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
+            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/3.00s reason/ContainerStart",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "registry-server",
+                    "namespace": "openshift-marketplace",
+                    "pod": "community-operators-sp6lm",
+                    "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "ContainerStart",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "cause": "",
+                    "constructed": "pod-lifecycle-constructor",
+                    "duration": "3.00s",
+                    "reason": "ContainerStart"
+                }
             },
             "from": "2022-03-07T22:47:07Z",
             "to": "2022-03-07T22:47:15Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "constructed/pod-lifecycle-constructor duration/1s reason/GracefulDelete",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Pod",
+                "keys": {
+                    "namespace": "openshift-marketplace",
+                    "pod": "community-operators-sp6lm",
+                    "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "GracefulDelete",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "duration": "1s",
+                    "reason": "GracefulDelete"
+                }
             },
             "from": "2022-03-07T22:47:14Z",
             "to": "2022-03-07T22:47:15Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
+            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "registry-server",
+                    "namespace": "openshift-marketplace",
+                    "pod": "community-operators-sp6lm",
+                    "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "Ready",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "Ready"
+                }
             },
             "from": "2022-03-07T22:47:14Z",
             "to": "2022-03-07T22:47:15Z"
         },
         {
             "level": "Info",
-            "locator": "ns/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
+            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
+            "tempSource": "PodState",
             "tempStructuredLocator": {
-                "type": "",
-                "keys": null
+                "type": "Container",
+                "keys": {
+                    "container": "registry-server",
+                    "namespace": "openshift-marketplace",
+                    "pod": "community-operators-sp6lm",
+                    "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+                }
             },
             "tempStructuredMessage": {
-                "reason": "",
+                "reason": "NotReady",
                 "cause": "",
                 "humanMessage": "",
-                "annotations": null
+                "annotations": {
+                    "constructed": "pod-lifecycle-constructor",
+                    "reason": "NotReady"
+                }
             },
             "from": "2022-03-07T22:47:15Z",
             "to": "2022-03-07T22:47:15Z"

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready/expected.json
@@ -27,7 +27,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -79,7 +79,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady missed real \"NotReady\"",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -105,7 +105,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "cause/ constructed/pod-lifecycle-constructor duration/3.00s reason/ContainerStart",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -159,7 +159,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "constructed/pod-lifecycle-constructor reason/Ready",
             "tempSource": "PodState",
             "tempStructuredLocator": {
@@ -185,7 +185,7 @@
         },
         {
             "level": "Info",
-            "locator": "container/registry-server namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+            "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
             "message": "constructed/pod-lifecycle-constructor reason/NotReady",
             "tempSource": "PodState",
             "tempStructuredLocator": {

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready/startingEvents.json
@@ -2,57 +2,190 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-marketplace pod/community-operators-sp6lm node/ uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+      "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm node/ uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
       "message": "reason/Created ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "community-operators-sp6lm",
+          "namespace": "openshift-marketplace",
+          "node": "",
+          "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-07T22:47:04Z",
       "to": "2022-03-07T22:47:04Z"
     },
     {
       "level": "Warning",
-      "locator": "ns/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+      "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
       "message": "reason/Scheduled node/ip-10-0-154-151.ec2.internal",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "community-operators-sp6lm",
+          "namespace": "openshift-marketplace",
+          "node": "ip-10-0-154-151.ec2.internal",
+          "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Scheduled",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "node": "ip-10-0-154-151.ec2.internal"
+        }
+      },
       "from": "2022-03-07T22:47:04Z",
       "to": "2022-03-07T22:47:04Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
+      "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
       "message": "reason/ContainerStart cause/ duration/3.00s",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry-server",
+          "pod": "community-operators-sp6lm",
+          "namespace": "openshift-marketplace",
+          "node": "ip-10-0-154-151.ec2.internal",
+          "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "ContainerStart",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "duration": "3.00s"
+        }
+      },
       "from": "2022-03-07T22:47:07Z",
       "to": "2022-03-07T22:47:07Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
+      "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
       "message": "reason/Ready ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry-server",
+          "pod": "community-operators-sp6lm",
+          "namespace": "openshift-marketplace",
+          "node": "ip-10-0-154-151.ec2.internal",
+          "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-07T22:47:14Z",
       "to": "2022-03-07T22:47:14Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+      "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
       "message": "reason/GracefulDelete duration/1s",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "community-operators-sp6lm",
+          "namespace": "openshift-marketplace",
+          "node": "ip-10-0-154-151.ec2.internal",
+          "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "GracefulDelete",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "duration": "1s"
+        }
+      },
       "from": "2022-03-07T22:47:14Z",
       "to": "2022-03-07T22:47:14Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
+      "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
       "message": "reason/ContainerExit code/0 cause/Completed ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry-server",
+          "pod": "community-operators-sp6lm",
+          "namespace": "openshift-marketplace",
+          "node": "ip-10-0-154-151.ec2.internal",
+          "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "ContainerExit",
+        "cause": "Completed",
+        "humanMessage": "",
+        "annotations": {
+          "code": "0",
+          "cause": "Completed"
+        }
+      },
       "from": "2022-03-07T22:47:15Z",
       "to": "2022-03-07T22:47:15Z"
     },
     {
       "level": "Warning",
-      "locator": "ns/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
+      "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
       "message": "reason/NotReady ",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry-server",
+          "pod": "community-operators-sp6lm",
+          "namespace": "openshift-marketplace",
+          "node": "ip-10-0-154-151.ec2.internal",
+          "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-07T22:47:15Z",
       "to": "2022-03-07T22:47:15Z"
     },
     {
       "level": "Info",
-      "locator": "ns/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
+      "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm node/ip-10-0-154-151.ec2.internal uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9",
       "message": "reason/Deleted ",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "pod": "community-operators-sp6lm",
+          "namespace": "openshift-marketplace",
+          "node": "ip-10-0-154-151.ec2.internal",
+          "uid": "efb1885a-1fe1-4f5b-ad41-044e55f806a9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Deleted",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": null
+      },
       "from": "2022-03-07T22:47:15Z",
       "to": "2022-03-07T22:47:15Z"
     }


### PR DESCRIPTION
Ports the code that generates the node and pod state intervals we show in spyglass to use, and generate new structured intervals. These components interpret other "source" intervals to determine what intervals they should generate. 

This was incredibly complex and time consuming to get working between the complexity and the use of raw json files as test inputs and outputs.

I discovered that Intervals were not serialized via the same logic as EventIntervals (a dupe type we use just for serialization for some reason), and this is now addressed. As a result you'll see in some of the expected.json files, a few intervals are reordered to where they should be by the new logic. (primarily consideration of the To timestamp)

There is an unfortunate hack involved where Locators cannot be used as map keys because they contain a map themselves, go does not allow this. You'll notice a couple spots where I am maintaining a map of locatorStr -> locator, for lookup later when we need the real locators. This was done because I do not want us parsing locator strings, as this was one of the problems that led to this entire effort.

Apologies for the size but it was largely unavoidable, these parts of the code are linked, one goes and they all need to.