### PR TITLE
OCPBUGS-20205: feat: added support for ImageRegistry capability

### DIFF
--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	"github.com/openshift/origin/test/extended/util/image"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -67,6 +68,16 @@ func InitializeTestFramework(context *e2e.TestContextType, config *ClusterConfig
 
 	// IPFamily constants are taken from kube e2e and used by tests
 	context.IPFamily = config.IPFamily
+
+	imageStreamString, _, err := exutil.NewCLIWithoutNamespace("").AsAdmin().Run("adm", "release", "info", `-ojsonpath={.references}`).Outputs()
+	if err != nil {
+		return err
+	}
+
+	if err := image.InitializeReleasePullSpecString(imageStreamString, config.HasNoOptionalCapabilities); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -178,6 +178,7 @@ func (pna *podNetworkAvalibility) StartCollection(ctx context.Context, adminREST
 	pna.targetService = service
 
 	hostNetworkTargetDeployment.Spec.Replicas = &numNodes
+	hostNetworkTargetDeployment.Spec.Template.Spec.Containers[0].Image = image.LimitedShellImage()
 	if _, err := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), hostNetworkTargetDeployment, metav1.CreateOptions{}); err != nil {
 		return err
 	}

--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -15,9 +15,11 @@ import (
 	k8simage "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	configv1 "github.com/openshift/api/config/v1"
 	imageapi "github.com/openshift/api/image/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned"
 	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
 )
 
 var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", func() {
@@ -35,12 +37,23 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 	oc = exutil.NewCLIWithPodSecurityLevel("image-extract", admissionapi.LevelBaseline)
 
 	g.It("should extract content from an image [apigroup:image.openshift.io]", func() {
+		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")
-		registry := strings.Split(is.Status.DockerImageRepository, "/")[0]
 
 		ns = oc.Namespace()
+		extractImage := image.ShellImage()
+
+		// If ImageRegistry is present, we expect DockerImageRepository to have a value
+		// and we create the registry url for ImageStream extracting, otherwise we use
+		// the ShellImage()
+		if hasImageRegistry {
+			o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")
+			registry := strings.Split(is.Status.DockerImageRepository, "/")[0]
+			extractImage = fmt.Sprintf("%s/%s/1:tools", registry, ns)
+		}
+
 		cli := e2epod.PodClientNS(oc.KubeFramework(), ns)
 		client := imageclientset.NewForConfigOrDie(oc.UserConfig()).ImageV1()
 
@@ -74,35 +87,30 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 			o.Expect(img.Status.Status).To(o.Equal("Success"), fmt.Sprintf("imagestreamimport status for spec.image[%d] (message: %s)", i, img.Status.Message))
 		}
 
-		// toolsLayers := isi.Status.Images[0].Image.DockerImageLayers
-		// toolsLen := len(toolsLayers)
-		// mysqlLayers := isi.Status.Images[1].Image.DockerImageLayers
-		// mysqlLen := len(mysqlLayers)
-
 		pod := cli.Create(context.TODO(), cliPodWithPullSecret(oc, heredoc.Docf(`
 			set -x
 
 			# command exits if directory doesn't exist
-			! oc image extract --insecure %[2]s/%[1]s/1:tools --path=/:/tmp/doesnotexist
+			! oc image extract --insecure %[1]s --path=/:/tmp/doesnotexist
 			# command exits if directory isn't empty
-			! oc image extract --insecure %[2]s/%[1]s/1:tools --path=/:/
+			! oc image extract --insecure %[1]s --path=/:/
 
 			# extract a directory to a directory, verify the contents
 			mkdir -p /tmp/test
-			oc image extract --insecure %[2]s/%[1]s/1:tools --path=/etc/cron.d/:/tmp/test/
+			oc image extract --insecure %[1]s --path=/etc/cron.d/:/tmp/test/
 			[ -f /tmp/test/0hourly ] && grep root /tmp/test/0hourly
 
 			# extract multiple individual files
 			mkdir -p /tmp/test2
-			oc image extract --insecure %[2]s/%[1]s/1:tools --path=/etc/shadow:/tmp/test2 --path=/etc/system-release:/tmp/test2
+			oc image extract --insecure %[1]s --path=/etc/shadow:/tmp/test2 --path=/etc/system-release:/tmp/test2
 			[ -f /tmp/test2/shadow ] && [ -L /tmp/test2/system-release ]
 
 			# extract a single file to the current directory
 			mkdir -p /tmp/test3
 			cd /tmp/test3
-			oc image extract --insecure %[2]s/%[1]s/1:tools --file=/etc/shadow
+			oc image extract --insecure %[1]s --file=/etc/shadow
 			[ -f /tmp/test3/shadow ]
-		`, ns, registry)))
+		`, extractImage)))
 		cli.WaitForSuccess(context.TODO(), pod.Name, podStartupTimeout)
 	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1023,9 +1023,9 @@ var Annotations = map[string]string{
 
 	"[sig-devex][Feature:ImageEcosystem][ruby][Slow] hot deploy for openshift ruby image Rails example should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]": "",
 
-	"[sig-devex][Feature:OpenShiftControllerManager] TestAutomaticCreationOfPullSecrets [apigroup:config.openshift.io][apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
+	"[sig-devex][Feature:OpenShiftControllerManager] TestAutomaticCreationOfPullSecrets [apigroup:config.openshift.io][apigroup:image.openshift.io]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 
-	"[sig-devex][Feature:OpenShiftControllerManager] TestDockercfgTokenDeletedController [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
+	"[sig-devex][Feature:OpenShiftControllerManager] TestDockercfgTokenDeletedController [apigroup:image.openshift.io]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 
 	"[sig-devex][Feature:Templates] template-api TestTemplate [apigroup:template.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
@@ -1061,9 +1061,9 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling] etcd is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "",
 
-	"[sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
+	"[sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 
-	"[sig-imageregistry][Feature:ImageAppend] Image append should create images by appending them [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[sig-imageregistry][Feature:ImageAppend] Image append should create images by appending them [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 
 	"[sig-imageregistry][Feature:ImageExtract] Image extract should extract content from an image [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -231,6 +231,15 @@ var (
 		"[Skipped:NoOptionalCapabilities]": {
 			// This test requires a valid console url which doesn't exist when the optional console capability is disabled.
 			`\[sig-cli\] oc basics can show correct whoami result with console`,
+
+			// Image Registry Skips:
+			// Requires ImageRegistry to upload appended images
+			`\[sig-imageregistry\]\[Feature:ImageAppend\] Image append should create images by appending them`,
+			// Requires ImageRegistry to redirect blob pull
+			`\[sig-imageregistry\] Image registry \[apigroup:route.openshift.io\] should redirect on blob pull`,
+			// Requires ImageRegistry service to be active for OCM to be able to create pull secrets
+			`\[sig-devex\]\[Feature:OpenShiftControllerManager\] TestAutomaticCreationOfPullSecrets \[apigroup:config.openshift.io\]`,
+			`\[sig-devex\]\[Feature:OpenShiftControllerManager\] TestDockercfgTokenDeletedController \[apigroup:image.openshift.io\]`,
 		},
 	}
 )


### PR DESCRIPTION
added skip annotation for situations when the image registry is not enabled via capabilities
added logic to handle imageregistry pullspecs when imageregistry is not enabled