### PR TITLE
pkg/monitortests/clusterversionoperator/legacycvomonitortests: Structured condition types

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -276,7 +276,13 @@ func testOperatorState(interestingCondition configv1.ClusterStatusConditionType,
 		if eventInterval.From == eventInterval.To {
 			continue
 		}
-		if !strings.Contains(eventInterval.Message, fmt.Sprintf("%v", interestingCondition)) {
+
+		condition := monitorapi.GetOperatorConditionStatus(eventInterval)
+		if condition == nil {
+			continue
+		}
+
+		if condition.Type != interestingCondition {
 			continue
 		}
 


### PR DESCRIPTION
For reasons that are not clear to me, e065648534 (#26034) moved `testOperatorState` from using:

```go
condition := monitorapi.GetOperatorConditionStatus(event.Message)
```

to using:

```go
strings.Contains(eventInterval.Message, fmt.Sprintf("%v", interestingCondition))
```

But that can lead to misidentification [like][1]:

```
  : [bz-service-ca] clusteroperator/service-ca should not change condition/Available
  Run #0: Failed	1h24m4s
  {  1 unexpected clusteroperator state transitions during e2e test run

    Oct 05 16:28:56.647 - 1s    W clusteroperator/service-ca condition/Progressing reason/_ManagedDeploymentsAvailable status/True Progressing: \nProgressing: service-ca does not have available replicas}
```

That mentions `Available` as part of the `reason`, but the condition `type` itself is `Progressing`, so it should not contribute to a `should not change condition/Available` violation.

There's a chance that e065648534's move away from
`GetOperatorConditionStatus` was because the function was broken at that time, but e00ec39d50 (#28262) recently adjusted its implementation, and `pkg/monitortests/clusterversionoperator/operatorstateanalyzer/operator.go`'s `intervalsFromEvents_OperatorStatus` has used `GetOperatorConditionStatus` since the file was created in 4dfccfc30f (#28185) and has all the way back to when the `intervalsFromEvents_OperatorStatus` function was created in bbd9949c83 (#26034, the same pull request as e065648534).

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.15-e2e-azure-ovn-upgrade/1709944908564926464