### PR TITLE
Add debug info for interval counts and times

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -177,6 +177,9 @@ func (m *Monitor) SerializeResults(ctx context.Context, junitSuiteName, timeSuff
 	}
 
 	fmt.Fprintf(os.Stderr, "Writing to storage.\n")
+	fmt.Fprintf(os.Stderr, "  m.startTime = %s\n", m.startTime)
+	fmt.Fprintf(os.Stderr, "  m.stopTime  = %s\n", m.stopTime)
+
 	monitorTestJunits, err := m.monitorTestRegistry.WriteContentToStorage(
 		ctx,
 		m.storageDir,

--- a/pkg/monitortestframework/impl.go
+++ b/pkg/monitortestframework/impl.go
@@ -3,6 +3,7 @@ package monitortestframework
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -268,6 +269,15 @@ func (r *monitorTestRegistry) WriteContentToStorage(ctx context.Context, storage
 		testName := fmt.Sprintf("[Jira:%q] monitor test %v writing to storage", monitorTest.jiraComponent, monitorTest.name)
 
 		start := time.Now()
+
+		var finalIntervalLength = len(finalIntervals)
+		fmt.Fprintf(os.Stderr, "Processing monitorTest: %s\n", monitorTest.name)
+		fmt.Fprintf(os.Stderr, "  finalIntervals size = %d\n", finalIntervalLength)
+		if finalIntervalLength > 1 {
+			fmt.Fprintf(os.Stderr, "  first interval time: From = %s; To = %s\n", finalIntervals[0].From, finalIntervals[0].To)
+		}
+		fmt.Fprintf(os.Stderr, "  last interval time: From = %s; To = %s\n", finalIntervals[finalIntervalLength-1].From, finalIntervals[finalIntervalLength-1].To)
+
 		err := writeContentToStorageWithPanicProtection(ctx, monitorTest.monitorTest, storageDir, timeSuffix, finalIntervals, finalResourceState)
 		end := time.Now()
 		duration := end.Sub(start)

--- a/pkg/monitortests/testframework/uploadtolokiserializer/monitortest.go
+++ b/pkg/monitortests/testframework/uploadtolokiserializer/monitortest.go
@@ -191,13 +191,11 @@ func UploadIntervalsToLoki(intervals monitorapi.Intervals) error {
 
 	for _, i := range intervals {
 		logLine := map[string]string{
-			"_entry": i.Message,
+			"_entry": fmt.Sprintf("%s, from=%s, to=%s", i.Message, i.From.String(), i.To.String()),
 		}
 
+		// We don't care to ingest intervals for e2e-tests at this time.
 		if strings.HasPrefix(i.Locator, "e2e-test/\"") {
-			startIndex := strings.Index(i.Locator, "\"") + 1
-			endIndex := strings.LastIndex(i.Locator, "\"")
-			logLine["e2e-test"] = i.Locator[startIndex:endIndex]
 			continue
 		}
 


### PR DESCRIPTION
Jobs like [this](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-azure-sdn-upgrade/1710475847271452672), show intervals in the second spyglass chart that are in the upgrade phase; this is seen in the events.json and html files (what you see for spyglass).  This PR prints the first/last interval times for when those json files are written to disk to try to figure out where these extra intervals are coming from.

Also, we use the To (instead of From) since To is later in hopes of avoiding 'entry too far behind'.

The symptom does not happen consistently in CI since the sno upgrade test is the only one with two spyglass charts.  We can let this run in the wild to see if we can get more data into when and why this is happening.

