### PR TITLE
MON-3449: Ensure monitoring statefulsets are not recreated after upgr…

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/auditloganalyzer"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests"
+	"github.com/openshift/origin/pkg/monitortests/monitoring/statefulsetsrecreation"
 	"github.com/openshift/origin/pkg/monitortests/network/disruptioningress"
 	"github.com/openshift/origin/pkg/monitortests/network/disruptionpodnetwork"
 	"github.com/openshift/origin/pkg/monitortests/network/disruptionserviceloadbalancer"
@@ -109,6 +110,8 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 	monitorTestRegistry.AddMonitorTestOrDie("external-service-availability", "Test Framework", disruptionexternalservicemonitoring.NewAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("pathological-event-analyzer", "Test Framework", pathologicaleventanalyzer.NewAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("disruption-summary-serializer", "Test Framework", disruptionserializer.NewDisruptionSummarySerializer())
+
+	monitorTestRegistry.AddMonitorTestOrDie("monitoring-statefulsets-recreation", "Monitoring", statefulsetsrecreation.NewStatefulsetsChecker())
 
 	return monitorTestRegistry
 }

--- a/pkg/monitortests/monitoring/statefulsetsrecreation/monitortest.go
+++ b/pkg/monitortests/monitoring/statefulsetsrecreation/monitortest.go
@@ -1,0 +1,170 @@
+package statefulsetsrecreation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	openshiftMonitoringNs = "openshift-monitoring"
+	testName              = "[sig-instrumentation] Monitoring statefulsets are not recreated after upgrade"
+)
+
+var statefulsetsToCheck = []string{"prometheus-k8s", "alertmanager-main"}
+
+type statefulsetsChecker struct {
+	statefulsetsUID map[string]string
+	kubeClient      kubernetes.Interface
+}
+
+// NewStatefulsetsChecker makes sure that some statefulsets are not recreated
+// after the upgrade to avoid downtime.
+func NewStatefulsetsChecker() monitortestframework.MonitorTest {
+	return &statefulsetsChecker{
+		statefulsetsUID: make(map[string]string),
+	}
+}
+
+func (sc *statefulsetsChecker) StartCollection(
+	ctx context.Context,
+	adminRESTConfig *rest.Config,
+	recorder monitorapi.RecorderWriter,
+) error {
+	var err error
+
+	sc.kubeClient, err = kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+	sc.statefulsetsUID, err = sc.getStatefulsetsUID(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc *statefulsetsChecker) CollectData(
+	ctx context.Context,
+	storageDir string,
+	beginning, end time.Time,
+) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	return nil, nil, nil
+}
+
+func (sc *statefulsetsChecker) ConstructComputedIntervals(
+	ctx context.Context,
+	startingIntervals monitorapi.Intervals,
+	recordedResources monitorapi.ResourcesMap,
+	beginning, end time.Time,
+) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+func (sc *statefulsetsChecker) EvaluateTestsFromConstructedIntervals(
+	ctx context.Context,
+	finalIntervals monitorapi.Intervals,
+) ([]*junitapi.JUnitTestCase, error) {
+	if !platformidentification.DidUpgradeHappenDuringCollection(
+		finalIntervals,
+		time.Time{},
+		time.Time{},
+	) {
+		return nil, nil
+	}
+
+	currentStatefulsetsUID, err := sc.getStatefulsetsUID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get the monitoring statefulsets UID: %v", err)
+	}
+	if len(currentStatefulsetsUID) != len(sc.statefulsetsUID) {
+		return nil, fmt.Errorf(
+			"got %d monitoring statefulsets' UID before but %d now, the mismatch means the test is broken",
+			len(sc.statefulsetsUID),
+			len(currentStatefulsetsUID),
+		)
+	}
+	for sts, initialUID := range sc.statefulsetsUID {
+		if finalUID, ok := currentStatefulsetsUID[sts]; !ok || finalUID != initialUID {
+			return []*junitapi.JUnitTestCase{
+				{
+					Name: testName,
+					SystemOut: fmt.Sprintf(
+						"Some monitoring statefulsets UID changed or were not collected, initial UID: %+v, current UID: %+v",
+						sc.statefulsetsUID,
+						currentStatefulsetsUID,
+					),
+					FailureOutput: &junitapi.FailureOutput{
+						Output: "Monitoring statefulsets UID changed, this will result in downtime.",
+					},
+				},
+			}, nil
+		}
+	}
+	return []*junitapi.JUnitTestCase{{Name: testName}}, nil
+}
+
+func (sc *statefulsetsChecker) WriteContentToStorage(
+	ctx context.Context,
+	storageDir, timeSuffix string,
+	finalIntervals monitorapi.Intervals,
+	finalResourceState monitorapi.ResourcesMap,
+) error {
+	return nil
+}
+
+func (sc *statefulsetsChecker) Cleanup(ctx context.Context) error {
+	return nil
+}
+
+func (sc *statefulsetsChecker) getStatefulsetsUID(ctx context.Context) (map[string]string, error) {
+	statefulsetsUID := make(map[string]string)
+	var failures []error
+	for _, statefulsetName := range statefulsetsToCheck {
+		var lastErr error
+		err := wait.PollUntilContextTimeout(
+			ctx,
+			time.Second,
+			1*time.Minute,
+			true,
+			func(context.Context) (bool, error) {
+				statefulset, err := sc.kubeClient.AppsV1().
+					StatefulSets(openshiftMonitoringNs).
+					Get(ctx, statefulsetName, metav1.GetOptions{})
+				if err != nil {
+					lastErr = err
+					return false, nil
+				}
+				statefulsetsUID[statefulsetName] = string(statefulset.UID)
+				return true, nil
+			},
+		)
+		if err != nil {
+			if lastErr != nil {
+				err = fmt.Errorf("%w: lastError: %w", err, lastErr)
+			}
+			logrus.Infof(
+				"Error occured while getting statefulset %s/%s: %v",
+				openshiftMonitoringNs,
+				statefulsetName,
+				err,
+			)
+			failures = append(failures, err)
+		}
+	}
+	return statefulsetsUID, utilerrors.NewAggregate(failures)
+}


### PR DESCRIPTION
…ades.

To recreate a statefulset (to change an immutable field e.g.), prometheus-operator will use foreground deletion which leads to downtime (Prometheus startup process might take minutes, depending on the amount of WAL to replay).

It's also better to avoit statefulset recreation as this may not be handeled well in some cases, leading to stuck Pods and thus more downtime.

We try as much as possible to avoid the changes that require statefulsets recreation, as we can in most cases do without them, but detecting them is not an easy task given that the statefulets are created in runtime by prometheus-operator.

Because "avoid statefulsets recreation" is the norm, it's better to have a safeguard upgrade test for it. Of course if for a certain upgrade we cannot by any means avoid the recreation of a statefulset, we can temporarily exclude it or skip the test.