### PR TITLE
OCPBUGS-20487: update egressFWTestE2E image which contains ping binary

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -23,7 +23,7 @@ const (
 	egressFWTestPod      = "egressfirewall"
 	egressFWE2E          = "egress-firewall-e2e"
 	noEgressFWE2E        = "no-egress-firewall-e2e"
-	egressFWTestImage    = "quay.io/redhat-developer/nfs-server:1.1"
+	egressFWTestImage    = "registry.k8s.io/e2e-test-images/agnhost:2.45"
 	oVNKManifest         = "ovnk-egressfirewall-test.yaml"
 	openShiftSDNManifest = "sdn-egressnetworkpolicy-test.yaml"
 )


### PR DESCRIPTION
This PR update the image to use a non-nfs image, since we did not see any reference using nfs image, the test just trys to ping and curl things. And it also fixes the missing ping binary issue on s390x.