### PR TITLE
hs, kubevirt: Wait node readiness before migration

### DIFF
--- a/test/extended/kubevirt/util.go
+++ b/test/extended/kubevirt/util.go
@@ -364,17 +364,6 @@ func InKubeVirtClusterContext(oc *exutil.CLI, body func()) {
 	)
 }
 
-func AfterLiveMigrateWorkersContext(f *e2e.Framework, body func()) {
-	Context("and live migrate hosted control plane workers [Early]",
-		func() {
-			BeforeEach(func() {
-				setMgmtFramework(f)
-				expectNoError(migrateWorkers(f))
-			})
-			body()
-		})
-}
-
 func setMgmtFramework(mgmtFramework *e2e.Framework) *exutil.CLI {
 	_, hcpNamespace, err := exutil.GetHypershiftManagementClusterConfigAndNamespace()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The test are re-run to check if they are just flaky, in the case of live migration it should wait for the cluster to settle before doing the live migration again. This change wait for cluster to reach readiness.