### PR TITLE
OCPBUGS-22703: tolerate AWS edge nodes on monitor tests

### DIFF
--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-target-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-target-deployment.yaml
@@ -44,6 +44,10 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on edge nodes
+        - key: "node-role.kubernetes.io/edge"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-to-host-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-to-host-network-poller-deployment.yaml
@@ -56,6 +56,10 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on edge nodes
+        - key: "node-role.kubernetes.io/edge"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-to-pod-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-to-pod-network-poller-deployment.yaml
@@ -54,6 +54,10 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on edge nodes
+        - key: "node-role.kubernetes.io/edge"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-to-service-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-to-service-poller-deployment.yaml
@@ -57,6 +57,10 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on edge nodes
+        - key: "node-role.kubernetes.io/edge"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-target-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-target-deployment.yaml
@@ -51,6 +51,10 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on edge nodes
+        - key: "node-role.kubernetes.io/edge"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-host-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-host-network-poller-deployment.yaml
@@ -55,6 +55,10 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on edge nodes
+        - key: "node-role.kubernetes.io/edge"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-pod-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-pod-network-poller-deployment.yaml
@@ -53,6 +53,10 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on edge nodes
+        - key: "node-role.kubernetes.io/edge"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-service-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-service-poller-deployment.yaml
@@ -56,6 +56,10 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on edge nodes
+        - key: "node-role.kubernetes.io/edge"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
fix/[OCPBUGS-22703](https://issues.redhat.com/browse/OCPBUGS-22703): tolerate AWS 'edge' nodes in monitor tests

Allowing monitor tests to be scheduled in edge nodes.

AWS Local Zones have been supported in OCP since 4.13, those nodes
are classified as 'edge' nodes setting by default NoScheduled taints
in the MachineSet.

Those taints are required to prevent scheduled cluster workloads into
those nodes that run outside of the regular AWS region.

For more information, please check the EP:
https://github.com/openshift/enhancements/blob/master/enhancements/installer/aws-custom-edge-machineset-local-zones.md#user-workload-deployments

This limitation in the monitor tests impacts the delivered feature
in 4.14 (full Local Zones automation), and in the feature planned for
4.15: Wavelength Zones.

## Details

Local Zone jobs[1] are perm failing, looking the failures I can a group of monitor tests failing monitor tests `[sig-network] can collect <typeOfConnection> poller pod logs`:

```
E1018 22:06:34.773866       1 disruption_backend_sampler.go:496] not finished writing all samples (1 remaining), but we're told to close
E1018 22:06:34.774669       1 disruption_backend_sampler.go:496] not finished writing all samples (1 remaining), but we're told to close
```

Do you think tolerating edge compute nodes can prevent this, as we are currently tolerating only `master`?

[1] local zones jobs failing
- e2e-aws-ovn-localzones: https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-installer-master-e2e-aws-ovn-localzones?buildId=1716457254460329984
- e2e-aws-ovn-shared-vpc-localzones: https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-installer-master-e2e-aws-ovn-shared-vpc-localzones