### PR TITLE
trt-1344: remove msg assertion

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/matches_test.go
+++ b/pkg/monitortestlibrary/allowedalerts/matches_test.go
@@ -233,9 +233,8 @@ func TestAlertDataFileParsing(t *testing.T) {
 			Topology:     "ha",
 		},
 	}
-	hd, msg, err := alertMatcher.BestMatchDuration(expectedKey)
-	assert.True(t, hd.P99 > 5*time.Minute, "AlertmanagerReceiversNotConfigured data not present for aws amd64 ovn ha")
-	assert.Equal(t, "", msg)
+	hd, _, err := alertMatcher.BestMatchDuration(expectedKey)
 	assert.NoError(t, err)
-
+	assert.NotNil(t, hd)
+	assert.True(t, hd.P99 > 5*time.Minute, "AlertmanagerReceiversNotConfigured data not present for aws amd64 ovn ha")
 }


### PR DESCRIPTION
Failure:
```
Error Trace:	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/monitortestlibrary/allowedalerts/matches_test.go:238
Error:      	Not equal: 
            	expected: ""
            	actual  : "(no exact match for historicaldata.AlertDataKey{AlertName:\"AlertmanagerReceiversNotConfigured\", AlertNamespace:\"openshift-monitoring\", AlertLevel:\"Warning\", JobType:platformidentification.JobType{Release:\"4.15\", FromRelease:\"4.15\", Platform:\"aws\", Architecture:\"amd64\", Network:\"ovn\", Topology:\"ha\"}}, fell back to historicaldata.AlertDataKey{AlertName:\"AlertmanagerReceiversNotConfigured\", AlertNamespace:\"openshift-monitoring\", AlertLevel:\"Warning\", JobType:platformidentification.JobType{Release:\"4.14\", FromRelease:\"4.14\", Platform:\"aws\", Architecture:\"amd64\", Network:\"ovn\", Topology:\"ha\"}})"

```

Test was looking for an empty msg but the data only has 80 JobRuns currently since we are switching over to a new release.  We don't really care about the message in this test, just that we got valid data.

```
  {
    "AlertName": "AlertmanagerReceiversNotConfigured",
    "AlertNamespace": "openshift-monitoring",
    "AlertLevel": "Warning",
    "FirstObserved": "2023-08-11T14:47:48Z",
    "LastObserved": "2023-11-02T20:37:02Z",
    "Release": "4.15",
    "FromRelease": "4.15",
    "Platform": "aws",
    "Architecture": "amd64",
    "Network": "ovn",
    "Topology": "ha",
    "MasterNodesUpdated": null,
    "JobRuns": 80,
    "P95": "6782.0999999999995",
    "P99": "7115.08",
    "P75": "7115.08",
    "P50": "6782.0999999999995"
  },
```