### PR TITLE
OCPBUGS-23079: fix: increase watch count for KubeControllerManagerOperator

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -305,7 +305,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"etcd-operator":                          220,
 				"ingress-operator":                       371,
 				"kube-apiserver-operator":                260,
-				"kube-controller-manager-operator":       165,
+				"kube-controller-manager-operator":       185,
 				"kube-storage-version-migrator-operator": 68,
 				"machine-api-operator":                   48,
 				"marketplace-operator":                   20,


### PR DESCRIPTION
After some dep bumps on kube controller operator we have seen an increase in watch count, increasing threshold