### PR TITLE
OCPBUGS-23084: expect to not see "git clone" and not just "clone" during a test

### DIFF
--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -48,7 +48,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 				// repository is not accessible. It should never get to the clone.
 				buildLog, err := br.Logs()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(buildLog).NotTo(o.ContainSubstring("clone"))
+				o.Expect(buildLog).NotTo(o.ContainSubstring("git clone"))
 				o.Expect(buildLog).To(o.MatchRegexp(`unable to access '%s': Failed( to)? connect to`, "https://github.com/openshift/ruby-hello-world.git/"))
 
 				g.By("verifying the build sample-build-1 status")


### PR DESCRIPTION
The "should start a build and wait for the build to fail" test expects to fail some time before openshift-git-clone runs "git clone", but at higher logging levels, this requires that openshift-git-clone not tell us how it was invoked, which is a useful thing to have it be able to do.

Instead of treating the presence of "clone" in the logged output as an error, look for "git clone" (logged along with the rest of the CLI args at level 4 by github.com/openshift/library-go/pkg/git.timedCommand) as the signifier of an error.