### PR TITLE
TRT-1354: Add support for intervals to have row differentiators

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -480,11 +480,9 @@
 
         timelineGroups.push({group: "node-state", data: []})
         createTimelineData(nodeStateValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isNodeState, regex)
+        // Sort the node-state intervals so rows are grouped by node
         timelineGroups[timelineGroups.length - 1].data.sort(function (e1 ,e2){
-            if (e1.label.includes("master") && e2.label.includes("worker")) {
-                return -1
-            }
-            return 0
+            return e1.label < e2.label ? -1 : e1.label > e2.label;
         })
 
         timelineGroups.push({group: "endpoint-availability", data: []})

--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -298,19 +298,20 @@
     const rePhase = new RegExp("(^| )phase/([^ ]+)")
     function nodeStateValue(item) {
         let roles = ""
-        if (item.tempStructuredMessage.hasOwnProperty('roles')) {
-            roles = item.tempStructuredMessage.roles
+        if (item.tempStructuredMessage.annotations.hasOwnProperty('roles')) {
+            roles = item.tempStructuredMessage.annotations.roles
         }
 
         if (item.tempStructuredMessage.reason === 'NotReady') {
             return [item.locator, ` (${roles},not ready)`, "NodeNotReady"]
         }
         // TODO: would like to get this to a structured field as well
-        let m = item.message.match(rePhase);
-        if (m && m[2] != "Update") {
-            return [item.locator, ` (${roles},update phases)`, m[2]];
+        let m = item.tempStructuredMessage.annotations.phase;
+        let ss = item.tempSubSource
+        if (m != "Update") {
+            return [item.locator, ` (${roles},${ss})`, m];
         }
-        return [item.locator, ` (${roles},updates)`, "Update"];
+        return [item.locator, ` (${roles},${ss})`, m];
     }
 
     function alertSeverity(item) {

--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -302,15 +302,11 @@
             roles = item.tempStructuredMessage.annotations.roles
         }
 
-        if (item.tempStructuredMessage.reason === 'NotReady') {
-            return [item.locator, ` (${roles},not ready)`, "NodeNotReady"]
-        }
-        // TODO: would like to get this to a structured field as well
-        let m = item.tempStructuredMessage.annotations.phase;
         let ss = item.tempSubSource
-        if (m != "Update") {
-            return [item.locator, ` (${roles},${ss})`, m];
+        if (item.tempStructuredMessage.reason === 'NotReady') {
+            return [item.locator, ` (${roles},${ss})`, "NodeNotReady"]
         }
+        let m = item.tempStructuredMessage.annotations.phase;
         return [item.locator, ` (${roles},${ss})`, m];
     }
 

--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -372,7 +372,15 @@
     }
 
     function defaultToolTip(item) {
-        return item.message + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
+        let tt = item.message
+        if ('tempSource' in item) {
+            tt = tt + " source/" + item.tempSource
+        }
+        if ('display' in item) {
+            tt = tt + " display/" + item.display
+        }
+        tt = tt + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
+        return tt
     }
 
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc, regex) {

--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -302,12 +302,11 @@
             roles = item.tempStructuredMessage.annotations.roles
         }
 
-        let ss = item.tempSubSource
         if (item.tempStructuredMessage.reason === 'NotReady') {
-            return [item.locator, ` (${roles},${ss})`, "NodeNotReady"]
+            return [item.locator, ` (${roles})`, "NodeNotReady"]
         }
         let m = item.tempStructuredMessage.annotations.phase;
-        return [item.locator, ` (${roles},${ss})`, m];
+        return [item.locator, ` (${roles})`, m];
     }
 
     function alertSeverity(item) {

--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -528,7 +528,7 @@
     const rePhase = new RegExp("(^| )phase/([^ ]+)")
     function nodeStateValue(item) {
         let roles = ""
-        if (item.tempStructuredMessage.hasOwnProperty('roles')) {
+        if (item.tempStructuredMessage.annotations.hasOwnProperty('roles')) {
             roles = item.tempStructuredMessage.roles
         }
 

--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -533,14 +533,10 @@
         }
 
         if (item.tempStructuredMessage.reason === 'NotReady') {
-            return [item.locator, ` (${roles},not ready)`, "NodeNotReady"]
+            return [item.locator, ` (${roles})`, "NodeNotReady"]
         }
-        // TODO: would like to get this to a structured field as well
-        let m = item.message.match(rePhase);
-        if (m && m[2] != "Update") {
-            return [item.locator, ` (${roles},update phases)`, m[2]];
-        }
-        return [item.locator, ` (${roles},updates)`, "Update"];
+        let m = item.tempStructuredMessage.annotations.phase;
+        return [item.locator, ` (${roles})`, m];
     }
 
 
@@ -591,7 +587,15 @@
     }
 
     function defaultToolTip(item) {
-        return item.message + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
+        let tt = item.message
+        if ('tempSource' in item) {
+            tt = tt + " source/" + item.tempSource
+        }
+        if ('display' in item) {
+            tt = tt + " display/" + item.display
+        }
+        tt = tt + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
+        return tt
     }
 
     function createTimelineData(timelineVal, timelineData, filteredEventIntervals, category) {

--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -794,12 +794,10 @@
 
         timelineGroups.push({group: "node-state", data: []});
         createTimelineData(nodeStateValue, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "node_state");
+        // Sort the node-state intervals so rows are grouped by node
         timelineGroups[timelineGroups.length - 1].data.sort(function (e1 ,e2){
-            if (e1.label.includes("master") && e2.label.includes("worker")) {
-                return -1
-            }
-            return 0
-        });
+            return e1.label < e2.label ? -1 : e1.label > e2.label;
+        })
 
         timelineGroups.push({group: "endpoint-availability", data: []});
         createTimelineData(disruptionValue, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "endpoint_availability");

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -14,7 +14,6 @@ import (
 type IntervalBuilder struct {
 	level             IntervalLevel
 	source            IntervalSource
-	subSource         IntervalSubSource
 	display           bool
 	structuredLocator Locator
 	structuredMessage Message
@@ -32,14 +31,6 @@ func NewInterval(source IntervalSource, level IntervalLevel) *IntervalBuilder {
 // Display is a coarse grained hint that any UI should display this interval to a user.
 func (b *IntervalBuilder) Display() *IntervalBuilder {
 	b.display = true
-	return b
-}
-
-// SubSource is an optional way to classify the interval. It is used in charting to isolate separate rows within
-// a group that would otherwise have the same locator. (i.e. node upgrade, node upgrade phases, and node not ready, all
-// show on separate rows despite being in the same group)
-func (b *IntervalBuilder) SubSource(subSource IntervalSubSource) *IntervalBuilder {
-	b.subSource = subSource
 	return b
 }
 
@@ -67,7 +58,6 @@ func (b *IntervalBuilder) Build(from, to time.Time) Interval {
 		Condition: b.BuildCondition(),
 		Display:   b.display,
 		Source:    b.source,
-		SubSource: b.subSource,
 		From:      from,
 		To:        to,
 	}
@@ -117,6 +107,14 @@ func (b *LocatorBuilder) NodeFromName(nodeName string) Locator {
 	return b.
 		withTargetType(LocatorTypeNode).
 		withNode(nodeName).
+		Build()
+}
+
+func (b *LocatorBuilder) NodeFromNameWithRow(nodeName, row string) Locator {
+	return b.
+		withTargetType(LocatorTypeNode).
+		withNode(nodeName).
+		withRow(row).
 		Build()
 }
 
@@ -210,6 +208,11 @@ func (b *LocatorBuilder) withNamespace(namespace string) *LocatorBuilder {
 
 func (b *LocatorBuilder) withNode(nodeName string) *LocatorBuilder {
 	b.annotations[LocatorNodeKey] = nodeName
+	return b
+}
+
+func (b *LocatorBuilder) withRow(row string) *LocatorBuilder {
+	b.annotations[LocatorRowKey] = row
 	return b
 }
 

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -14,11 +14,14 @@ import (
 type IntervalBuilder struct {
 	level             IntervalLevel
 	source            IntervalSource
+	subSource         IntervalSubSource
 	display           bool
 	structuredLocator Locator
 	structuredMessage Message
 }
 
+// NewInterval creates a new interval builder. Source is an indicator of what created this interval, used for
+// safely identifying intervals we're looking for, and for grouping in charts.
 func NewInterval(source IntervalSource, level IntervalLevel) *IntervalBuilder {
 	return &IntervalBuilder{
 		level:  level,
@@ -29,6 +32,14 @@ func NewInterval(source IntervalSource, level IntervalLevel) *IntervalBuilder {
 // Display is a coarse grained hint that any UI should display this interval to a user.
 func (b *IntervalBuilder) Display() *IntervalBuilder {
 	b.display = true
+	return b
+}
+
+// SubSource is an optional way to classify the interval. It is used in charting to isolate separate rows within
+// a group that would otherwise have the same locator. (i.e. node upgrade, node upgrade phases, and node not ready, all
+// show on separate rows despite being in the same group)
+func (b *IntervalBuilder) SubSource(subSource IntervalSubSource) *IntervalBuilder {
+	b.subSource = subSource
 	return b
 }
 
@@ -56,6 +67,7 @@ func (b *IntervalBuilder) Build(from, to time.Time) Interval {
 		Condition: b.BuildCondition(),
 		Display:   b.display,
 		Source:    b.source,
+		SubSource: b.subSource,
 		From:      from,
 		To:        to,
 	}

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -273,10 +273,21 @@ const (
 	SourcePodState                               = "PodState"
 )
 
+// IntervalSubSource is an optional further categorization of the interval, used to differentiate intervals we intend to
+// chart within the same source, but which we'd want displayed on separate rows.
+type IntervalSubSource string
+
+const (
+	SubSourceNodeUpdate       IntervalSubSource = "NodeUpdate"
+	SubSourceNodeUpdatePhases IntervalSubSource = "NodeUpdatePhases"
+	SubSourceNodeNotReady     IntervalSubSource = "NodeNotReady"
+)
+
 type Interval struct {
 	// Deprecated: We hope to fold this into Interval itself.
 	Condition
-	Source IntervalSource
+	Source    IntervalSource
+	SubSource IntervalSubSource
 
 	// Display is a very coarse hint to any UI that this event was considered important enough to *possibly* be displayed by the source that produced it.
 	// UI may apply further filtering.

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -137,6 +137,7 @@ const (
 	LocatorConnectionKey            LocatorKey = "connection"
 	LocatorProtocolKey              LocatorKey = "protocol"
 	LocatorTargetKey                LocatorKey = "target"
+	LocatorRowKey                   LocatorKey = "row"
 	LocatorShutdownKey              LocatorKey = "shutdown"
 	LocatorServerKey                LocatorKey = "server"
 )
@@ -273,21 +274,10 @@ const (
 	SourcePodState                               = "PodState"
 )
 
-// IntervalSubSource is an optional further categorization of the interval, used to differentiate intervals we intend to
-// chart within the same source, but which we'd want displayed on separate rows.
-type IntervalSubSource string
-
-const (
-	SubSourceNodeUpdate       IntervalSubSource = "NodeUpdate"
-	SubSourceNodeUpdatePhases IntervalSubSource = "NodeUpdatePhases"
-	SubSourceNodeNotReady     IntervalSubSource = "NodeNotReady"
-)
-
 type Interval struct {
 	// Deprecated: We hope to fold this into Interval itself.
 	Condition
-	Source    IntervalSource
-	SubSource IntervalSubSource
+	Source IntervalSource
 
 	// Display is a very coarse hint to any UI that this event was considered important enough to *possibly* be displayed by the source that produced it.
 	// UI may apply further filtering.
@@ -372,7 +362,7 @@ func sortKeys(keys []string) []string {
 
 	// Ensure these keys appear in this order. Other keys can be mixed in and will appear at the end in alphabetical
 	// order.
-	orderedKeys := []string{"namespace", "node", "pod", "uid", "server", "container", "shutdown"}
+	orderedKeys := []string{"namespace", "node", "pod", "uid", "server", "container", "shutdown", "row"}
 
 	// Create a map to store the indices of keys in the orderedKeys array.
 	// This will allow us to efficiently check if a key is in orderedKeys and find its position.

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -21,7 +21,8 @@ type EventInterval struct {
 
 	// TODO: Remove the omitempty, just here to keep from having to repeatedly updated the json
 	// files used in some new tests
-	Source string `json:"tempSource,omitempty"` // also temporary, unsure if this concept will survive
+	Source    string `json:"tempSource,omitempty"`    // also temporary, unsure if this concept will survive
+	SubSource string `json:"tempSubSource,omitempty"` // also temporary, unsure if this concept will survive
 
 	// TODO: we're hoping to move these to just locator/message when everything is ready.
 	StructuredLocator monitorapi.Locator `json:"tempStructuredLocator"`
@@ -64,7 +65,8 @@ func IntervalsFromJSON(data []byte) (monitorapi.Intervals, error) {
 			return nil, err
 		}
 		events = append(events, monitorapi.Interval{
-			Source: monitorapi.IntervalSource(interval.Source),
+			Source:    monitorapi.IntervalSource(interval.Source),
+			SubSource: monitorapi.IntervalSubSource(interval.SubSource),
 			Condition: monitorapi.Condition{
 				Level:             level,
 				Locator:           interval.Locator,
@@ -91,7 +93,8 @@ func IntervalFromJSON(data []byte) (*monitorapi.Interval, error) {
 		return nil, err
 	}
 	return &monitorapi.Interval{
-		Source: monitorapi.IntervalSource(serializedInterval.Source),
+		Source:    monitorapi.IntervalSource(serializedInterval.Source),
+		SubSource: monitorapi.IntervalSubSource(serializedInterval.SubSource),
 		Condition: monitorapi.Condition{
 			Level:             level,
 			Locator:           serializedInterval.Locator,
@@ -164,6 +167,7 @@ func monitorEventIntervalToEventInterval(interval monitorapi.Interval) EventInte
 		StructuredLocator: interval.StructuredLocator,
 		StructuredMessage: interval.StructuredMessage,
 		Source:            string(interval.Source),
+		SubSource:         string(interval.SubSource),
 
 		From: metav1.Time{Time: interval.From},
 		To:   metav1.Time{Time: interval.To},

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -65,8 +65,7 @@ func IntervalsFromJSON(data []byte) (monitorapi.Intervals, error) {
 			return nil, err
 		}
 		events = append(events, monitorapi.Interval{
-			Source:    monitorapi.IntervalSource(interval.Source),
-			SubSource: monitorapi.IntervalSubSource(interval.SubSource),
+			Source: monitorapi.IntervalSource(interval.Source),
 			Condition: monitorapi.Condition{
 				Level:             level,
 				Locator:           interval.Locator,
@@ -93,8 +92,7 @@ func IntervalFromJSON(data []byte) (*monitorapi.Interval, error) {
 		return nil, err
 	}
 	return &monitorapi.Interval{
-		Source:    monitorapi.IntervalSource(serializedInterval.Source),
-		SubSource: monitorapi.IntervalSubSource(serializedInterval.SubSource),
+		Source: monitorapi.IntervalSource(serializedInterval.Source),
 		Condition: monitorapi.Condition{
 			Level:             level,
 			Locator:           serializedInterval.Locator,
@@ -167,7 +165,6 @@ func monitorEventIntervalToEventInterval(interval monitorapi.Interval) EventInte
 		StructuredLocator: interval.StructuredLocator,
 		StructuredMessage: interval.StructuredMessage,
 		Source:            string(interval.Source),
-		SubSource:         string(interval.SubSource),
 
 		From: metav1.Time{Time: interval.From},
 		To:   metav1.Time{Time: interval.To},

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -21,8 +21,9 @@ type EventInterval struct {
 
 	// TODO: Remove the omitempty, just here to keep from having to repeatedly updated the json
 	// files used in some new tests
-	Source    string `json:"tempSource,omitempty"`    // also temporary, unsure if this concept will survive
-	SubSource string `json:"tempSubSource,omitempty"` // also temporary, unsure if this concept will survive
+	Source string `json:"tempSource,omitempty"` // also temporary, unsure if this concept will survive
+
+	Display bool `json:"display,omitempty"`
 
 	// TODO: we're hoping to move these to just locator/message when everything is ready.
 	StructuredLocator monitorapi.Locator `json:"tempStructuredLocator"`
@@ -65,7 +66,8 @@ func IntervalsFromJSON(data []byte) (monitorapi.Intervals, error) {
 			return nil, err
 		}
 		events = append(events, monitorapi.Interval{
-			Source: monitorapi.IntervalSource(interval.Source),
+			Source:  monitorapi.IntervalSource(interval.Source),
+			Display: interval.Display,
 			Condition: monitorapi.Condition{
 				Level:             level,
 				Locator:           interval.Locator,
@@ -92,7 +94,8 @@ func IntervalFromJSON(data []byte) (*monitorapi.Interval, error) {
 		return nil, err
 	}
 	return &monitorapi.Interval{
-		Source: monitorapi.IntervalSource(serializedInterval.Source),
+		Source:  monitorapi.IntervalSource(serializedInterval.Source),
+		Display: serializedInterval.Display,
 		Condition: monitorapi.Condition{
 			Level:             level,
 			Locator:           serializedInterval.Locator,
@@ -165,6 +168,7 @@ func monitorEventIntervalToEventInterval(interval monitorapi.Interval) EventInte
 		StructuredLocator: interval.StructuredLocator,
 		StructuredMessage: interval.StructuredMessage,
 		Source:            string(interval.Source),
+		Display:           interval.Display,
 
 		From: metav1.Time{Time: interval.From},
 		To:   metav1.Time{Time: interval.To},

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -1,7 +1,6 @@
 package statetracker
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -140,7 +139,6 @@ func (t *stateTracker) CloseInterval(locator monitorapi.Locator, state StateInfo
 	}
 	delete(states, state)
 	locatorKey := locator.OldLocator()
-	fmt.Printf("locatorKey = %s\n", locatorKey)
 	t.locatorToStateMap[locatorKey] = states
 	t.locators[locatorKey] = locator
 	locatorWithRow := locator.DeepCopy()

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -155,10 +155,13 @@ func (t *stateTracker) CloseInterval(locator monitorapi.Locator, state StateInfo
 	return []monitorapi.Interval{ib.Build(from, to)}
 }
 
-func (t *stateTracker) CloseAllIntervals(end time.Time) []monitorapi.Interval {
+func (t *stateTracker) CloseAllIntervals(locatorToMessageAnnotations map[string]map[string]string, end time.Time) []monitorapi.Interval {
 	ret := []monitorapi.Interval{}
 	for locator, states := range t.locatorToStateMap {
 		annotations := map[monitorapi.AnnotationKey]string{}
+		for k, v := range locatorToMessageAnnotations[locator] {
+			annotations[monitorapi.AnnotationKey(k)] = v
+		}
 
 		l := t.locators[locator]
 		for state := range states {

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -31,12 +31,11 @@ type stateTracker struct {
 type intervalCreationFunc func(locator monitorapi.Locator,
 	from, to time.Time) (*monitorapi.IntervalBuilder, bool)
 
-func SimpleInterval(constructedBy monitorapi.ConstructionOwner,
-	source monitorapi.IntervalSource, level monitorapi.IntervalLevel,
-	messageBuilder *monitorapi.MessageBuilder) intervalCreationFunc {
+func SimpleInterval(source monitorapi.IntervalSource, level monitorapi.IntervalLevel, messageBuilder *monitorapi.MessageBuilder,
+	subSource monitorapi.IntervalSubSource) intervalCreationFunc {
 	return func(locator monitorapi.Locator, from, to time.Time) (*monitorapi.IntervalBuilder, bool) {
 		interval := monitorapi.NewInterval(source, level).Locator(locator).
-			Message(messageBuilder)
+			Message(messageBuilder).SubSource(subSource)
 		return interval, true
 	}
 }
@@ -163,7 +162,7 @@ func (t *stateTracker) CloseAllIntervals(locatorToMessageAnnotations map[string]
 			annotations[monitorapi.AnnotationState] = stateName.stateName
 			annotations[monitorapi.AnnotationConstructed] = string(t.constructedBy)
 			mb := monitorapi.NewMessage().WithAnnotations(annotations).HumanMessage("never completed").Reason(stateName.reason)
-			ret = append(ret, t.CloseInterval(l, stateName, SimpleInterval(t.constructedBy, t.intervalSource, monitorapi.Warning, mb), end)...)
+			ret = append(ret, t.CloseInterval(l, stateName, SimpleInterval(t.intervalSource, monitorapi.Warning, mb, ""), end)...)
 		}
 	}
 

--- a/pkg/monitortests/node/nodestateanalyzer/node.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node.go
@@ -100,7 +100,6 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 		case "OSUpdateStarted":
 			// Not ported, so we don't have a Source to check
 			nodeLocator := monitorapi.NewLocator().NodeFromNameWithRow(node, "NodeUpdatePhases")
-			nodeStateTracker.OpenInterval(nodeLocator, drainState, event.From)
 			mb := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
 				HumanMessage(msgPhaseDrain).
 				WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
@@ -112,7 +111,6 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 			nodeStateTracker.OpenInterval(nodeLocator, osUpdateState, event.From)
 		case "Reboot":
 			nodeLocator := monitorapi.NewLocator().NodeFromNameWithRow(node, "NodeUpdatePhases")
-			nodeStateTracker.OpenInterval(nodeLocator, drainState, event.From)
 			// Not ported, so we don't have a Source to check
 			mb := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
 				HumanMessage(msgPhaseDrain).
@@ -135,7 +133,6 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 		case "Starting":
 			// Not ported, so we don't have a Source to check
 			nodeLocator := monitorapi.NewLocator().NodeFromNameWithRow(node, "NodeUpdatePhases")
-			nodeStateTracker.OpenInterval(nodeLocator, drainState, event.From)
 			mb := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
 				HumanMessage(msgPhaseDrain).
 				WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).

--- a/pkg/monitortests/node/nodestateanalyzer/node.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node.go
@@ -68,11 +68,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 					WithAnnotation(monitorapi.AnnotationConstructed, monitorapi.ConstructionOwnerNodeLifecycle).
 					WithAnnotation(monitorapi.AnnotationRoles, roles)
 				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, notReadyState,
-					statetracker.SimpleInterval(
-						monitorapi.ConstructionOwnerNodeLifecycle,
-						monitorapi.SourceNodeState,
-						monitorapi.Warning,
-						mb),
+					statetracker.SimpleInterval(monitorapi.SourceNodeState, monitorapi.Warning, mb, monitorapi.SubSourceNodeNotReady),
 					event.From)...)
 			}
 		case "MachineConfigChange":
@@ -87,11 +83,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 					WithAnnotation(monitorapi.AnnotationRoles, roles).
 					WithAnnotation(monitorapi.AnnotationPhase, "Update")
 				intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, updateState,
-					statetracker.SimpleInterval(
-						monitorapi.ConstructionOwnerNodeLifecycle,
-						monitorapi.SourceNodeState,
-						monitorapi.Info,
-						mb),
+					statetracker.SimpleInterval(monitorapi.SourceNodeState, monitorapi.Info, mb, monitorapi.SubSourceNodeUpdate),
 					event.From)...)
 			}
 		case "Cordon", "Drain":
@@ -105,11 +97,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 				WithAnnotation(monitorapi.AnnotationRoles, roles).
 				WithAnnotation(monitorapi.AnnotationPhase, "Drain")
 			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState,
-				statetracker.SimpleInterval(
-					monitorapi.ConstructionOwnerNodeLifecycle,
-					monitorapi.SourceNodeState,
-					monitorapi.Info,
-					mb),
+				statetracker.SimpleInterval(monitorapi.SourceNodeState, monitorapi.Info, mb, monitorapi.SubSourceNodeUpdatePhases),
 				event.From)...)
 			nodeStateTracker.OpenInterval(nodeLocator, osUpdateState, event.From)
 		case "Reboot":
@@ -120,11 +108,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 				WithAnnotation(monitorapi.AnnotationRoles, roles).
 				WithAnnotation(monitorapi.AnnotationPhase, "Drain")
 			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState,
-				statetracker.SimpleInterval(
-					monitorapi.ConstructionOwnerNodeLifecycle,
-					monitorapi.SourceNodeState,
-					monitorapi.Info,
-					mb),
+				statetracker.SimpleInterval(monitorapi.SourceNodeState, monitorapi.Info, mb, monitorapi.SubSourceNodeUpdatePhases),
 				event.From)...)
 
 			osUpdateMB := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
@@ -133,11 +117,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 				WithAnnotation(monitorapi.AnnotationRoles, roles).
 				WithAnnotation(monitorapi.AnnotationPhase, "OperatingSystemUpdate")
 			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState,
-				statetracker.SimpleInterval(
-					monitorapi.ConstructionOwnerNodeLifecycle,
-					monitorapi.SourceNodeState,
-					monitorapi.Info,
-					osUpdateMB),
+				statetracker.SimpleInterval(monitorapi.SourceNodeState, monitorapi.Info, osUpdateMB, monitorapi.SubSourceNodeUpdatePhases),
 				event.From)...)
 			nodeStateTracker.OpenInterval(nodeLocator, rebootState, event.From)
 		case "Starting":
@@ -148,11 +128,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 				WithAnnotation(monitorapi.AnnotationRoles, roles).
 				WithAnnotation(monitorapi.AnnotationPhase, "Drain")
 			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, drainState,
-				statetracker.SimpleInterval(
-					monitorapi.ConstructionOwnerNodeLifecycle,
-					monitorapi.SourceNodeState,
-					monitorapi.Info,
-					mb),
+				statetracker.SimpleInterval(monitorapi.SourceNodeState, monitorapi.Info, mb, monitorapi.SubSourceNodeUpdatePhases),
 				event.From)...)
 
 			osUpdateMB := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
@@ -161,11 +137,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 				WithAnnotation(monitorapi.AnnotationRoles, roles).
 				WithAnnotation(monitorapi.AnnotationPhase, "OperatingSystemUpdate")
 			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, osUpdateState,
-				statetracker.SimpleInterval(
-					monitorapi.ConstructionOwnerNodeLifecycle,
-					monitorapi.SourceNodeState,
-					monitorapi.Info,
-					osUpdateMB),
+				statetracker.SimpleInterval(monitorapi.SourceNodeState, monitorapi.Info, osUpdateMB, monitorapi.SubSourceNodeUpdatePhases),
 				event.From)...)
 
 			rebootMB := monitorapi.NewMessage().Reason(monitorapi.NodeUpdateReason).
@@ -174,11 +146,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 				WithAnnotation(monitorapi.AnnotationRoles, roles).
 				WithAnnotation(monitorapi.AnnotationPhase, "Reboot")
 			intervals = append(intervals, nodeStateTracker.CloseIfOpenedInterval(nodeLocator, rebootState,
-				statetracker.SimpleInterval(
-					monitorapi.ConstructionOwnerNodeLifecycle,
-					monitorapi.SourceNodeState,
-					monitorapi.Info,
-					rebootMB),
+				statetracker.SimpleInterval(monitorapi.SourceNodeState, monitorapi.Info, rebootMB, monitorapi.SubSourceNodeUpdatePhases),
 				event.From)...)
 		}
 	}

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
@@ -2,13 +2,14 @@
     "items": [
         {
             "level": "Info",
-            "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
+            "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7 row/NodeUpdatePhases",
             "message": "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
             "tempSource": "NodeState",
             "tempStructuredLocator": {
                 "type": "Node",
                 "keys": {
-                    "node": "ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7"
+                    "node": "ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
+                    "row": "NodeUpdatePhases"
                 }
             },
             "tempStructuredMessage": {
@@ -27,13 +28,14 @@
         },
         {
             "level": "Warning",
-            "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
+            "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7 row/NodeUpdatePhases",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate role/worker state/OperatingSystemUpdate never completed",
             "tempSource": "NodeState",
             "tempStructuredLocator": {
                 "type": "Node",
                 "keys": {
-                    "node": "ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7"
+                    "node": "ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
+                    "row": "NodeUpdatePhases"
                 }
             },
             "tempStructuredMessage": {
@@ -43,7 +45,7 @@
                 "annotations": {
                     "constructed": "node-lifecycle-constructor",
                     "reason": "NodeUpdate",
-                    "role": "worker",
+                    "roles": "worker",
                     "state": "OperatingSystemUpdate"
                 }
             },

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
@@ -29,7 +29,7 @@
         {
             "level": "Warning",
             "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7 row/NodeUpdatePhases",
-            "message": "constructed/node-lifecycle-constructor reason/NodeUpdate role/worker state/OperatingSystemUpdate never completed",
+            "message": "constructed/node-lifecycle-constructor reason/NodeUpdate roles/worker state/OperatingSystemUpdate never completed",
             "tempSource": "NodeState",
             "tempStructuredLocator": {
                 "type": "Node",

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/expected.json
@@ -2,13 +2,14 @@
     "items": [
         {
             "level": "Info",
-            "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
+            "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm row/NodeUpdatePhases",
             "message": "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
             "tempSource": "NodeState",
             "tempStructuredLocator": {
                 "type": "Node",
                 "keys": {
-                    "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm"
+                    "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
+                    "row": "NodeUpdatePhases"
                 }
             },
             "tempStructuredMessage": {
@@ -27,13 +28,14 @@
         },
         {
             "level": "Warning",
-            "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
-            "message": "constructed/node-lifecycle-constructor reason/NodeUpdate role/worker state/OperatingSystemUpdate never completed",
+            "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm row/NodeUpdatePhases",
+            "message": "constructed/node-lifecycle-constructor reason/NodeUpdate roles/worker state/OperatingSystemUpdate never completed",
             "tempSource": "NodeState",
             "tempStructuredLocator": {
                 "type": "Node",
                 "keys": {
-                    "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm"
+                    "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
+                    "row": "NodeUpdatePhases"
                 }
             },
             "tempStructuredMessage": {
@@ -43,7 +45,7 @@
                 "annotations": {
                     "constructed": "node-lifecycle-constructor",
                     "reason": "NodeUpdate",
-                    "role": "worker",
+                    "roles": "worker",
                     "state": "OperatingSystemUpdate"
                 }
             },

--- a/pkg/monitortests/node/nodestateanalyzer/node_test.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node_test.go
@@ -27,7 +27,7 @@ func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 	assert.Equal(t, "constructed/node-lifecycle-constructor phase/OperatingSystemUpdate reason/NodeUpdate roles/worker updated operating system",
 		changes[1].Message, "unexpected event")
 	assert.Equal(t, "constructed/node-lifecycle-constructor phase/Reboot reason/NodeUpdate roles/worker rebooted and kubelet started",
-		changes[0].Message, "unexpected event")
+		changes[2].Message, "unexpected event")
 }
 
 func TestNodeUpdateCreation(t *testing.T) {

--- a/pkg/monitortests/node/nodestateanalyzer/node_test.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node_test.go
@@ -17,19 +17,17 @@ func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	changes := intervalsFromEvents_NodeChanges(intervals, nil, time.Time{}, time.Now())
-	out, _ := monitorserialization.EventsIntervalsToJSON(changes)
-	if len(changes) != 3 {
-		t.Fatalf("unexpected changes: %s", string(out))
+	for _, c := range changes {
+		t.Logf("%s - %s", c.From.UTC().Format(time.RFC3339), c.Message)
 	}
-	if changes[0].Message != "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node" {
-		t.Errorf("unexpected event: %s", string(out))
-	}
-	if changes[1].Message != "constructed/node-lifecycle-constructor phase/OperatingSystemUpdate reason/NodeUpdate roles/worker updated operating system" {
-		t.Errorf("unexpected event: %s", string(out))
-	}
-	if changes[2].Message != "constructed/node-lifecycle-constructor phase/Reboot reason/NodeUpdate roles/worker rebooted and kubelet started" {
-		t.Errorf("unexpected event: %s", string(out))
-	}
+	//out, _ := monitorserialization.EventsIntervalsToJSON(changes)
+	assert.Equal(t, 3, len(changes))
+	assert.Equal(t, "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
+		changes[0].Message, "unexpected event")
+	assert.Equal(t, "constructed/node-lifecycle-constructor phase/OperatingSystemUpdate reason/NodeUpdate roles/worker updated operating system",
+		changes[1].Message, "unexpected event")
+	assert.Equal(t, "constructed/node-lifecycle-constructor phase/Reboot reason/NodeUpdate roles/worker rebooted and kubelet started",
+		changes[0].Message, "unexpected event")
 }
 
 func TestNodeUpdateCreation(t *testing.T) {

--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -29,7 +29,7 @@ func intervalsFromEvents_PodChanges(events monitorapi.Intervals, beginning, end 
 			continue
 		}
 
-		podPendingState := statetracker.State("Pending", "PodWasPending")
+		podPendingState := statetracker.State("Pending", "", "PodWasPending")
 
 		switch reason {
 		case monitorapi.PodPendingReason:

--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -16,7 +16,6 @@ import (
 func intervalsFromEvents_PodChanges(events monitorapi.Intervals, beginning, end time.Time) monitorapi.Intervals {
 	var intervals monitorapi.Intervals
 	podStateTracker := statetracker.NewStateTracker(monitorapi.ConstructionOwnerPodLifecycle, monitorapi.SourcePodState, beginning)
-	locatorToMessageAnnotations := map[string]map[string]string{}
 
 	for _, event := range events {
 		if _, ok := event.StructuredLocator.Keys[monitorapi.LocatorPodKey]; !ok {
@@ -43,7 +42,7 @@ func intervalsFromEvents_PodChanges(events monitorapi.Intervals, beginning, end 
 				podPendingState, pendingPodCondition, event.From)...)
 		}
 	}
-	intervals = append(intervals, podStateTracker.CloseAllIntervals(locatorToMessageAnnotations, end)...)
+	intervals = append(intervals, podStateTracker.CloseAllIntervals(end)...)
 
 	return intervals
 }

--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -42,7 +42,7 @@ func intervalsFromEvents_PodChanges(events monitorapi.Intervals, beginning, end 
 				podPendingState, pendingPodCondition, event.From)...)
 		}
 	}
-	intervals = append(intervals, podStateTracker.CloseAllIntervals(end)...)
+	intervals = append(intervals, podStateTracker.CloseAllIntervals(map[string]map[string]string{}, end)...)
 
 	return intervals
 }

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53605,12 +53605,10 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
 
         timelineGroups.push({group: "node-state", data: []});
         createTimelineData(nodeStateValue, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "node_state");
+        // Sort the node-state intervals so rows are grouped by node
         timelineGroups[timelineGroups.length - 1].data.sort(function (e1 ,e2){
-            if (e1.label.includes("master") && e2.label.includes("worker")) {
-                return -1
-            }
-            return 0
-        });
+            return e1.label < e2.label ? -1 : e1.label > e2.label;
+        })
 
         timelineGroups.push({group: "endpoint-availability", data: []});
         createTimelineData(disruptionValue, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "endpoint_availability");

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53339,7 +53339,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
     const rePhase = new RegExp("(^| )phase/([^ ]+)")
     function nodeStateValue(item) {
         let roles = ""
-        if (item.tempStructuredMessage.hasOwnProperty('roles')) {
+        if (item.tempStructuredMessage.annotations.hasOwnProperty('roles')) {
             roles = item.tempStructuredMessage.roles
         }
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52524,15 +52524,11 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             roles = item.tempStructuredMessage.annotations.roles
         }
 
-        if (item.tempStructuredMessage.reason === 'NotReady') {
-            return [item.locator, ` + "`" + ` (${roles},not ready)` + "`" + `, "NodeNotReady"]
-        }
-        // TODO: would like to get this to a structured field as well
-        let m = item.tempStructuredMessage.annotations.phase;
         let ss = item.tempSubSource
-        if (m != "Update") {
-            return [item.locator, ` + "`" + ` (${roles},${ss})` + "`" + `, m];
+        if (item.tempStructuredMessage.reason === 'NotReady') {
+            return [item.locator, ` + "`" + ` (${roles},${ss})` + "`" + `, "NodeNotReady"]
         }
+        let m = item.tempStructuredMessage.annotations.phase;
         return [item.locator, ` + "`" + ` (${roles},${ss})` + "`" + `, m];
     }
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52520,19 +52520,20 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     const rePhase = new RegExp("(^| )phase/([^ ]+)")
     function nodeStateValue(item) {
         let roles = ""
-        if (item.tempStructuredMessage.hasOwnProperty('roles')) {
-            roles = item.tempStructuredMessage.roles
+        if (item.tempStructuredMessage.annotations.hasOwnProperty('roles')) {
+            roles = item.tempStructuredMessage.annotations.roles
         }
 
         if (item.tempStructuredMessage.reason === 'NotReady') {
             return [item.locator, ` + "`" + ` (${roles},not ready)` + "`" + `, "NodeNotReady"]
         }
         // TODO: would like to get this to a structured field as well
-        let m = item.message.match(rePhase);
-        if (m && m[2] != "Update") {
-            return [item.locator, ` + "`" + ` (${roles},update phases)` + "`" + `, m[2]];
+        let m = item.tempStructuredMessage.annotations.phase;
+        let ss = item.tempSubSource
+        if (m != "Update") {
+            return [item.locator, ` + "`" + ` (${roles},${ss})` + "`" + `, m];
         }
-        return [item.locator, ` + "`" + ` (${roles},updates)` + "`" + `, "Update"];
+        return [item.locator, ` + "`" + ` (${roles},${ss})` + "`" + `, m];
     }
 
     function alertSeverity(item) {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52702,11 +52702,9 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
         timelineGroups.push({group: "node-state", data: []})
         createTimelineData(nodeStateValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isNodeState, regex)
+        // Sort the node-state intervals so rows are grouped by node
         timelineGroups[timelineGroups.length - 1].data.sort(function (e1 ,e2){
-            if (e1.label.includes("master") && e2.label.includes("worker")) {
-                return -1
-            }
-            return 0
+            return e1.label < e2.label ? -1 : e1.label > e2.label;
         })
 
         timelineGroups.push({group: "endpoint-availability", data: []})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52524,12 +52524,11 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             roles = item.tempStructuredMessage.annotations.roles
         }
 
-        let ss = item.tempSubSource
         if (item.tempStructuredMessage.reason === 'NotReady') {
-            return [item.locator, ` + "`" + ` (${roles},${ss})` + "`" + `, "NodeNotReady"]
+            return [item.locator, ` + "`" + ` (${roles})` + "`" + `, "NodeNotReady"]
         }
         let m = item.tempStructuredMessage.annotations.phase;
-        return [item.locator, ` + "`" + ` (${roles},${ss})` + "`" + `, m];
+        return [item.locator, ` + "`" + ` (${roles})` + "`" + `, m];
     }
 
     function alertSeverity(item) {
@@ -53345,14 +53344,10 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         }
 
         if (item.tempStructuredMessage.reason === 'NotReady') {
-            return [item.locator, ` + "`" + ` (${roles},not ready)` + "`" + `, "NodeNotReady"]
+            return [item.locator, ` + "`" + ` (${roles})` + "`" + `, "NodeNotReady"]
         }
-        // TODO: would like to get this to a structured field as well
-        let m = item.message.match(rePhase);
-        if (m && m[2] != "Update") {
-            return [item.locator, ` + "`" + ` (${roles},update phases)` + "`" + `, m[2]];
-        }
-        return [item.locator, ` + "`" + ` (${roles},updates)` + "`" + `, "Update"];
+        let m = item.tempStructuredMessage.annotations.phase;
+        return [item.locator, ` + "`" + ` (${roles})` + "`" + `, m];
     }
 
 
@@ -53403,7 +53398,15 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function defaultToolTip(item) {
-        return item.message + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
+        let tt = item.message
+        if ('tempSource' in item) {
+            tt = tt + " source/" + item.tempSource
+        }
+        if ('display' in item) {
+            tt = tt + " display/" + item.display
+        }
+        tt = tt + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
+        return tt
     }
 
     function createTimelineData(timelineVal, timelineData, filteredEventIntervals, category) {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52594,7 +52594,15 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function defaultToolTip(item) {
-        return item.message + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
+        let tt = item.message
+        if ('tempSource' in item) {
+            tt = tt + " source/" + item.tempSource
+        }
+        if ('display' in item) {
+            tt = tt + " display/" + item.display
+        }
+        tt = tt + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
+        return tt
     }
 
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc, regex) {


### PR DESCRIPTION
With a goal of having intervals be produced by origin and then immediately visible in the charts, which will soon live in sippy, we need a way to inject some kind of differentiator to force rows within one section onto different lines so they do not overlap. The clearest example of this today is the node state category where we would have the same node locator for multiple rows, but we break them out so we can clearly see the phases of update, when the node was not ready, and the overall os update. 

To do this, I've added a row key to the locator, as this feels most closely related. Changes were then required in the state tracker to support this without it getting confused.
