### PR TITLE
OCPBUGS-21600: ignore alert during ci run as it can be flaky

### DIFF
--- a/pkg/alerts/allowed_conformance.go
+++ b/pkg/alerts/allowed_conformance.go
@@ -33,6 +33,10 @@ func AllowedAlertsDuringConformance(featureSet configv1.FeatureSet) (allowedFiri
 			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
 			Text:     "high CPU utilization during e2e runs is normal",
 		},
+		{
+			Selector: map[string]string{"alertname": "SystemMemoryExceedsReservation"},
+			Text:     "high memory utilization during e2e runs is normal",
+		},
 	}
 	pendingAlertsWithBugs := helper.MetricConditions{}
 	allowedPendingAlerts := helper.MetricConditions{
@@ -43,6 +47,10 @@ func AllowedAlertsDuringConformance(featureSet configv1.FeatureSet) (allowedFiri
 		{
 			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
 			Text:     "high CPU utilization during e2e runs is normal",
+		},
+		{
+			Selector: map[string]string{"alertname": "SystemMemoryExceedsReservation"},
+			Text:     "high memory utilization during e2e runs is normal",
 		},
 	}
 


### PR DESCRIPTION
This alert is not very useful for CI runs as sometimes high memory limits can be normal.  

We are going to exclude this from the list of alerts that we are concerned about.