### PR TITLE
TRT-1340: Increase cmd support for ExactMonitorTests and DisableMonitorTests

### DIFF
--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -82,11 +82,7 @@ func newRunCommand(name string, streams genericclioptions.IOStreams) *cobra.Comm
 }
 
 func (f *RunMonitorFlags) BindFlags(flags *pflag.FlagSet) {
-	allMonitors, _ := f.getMonitorTestRegistry()
-	monitorNames := []string{}
-	if allMonitors != nil {
-		monitorNames = allMonitors.ListMonitorTests().List()
-	}
+	monitorNames := defaultmonitortests.ListAllMonitorTests()
 
 	flags.StringVar(&f.ArtifactDir, "artifact-dir", f.ArtifactDir, "The directory where monitor events will be stored.")
 	flags.BoolVar(&f.DisplayFromNow, "display-from-now", f.DisplayFromNow, "Only display intervals from at or after this comand was started.")
@@ -125,21 +121,10 @@ func (f *RunMonitorFlags) ToOptions() (*RunMonitorOptions, error) {
 func (f *RunMonitorFlags) getMonitorTestRegistry() (monitortestframework.MonitorTestRegistry, error) {
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest: monitortestframework.Stable,
+		ExactMonitorTests:          f.ExactMonitorTests,
+		DisableMonitorTests:        f.DisableMonitorTests,
 	}
-	startingRegistry := defaultmonitortests.NewMonitorTestsFor(monitorTestInfo)
-
-	switch {
-	case len(f.ExactMonitorTests) > 0:
-		return startingRegistry.GetRegistryFor(f.ExactMonitorTests...)
-
-	case len(f.DisableMonitorTests) > 0:
-		testsToInclude := startingRegistry.ListMonitorTests()
-		testsToInclude.Delete(f.DisableMonitorTests...)
-		return startingRegistry.GetRegistryFor(testsToInclude.List()...)
-
-	default:
-		return startingRegistry, nil
-	}
+	return defaultmonitortests.NewMonitorTestsFor(monitorTestInfo)
 }
 
 type RunMonitorOptions struct {

--- a/pkg/cmd/openshift-tests/run-test/command.go
+++ b/pkg/cmd/openshift-tests/run-test/command.go
@@ -1,7 +1,10 @@
 package run_test
 
 import (
+	"fmt"
+	"github.com/openshift/origin/pkg/defaultmonitortests"
 	"os"
+	"strings"
 
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/clioptions/imagesetup"
@@ -17,6 +20,7 @@ import (
 
 func NewRunTestCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	testOpt := testginkgo.NewTestOptions(streams)
+	monitorNames := defaultmonitortests.ListAllMonitorTests()
 
 	cmd := &cobra.Command{
 		Use:   "run-test NAME",
@@ -71,5 +75,8 @@ func NewRunTestCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&testOpt.DryRun, "dry-run", testOpt.DryRun, "Print the test to run without executing them.")
+	cmd.Flags().StringSliceVar(&testOpt.ExactMonitorTests, "monitor", testOpt.ExactMonitorTests,
+		fmt.Sprintf("list of exactly which monitors to enable. All others will be disabled.  Current monitors are: [%s]", strings.Join(monitorNames, ", ")))
+	cmd.Flags().StringSliceVar(&testOpt.DisableMonitorTests, "disable-monitor", testOpt.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored.")
 	return cmd
 }

--- a/pkg/cmd/openshift-tests/run-upgrade/flags.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/flags.go
@@ -2,7 +2,6 @@ package run_upgrade
 
 import (
 	"fmt"
-
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/clioptions/iooptions"
 	"github.com/openshift/origin/pkg/clioptions/kubeconfig"

--- a/pkg/cmd/openshift-tests/run-upgrade/options.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/options.go
@@ -29,20 +29,23 @@ type RunUpgradeSuiteOptions struct {
 	ToImage        string
 	FromRepository string
 	// I don't see where this is initialized in this flow
-	//CloudProviderJSON string
+	// CloudProviderJSON string
 
 	TestOptions []string
 
 	CloseFn iooptions.CloseFunc
 
 	genericclioptions.IOStreams
+
+	ExactMonitorTests   []string
+	DisableMonitorTests []string
 }
 
 func (o *RunUpgradeSuiteOptions) TestCommandEnvironment() []string {
 	var args []string
 	args = append(args, "KUBE_TEST_REPO_LIST=") // explicitly prevent selective override
 	args = append(args, fmt.Sprintf("KUBE_TEST_REPO=%s", o.FromRepository))
-	//args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.CloudProviderJSON))  I don't think we actually have this.
+	// args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.CloudProviderJSON))  I don't think we actually have this.
 	args = append(args, fmt.Sprintf("TEST_JUNIT_DIR=%s", o.GinkgoRunSuiteOptions.JUnitDir))
 	for i := 10; i > 0; i-- {
 		if klog.V(klog.Level(i)).Enabled() {
@@ -98,7 +101,7 @@ func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {
 	}
 	// we now re-trigger the upstream image determination since one of the env vars is set with our repo value.
 	// this will re-write the images to be used.
-	// TODO fix the the upstream so that the AfterReadingAllFlags will properly check for either of the inputs having values.
+	// TODO fix the upstream so that the AfterReadingAllFlags will properly check for either of the inputs having values.
 	k8simage.Init("")
 
 	if err := o.UpgradeTestPreSuite(); err != nil {
@@ -109,6 +112,8 @@ func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest:        monitortestframework.Stable,
 		UpgradeTargetPayloadImagePullSpec: o.ToImage,
+		ExactMonitorTests:                 o.ExactMonitorTests,
+		DisableMonitorTests:               o.DisableMonitorTests,
 	}
 
 	o.GinkgoRunSuiteOptions.CommandEnv = o.TestCommandEnvironment()

--- a/pkg/cmd/openshift-tests/run/flags.go
+++ b/pkg/cmd/openshift-tests/run/flags.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"fmt"
-
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/clioptions/iooptions"
 	"github.com/openshift/origin/pkg/clioptions/kubeconfig"

--- a/pkg/cmd/openshift-tests/run/options.go
+++ b/pkg/cmd/openshift-tests/run/options.go
@@ -82,6 +82,8 @@ func (o *RunSuiteOptions) Run(ctx context.Context) error {
 
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest: monitortestframework.ClusterStabilityDuringTest(stabilitySetting),
+		ExactMonitorTests:          o.GinkgoRunSuiteOptions.ExactMonitorTests,
+		DisableMonitorTests:        o.GinkgoRunSuiteOptions.DisableMonitorTests,
 	}
 
 	o.GinkgoRunSuiteOptions.CommandEnv = o.TestCommandEnvironment()

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -423,6 +423,8 @@ type Intervals []Interval
 var _ sort.Interface = Intervals{}
 
 func (intervals Intervals) Less(i, j int) bool {
+	// currently synced with https://github.com/openshift/origin/blob/9b001745ec8006eb406bd92e3555d1070b9b656e/pkg/monitor/serialization/serialize.go#L175
+
 	switch d := intervals[i].From.Sub(intervals[j].From); {
 	case d < 0:
 		return true
@@ -435,7 +437,11 @@ func (intervals Intervals) Less(i, j int) bool {
 	case d > 0:
 		return false
 	}
-	return intervals[i].Message < intervals[j].Message
+	if intervals[i].Message != intervals[j].Message {
+		return intervals[i].Message < intervals[j].Message
+	}
+
+	return intervals[i].Locator < intervals[j].Locator
 }
 func (intervals Intervals) Len() int { return len(intervals) }
 func (intervals Intervals) Swap(i, j int) {

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -173,6 +173,8 @@ func monitorEventIntervalToEventInterval(interval monitorapi.Interval) EventInte
 type byTime []EventInterval
 
 func (intervals byTime) Less(i, j int) bool {
+	// currently synced with https://github.com/openshift/origin/blob/9b001745ec8006eb406bd92e3555d1070b9b656e/pkg/monitor/monitorapi/types.go#L425
+
 	switch d := intervals[i].From.Sub(intervals[j].From.Time); {
 	case d < 0:
 		return true
@@ -186,7 +188,11 @@ func (intervals byTime) Less(i, j int) bool {
 	case d > 0:
 		return false
 	}
-	return intervals[i].Message < intervals[j].Message
+	if intervals[i].Message != intervals[j].Message {
+		return intervals[i].Message < intervals[j].Message
+	}
+
+	return intervals[i].Locator < intervals[j].Locator
 }
 
 func (intervals byTime) Len() int { return len(intervals) }

--- a/pkg/monitortestframework/types.go
+++ b/pkg/monitortestframework/types.go
@@ -19,7 +19,7 @@ var (
 	Stable ClusterStabilityDuringTest = "Stable"
 	// TODO only bring this back if we have some reason to collect Upgrade specific information.  I can't think of reason.
 	// TODO please contact @deads2k for vetting if you think you found something
-	//Upgrade    ClusterStabilityDuringTest = "Upgrade"
+	// Upgrade    ClusterStabilityDuringTest = "Upgrade"
 	// Disruptive means that the suite is expected to induce outages to the cluster.
 	Disruptive ClusterStabilityDuringTest = "Disruptive"
 )
@@ -28,6 +28,12 @@ type MonitorTestInitializationInfo struct {
 	ClusterStabilityDuringTest ClusterStabilityDuringTest
 	// UpgradeTargetImage is only set for upgrades.  It is set to the *final* destination version.
 	UpgradeTargetPayloadImagePullSpec string
+
+	// ExactMonitorTests will filter the available monitor tests down to only those contained in the provided list
+	ExactMonitorTests []string
+
+	// DisableMonitorTests will remove any monitor tests contained in the provided list
+	DisableMonitorTests []string
 }
 
 type MonitorTest interface {

--- a/pkg/test/ginkgo/cmd_runtest.go
+++ b/pkg/test/ginkgo/cmd_runtest.go
@@ -3,6 +3,7 @@ package ginkgo
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"os"
 	"regexp"
 	"strings"
@@ -36,6 +37,9 @@ type TestOptions struct {
 
 	DryRun bool
 	genericclioptions.IOStreams
+
+	ExactMonitorTests   []string
+	DisableMonitorTests []string
 }
 
 var _ ginkgo.GinkgoTestingT = &TestOptions{}
@@ -83,16 +87,23 @@ func (o *TestOptions) Run(args []string) error {
 	}
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest: monitortestframework.Stable,
+		ExactMonitorTests:          o.ExactMonitorTests,
+		DisableMonitorTests:        o.DisableMonitorTests,
 	}
 	var m monitor.Interface
 	if o.EnableMonitor {
 		// individual tests are always stable, it's the jobs that aren't.
+		monitorTests, err := defaultmonitortests.NewMonitorTestsFor(monitorTestInfo)
+		if err != nil {
+			logrus.Errorf("Error getting monitor tests: %v", err)
+		}
+
 		monitorEventRecorder := monitor.NewRecorder()
 		m = monitor.NewMonitor(
 			monitorEventRecorder,
 			restConfig,
 			"",
-			defaultmonitortests.NewMonitorTestsFor(monitorTestInfo),
+			monitorTests,
 		)
 		if err := m.Start(ctx); err != nil {
 			return err


### PR DESCRIPTION
Moves ExactMonitorTests and DisableMonitorTests filtering to defaultmonitortests

Adds ExactMonitorTests and DisableMonitorTests to openshift-tests run-test and run-upgrade