### PR TITLE
Certs 11 fix certs after break

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openshift/apiserver-library-go v0.0.0-20230915134751-5c71e94d6f05
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
-	github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87
+	github.com/openshift/library-go v0.0.0-20231114105342-8fcee5af3f13
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -711,8 +711,8 @@ github.com/openshift/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0
 github.com/openshift/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20230926120034-e3ba6d9fbe72/go.mod h1:oLJ4FetmCVvyDXVnFb66XAdf9DXcnR4v3EE6ENVzDQI=
 github.com/openshift/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20230926120034-e3ba6d9fbe72 h1:W8NL1MiHFYzofXMtXE7ma2zH/wAzlj87crc9l/J8QzU=
 github.com/openshift/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20230926120034-e3ba6d9fbe72/go.mod h1:WYbrwAJFfUVjC8ddXYCLss7gvvlmZULpvn9aVcaZZME=
-github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87 h1:GcaI98ric0Q3WbZsTh8cIE39pgw12v3s3xuiIFO5zQ0=
-github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87/go.mod h1:8UzmrBMCn7+GzouL8DVYkL9COBQTB1Ggd13/mHJQCUg=
+github.com/openshift/library-go v0.0.0-20231114105342-8fcee5af3f13 h1:/ogd2wx77xZqW7sFXZRBGJ7qM36NrG2vr9P38nTeNzs=
+github.com/openshift/library-go v0.0.0-20231114105342-8fcee5af3f13/go.mod h1:8UzmrBMCn7+GzouL8DVYkL9COBQTB1Ggd13/mHJQCUg=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20230811135323-13a5964cc98e h1:WgaylNSIB4uff7ieewaqIiEG3mP6jSMER8LCkoOEkys=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20230811135323-13a5964cc98e/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/test/extended/operators/certs.go
+++ b/test/extended/operators/certs.go
@@ -41,12 +41,8 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 		tlsArtifactFilename := fmt.Sprintf("raw-tls-artifacts-%s-%s-%s-%s.json", jobType.Topology, jobType.Architecture, jobType.Platform, jobType.Network)
 
-		currentPKIContent, err := certgraphanalysis.GatherCertsFromPlatformNamespaces(ctx, kubeClient, certgraphanalysis.SkipRevisioned)
+		currentPKIContent, err := certgraphanalysis.GatherCertsFromPlatformNamespaces(ctx, kubeClient, certgraphanalysis.SkipRevisioned, certgraphanalysis.ElideProxyCADetails)
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// the content here is good, but proxy-ca contains a lot of entries for system-trust that doesn't help
-		// us visualize the OCP certs, so if we detect that condition snip it
-		pruneSystemTrust(currentPKIContent)
 
 		jsonBytes, err := json.MarshalIndent(currentPKIContent, "", "  ")
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/vendor/github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphanalysis/collection_options.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphanalysis/collection_options.go
@@ -1,0 +1,46 @@
+package certgraphanalysis
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type configMapFilterFunc func(configMap *corev1.ConfigMap) bool
+
+type secretFilterFunc func(configMap *corev1.Secret) bool
+
+type resourceFilteringOptions struct {
+	rejectConfigMap configMapFilterFunc
+	rejectSecret    secretFilterFunc
+}
+
+func (resourceFilteringOptions) approved() {}
+
+var (
+	SkipRevisioned = &resourceFilteringOptions{
+		rejectConfigMap: func(configMap *corev1.ConfigMap) bool {
+			if isRevisioned(configMap.OwnerReferences) {
+				return true
+			}
+			return false
+		},
+		rejectSecret: func(secret *corev1.Secret) bool {
+			if isRevisioned(secret.OwnerReferences) {
+				return true
+			}
+			return false
+		},
+	}
+)
+
+func isRevisioned(ownerReferences []metav1.OwnerReference) bool {
+	for _, curr := range ownerReferences {
+		if strings.HasPrefix(curr.Name, "revision-status-") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphanalysis/metadata_options.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphanalysis/metadata_options.go
@@ -1,0 +1,46 @@
+package certgraphanalysis
+
+import (
+	"github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi"
+)
+
+type caBundleRewriteFunc func(caBundle *certgraphapi.CertificateAuthorityBundle)
+
+type certKeyPairRewriteFunc func(certKeyPair *certgraphapi.CertKeyPair)
+
+type metadataOptions struct {
+	rewriteCABundle    caBundleRewriteFunc
+	rewriteCertKeyPair certKeyPairRewriteFunc
+}
+
+func (metadataOptions) approved() {}
+
+var (
+	ElideProxyCADetails = &metadataOptions{
+		rewriteCABundle: func(caBundle *certgraphapi.CertificateAuthorityBundle) {
+			isProxyCA := false
+			for _, location := range caBundle.Spec.ConfigMapLocations {
+				if location.Namespace == "openshift-config-managed" && location.Name == "trusted-ca-bundle" {
+					isProxyCA = true
+				}
+			}
+			if !isProxyCA {
+				return
+			}
+			if len(caBundle.Spec.CertificateMetadata) < 10 {
+				return
+			}
+			caBundle.Name = "proxy-ca"
+			caBundle.LogicalName = "proxy-ca"
+			caBundle.Spec.CertificateMetadata = []certgraphapi.CertKeyMetadata{
+				{
+					CertIdentifier: certgraphapi.CertIdentifier{
+						CommonName:   "synthetic-proxy-ca",
+						SerialNumber: "0",
+						Issuer:       nil,
+					},
+				},
+			}
+		},
+	}
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -971,7 +971,7 @@ github.com/openshift/client-go/user/informers/externalversions/internalinterface
 github.com/openshift/client-go/user/informers/externalversions/user
 github.com/openshift/client-go/user/informers/externalversions/user/v1
 github.com/openshift/client-go/user/listers/user/v1
-# github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87
+# github.com/openshift/library-go v0.0.0-20231114105342-8fcee5af3f13
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig
 github.com/openshift/library-go/pkg/apiserver/admission/admissiontimeout


### PR DESCRIPTION
The logical name removal broke consumers.  We need to restore the proxy-ca eliding because it's so long and not really useful.

proof of https://github.com/openshift/library-go/pull/1617

/hold

hold until we see it work.