### PR TITLE
trt-1271: add risk analysis for monitor junit suites

### DIFF
--- a/pkg/clioptions/clusterinfo/api.go
+++ b/pkg/clioptions/clusterinfo/api.go
@@ -1,4 +1,4 @@
-package monitor
+package clusterinfo
 
 import (
 	"fmt"

--- a/pkg/clioptions/clusterinfo/write_job_run_data.go
+++ b/pkg/clioptions/clusterinfo/write_job_run_data.go
@@ -1,4 +1,4 @@
-package monitor
+package clusterinfo
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
-// TODO these don't belong here. They should move to a clioptions package about cluster info
 func WasMasterNodeUpdated(events monitorapi.Intervals) string {
 	nodeUpdates := events.Filter(monitorapi.NodeUpdate)
 
@@ -30,7 +29,6 @@ func WasMasterNodeUpdated(events monitorapi.Intervals) string {
 	return "N"
 }
 
-// TODO these don't belong here. They should move to a clioptions package about cluster info
 // TODO this should be taking a client, not a kubeconfig. Can't test a client.
 func CollectClusterData(adminKubeConfig *rest.Config, masterNodeUpdated string) platformidentification.ClusterData {
 	clusterData := platformidentification.ClusterData{}

--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
+
 	"github.com/openshift/origin/pkg/clioptions/imagesetup"
 	"github.com/openshift/origin/pkg/monitortestframework"
 
@@ -158,7 +160,7 @@ func (o *RunMonitorOptions) Run() error {
 
 	fmt.Fprintf(o.Out, "Starting the monitor.\n")
 
-	restConfig, err := monitor.GetMonitorRESTConfig()
+	restConfig, err := clusterinfo.GetMonitorRESTConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/openshift-tests/run-disruption/disruption.go
+++ b/pkg/cmd/openshift-tests/run-disruption/disruption.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
+
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -70,7 +72,7 @@ func NewRunInClusterDisruptionMonitorCommand(ioStreams genericclioptions.IOStrea
 }
 
 func (opt *RunAPIDisruptionMonitorOptions) Run() error {
-	restConfig, err := monitor.GetMonitorRESTConfig()
+	restConfig, err := clusterinfo.GetMonitorRESTConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/origin/pkg/riskanalysis"
+
 	"github.com/openshift/origin/pkg/monitortestframework"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -162,7 +164,7 @@ func (m *Monitor) SerializeResults(ctx context.Context, junitSuiteName, timeSuff
 	finalIntervals := m.recorder.Intervals(time.Time{}, time.Time{})
 	finalResources := m.recorder.CurrentResourceState()
 	// TODO stop taking timesuffix as an arg and make this authoritative.
-	//timeSuffix := fmt.Sprintf("_%s", time.Now().UTC().Format("20060102-150405"))
+	// timeSuffix := fmt.Sprintf("_%s", time.Now().UTC().Format("20060102-150405"))
 
 	eventDir := filepath.Join(m.storageDir, monitorapi.EventDir)
 	if err := os.MkdirAll(eventDir, os.ModePerm); err != nil {
@@ -185,15 +187,20 @@ func (m *Monitor) SerializeResults(ctx context.Context, junitSuiteName, timeSuff
 	m.junits = append(m.junits, monitorTestJunits...)
 
 	fmt.Fprintf(os.Stderr, "Writing junits.\n")
-	if err := m.serializeJunit(ctx, m.storageDir, junitSuiteName, timeSuffix); err != nil {
+	var junitSuite *junitapi.JUnitTestSuite
+	if junitSuite, err = m.serializeJunit(ctx, m.storageDir, junitSuiteName, timeSuffix); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to write junit xml, err: %v\n", err)
 		return err
+	}
+
+	if err := riskanalysis.WriteJobRunTestFailureSummary(m.storageDir, timeSuffix, junitSuite, "", "_monitor"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: Unable to write e2e job run failures summary: %v", err)
 	}
 
 	return nil
 }
 
-func (m *Monitor) serializeJunit(ctx context.Context, storageDir, junitSuiteName, fileSuffix string) error {
+func (m *Monitor) serializeJunit(ctx context.Context, storageDir, junitSuiteName, fileSuffix string) (*junitapi.JUnitTestSuite, error) {
 	junitSuite := junitapi.JUnitTestSuite{
 		Name:       junitSuiteName,
 		NumTests:   0,
@@ -218,10 +225,10 @@ func (m *Monitor) serializeJunit(ctx context.Context, storageDir, junitSuiteName
 
 	out, err := xml.MarshalIndent(junitSuite, "", "    ")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	filePrefix := "e2e-monitor-tests"
 	path := filepath.Join(storageDir, fmt.Sprintf("%s_%s.xml", filePrefix, fileSuffix))
 	fmt.Fprintf(os.Stderr, "Writing JUnit report to %s\n", path)
-	return os.WriteFile(path, test.StripANSI(out), 0640)
+	return &junitSuite, os.WriteFile(path, test.StripANSI(out), 0640)
 }

--- a/pkg/monitortests/node/legacynodemonitortests/updates.go
+++ b/pkg/monitortests/node/legacynodemonitortests/updates.go
@@ -1,7 +1,7 @@
 package legacynodemonitortests
 
 import (
-	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 )
@@ -11,7 +11,7 @@ func testMasterNodesUpdated(events monitorapi.Intervals) []*junitapi.JUnitTestCa
 
 	// Only return a Junit if we detect that the master nodes were updated
 	// Used in sippy to differentiate between jobs where the master nodes update and do not (no junit in that case)
-	if "Y" == monitor.WasMasterNodeUpdated(events) {
+	if "Y" == clusterinfo.WasMasterNodeUpdated(events) {
 		return []*junitapi.JUnitTestCase{{
 			Name: testName,
 		}}

--- a/pkg/monitortests/testframework/clusterinfoserializer/monitortest.go
+++ b/pkg/monitortests/testframework/clusterinfoserializer/monitortest.go
@@ -8,11 +8,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
+
 	"github.com/openshift/origin/pkg/monitortestframework"
 
 	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 
-	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	"k8s.io/client-go/rest"
@@ -46,7 +47,7 @@ func (*clusterInfoSerializer) EvaluateTestsFromConstructedIntervals(ctx context.
 func (w *clusterInfoSerializer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
 	return writeClusterData(
 		filepath.Join(storageDir, fmt.Sprintf("cluster-data%s.json", timeSuffix)),
-		w.collectClusterData(monitor.WasMasterNodeUpdated(finalIntervals)),
+		w.collectClusterData(clusterinfo.WasMasterNodeUpdated(finalIntervals)),
 	)
 }
 
@@ -64,5 +65,5 @@ func writeClusterData(filename string, clusterData platformidentification.Cluste
 }
 
 func (w *clusterInfoSerializer) collectClusterData(masterNodeUpdated string) platformidentification.ClusterData {
-	return monitor.CollectClusterData(w.adminRESTConfig, masterNodeUpdated)
+	return clusterinfo.CollectClusterData(w.adminRESTConfig, masterNodeUpdated)
 }

--- a/pkg/resourcewatch/operator/starter.go
+++ b/pkg/resourcewatch/operator/starter.go
@@ -6,10 +6,11 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
+
 	"github.com/openshift/origin/pkg/resourcewatch/controller/configmonitor"
 	"github.com/openshift/origin/pkg/resourcewatch/storage"
 
-	"github.com/openshift/origin/pkg/monitor"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -37,7 +38,7 @@ func RunResourceWatch() error {
 	}()
 	signal.Notify(abortCh, syscall.SIGINT, syscall.SIGTERM)
 
-	kubeConfig, err := monitor.GetMonitorRESTConfig()
+	kubeConfig, err := clusterinfo.GetMonitorRESTConfig()
 	if err != nil {
 		klog.Errorf("Failed to get kubeconfig with error %v", err)
 		return err

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
+
 	"github.com/openshift/origin/pkg/monitortestframework"
 
 	"github.com/onsi/ginkgo/v2"
@@ -234,7 +236,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 		parallelism = 10
 	}
 
-	restConfig, err := monitor.GetMonitorRESTConfig()
+	restConfig, err := clusterinfo.GetMonitorRESTConfig()
 	if err != nil {
 		return err
 	}
@@ -532,7 +534,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 			}
 		}
 
-		wasMasterNodeUpdated = monitor.WasMasterNodeUpdated(events)
+		wasMasterNodeUpdated = clusterinfo.WasMasterNodeUpdated(events)
 	}
 
 	// report the outcome of the test
@@ -547,7 +549,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 			fmt.Fprintf(o.Out, "error: Unable to write e2e JUnit xml results: %v", err)
 		}
 
-		if err := riskanalysis.WriteJobRunTestFailureSummary(o.JUnitDir, timeSuffix, finalSuiteResults, wasMasterNodeUpdated); err != nil {
+		if err := riskanalysis.WriteJobRunTestFailureSummary(o.JUnitDir, timeSuffix, finalSuiteResults, wasMasterNodeUpdated, ""); err != nil {
 			fmt.Fprintf(o.Out, "error: Unable to write e2e job run failures summary: %v", err)
 		}
 	}

--- a/pkg/test/ginkgo/cmd_runtest.go
+++ b/pkg/test/ginkgo/cmd_runtest.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
+
 	"github.com/openshift/origin/pkg/monitortestframework"
 
 	"github.com/onsi/ginkgo/v2"
@@ -75,7 +77,7 @@ func (o *TestOptions) Run(args []string) error {
 		return nil
 	}
 
-	restConfig, err := monitor.GetMonitorRESTConfig()
+	restConfig, err := clusterinfo.GetMonitorRESTConfig()
 	if err != nil {
 		return err
 	}

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -158,7 +158,7 @@ func runChaosmonkey(
 			// we don't currently need this field set for RiskAnalysis.  We could change this logic to either
 			// parse the events for the NodeUpdated interval or read the ClusterData.json from storage
 			// and pass it in if needed.
-			if err := riskanalysis.WriteJobRunTestFailureSummary(framework.TestContext.ReportDir, timeSuffix, testSuite, ""); err != nil {
+			if err := riskanalysis.WriteJobRunTestFailureSummary(framework.TestContext.ReportDir, timeSuffix, testSuite, "", ""); err != nil {
 				fmt.Fprintf(os.Stderr, "error: Failed to write file %v: %v\n", fname, err)
 				return
 			}


### PR DESCRIPTION
Add risk analysis test failure summary for monitor junit suites
Moves cluster info apis to clusterinfo package due to comments / circular dependencies 