### PR TITLE
Skip FailedScheduling intervals when masters are in NodeUpdate

### DIFF
--- a/pkg/cmd/openshift-tests/monitor/timeline/timeline_command.go
+++ b/pkg/cmd/openshift-tests/monitor/timeline/timeline_command.go
@@ -247,7 +247,7 @@ func renderHTML(events monitorapi.Intervals) ([]byte, error) {
 		return nil, err
 
 	}
-	e2eChartTemplate := testdata.MustAsset("e2echart/non-spyglass-e2e-chart-template.html")
+	e2eChartTemplate := testdata.MustAsset("e2echart/e2e-chart-template.html")
 	e2eChartTitle := "Timeline"
 	e2eChartHTML := bytes.ReplaceAll(e2eChartTemplate, []byte("EVENT_INTERVAL_TITLE_GOES_HERE"), []byte(e2eChartTitle))
 	e2eChartHTML = bytes.ReplaceAll(e2eChartHTML, []byte("EVENT_INTERVAL_JSON_GOES_HERE"), eventIntervalsJSON)

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -123,7 +123,7 @@ func ConstructionOwnerFrom(message string) IntervalReason {
 
 func PhaseFrom(message string) string {
 	annotations := AnnotationsFromMessage(message)
-	return annotations[AnnotationPodPhase]
+	return annotations[AnnotationPhase]
 }
 
 const (

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -212,9 +212,9 @@ const (
 	AnnotationEtcdTerm           AnnotationKey = "term"
 	AnnotationEtcdLeader         AnnotationKey = "leader"
 	AnnotationPreviousEtcdLeader AnnotationKey = "prev-leader"
-	AnnotationConstructed        AnnotationKey = "constructed"
-	AnnotationPodPhase           AnnotationKey = "phase"
-	AnnotationIsStaticPod        AnnotationKey = "mirrored"
+	AnnotationConstructed AnnotationKey = "constructed"
+	AnnotationPhase       AnnotationKey = "phase"
+	AnnotationIsStaticPod AnnotationKey = "mirrored"
 	// TODO this looks wrong. seems like it ought to be set in the to/from
 	AnnotationDuration       AnnotationKey = "duration"
 	AnnotationRequestAuditID AnnotationKey = "request-audit-id"

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -202,6 +202,7 @@ type AnnotationKey string
 
 const (
 	AnnotationAlertState         AnnotationKey = "alertstate"
+	AnnotationState              AnnotationKey = "state"
 	AnnotationSeverity           AnnotationKey = "severity"
 	AnnotationReason             AnnotationKey = "reason"
 	AnnotationContainerExitCode  AnnotationKey = "code"
@@ -212,9 +213,9 @@ const (
 	AnnotationEtcdTerm           AnnotationKey = "term"
 	AnnotationEtcdLeader         AnnotationKey = "leader"
 	AnnotationPreviousEtcdLeader AnnotationKey = "prev-leader"
-	AnnotationConstructed AnnotationKey = "constructed"
-	AnnotationPhase       AnnotationKey = "phase"
-	AnnotationIsStaticPod AnnotationKey = "mirrored"
+	AnnotationConstructed        AnnotationKey = "constructed"
+	AnnotationPhase              AnnotationKey = "phase"
+	AnnotationIsStaticPod        AnnotationKey = "mirrored"
 	// TODO this looks wrong. seems like it ought to be set in the to/from
 	AnnotationDuration       AnnotationKey = "duration"
 	AnnotationRequestAuditID AnnotationKey = "request-audit-id"

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
@@ -223,8 +224,32 @@ func (d duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOnl
 		eventMessage string // holds original message so you can compare with d.knownRepeatedEventsBugs
 	}
 
+	// Filter out a list of NodeUpdate events, we use these to ignore some other potential pathological events that are
+	// expected during NodeUpdate.
+	nodeUpdateIntervals := events.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Source == monitorapi.SourceNodeState &&
+			eventInterval.StructuredLocator.Type == monitorapi.LocatorTypeNode &&
+			eventInterval.StructuredMessage.Annotations[monitorapi.AnnotationConstructed] == monitorapi.ConstructionOwnerNodeLifecycle &&
+			eventInterval.StructuredMessage.Annotations[monitorapi.AnnotationPhase] == "Update" &&
+			strings.Contains(eventInterval.StructuredMessage.Annotations[monitorapi.AnnotationRoles], "master")
+	})
+	logrus.Infof("found %d NodeUpdate intervals", len(nodeUpdateIntervals))
+
 	displayToCount := map[string]*pathologicalEvents{}
 	for _, event := range events {
+		// Filter out FailedScheduling events while masters are updating
+		var foundOverlap bool
+		for _, nui := range nodeUpdateIntervals {
+			// TODO: port to use structured message reason once kube event intervals are ported over
+			if strings.Contains(event.Message, "reason/FailedScheduling") && nui.From.Before(event.From) && nui.To.After(event.To) {
+				logrus.Infof("%s was found to overlap with %s, ignoring pathological event as we expect these during master updates", event, nui)
+				foundOverlap = true
+				break
+			}
+		}
+		if foundOverlap {
+			break
+		}
 		eventDisplayMessage, times := GetTimesAnEventHappened(fmt.Sprintf("%s - %s", event.Locator, event.Message))
 		if times > DuplicateEventThreshold {
 

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -182,7 +182,7 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			// This is ignored because it was during a master NodeUpdate interval
 			name: "matches 22 with namespace openshift FailedScheduling during NodeUpdate",
 			intervals: []monitorapi.Interval{
-				monitorapi.Interval{
+				{
 					Condition: monitorapi.Condition{
 						Level: monitorapi.Info,
 						StructuredLocator: monitorapi.Locator{

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -161,6 +161,7 @@ func (t *stateTracker) CloseAllIntervals(locatorToMessageAnnotations map[string]
 		l := t.locators[locator]
 		for stateName := range states {
 			annotations[monitorapi.AnnotationState] = stateName.stateName
+			annotations[monitorapi.AnnotationConstructed] = string(t.constructedBy)
 			mb := monitorapi.NewMessage().WithAnnotations(annotations).HumanMessage("never completed").Reason(stateName.reason)
 			ret = append(ret, t.CloseInterval(l, stateName, SimpleInterval(t.constructedBy, t.intervalSource, monitorapi.Warning, mb), end)...)
 		}

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -34,11 +34,12 @@ type intervalCreationFunc func(locator monitorapi.Locator,
 
 func SimpleInterval(constructedBy monitorapi.ConstructionOwner,
 	source monitorapi.IntervalSource, level monitorapi.IntervalLevel,
-	reason monitorapi.IntervalReason, message string) intervalCreationFunc {
+	reason monitorapi.IntervalReason, message string, messageAnnotations map[monitorapi.AnnotationKey]string) intervalCreationFunc {
 	return func(locator monitorapi.Locator, from, to time.Time) (*monitorapi.IntervalBuilder, bool) {
 		interval := monitorapi.NewInterval(source, level).Locator(locator).
 			Message(monitorapi.NewMessage().Reason(reason).
 				WithAnnotation(monitorapi.AnnotationConstructed, string(constructedBy)).
+				WithAnnotations(messageAnnotations).
 				HumanMessage(message))
 		return interval, true
 	}
@@ -162,7 +163,7 @@ func (t *stateTracker) CloseAllIntervals(locatorToMessageAnnotations map[string]
 		l := t.locators[locator]
 		for stateName := range states {
 			message := fmt.Sprintf("%v state/%v never completed", strings.Join(annotationStrings, " "), stateName.stateName)
-			ret = append(ret, t.CloseInterval(l, stateName, SimpleInterval(t.constructedBy, t.intervalSource, monitorapi.Warning, stateName.reason, message), end)...)
+			ret = append(ret, t.CloseInterval(l, stateName, SimpleInterval(t.constructedBy, t.intervalSource, monitorapi.Warning, stateName.reason, message, map[monitorapi.AnnotationKey]string{}), end)...)
 		}
 	}
 

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -2,7 +2,6 @@ package statetracker
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -34,13 +33,10 @@ type intervalCreationFunc func(locator monitorapi.Locator,
 
 func SimpleInterval(constructedBy monitorapi.ConstructionOwner,
 	source monitorapi.IntervalSource, level monitorapi.IntervalLevel,
-	reason monitorapi.IntervalReason, message string, messageAnnotations map[monitorapi.AnnotationKey]string) intervalCreationFunc {
+	messageBuilder *monitorapi.MessageBuilder) intervalCreationFunc {
 	return func(locator monitorapi.Locator, from, to time.Time) (*monitorapi.IntervalBuilder, bool) {
 		interval := monitorapi.NewInterval(source, level).Locator(locator).
-			Message(monitorapi.NewMessage().Reason(reason).
-				WithAnnotation(monitorapi.AnnotationConstructed, string(constructedBy)).
-				WithAnnotations(messageAnnotations).
-				HumanMessage(message))
+			Message(messageBuilder)
 		return interval, true
 	}
 }
@@ -156,14 +152,17 @@ func (t *stateTracker) CloseAllIntervals(locatorToMessageAnnotations map[string]
 	ret := []monitorapi.Interval{}
 	for locator, states := range t.locatorToStateMap {
 		annotationStrings := []string{}
+		annotations := map[monitorapi.AnnotationKey]string{}
 		for k, v := range locatorToMessageAnnotations[locator] {
 			annotationStrings = append(annotationStrings, fmt.Sprintf("%v/%v", k, v))
+			annotations[monitorapi.AnnotationKey(k)] = v
 		}
 
 		l := t.locators[locator]
 		for stateName := range states {
-			message := fmt.Sprintf("%v state/%v never completed", strings.Join(annotationStrings, " "), stateName.stateName)
-			ret = append(ret, t.CloseInterval(l, stateName, SimpleInterval(t.constructedBy, t.intervalSource, monitorapi.Warning, stateName.reason, message, map[monitorapi.AnnotationKey]string{}), end)...)
+			annotations[monitorapi.AnnotationState] = stateName.stateName
+			mb := monitorapi.NewMessage().WithAnnotations(annotations).HumanMessage("never completed").Reason(stateName.reason)
+			ret = append(ret, t.CloseInterval(l, stateName, SimpleInterval(t.constructedBy, t.intervalSource, monitorapi.Warning, mb), end)...)
 		}
 	}
 

--- a/pkg/monitortests/node/nodestateanalyzer/node.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node.go
@@ -65,8 +65,9 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 			}
 		case "Ready":
 			if event.Source == monitorapi.SourceNodeMonitor {
-				message := monitorapi.NewMessage().Reason(monitorapi.NodeNotReadyReason).HumanMessagef("role/%v node is not ready", roles).BuildString()
-				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, notReadyState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Warning, monitorapi.NodeNotReadyReason, message), event.From)...)
+				message := monitorapi.NewMessage().Reason(monitorapi.NodeNotReadyReason).HumanMessagef("role/%v is not ready", roles).BuildString()
+				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, notReadyState,
+					statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Warning, monitorapi.NodeNotReadyReason, message, map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles}), event.From)...)
 			}
 		case "MachineConfigChange":
 			if event.Source == monitorapi.SourceNodeMonitor {
@@ -75,25 +76,25 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 		case "MachineConfigReached":
 			if event.Source == monitorapi.SourceNodeMonitor {
 				message := strings.ReplaceAll(event.Message, "reason/MachineConfigReached ", "phase/Update ") + " roles/" + roles
-				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, updateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, message), event.From)...)
+				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, updateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, message, map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: "Update"}), event.From)...)
 			}
 		case "Cordon", "Drain":
 			// Not ported, so we don't have a Source to check
 			nodeStateTracker.OpenInterval(nodeLocator, drainState, event.From)
 		case "OSUpdateStarted":
 			// Not ported, so we don't have a Source to check
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseDrain}), event.From)...)
 			nodeStateTracker.OpenInterval(nodeLocator, osUpdateState, event.From)
 		case "Reboot":
 			// Not ported, so we don't have a Source to check
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseDrain}), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseOSUpdate}), event.From)...)
 			nodeStateTracker.OpenInterval(nodeLocator, rebootState, event.From)
 		case "Starting":
 			// Not ported, so we don't have a Source to check
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles)), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles)), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, rebootState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseReboot, roles)), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseDrain}), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseOSUpdate}), event.From)...)
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, rebootState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseReboot, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseReboot}), event.From)...)
 		}
 	}
 	intervals = append(intervals, nodeStateTracker.CloseAllIntervals(locatorToMessageAnnotations, end)...)

--- a/pkg/monitortests/node/nodestateanalyzer/node.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node.go
@@ -1,8 +1,6 @@
 package nodestateanalyzer
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestlibrary/statetracker"
@@ -11,9 +9,9 @@ import (
 )
 
 const (
-	msgPhaseDrain    = "phase/Drain roles/%s drained node"
-	msgPhaseOSUpdate = "phase/OperatingSystemUpdate roles/%s updated operating system"
-	msgPhaseReboot   = "phase/Reboot roles/%s rebooted and kubelet started"
+	msgPhaseDrain    = "drained node"
+	msgPhaseOSUpdate = "updated operating system"
+	msgPhaseReboot   = "rebooted and kubelet started"
 )
 
 func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.ResourcesMap, beginning, end time.Time) monitorapi.Intervals {
@@ -65,9 +63,17 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 			}
 		case "Ready":
 			if event.Source == monitorapi.SourceNodeMonitor {
-				message := monitorapi.NewMessage().Reason(monitorapi.NodeNotReadyReason).HumanMessagef("role/%v is not ready", roles).BuildString()
+				mb := monitorapi.NewMessage().Reason(monitorapi.NodeNotReadyReason).
+					HumanMessage("node is not ready").
+					WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
+					WithAnnotation(monitorapi.AnnotationRoles, roles)
 				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, notReadyState,
-					statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Warning, monitorapi.NodeNotReadyReason, message, map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles}), event.From)...)
+					statetracker.SimpleInterval(
+						monitorapi.ConstructionOwnerNodeLifecycle,
+						monitorapi.SourceNodeState,
+						monitorapi.Warning,
+						mb),
+					event.From)...)
 			}
 		case "MachineConfigChange":
 			if event.Source == monitorapi.SourceNodeMonitor {
@@ -75,26 +81,105 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 			}
 		case "MachineConfigReached":
 			if event.Source == monitorapi.SourceNodeMonitor {
-				message := strings.ReplaceAll(event.Message, "reason/MachineConfigReached ", "phase/Update ") + " roles/" + roles
-				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, updateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, message, map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: "Update"}), event.From)...)
+				mb := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
+					HumanMessage(event.StructuredMessage.HumanMessage). // re-use the human message from the MachineConfigReached event
+					WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
+					WithAnnotation(monitorapi.AnnotationRoles, roles).
+					WithAnnotation(monitorapi.AnnotationPhase, "Update")
+				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, updateState,
+					statetracker.SimpleInterval(
+						monitorapi.ConstructionOwnerNodeLifecycle,
+						monitorapi.SourceNodeState,
+						monitorapi.Info,
+						mb),
+					event.From)...)
 			}
 		case "Cordon", "Drain":
 			// Not ported, so we don't have a Source to check
 			nodeStateTracker.OpenInterval(nodeLocator, drainState, event.From)
 		case "OSUpdateStarted":
 			// Not ported, so we don't have a Source to check
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseDrain}), event.From)...)
+			mb := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
+				HumanMessage(msgPhaseDrain).
+				WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
+				WithAnnotation(monitorapi.AnnotationRoles, roles).
+				WithAnnotation(monitorapi.AnnotationPhase, "Drain")
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState,
+				statetracker.SimpleInterval(
+					monitorapi.ConstructionOwnerNodeLifecycle,
+					monitorapi.SourceNodeState,
+					monitorapi.Info,
+					mb),
+				event.From)...)
 			nodeStateTracker.OpenInterval(nodeLocator, osUpdateState, event.From)
 		case "Reboot":
 			// Not ported, so we don't have a Source to check
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseDrain}), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseOSUpdate}), event.From)...)
+			mb := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
+				HumanMessage(msgPhaseDrain).
+				WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
+				WithAnnotation(monitorapi.AnnotationRoles, roles).
+				WithAnnotation(monitorapi.AnnotationPhase, "Drain")
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState,
+				statetracker.SimpleInterval(
+					monitorapi.ConstructionOwnerNodeLifecycle,
+					monitorapi.SourceNodeState,
+					monitorapi.Info,
+					mb),
+				event.From)...)
+
+			osUpdateMB := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
+				HumanMessage(msgPhaseOSUpdate).
+				WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
+				WithAnnotation(monitorapi.AnnotationRoles, roles).
+				WithAnnotation(monitorapi.AnnotationPhase, "OperatingSystemUpdate")
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState,
+				statetracker.SimpleInterval(
+					monitorapi.ConstructionOwnerNodeLifecycle,
+					monitorapi.SourceNodeState,
+					monitorapi.Info,
+					osUpdateMB),
+				event.From)...)
 			nodeStateTracker.OpenInterval(nodeLocator, rebootState, event.From)
 		case "Starting":
 			// Not ported, so we don't have a Source to check
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseDrain, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseDrain}), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseOSUpdate, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseOSUpdate}), event.From)...)
-			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, rebootState, statetracker.SimpleInterval(monitorapi.ConstructionOwnerNodeLifecycle, monitorapi.SourceNodeState, monitorapi.Info, monitorapi.NodeUpdateReason, fmt.Sprintf(msgPhaseReboot, roles), map[monitorapi.AnnotationKey]string{monitorapi.AnnotationRoles: roles, monitorapi.AnnotationPhase: msgPhaseReboot}), event.From)...)
+			mb := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
+				HumanMessage(msgPhaseDrain).
+				WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
+				WithAnnotation(monitorapi.AnnotationRoles, roles).
+				WithAnnotation(monitorapi.AnnotationPhase, "Drain")
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState,
+				statetracker.SimpleInterval(
+					monitorapi.ConstructionOwnerNodeLifecycle,
+					monitorapi.SourceNodeState,
+					monitorapi.Info,
+					mb),
+				event.From)...)
+
+			osUpdateMB := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
+				HumanMessage(msgPhaseOSUpdate).
+				WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
+				WithAnnotation(monitorapi.AnnotationRoles, roles).
+				WithAnnotation(monitorapi.AnnotationPhase, "OperatingSystemUpdate")
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState,
+				statetracker.SimpleInterval(
+					monitorapi.ConstructionOwnerNodeLifecycle,
+					monitorapi.SourceNodeState,
+					monitorapi.Info,
+					osUpdateMB),
+				event.From)...)
+
+			rebootMB := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
+				HumanMessage(msgPhaseReboot).
+				WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
+				WithAnnotation(monitorapi.AnnotationRoles, roles).
+				WithAnnotation(monitorapi.AnnotationPhase, "Reboot")
+			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, rebootState,
+				statetracker.SimpleInterval(
+					monitorapi.ConstructionOwnerNodeLifecycle,
+					monitorapi.SourceNodeState,
+					monitorapi.Info,
+					rebootMB),
+				event.From)...)
 		}
 	}
 	intervals = append(intervals, nodeStateTracker.CloseAllIntervals(locatorToMessageAnnotations, end)...)

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
@@ -3,7 +3,7 @@
         {
             "level": "Info",
             "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
-            "message": "constructed/node-lifecycle-constructor reason/NodeUpdate phase/Drain roles/worker drained node",
+            "message": "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
             "tempSource": "NodeState",
             "tempStructuredLocator": {
                 "type": "Node",
@@ -14,10 +14,12 @@
             "tempStructuredMessage": {
                 "reason": "NodeUpdate",
                 "cause": "",
-                "humanMessage": "phase/Drain roles/worker drained node",
+                "humanMessage": "drained node",
                 "annotations": {
                     "constructed": "node-lifecycle-constructor",
-                    "reason": "NodeUpdate"
+                    "phase": "Drain",
+                    "reason": "NodeUpdate",
+                    "roles": "worker"
                 }
             },
             "from": "2023-07-17T22:58:52Z",
@@ -37,10 +39,12 @@
             "tempStructuredMessage": {
                 "reason": "NodeUpdate",
                 "cause": "",
-                "humanMessage": "role/worker state/OperatingSystemUpdate never completed",
+                "humanMessage": "never completed",
                 "annotations": {
                     "constructed": "node-lifecycle-constructor",
-                    "reason": "NodeUpdate"
+                    "reason": "NodeUpdate",
+                    "role": "worker",
+                    "state": "OperatingSystemUpdate"
                 }
             },
             "from": "2023-07-17T23:00:24Z",

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/expected.json
@@ -3,7 +3,7 @@
         {
             "level": "Info",
             "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
-            "message": "constructed/node-lifecycle-constructor reason/NodeUpdate phase/Drain roles/worker drained node",
+            "message": "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
             "tempSource": "NodeState",
             "tempStructuredLocator": {
                 "type": "Node",
@@ -14,10 +14,12 @@
             "tempStructuredMessage": {
                 "reason": "NodeUpdate",
                 "cause": "",
-                "humanMessage": "phase/Drain roles/worker drained node",
+                "humanMessage": "drained node",
                 "annotations": {
                     "constructed": "node-lifecycle-constructor",
-                    "reason": "NodeUpdate"
+                    "phase": "Drain",
+                    "reason": "NodeUpdate",
+                    "roles": "worker"
                 }
             },
             "from": "2023-07-18T16:40:16Z",
@@ -37,10 +39,12 @@
             "tempStructuredMessage": {
                 "reason": "NodeUpdate",
                 "cause": "",
-                "humanMessage": "role/worker state/OperatingSystemUpdate never completed",
+                "humanMessage": "never completed",
                 "annotations": {
                     "constructed": "node-lifecycle-constructor",
-                    "reason": "NodeUpdate"
+                    "reason": "NodeUpdate",
+                    "role": "worker",
+                    "state": "OperatingSystemUpdate"
                 }
             },
             "from": "2023-07-18T16:41:49Z",

--- a/pkg/monitortests/node/nodestateanalyzer/node_test.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node_test.go
@@ -21,13 +21,13 @@ func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 	if len(changes) != 3 {
 		t.Fatalf("unexpected changes: %s", string(out))
 	}
-	if changes[0].Message != "constructed/node-lifecycle-constructor reason/NodeUpdate phase/Drain roles/worker drained node" {
+	if changes[0].Message != "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node" {
 		t.Errorf("unexpected event: %s", string(out))
 	}
-	if changes[1].Message != "constructed/node-lifecycle-constructor reason/NodeUpdate phase/OperatingSystemUpdate roles/worker updated operating system" {
+	if changes[1].Message != "constructed/node-lifecycle-constructor phase/OperatingSystemUpdate reason/NodeUpdate roles/worker updated operating system" {
 		t.Errorf("unexpected event: %s", string(out))
 	}
-	if changes[2].Message != "constructed/node-lifecycle-constructor reason/NodeUpdate phase/Reboot roles/worker rebooted and kubelet started" {
+	if changes[2].Message != "constructed/node-lifecycle-constructor phase/Reboot reason/NodeUpdate roles/worker rebooted and kubelet started" {
 		t.Errorf("unexpected event: %s", string(out))
 	}
 }


### PR DESCRIPTION
These events are expected for certain pods during master updates, sometimes if the scheduler retries enough times they can trip our 20x limit and be considered a pathological event, failing tests when in reality this is a fairly normal condition.

I did some more work on the structured intervals so we could detect the NodeUpdate intervals in a structured manner.

[TRT-1335](https://issues.redhat.com//browse/TRT-1335)
