### PR TITLE
Revert #28295 "Automating test \"check the quota after import-image with --all option\" in upstrem"

### DIFF
--- a/test/extended/quota/resourcequota.go
+++ b/test/extended/quota/resourcequota.go
@@ -164,58 +164,6 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
-
-		g.It("check the quota after import-image with --all option", func() {
-			testProject := oc.SetupProject()
-			testResourceQuotaName := "my-imagestream-quota-" + testProject
-			clusterAdminKubeClient := oc.AdminKubeClient()
-
-			rq := &corev1.ResourceQuota{
-				ObjectMeta: metav1.ObjectMeta{Name: testResourceQuotaName, Namespace: testProject},
-				Spec: corev1.ResourceQuotaSpec{
-					Hard: corev1.ResourceList{
-						"openshift.io/imagestreams": resource.MustParse("10"),
-					},
-				},
-			}
-
-			g.By("create the imagestreams and checking the usage")
-			_, err := clusterAdminKubeClient.CoreV1().ResourceQuotas(testProject).Create(context.Background(), rq, metav1.CreateOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			err = waitForResourceQuotaStatus(clusterAdminKubeClient, testResourceQuotaName, testProject, func(actualResourceQuota *corev1.ResourceQuota) error {
-				expectedUsedStatus := corev1.ResourceList{
-					"openshift.io/imagestreams": resource.MustParse("0"),
-				}
-				if !equality.Semantic.DeepEqual(actualResourceQuota.Status.Used, expectedUsedStatus) {
-					return fmt.Errorf("unexpected current total usage: actual: %#v, expected: %#v", actualResourceQuota.Status.Used, expectedUsedStatus)
-				}
-				return nil
-			})
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("trying to tag a container image")
-			err = oc.AsAdmin().WithoutNamespace().Run("import-image").Args("centos", "--from=quay.io/openshifttest/alpine", "--confirm=true", "--all=true", "-n", testProject).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			err = oc.AsAdmin().WithoutNamespace().Run("tag").Args("quay.io/openshifttest/base-alpine@sha256:3126e4eed4a3ebd8bf972b2453fa838200988ee07c01b2251e3ea47e4b1f245c", "--source=docker", "mystream:latest", "-n", testProject).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			err = exutil.WaitForAnImageStreamTag(oc, testProject, "mystream", "latest")
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("checking the imagestream usage again")
-			err = waitForResourceQuotaStatus(clusterAdminKubeClient, testResourceQuotaName, testProject, func(actualResourceQuota *corev1.ResourceQuota) error {
-				expectedUsedStatus := corev1.ResourceList{
-					"openshift.io/imagestreams": resource.MustParse("2"),
-				}
-				if !equality.Semantic.DeepEqual(actualResourceQuota.Status.Used, expectedUsedStatus) {
-					return fmt.Errorf("unexpected current total usage: actual: %#v, expected: %#v", actualResourceQuota.Status.Used, expectedUsedStatus)
-				}
-				return nil
-			})
-			o.Expect(err).NotTo(o.HaveOccurred())
-		})
 	})
 })
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -47,8 +47,6 @@ var Annotations = map[string]string{
 
 	"[sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io][apigroup:monitoring.coreos.com][apigroup:template.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-api-machinery][Feature:ResourceQuota] Object count check the quota after import-image with --all option": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of imagestreams resources [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of persistentvolumeclaims resources [Serial]": " [Suite:openshift/conformance/serial]",


### PR DESCRIPTION
Reverts #28295 ; tracked by [TRT-1291](https://issues.redhat.com//browse/TRT-1291)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This broke metal-ipi-ovn-ipv6 jobs, this test is permafailing there.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-ovn-ipv6
```

CC: @gangwgr, @soltysh

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
