### PR TITLE
kubevirt: Run live migration at the end too

### DIFF
--- a/test/extended/kubevirt/migration.go
+++ b/test/extended/kubevirt/migration.go
@@ -40,7 +40,7 @@ var _ = Describe("[sig-kubevirt] migration", func() {
 				return numberOfReadyNodes, nil
 			}
 		)
-		Context("and live migrate hosted control plane workers [Early]", func() {
+		Context("and live migrate hosted control plane workers [Early][Late]", func() {
 			var (
 				numberOfNodes = 0
 			)

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1213,7 +1213,7 @@ var Annotations = map[string]string{
 
 	"[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[sig-kubevirt] migration when running openshift cluster on KubeVirt virtual machines and live migrate hosted control plane workers [Early] should maintain node readiness": " [Suite:openshift/conformance/parallel]",
+	"[sig-kubevirt] migration when running openshift cluster on KubeVirt virtual machines and live migrate hosted control plane workers [Early][Late] should maintain node readiness": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow connections to pods from guest cluster PodNetwork pod via LoadBalancer service across different guest nodes": " [Suite:openshift/conformance/parallel]",
 


### PR DESCRIPTION
Some issues running live migration after conformance where discovered. This change runs the live migration at the end too to discover this kind of issues.