### PR TITLE
OCPBUGS-21774: backport-ocp-11594-ocp-12339-to-4.14 with fix

### DIFF
--- a/test/extended/quota/resourcequota.go
+++ b/test/extended/quota/resourcequota.go
@@ -85,6 +85,137 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
+
+		g.It("should properly count the number of persistentvolumeclaims resources [Serial]", func() {
+			testProject := oc.SetupProject()
+			testResourceQuotaName := "my-resource-quota-" + testProject
+			pvcName := "myclaim-" + testProject
+			clusterAdminKubeClient := oc.AdminKubeClient()
+
+			rq := &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: testResourceQuotaName, Namespace: testProject},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: corev1.ResourceList{
+						"persistentvolumeclaims": resource.MustParse("1"),
+					},
+				},
+			}
+
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: pvcName,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("3Gi"),
+						},
+					},
+				},
+			}
+
+			g.By("create the persistent volume and checking the usage")
+			_, err := clusterAdminKubeClient.CoreV1().ResourceQuotas(testProject).Create(context.Background(), rq, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = waitForResourceQuotaStatus(clusterAdminKubeClient, testResourceQuotaName, testProject, func(actualResourceQuota *corev1.ResourceQuota) error {
+				expectedUsedStatus := corev1.ResourceList{
+					"persistentvolumeclaims": resource.MustParse("0"),
+				}
+				if !equality.Semantic.DeepEqual(actualResourceQuota.Status.Used, expectedUsedStatus) {
+					return fmt.Errorf("unexpected current total usage: actual: %#v, expected: %#v", actualResourceQuota.Status.Used, expectedUsedStatus)
+				}
+				return nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			_, err = clusterAdminKubeClient.CoreV1().PersistentVolumeClaims(testProject).Create(context.Background(), pvc, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = waitForResourceQuotaStatus(clusterAdminKubeClient, testResourceQuotaName, testProject, func(actualResourceQuota *corev1.ResourceQuota) error {
+				expectedUsedStatus := corev1.ResourceList{
+					"persistentvolumeclaims": resource.MustParse("1"),
+				}
+				if !equality.Semantic.DeepEqual(actualResourceQuota.Status.Used, expectedUsedStatus) {
+					return fmt.Errorf("unexpected current total usage: actual: %v, expected: %v", actualResourceQuota.Status.Used, expectedUsedStatus)
+				}
+				return nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			_, err = clusterAdminKubeClient.CoreV1().PersistentVolumeClaims(testProject).Create(context.Background(), pvc, metav1.CreateOptions{})
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.MatchRegexp(pvcName + `.*forbidden.*[Ee]xceeded quota`))
+
+			g.By("deleting the persistent volume and checking the usage")
+			err = clusterAdminKubeClient.CoreV1().PersistentVolumeClaims(testProject).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = waitForResourceQuotaStatus(clusterAdminKubeClient, testResourceQuotaName, testProject, func(actualResourceQuota *corev1.ResourceQuota) error {
+				expectedUsedStatus := corev1.ResourceList{
+					"persistentvolumeclaims": resource.MustParse("0"),
+				}
+				if !equality.Semantic.DeepEqual(actualResourceQuota.Status.Used, expectedUsedStatus) {
+					return fmt.Errorf("unexpected current total usage: actual: %v, expected: %v", actualResourceQuota.Status.Used, expectedUsedStatus)
+				}
+				return nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
+		g.It("check the quota after import-image with --all option [Skipped:Disconnected]", func() {
+			testProject := oc.SetupProject()
+			testResourceQuotaName := "my-imagestream-quota-" + testProject
+			clusterAdminKubeClient := oc.AdminKubeClient()
+
+			rq := &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: testResourceQuotaName, Namespace: testProject},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: corev1.ResourceList{
+						"openshift.io/imagestreams": resource.MustParse("10"),
+					},
+				},
+			}
+
+			g.By("create the imagestreams and checking the usage")
+			_, err := clusterAdminKubeClient.CoreV1().ResourceQuotas(testProject).Create(context.Background(), rq, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = waitForResourceQuotaStatus(clusterAdminKubeClient, testResourceQuotaName, testProject, func(actualResourceQuota *corev1.ResourceQuota) error {
+				expectedUsedStatus := corev1.ResourceList{
+					"openshift.io/imagestreams": resource.MustParse("0"),
+				}
+				if !equality.Semantic.DeepEqual(actualResourceQuota.Status.Used, expectedUsedStatus) {
+					return fmt.Errorf("unexpected current total usage: actual: %#v, expected: %#v", actualResourceQuota.Status.Used, expectedUsedStatus)
+				}
+				return nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("trying to tag a container image")
+			err = oc.AsAdmin().WithoutNamespace().Run("import-image").Args("centos", "--from=quay.io/openshifttest/alpine", "--confirm=true", "--all=true", "-n", testProject).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = oc.AsAdmin().WithoutNamespace().Run("tag").Args("quay.io/openshifttest/base-alpine@sha256:3126e4eed4a3ebd8bf972b2453fa838200988ee07c01b2251e3ea47e4b1f245c", "--source=docker", "mystream:latest", "-n", testProject).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = exutil.WaitForAnImageStreamTag(oc, testProject, "mystream", "latest")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("checking the imagestream usage again")
+			err = waitForResourceQuotaStatus(clusterAdminKubeClient, testResourceQuotaName, testProject, func(actualResourceQuota *corev1.ResourceQuota) error {
+				expectedUsedStatus := corev1.ResourceList{
+					"openshift.io/imagestreams": resource.MustParse("2"),
+				}
+				if !equality.Semantic.DeepEqual(actualResourceQuota.Status.Used, expectedUsedStatus) {
+					return fmt.Errorf("unexpected current total usage: actual: %#v, expected: %#v", actualResourceQuota.Status.Used, expectedUsedStatus)
+				}
+				return nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
 	})
 })
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -47,7 +47,11 @@ var Annotations = map[string]string{
 
 	"[sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io][apigroup:monitoring.coreos.com][apigroup:template.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-api-machinery][Feature:ResourceQuota] Object count check the quota after import-image with --all option [Skipped:Disconnected]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of imagestreams resources [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of persistentvolumeclaims resources [Serial]": " [Suite:openshift/conformance/serial]",
 
 	"[sig-api-machinery][Feature:ServerSideApply] Server-Side Apply should work for apps.openshift.io/v1, Resource=deploymentconfigs [apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
@elfosardo @stbenjam Please review this backporting PR.
@soltysh Again adding this reverted pr https://github.com/openshift/origin/pull/28314 in 4.14 with fix  https://github.com/openshift/origin/pull/28328/files#diff-32e49140009708cb088e99988f5471cbf622f7ef2fe9d7bd6fa4fb1a98a67a42R168 
Reverts https://github.com/openshift/origin/pull/28304 ; tracked by [TRT-1291](https://issues.redhat.com//browse/TRT-1291)
