### PR TITLE
put back previous Interval Slice algorithm

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -675,29 +675,14 @@ func (intervals Intervals) Slice(from, to time.Time) Intervals {
 		return intervals
 	}
 
-	// forget being fancy, just iterate from the beginning.
-	first := -1
-	if from.IsZero() {
-		first = 0
-	} else {
-		for i := range intervals {
-			curr := intervals[i]
-			if curr.To.IsZero() {
-				if curr.From.After(from) || curr.From == from {
-					first = i
-					break
-				}
-			}
-			if curr.To.After(from) || curr.To == from {
-				first = i
-				break
-			}
-		}
+	// assume that the from is always before the to in an interval,
+	// Then we want to start when the interval.TO is after the argument.From
+	first := sort.Search(len(intervals), func(i int) bool {
+		return !intervals[i].To.Before(from) // equal to or after
+	})
+	if first == -1 {
+		return nil
 	}
-	if first == -1 || len(intervals) == 0 {
-		return Intervals{}
-	}
-
 	if to.IsZero() {
 		return intervals[first:]
 	}


### PR DESCRIPTION
[TRT-1267](https://issues.redhat.com//browse/TRT-1267)

The symptom I'm trying to solve is what appears in the [build-log.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.15-e2e-aws-ovn-upgrade/1715259800222175232/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/build-log.txt):

```
  Writing to storage.
    m.startTime = 2023-10-20 09:37:04.165909951 +0000 UTC m=+7.219893181
    m.stopTime  = 2023-10-20 10:35:24.147320609 +0000 UTC m=+3507.201303839
  Processing monitorTest: etcd-log-analyzer
    finalIntervals size = 111920
    first interval time: From = 2023-10-20 07:06:45 +0000 UTC; To = 2023-10-20 09:37:04.735409113 +0000 UTC
    last interval time: From = 2023-10-20 10:34:07.756247353 +0000 UTC; To = 2023-10-20 10:34:07.756247353 +0000 UTC
```

These are the intervals that should not be in the [second set of intervals](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.15-e2e-aws-ovn-upgrade/1715259800222175232/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/e2e-events_20231020-093704.json) (take out the |length to see them):

```bash
$ cat e2e-events_20231020-093704.json| jq '[.items[] | select(.from < "2023-10-20T09:35:52Z")] | length'
6954
```
  If the Slice() function was working, intervals with first interval time would not be before the m.startTime above.  So I essentially revert [this commit](https://github.com/openshift/origin//commit/791b15e7c7de618cf46e9782a87c77e8717f954d).

Once this is mitigated, we should no longer get intervals ignored due to `entry too far behind` and satisfy loki's ["validity window"](https://github.com/grafana/loki/blob/b43e2539256cb2fe499c6f586b1231cc1a5e40d1/pkg/ingester/stream.go#L396).