### PR TITLE
MON-3481: Thanos use /api/v1 endpoints for authentification test.

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -389,7 +389,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			})).NotTo(o.HaveOccurred(), fmt.Sprintf("Did not find tsdb_samples_appended_total, tsdb_head_samples_appended_total, or prometheus_tsdb_head_samples_appended_total"))
 
 			g.By("verifying the Thanos querier service requires authentication")
-			err := helper.ExpectURLStatusCodeExecViaPod(ns, execPod.Name, querySvcURL, 401, 403)
+			err := helper.ExpectURLStatusCodeExecViaPod(ns, execPod.Name, fmt.Sprintf("%s/api/v1/targets", querySvcURL), 401, 403)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("verifying a service account token is able to authenticate")


### PR DESCRIPTION
Openshift Monitoring components are replacing Oauth proxy with kube-rbac-proxy and restrict access to path under `/api/` only. By consequence, the root URL for Thanos service will no longer be accessible and return 404. 
https://issues.redhat.com/browse/MON-3379

This is for deblocking the test like `e2e-aws-ovn`. here is an example of error: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-monitoring-operator/2136/pull-ci-openshift-cluster-monitoring-operator-master-e2e-aws-ovn/1722971201866829824
