### PR TITLE
Allow the unknown alerts test to fail as it looks stable

### DIFF
--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
@@ -255,13 +255,6 @@ func isSkippedAlert(alertName string) bool {
 func runNoNewAlertsFiringTest(historicalData *historicaldata.AlertBestMatcher,
 	firingIntervals monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[sig-trt][invariant] No new alerts should be firing"
-	ret := []*junitapi.JUnitTestCase{
-		{
-			// Success test to force a flake until we're ready to let things fail here.
-			Name: testName,
-		},
-	}
-
 	// accumulate all alerts firing that we have no historical data for this release, or we know it only
 	// recently appeared. (less than two weeks ago) Any alerts in either category will fail this test.
 	newAlertsFiring := []string{}
@@ -306,7 +299,10 @@ func runNoNewAlertsFiringTest(historicalData *historicaldata.AlertBestMatcher,
 		// if firstObserved was still nil, we can't do the two week check, but we saw the alert, so assume a test pass, the alert must be known
 	}
 
+	ret := []*junitapi.JUnitTestCase{}
+
 	if len(newAlertsFiring) > 0 {
+		// test failed
 		output := fmt.Sprintf("Found alerts firing which are new or less than two weeks old, which should not be firing: \n\n%s",
 			strings.Join(newAlertsFiring, "\n"))
 		ret = append(ret, &junitapi.JUnitTestCase{
@@ -316,6 +312,12 @@ func runNoNewAlertsFiringTest(historicalData *historicaldata.AlertBestMatcher,
 			},
 			SystemOut: output,
 		})
+	} else {
+		// test passed
+		ret = append(ret, &junitapi.JUnitTestCase{
+			Name: testName,
+		})
 	}
+
 	return ret
 }

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_test.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_test.go
@@ -73,14 +73,14 @@ func TestNoNewAlertsFiringBackstop(t *testing.T) {
 					},
 				}),
 			firingIntervals: monitorapi.Intervals{interval},
-			expectedStatus:  []string{"pass", "fail"},
+			expectedStatus:  []string{"fail"},
 		},
 		{
 			name: "firing alert never seen before",
 			historicalData: historicaldata.NewAlertMatcherWithHistoricalData(
 				map[historicaldata.AlertDataKey]historicaldata.AlertStatisticalData{}),
 			firingIntervals: monitorapi.Intervals{interval},
-			expectedStatus:  []string{"pass", "fail"},
+			expectedStatus:  []string{"fail"},
 		},
 		{
 			name: "firing severity info alert never seen before",


### PR DESCRIPTION
500 runs and no flakes so far. Couple more days we should let this merge and allow the test to fail if it does find something.

[TRT-934](https://issues.redhat.com//browse/TRT-934)