### PR TITLE
OCPBUGS-20479: Add pod sandbox failures to e2e charts

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -229,6 +229,10 @@
                 return [item.locator, ` (pathological new)`, "PathologicalNew"];
             }
         }
+        // TODO: hack that can likely be removed when we get to structured intervals for these
+        if (item.message.includes("interesting/true") && item.message.includes("pod sandbox")) {
+            return [item.locator, ` (pod sandbox)`, "PodSandbox"];
+        }
         if (item.message.includes("interesting/true")) {
 		    return [item.locator, ` (interesting event)`, "InterestingEvent"];
         }
@@ -522,7 +526,7 @@
         const myChart = TimelinesChart();
         var ordinalScale = d3.scaleOrdinal()
             .domain([
-                'InterestingEvent', 'PathologicalKnown', "PathologicalNew", // interesting and pathological events
+                'InterestingEvent', 'PathologicalKnown', "PathologicalNew", "PodSandbox", // interesting and pathological events
                 'AlertInfo', 'AlertPending', 'AlertWarning', 'AlertCritical', // alerts
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
                 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', // nodes
@@ -532,7 +536,7 @@
                 'Degraded', 'Upgradeable', 'False', 'Unknown',
                 'PodLogInfo', 'PodLogWarning', 'PodLogError'])
             .range([
-                '#6E6E6E', '#0000ff', '#d0312d', // pathological and interesting events
+                '#6E6E6E', '#0000ff', '#d0312d', '#ffa500', // pathological and interesting events
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators
                 '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -144,7 +144,7 @@ func IntervalsToFile(filename string, intervals monitorapi.Intervals) error {
 func EventsIntervalsToJSON(events monitorapi.Intervals) ([]byte, error) {
 	outputEvents := []EventInterval{}
 	for _, curr := range events {
-		if !curr.Display || (curr.From == curr.To && !curr.To.IsZero()) {
+		if curr.From == curr.To && !curr.To.IsZero() {
 			continue
 		}
 

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -144,9 +144,10 @@ func IntervalsToFile(filename string, intervals monitorapi.Intervals) error {
 func EventsIntervalsToJSON(events monitorapi.Intervals) ([]byte, error) {
 	outputEvents := []EventInterval{}
 	for _, curr := range events {
-		if curr.From == curr.To && !curr.To.IsZero() {
+		if !curr.Display && curr.From == curr.To && !curr.To.IsZero() {
 			continue
 		}
+
 		outputEvents = append(outputEvents, monitorEventIntervalToEventInterval(curr))
 	}
 

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -144,7 +144,7 @@ func IntervalsToFile(filename string, intervals monitorapi.Intervals) error {
 func EventsIntervalsToJSON(events monitorapi.Intervals) ([]byte, error) {
 	outputEvents := []EventInterval{}
 	for _, curr := range events {
-		if !curr.Display && curr.From == curr.To && !curr.To.IsZero() {
+		if !curr.Display || (curr.From == curr.To && !curr.To.IsZero()) {
 			continue
 		}
 

--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -103,6 +103,10 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 
 	for _, event := range events {
 
+		if !strings.Contains(event.Message, "reason/FailedCreatePodSandBox Failed to create pod sandbox") {
+			continue
+		}
+
 		// Skip pod sandbox failures when nodes are updating
 		var foundOverlap bool
 		for _, nui := range nodeNotReadyIntervals {
@@ -116,9 +120,6 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 			continue
 		}
 
-		if !strings.Contains(event.Message, "reason/FailedCreatePodSandBox Failed to create pod sandbox") {
-			continue
-		}
 		if strings.Contains(event.Locator, "pod/simpletest-rc-to-be-deleted") &&
 			(strings.Contains(event.Message, "not found") ||
 				strings.Contains(event.Message, "pod was already deleted") ||

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52471,6 +52471,10 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
                 return [item.locator, ` + "`" + ` (pathological new)` + "`" + `, "PathologicalNew"];
             }
         }
+        // TODO: hack that can likely be removed when we get to structured intervals for these
+        if (item.message.includes("interesting/true") && item.message.includes("pod sandbox")) {
+            return [item.locator, ` + "`" + ` (pod sandbox)` + "`" + `, "PodSandbox"];
+        }
         if (item.message.includes("interesting/true")) {
 		    return [item.locator, ` + "`" + ` (interesting event)` + "`" + `, "InterestingEvent"];
         }
@@ -52764,7 +52768,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         const myChart = TimelinesChart();
         var ordinalScale = d3.scaleOrdinal()
             .domain([
-                'InterestingEvent', 'PathologicalKnown', "PathologicalNew", // interesting and pathological events
+                'InterestingEvent', 'PathologicalKnown', "PathologicalNew", "PodSandbox", // interesting and pathological events
                 'AlertInfo', 'AlertPending', 'AlertWarning', 'AlertCritical', // alerts
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
                 'Update', 'Drain', 'Reboot', 'OperatingSystemUpdate', 'NodeNotReady', // nodes
@@ -52774,7 +52778,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
                 'Degraded', 'Upgradeable', 'False', 'Unknown',
                 'PodLogInfo', 'PodLogWarning', 'PodLogError'])
             .range([
-                '#6E6E6E', '#0000ff', '#d0312d', // pathological and interesting events
+                '#6E6E6E', '#0000ff', '#d0312d', '#ffa500', // pathological and interesting events
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators
                 '#1e7bd9', '#4294e6', '#6aaef2', '#96cbff', '#fada5e', // nodes


### PR DESCRIPTION
A little hacky until we revisit this for structured intervals, but
should be possible to clean up soon.

OCPBUGS-20479
