### PR TITLE
test/extended: Consolidate hard-coded local image registry dependencies

### DIFF
--- a/test/extended/cli/basics.go
+++ b/test/extended/cli/basics.go
@@ -17,6 +17,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	exutilimage "github.com/openshift/origin/test/extended/util/image"
 )
 
 var (
@@ -67,7 +68,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 
 	g.It("can create deploymentconfig and clusterquota [apigroup:apps.openshift.io]", func() {
 		nginx := k8simage.GetE2EImage(k8simage.Nginx)
-		tools := "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"
+		tools := exutilimage.ShellImage()
 
 		err := oc.Run("create").Args("dc", "my-nginx", "--image="+nginx).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/status.go
+++ b/test/extended/cli/status.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	exutilimage "github.com/openshift/origin/test/extended/util/image"
 )
 
 var _ = g.Describe("[sig-cli] oc status", func() {
@@ -88,11 +89,12 @@ var _ = g.Describe("[sig-cli] oc status", func() {
 		}()
 
 		g.By("verify jobs are showing in status")
-		err = oc.Run("create").Args("job", "pi", "--image=image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "--namespace", projectStatus).Execute()
+		image := exutilimage.ShellImage()
+		err = oc.Run("create").Args("job", "pi", "--image", image, "--namespace", projectStatus).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("status", "--namespace", projectStatus).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("job/pi manages image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"))
+		o.Expect(out).To(o.ContainSubstring(fmt.Sprintf("job/pi manages %s", image)))
 	})
 })

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -428,7 +428,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForSyncedConfig(oc, dcName, deploymentRunTimeout)).NotTo(o.HaveOccurred())
 
 			g.By("tagging the initial test:v1 image")
-			_, err = oc.Run("tag").Args("image-registry.openshift-image-registry.svc:5000/openshift/cli:latest", "test:v1").Output()
+			_, err = oc.Run("tag").Args(image.LimitedShellImage(), "test:v1").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			expectLatestVersion := func(version int) {
@@ -459,7 +459,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForSyncedConfig(oc, dcName, deploymentRunTimeout)).NotTo(o.HaveOccurred())
 
 			g.By("tagging a different image as test:v2")
-			_, err = oc.Run("tag").Args("image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "test:v2").Output()
+			_, err = oc.Run("tag").Args(image.ShellImage(), "test:v2").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("ensuring the deployment config latest version is 2 and rollout completed")
@@ -1535,7 +1535,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("tagging the tools image as test:v1 to create ImageStream")
-			out, err := oc.Run("tag").Args("image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "test:v1").Output()
+			out, err := oc.Run("tag").Args(image.ShellImage(), "test:v1").Output()
 			e2e.Logf("%s", out)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -22,6 +22,7 @@ import (
 	etcddata "k8s.io/kubernetes/test/integration/etcd"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	exutilimage "github.com/openshift/origin/test/extended/util/image"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -74,7 +75,7 @@ func GetOpenshiftEtcdStorageData(namespace string) map[schema.GroupVersionResour
 
 		// github.com/openshift/api/apps/v1
 		gvr("apps.openshift.io", "v1", "deploymentconfigs"): {
-			Stub:             `{"metadata": {"name": "dc1g"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "name": "container2"}]}}}}`,
+			Stub:             fmt.Sprintf(`{"metadata": {"name": "dc1g"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "%s", "name": "container2"}]}}}}`, exutilimage.ShellImage()),
 			ExpectedEtcdPath: "openshift.io/deploymentconfigs/" + namespace + "/dc1g",
 		},
 		// --

--- a/test/extended/images/trigger/annotation.go
+++ b/test/extended/images/trigger/annotation.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	exutilimage "github.com/openshift/origin/test/extended/util/image"
 )
 
 var (
@@ -41,8 +42,8 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers] Annotation trigge
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(o.Equal(" "))
 
-		g.By("tagging the image-registry.openshift-image-registry.svc:5000/openshift/tools:latest as test:v1 image to create ImageStream")
-		out, err := oc.Run("tag").Args("image-registry.openshift-image-registry.svc:5000/openshift/tools:latest", "test:v1").Output()
+		g.By("tagging a new image as test:v1 image to create ImageStream")
+		out, err := oc.Run("tag").Args(exutilimage.ShellImage(), "test:v1").Output()
 		framework.Logf("%s", out)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -25,6 +25,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	unidlingapi "github.com/openshift/api/unidling/v1alpha1"
 	exutil "github.com/openshift/origin/test/extended/util"
+	exutilimage "github.com/openshift/origin/test/extended/util/image"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -134,7 +135,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Image: "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest",
+									Image: exutilimage.ShellImage(),
 									Name:  "idle-test",
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -153,9 +153,6 @@ func ShellImage() string {
 // has access to that contains bash and standard commandline tools.
 // This image should be used when you only need oc and can't use the shell image.
 // This image has oc.
-//
-// TODO: this will be removed when https://bugzilla.redhat.com/show_bug.cgi?id=1843232
-// is fixed
 func LimitedShellImage() string {
 	return "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
 }


### PR DESCRIPTION
`ImageRegistry` became a new optional component in 4.14 (openshift/api#1572, openshift/openshift-docs#64469). And even before that, it has long been [configurable for `managementState: Removed`][3]. However the no-capabilities test is currently failing [like][4]:

    message: Back-off pulling image "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest"

in clusters without a local registry.  This pull request consolidates some `image-registry.openshift-image-registry.svc:5000` consumers around the `ShellImage` and `LimitedShellImage` functions.  Future work can teach those functions to be more flexible about choosing external pullspecs for clusters without a local registry.

[1]: https://github.com/openshift/api/pull/1572
[2]: https://github.com/openshift/openshift-docs/pull/64469
[3]: https://docs.openshift.com/container-platform/4.11/registry/configuring-registry-operator.html#registry-operator-configuration-resource-overview_configuring-registry-operator
[4]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.15-e2e-aws-ovn-no-capabilities/1709539450616287232