### PR TITLE
Restore APIServer graceful shutdown windows

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -188,19 +188,7 @@
     }
 
     function isGracefulShutdownActivity(eventInterval) {
-        if (eventInterval.locator.includes("shutdown/graceful")) {
-            return true
-        }
-
-        return false
-    }
-
-    function isAPIServerShutdownEventActivity(eventInterval) {
-        if (eventInterval.locator.includes("shutdown/apiserver")) {
-            return true
-        }
-
-        return false
+        return (eventInterval.tempSource === "APIServerGracefulShutdown")
     }
 
     function isEndpointConnectivity(eventInterval) {
@@ -493,11 +481,8 @@
         timelineGroups.push({group: "endpoint-availability", data: []})
         createTimelineData(disruptionValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEndpointConnectivity, regex)
 
-        timelineGroups.push({group: "shutdown-interval", data: []})
+        timelineGroups.push({group: "apiserver-shutdown", data: []})
         createTimelineData(apiserverShutdownValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isGracefulShutdownActivity, regex)
-
-        timelineGroups.push({group: "shutdown-events", data: []})
-        createTimelineData(apiserverShutdownEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerShutdownEventActivity, regex)
 
         timelineGroups.push({group: "e2e-test-failed", data: []})
         createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed, regex)

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -263,7 +263,7 @@ const (
 	SourceSystemJournalScanner    IntervalSource = "KubeletLogScanner"
 	SourcePodLog                  IntervalSource = "PodLog"
 	SourcePodMonitor              IntervalSource = "PodMonitor"
-	SourceKubeEvent               IntervalSource = "KubeEvent"
+	APIServerGracefulShutdown     IntervalSource = "APIServerGracefulShutdown"
 	SourceTestData                IntervalSource = "TestData"                // some tests have no real source to assign
 	SourcePathologicalEventMarker IntervalSource = "PathologicalEventMarker" // not sure if this is really helpful since the events all have a different origin
 	SourceClusterOperatorMonitor  IntervalSource = "ClusterOperatorMonitor"

--- a/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest.go
@@ -87,7 +87,7 @@ func (*apiserverGracefulShutdownAnalyzer) ConstructComputedIntervals(ctx context
 			}
 
 			computedIntervals = append(computedIntervals,
-				monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
+				monitorapi.NewInterval(monitorapi.APIServerGracefulShutdown, monitorapi.Info).
 					Locator(monitorapi.NewLocator().
 						LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name, true),
 					).
@@ -107,7 +107,7 @@ func (*apiserverGracefulShutdownAnalyzer) ConstructComputedIntervals(ctx context
 		nodeName, _ := monitorapi.NodeFromLocator(fakeLocator)
 
 		computedIntervals = append(computedIntervals,
-			monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Error).
+			monitorapi.NewInterval(monitorapi.APIServerGracefulShutdown, monitorapi.Error).
 				Locator(monitorapi.NewLocator().
 					LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name, true),
 				).

--- a/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest_test.go
+++ b/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest_test.go
@@ -12,7 +12,7 @@ func TestBuilder(t *testing.T) {
 	podRef := monitorapi.PodFrom(oldLocator)
 	nodeName, _ := monitorapi.NodeFromLocator(oldLocator)
 
-	interval := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
+	interval := monitorapi.NewInterval(monitorapi.APIServerGracefulShutdown, monitorapi.Info).
 		Locator(monitorapi.NewLocator().
 			LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name, true),
 		).

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52410,19 +52410,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function isGracefulShutdownActivity(eventInterval) {
-        if (eventInterval.locator.includes("shutdown/graceful")) {
-            return true
-        }
-
-        return false
-    }
-
-    function isAPIServerShutdownEventActivity(eventInterval) {
-        if (eventInterval.locator.includes("shutdown/apiserver")) {
-            return true
-        }
-
-        return false
+        return (eventInterval.tempSource === "APIServerGracefulShutdown")
     }
 
     function isEndpointConnectivity(eventInterval) {
@@ -52715,11 +52703,8 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         timelineGroups.push({group: "endpoint-availability", data: []})
         createTimelineData(disruptionValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEndpointConnectivity, regex)
 
-        timelineGroups.push({group: "shutdown-interval", data: []})
+        timelineGroups.push({group: "apiserver-shutdown", data: []})
         createTimelineData(apiserverShutdownValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isGracefulShutdownActivity, regex)
-
-        timelineGroups.push({group: "shutdown-events", data: []})
-        createTimelineData(apiserverShutdownEventsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIServerShutdownEventActivity, regex)
 
         timelineGroups.push({group: "e2e-test-failed", data: []})
         createTimelineData("Failed", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isE2EFailed, regex)


### PR DESCRIPTION
Discovered these were mistakenly using an incorrect source
classification, so this is changed to be apiserver specific.

Also restore them on the intervals chart and collapse into one group.
