### PR TITLE
TRT-1339: Revert #28233 "ignore repeated TopologyAwareHintsDisabled events"

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -224,6 +224,10 @@ var KnownEventsBugs = []KnownProblem{
 		BZ:     "https://bugzilla.redhat.com/show_bug.cgi?id=2006975",
 	},
 	{
+		Regexp: regexp.MustCompile("reason/TopologyAwareHintsDisabled"),
+		BZ:     "https://issues.redhat.com/browse/OCPBUGS-13366",
+	},
+	{
 		Regexp:   regexp.MustCompile("ns/.*reason/.*APICheckFailed.*503.*"),
 		BZ:       "https://bugzilla.redhat.com/show_bug.cgi?id=2017435",
 		Topology: TopologyPointer(v1.SingleReplicaTopologyMode),

--- a/pkg/monitortests/testframework/watchevents/event_test.go
+++ b/pkg/monitortests/testframework/watchevents/event_test.go
@@ -98,26 +98,25 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 			expectedMessage: "pathological/true interesting/true reason/SomethingHappened Readiness probe failed (40 times)",
 		},
 		{
-			name: "allowed pathological event with known bug (BZ 2000234)",
+			name: "allowed pathological event with known bug",
 			args: args{
 				ctx: context.TODO(),
 				m:   monitor.NewRecorder(),
 				kubeEvent: &corev1.Event{
 					Count:  40,
-					Reason: "ns/openshift-etcd pod/etcd-quorum-guard-42 node/worker-42 - reason/Unhealthy",
+					Reason: "TopologyAwareHintsDisabled",
 					InvolvedObject: corev1.ObjectReference{
 						Kind:      "Pod",
-						Namespace: "openshift-etcd",
-						Name:      "etcd-quorum-guard-42",
+						Namespace: "any",
+						Name:      "any",
 					},
-					Message:       "Readiness probe failed:",
+					Message:       "irrelevant",
 					LastTimestamp: metav1.Now(),
 				},
 				significantlyBeforeNow: now.UTC().Add(-15 * time.Minute),
 			},
-			// hmsg in expectedLocator is the hash of the entire expectedMessage except the number of times
-			expectedLocator: "ns/openshift-etcd pod/etcd-quorum-guard-42 hmsg/9100aa725d",
-			expectedMessage: "pathological/true interesting/true reason/ns/openshift-etcd pod/etcd-quorum-guard-42 node/worker-42 - reason/Unhealthy Readiness probe failed: (40 times)",
+			expectedLocator: "ns/any pod/any hmsg/e13faa98ab",
+			expectedMessage: "pathological/true interesting/true reason/TopologyAwareHintsDisabled irrelevant (40 times)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION

Reverts #28233 ; tracked by [TRT-1339](https://issues.redhat.com//browse/TRT-1339)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

See JIRA for additional detials.  May jobs are flatlined on this failing, and it's caused many payload rejections. Example job https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.15-e2e-azure-sdn-techpreview-serial/1721106743041200128

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Suggest using payload commands and/or /test to invoke many serial jobs and prove this isn't firing
```

CC: @candita

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
