### PR TITLE
OCPBUGS-22358: fix: increase upper bounds for samples operator

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -297,7 +297,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"cluster-image-registry-operator":        119,
 				"cluster-monitoring-operator":            88,
 				"cluster-node-tuning-operator":           97,
-				"cluster-samples-operator":               23,
+				"cluster-samples-operator":               27,
 				"cluster-storage-operator":               202,
 				"console-operator":                       200,
 				"csi-snapshot-controller-operator":       120,


### PR DESCRIPTION
Samples Operator added another watching triggerig the upper bound for SNO.

The upper limit was calculated to 52 via curl command below, increasing to 27*2 to buffer the change.

```
curl -L https://search.ci.openshift.org/\?search\=.\*Operator.\*cluster-samples.\*produces+more+watch+requests+than+expected\&maxAge\=168h\&context\=1\&type\=junit\&name\=aws.\*single-node\&excludeName\=\&maxMatches\=5\&maxBytes\=20971520\&groupBy\=job | grep watchrequestcount= | cut -d= -f2 | cut -d, -f1
```