### PR TITLE
"TRT-1342: Trim the intervals for loki serializer to avoid errors during ingest"

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -676,14 +676,29 @@ func (intervals Intervals) Slice(from, to time.Time) Intervals {
 		return intervals
 	}
 
-	// assume that the from is always before the to in an interval,
-	// Then we want to start when the interval.TO is after the argument.From
-	first := sort.Search(len(intervals), func(i int) bool {
-		return !intervals[i].To.Before(from) // equal to or after
-	})
-	if first == -1 {
-		return nil
+	// forget being fancy, just iterate from the beginning.
+	first := -1
+	if from.IsZero() {
+		first = 0
+	} else {
+		for i := range intervals {
+			curr := intervals[i]
+			if curr.To.IsZero() {
+				if curr.From.After(from) || curr.From == from {
+					first = i
+					break
+				}
+			}
+			if curr.To.After(from) || curr.To == from {
+				first = i
+				break
+			}
+		}
 	}
+	if first == -1 || len(intervals) == 0 {
+		return Intervals{}
+	}
+
 	if to.IsZero() {
 		return intervals[first:]
 	}


### PR DESCRIPTION
[TRT-1342](https://issues.redhat.com//browse/TRT-1342)

With this PR, ...

* I [revert my earlier PR](https://github.com/openshift/origin/pull/28372/commits/a62bcf00c40db061535eb859ad218756544def2e) so the second spyglass chart (for upgrade jobs) goes back to getting some intervals that started during the upgrade phase (i.e., we go back to the previous `Slice()` algorithm).
* For loki serialization/ingestion, only intervals that happened after the upgrade will be pushed (this will avoid the "entry too far behind" problem that happens when we push intervals that are too old).