### PR TITLE
trt-1340: backport exact and disable monitor tests options to 4.14

### DIFF
--- a/pkg/cmd/openshift-tests/monitor/timeline/timeline_command.go
+++ b/pkg/cmd/openshift-tests/monitor/timeline/timeline_command.go
@@ -255,7 +255,8 @@ func (o *Timeline) Run() error {
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest: monitortestframework.Stable,
 	}
-	invariantRegistry := defaultmonitortests.NewMonitorTestsFor(monitorTestInfo)
+	// code is removed in 4.15, adding minimal change and ignoring any returned error
+	invariantRegistry, _ := defaultmonitortests.NewMonitorTestsFor(monitorTestInfo)
 	computedIntervals, _, err := invariantRegistry.ConstructComputedIntervals(
 		context.TODO(),
 		filteredEvents,
@@ -326,7 +327,7 @@ func loadKnownPods(filename string) (monitorapi.ResourcesMap, error) {
 		if err != nil {
 			return nil, err
 		}
-		//nsList := &unstructured.UnstructuredList{}
+		// nsList := &unstructured.UnstructuredList{}
 
 		for _, item := range unstructuredList.Items {
 			item.SetKind("Pod")

--- a/pkg/cmd/openshift-tests/run-test/command.go
+++ b/pkg/cmd/openshift-tests/run-test/command.go
@@ -1,7 +1,10 @@
 package run_test
 
 import (
+	"fmt"
+	"github.com/openshift/origin/pkg/defaultmonitortests"
 	"os"
+	"strings"
 
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/clioptions/imagesetup"
@@ -17,6 +20,7 @@ import (
 
 func NewRunTestCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	testOpt := testginkgo.NewTestOptions(streams)
+	monitorNames := defaultmonitortests.ListAllMonitorTests()
 
 	cmd := &cobra.Command{
 		Use:   "run-test NAME",
@@ -71,5 +75,8 @@ func NewRunTestCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&testOpt.DryRun, "dry-run", testOpt.DryRun, "Print the test to run without executing them.")
+	cmd.Flags().StringSliceVar(&testOpt.ExactMonitorTests, "monitor", testOpt.ExactMonitorTests,
+		fmt.Sprintf("list of exactly which monitors to enable. All others will be disabled.  Current monitors are: [%s]", strings.Join(monitorNames, ", ")))
+	cmd.Flags().StringSliceVar(&testOpt.DisableMonitorTests, "disable-monitor", testOpt.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored.")
 	return cmd
 }

--- a/pkg/cmd/openshift-tests/run-upgrade/options.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/options.go
@@ -29,7 +29,7 @@ type RunUpgradeSuiteOptions struct {
 	ToImage        string
 	FromRepository string
 	// I don't see where this is initialized in this flow
-	//CloudProviderJSON string
+	// CloudProviderJSON string
 
 	TestOptions []string
 
@@ -42,7 +42,7 @@ func (o *RunUpgradeSuiteOptions) TestCommandEnvironment() []string {
 	var args []string
 	args = append(args, "KUBE_TEST_REPO_LIST=") // explicitly prevent selective override
 	args = append(args, fmt.Sprintf("KUBE_TEST_REPO=%s", o.FromRepository))
-	//args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.CloudProviderJSON))  I don't think we actually have this.
+	// args = append(args, fmt.Sprintf("TEST_PROVIDER=%s", o.CloudProviderJSON))  I don't think we actually have this.
 	args = append(args, fmt.Sprintf("TEST_JUNIT_DIR=%s", o.GinkgoRunSuiteOptions.JUnitDir))
 	for i := 10; i > 0; i-- {
 		if klog.V(klog.Level(i)).Enabled() {
@@ -109,6 +109,8 @@ func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest:        monitortestframework.ClusterStabilityDuringTest(o.GinkgoRunSuiteOptions.ClusterStabilityDuringTest),
 		UpgradeTargetPayloadImagePullSpec: o.ToImage,
+		ExactMonitorTests:                 o.GinkgoRunSuiteOptions.ExactMonitorTests,
+		DisableMonitorTests:               o.GinkgoRunSuiteOptions.DisableMonitorTests,
 	}
 
 	o.GinkgoRunSuiteOptions.CommandEnv = o.TestCommandEnvironment()

--- a/pkg/cmd/openshift-tests/run/options.go
+++ b/pkg/cmd/openshift-tests/run/options.go
@@ -75,6 +75,8 @@ func (o *RunSuiteOptions) Run(ctx context.Context) error {
 	// TODO the gingkoRunSuiteOptions needs to have flags then calculated options to express specified versus computed values
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest: monitortestframework.ClusterStabilityDuringTest(o.GinkgoRunSuiteOptions.ClusterStabilityDuringTest),
+		ExactMonitorTests:          o.GinkgoRunSuiteOptions.ExactMonitorTests,
+		DisableMonitorTests:        o.GinkgoRunSuiteOptions.DisableMonitorTests,
 	}
 
 	o.GinkgoRunSuiteOptions.CommandEnv = o.TestCommandEnvironment()

--- a/pkg/monitortestframework/types.go
+++ b/pkg/monitortestframework/types.go
@@ -2,6 +2,7 @@ package monitortestframework
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"time"
 
 	"k8s.io/client-go/rest"
@@ -17,7 +18,7 @@ var (
 	Stable ClusterStabilityDuringTest = "Stable"
 	// TODO only bring this back if we have some reason to collect Upgrade specific information.  I can't think of reason.
 	// TODO please contact @deads2k for vetting if you think you found something
-	//Upgrade    ClusterStabilityDuringTest = "Upgrade"
+	// Upgrade    ClusterStabilityDuringTest = "Upgrade"
 	// Disruptive means that the suite is expected to induce outages to the cluster.
 	Disruptive ClusterStabilityDuringTest = "Disruptive"
 )
@@ -26,6 +27,12 @@ type MonitorTestInitializationInfo struct {
 	ClusterStabilityDuringTest ClusterStabilityDuringTest
 	// UpgradeTargetImage is only set for upgrades.  It is set to the *final* destination version.
 	UpgradeTargetPayloadImagePullSpec string
+
+	// ExactMonitorTests will filter the available monitor tests down to only those contained in the provided list
+	ExactMonitorTests []string
+
+	// DisableMonitorTests will remove any monitor tests contained in the provided list
+	DisableMonitorTests []string
 }
 
 type MonitorTest interface {
@@ -74,6 +81,9 @@ type MonitorTestRegistry interface {
 	AddMonitorTest(name, jiraComponent string, monitorTest MonitorTest) error
 
 	AddMonitorTestOrDie(name, jiraComponent string, monitorTest MonitorTest)
+
+	GetRegistryFor(names ...string) (MonitorTestRegistry, error)
+	ListMonitorTests() sets.String
 
 	// StartCollection is responsible for setting up all resources required for collection of data on the cluster.
 	// An error will not stop execution, but will cause a junit failure that will cause the job run to fail.

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -62,6 +63,9 @@ type GinkgoRunSuiteOptions struct {
 	genericclioptions.IOStreams
 
 	StartTime time.Time
+
+	ExactMonitorTests   []string
+	DisableMonitorTests []string
 }
 
 func NewGinkgoRunSuiteOptions(streams genericclioptions.IOStreams) *GinkgoRunSuiteOptions {
@@ -72,6 +76,8 @@ func NewGinkgoRunSuiteOptions(streams genericclioptions.IOStreams) *GinkgoRunSui
 }
 
 func (o *GinkgoRunSuiteOptions) BindFlags(flags *pflag.FlagSet) {
+	monitorNames := defaultmonitortests.ListAllMonitorTests()
+
 	flags.BoolVar(&o.DryRun, "dry-run", o.DryRun, "Print the tests to run without executing them.")
 	flags.BoolVar(&o.PrintCommands, "print-commands", o.PrintCommands, "Print the sub-commands that would be executed instead.")
 	flags.StringVar(&o.ClusterStabilityDuringTest, "cluster-stability", o.ClusterStabilityDuringTest, "cluster stability during test, usually dependent on the job: Stable or Disruptive")
@@ -81,6 +87,9 @@ func (o *GinkgoRunSuiteOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.DurationVar(&o.Timeout, "timeout", o.Timeout, "Set the maximum time a test can run before being aborted. This is read from the suite by default, but will be 10 minutes otherwise.")
 	flags.BoolVar(&o.IncludeSuccessOutput, "include-success", o.IncludeSuccessOutput, "Print output from successful tests.")
 	flags.IntVar(&o.Parallelism, "max-parallel-tests", o.Parallelism, "Maximum number of tests running in parallel. 0 defaults to test suite recommended value, which is different in each suite.")
+	flags.StringSliceVar(&o.ExactMonitorTests, "monitor", o.ExactMonitorTests,
+		fmt.Sprintf("list of exactly which monitors to enable. All others will be disabled.  Current monitors are: [%s]", strings.Join(monitorNames, ", ")))
+	flags.StringSliceVar(&o.DisableMonitorTests, "disable-monitor", o.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored.")
 }
 
 func (o *GinkgoRunSuiteOptions) Validate() error {
@@ -244,12 +253,17 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 	}()
 	signal.Notify(abortCh, syscall.SIGINT, syscall.SIGTERM)
 
+	monitorTests, err := defaultmonitortests.NewMonitorTestsFor(monitorTestInfo)
+	if err != nil {
+		logrus.Errorf("Error getting monitor tests: %v", err)
+	}
+
 	monitorEventRecorder := monitor.NewRecorder()
 	m := monitor.NewMonitor(
 		monitorEventRecorder,
 		restConfig,
 		o.JUnitDir,
-		defaultmonitortests.NewMonitorTestsFor(monitorTestInfo),
+		monitorTests,
 	)
 	if err := m.Start(ctx); err != nil {
 		return err


### PR DESCRIPTION
Backport [TRT-1340](https://issues.redhat.com/browse/TRT-1340) Exact / Disable monitor command options for IBM-ROKS support