### PR TITLE
TRT-1235: Add ability to specify alerts that should never fire

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/all.go
+++ b/pkg/monitortestlibrary/allowedalerts/all.go
@@ -15,22 +15,22 @@ func AllAlertTests(jobType *platformidentification.JobType, etcdAllowance AlertT
 	ret = append(ret, newAlertTestPerNamespace("KubePodNotReady", jobType).pending().neverFail().toTests()...)
 	ret = append(ret, newAlertTestPerNamespace("KubePodNotReady", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("etcd", "etcdMembersDown", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdMembersDown", jobType).firing().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdGRPCRequestsSlow", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdGRPCRequestsSlow", jobType).firing().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdHighNumberOfFailedGRPCRequests", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdHighNumberOfFailedGRPCRequests", jobType).firing().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdMemberCommunicationSlow", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdMemberCommunicationSlow", jobType).firing().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdNoLeader", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdNoLeader", jobType).firing().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdHighFsyncDurations", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdHighFsyncDurations", jobType).firing().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdHighCommitDurations", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdHighCommitDurations", jobType).firing().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdInsufficientMembers", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("etcd", "etcdInsufficientMembers", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdMembersDown", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdMembersDown", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdGRPCRequestsSlow", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdGRPCRequestsSlow", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdHighNumberOfFailedGRPCRequests", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdHighNumberOfFailedGRPCRequests", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdMemberCommunicationSlow", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdMemberCommunicationSlow", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdNoLeader", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdNoLeader", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdHighFsyncDurations", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdHighFsyncDurations", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdHighCommitDurations", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdHighCommitDurations", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdInsufficientMembers", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdInsufficientMembers", jobType).firing().toTests()...)
 
 	// A rare and pretty serious failure, should always be accompanied by other failures but we want to see a specific test failure for this.
 	// It likely means a kubelet is down.
@@ -38,45 +38,45 @@ func AllAlertTests(jobType *platformidentification.JobType, etcdAllowance AlertT
 		"sig-node", "TargetDown", "kube-system", jobType).
 		firing().alwaysFail().toTests()...)
 
-	ret = append(ret, newAlertTest("etcd", "etcdHighNumberOfLeaderChanges", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdHighNumberOfLeaderChanges", jobType).pending().neverFail().toTests()...)
 
 	// This test gets a little special treatment, if we're moving through etcd updates, we expect leader changes, so if this scenario is detected
 	// this test is given fixed leeway for the alert to fire, otherwise it too falls back to historical data.
-	ret = append(ret, newAlertTest("etcd", "etcdHighNumberOfLeaderChanges", jobType).withAllowance(etcdAllowance).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-etcd", "etcdHighNumberOfLeaderChanges", jobType).withAllowance(etcdAllowance).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("kube-apiserver", "KubeAPIErrorBudgetBurn", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("kube-apiserver", "KubeAPIErrorBudgetBurn", jobType).firing().toTests()...)
-	ret = append(ret, newAlertTest("kube-apiserver", "KubeClientErrors", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("kube-apiserver", "KubeClientErrors", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-kube-apiserver", "KubeAPIErrorBudgetBurn", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-kube-apiserver", "KubeAPIErrorBudgetBurn", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-kube-apiserver", "KubeClientErrors", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-kube-apiserver", "KubeClientErrors", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("storage", "KubePersistentVolumeErrors", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("storage", "KubePersistentVolumeErrors", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-storage", "KubePersistentVolumeErrors", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-storage", "KubePersistentVolumeErrors", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("machine config operator", "MCDDrainError", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("machine config operator", "MCDDrainError", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-machine config operator", "MCDDrainError", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-machine config operator", "MCDDrainError", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("single-node", "KubeMemoryOvercommit", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-single-node", "KubeMemoryOvercommit", jobType).pending().neverFail().toTests()...)
 	// this appears to have no direct impact on the cluster in CI.  It's important in general, but for CI we're willing to run pretty hot.
-	ret = append(ret, newAlertTest("single-node", "KubeMemoryOvercommit", jobType).firing().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("machine config operator", "MCDPivotError", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("machine config operator", "MCDPivotError", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-single-node", "KubeMemoryOvercommit", jobType).firing().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-machine config operator", "MCDPivotError", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-machine config operator", "MCDPivotError", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("monitoring", "PrometheusOperatorWatchErrors", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("monitoring", "PrometheusOperatorWatchErrors", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-monitoring", "PrometheusOperatorWatchErrors", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-monitoring", "PrometheusOperatorWatchErrors", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("networking", "OVNKubernetesResourceRetryFailure", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("networking", "OVNKubernetesResourceRetryFailure", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-networking", "OVNKubernetesResourceRetryFailure", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-networking", "OVNKubernetesResourceRetryFailure", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("OLM", "RedhatOperatorsCatalogError", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("OLM", "RedhatOperatorsCatalogError", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-OLM", "RedhatOperatorsCatalogError", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-OLM", "RedhatOperatorsCatalogError", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("storage", "VSphereOpenshiftNodeHealthFail", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("storage", "VSphereOpenshiftNodeHealthFail", jobType).firing().neverFail().toTests()...) // https://bugzilla.redhat.com/show_bug.cgi?id=2055729
+	ret = append(ret, newAlertTest("bz-storage", "VSphereOpenshiftNodeHealthFail", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-storage", "VSphereOpenshiftNodeHealthFail", jobType).firing().neverFail().toTests()...) // https://bugzilla.redhat.com/show_bug.cgi?id=2055729
 
-	ret = append(ret, newAlertTest("samples", "SamplesImagestreamImportFailing", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlertTest("samples", "SamplesImagestreamImportFailing", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-samples", "SamplesImagestreamImportFailing", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("bz-samples", "SamplesImagestreamImportFailing", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlertTest("apiserver-auth", "PodSecurityViolation", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("bz-apiserver-auth", "PodSecurityViolation", jobType).firing().toTests()...)
 
 	return ret
 }

--- a/pkg/monitortestlibrary/allowedalerts/all.go
+++ b/pkg/monitortestlibrary/allowedalerts/all.go
@@ -34,8 +34,8 @@ func AllAlertTests(jobType *platformidentification.JobType, etcdAllowance AlertT
 
 	// A rare and pretty serious failure, should always be accompanied by other failures but we want to see a specific test failure for this.
 	// It likely means a kubelet is down.
-	ret = append(ret, newAlertTestWithNamespace(
-		"sig-node", "TargetDown", "kube-system", jobType).
+	ret = append(ret, newAlertTest(
+		"sig-node", "TargetDown", jobType).inNamespace("kube-system").
 		firing().alwaysFail().toTests()...)
 
 	ret = append(ret, newAlertTest("bz-etcd", "etcdHighNumberOfLeaderChanges", jobType).pending().neverFail().toTests()...)

--- a/pkg/monitortestlibrary/allowedalerts/all.go
+++ b/pkg/monitortestlibrary/allowedalerts/all.go
@@ -12,64 +12,71 @@ func AllAlertTests(jobType *platformidentification.JobType, etcdAllowance AlertT
 
 	ret := []AlertTest{}
 	ret = append(ret, newWatchdogAlert(jobType))
-	ret = append(ret, newNamespacedAlert("KubePodNotReady", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newNamespacedAlert("KubePodNotReady", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTestPerNamespace("KubePodNotReady", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTestPerNamespace("KubePodNotReady", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("etcd", "etcdMembersDown", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdMembersDown", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdGRPCRequestsSlow", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdGRPCRequestsSlow", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdHighNumberOfFailedGRPCRequests", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdHighNumberOfFailedGRPCRequests", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdMemberCommunicationSlow", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdMemberCommunicationSlow", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdNoLeader", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdNoLeader", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdHighFsyncDurations", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdHighFsyncDurations", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdHighCommitDurations", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdHighCommitDurations", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdInsufficientMembers", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdInsufficientMembers", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("etcd", "etcdHighNumberOfLeaderChanges", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdMembersDown", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdMembersDown", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdGRPCRequestsSlow", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdGRPCRequestsSlow", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdHighNumberOfFailedGRPCRequests", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdHighNumberOfFailedGRPCRequests", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdMemberCommunicationSlow", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdMemberCommunicationSlow", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdNoLeader", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdNoLeader", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdHighFsyncDurations", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdHighFsyncDurations", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdHighCommitDurations", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdHighCommitDurations", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdInsufficientMembers", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdInsufficientMembers", jobType).firing().toTests()...)
+
+	// A rare and pretty serious failure, should always be accompanied by other failures but we want to see a specific test failure for this.
+	// It likely means a kubelet is down.
+	ret = append(ret, newAlertTestWithNamespace(
+		"sig-node", "TargetDown", "kube-system", jobType).
+		firing().alwaysFail().toTests()...)
+
+	ret = append(ret, newAlertTest("etcd", "etcdHighNumberOfLeaderChanges", jobType).pending().neverFail().toTests()...)
 
 	// This test gets a little special treatment, if we're moving through etcd updates, we expect leader changes, so if this scenario is detected
 	// this test is given fixed leeway for the alert to fire, otherwise it too falls back to historical data.
-	ret = append(ret, newAlert("etcd", "etcdHighNumberOfLeaderChanges", jobType).withAllowance(etcdAllowance).firing().toTests()...)
+	ret = append(ret, newAlertTest("etcd", "etcdHighNumberOfLeaderChanges", jobType).withAllowance(etcdAllowance).firing().toTests()...)
 
-	ret = append(ret, newAlert("kube-apiserver", "KubeAPIErrorBudgetBurn", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("kube-apiserver", "KubeAPIErrorBudgetBurn", jobType).firing().toTests()...)
-	ret = append(ret, newAlert("kube-apiserver", "KubeClientErrors", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("kube-apiserver", "KubeClientErrors", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("kube-apiserver", "KubeAPIErrorBudgetBurn", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("kube-apiserver", "KubeAPIErrorBudgetBurn", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("kube-apiserver", "KubeClientErrors", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("kube-apiserver", "KubeClientErrors", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("storage", "KubePersistentVolumeErrors", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("storage", "KubePersistentVolumeErrors", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("storage", "KubePersistentVolumeErrors", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("storage", "KubePersistentVolumeErrors", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("machine config operator", "MCDDrainError", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("machine config operator", "MCDDrainError", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("machine config operator", "MCDDrainError", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("machine config operator", "MCDDrainError", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("single-node", "KubeMemoryOvercommit", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("single-node", "KubeMemoryOvercommit", jobType).pending().neverFail().toTests()...)
 	// this appears to have no direct impact on the cluster in CI.  It's important in general, but for CI we're willing to run pretty hot.
-	ret = append(ret, newAlert("single-node", "KubeMemoryOvercommit", jobType).firing().neverFail().toTests()...)
-	ret = append(ret, newAlert("machine config operator", "MCDPivotError", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("machine config operator", "MCDPivotError", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("single-node", "KubeMemoryOvercommit", jobType).firing().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("machine config operator", "MCDPivotError", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("machine config operator", "MCDPivotError", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("monitoring", "PrometheusOperatorWatchErrors", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("monitoring", "PrometheusOperatorWatchErrors", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("monitoring", "PrometheusOperatorWatchErrors", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("monitoring", "PrometheusOperatorWatchErrors", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("networking", "OVNKubernetesResourceRetryFailure", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("networking", "OVNKubernetesResourceRetryFailure", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("networking", "OVNKubernetesResourceRetryFailure", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("networking", "OVNKubernetesResourceRetryFailure", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("OLM", "RedhatOperatorsCatalogError", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("OLM", "RedhatOperatorsCatalogError", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("OLM", "RedhatOperatorsCatalogError", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("OLM", "RedhatOperatorsCatalogError", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("storage", "VSphereOpenshiftNodeHealthFail", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("storage", "VSphereOpenshiftNodeHealthFail", jobType).firing().neverFail().toTests()...) // https://bugzilla.redhat.com/show_bug.cgi?id=2055729
+	ret = append(ret, newAlertTest("storage", "VSphereOpenshiftNodeHealthFail", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("storage", "VSphereOpenshiftNodeHealthFail", jobType).firing().neverFail().toTests()...) // https://bugzilla.redhat.com/show_bug.cgi?id=2055729
 
-	ret = append(ret, newAlert("samples", "SamplesImagestreamImportFailing", jobType).pending().neverFail().toTests()...)
-	ret = append(ret, newAlert("samples", "SamplesImagestreamImportFailing", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("samples", "SamplesImagestreamImportFailing", jobType).pending().neverFail().toTests()...)
+	ret = append(ret, newAlertTest("samples", "SamplesImagestreamImportFailing", jobType).firing().toTests()...)
 
-	ret = append(ret, newAlert("apiserver-auth", "PodSecurityViolation", jobType).firing().toTests()...)
+	ret = append(ret, newAlertTest("apiserver-auth", "PodSecurityViolation", jobType).firing().toTests()...)
 
 	return ret
 }

--- a/pkg/monitortestlibrary/allowedalerts/basic_alert.go
+++ b/pkg/monitortestlibrary/allowedalerts/basic_alert.go
@@ -74,18 +74,6 @@ func newAlertTest(bugzillaComponent, alertName string, jobType *platformidentifi
 	}
 }
 
-// newAlertTestWithNamespace creates a single alert test within a specific namespace.
-func newAlertTestWithNamespace(bugzillaComponent, alertName, alertNamespace string, jobType *platformidentification2.JobType) *alertBuilder {
-	return &alertBuilder{
-		bugzillaComponent:   bugzillaComponent,
-		alertName:           alertName,
-		alertNamespace:      alertNamespace,
-		alertState:          AlertPending,
-		allowanceCalculator: DefaultAllowances,
-		jobType:             jobType,
-	}
-}
-
 // newAlertTestPerNamespace creates an alert test builder per entry in the hardcoded list of namespaces we're interested in.
 func newAlertTestPerNamespace(alertName string, jobType *platformidentification2.JobType) *alertBuilder {
 	return &alertBuilder{
@@ -104,6 +92,12 @@ func (a *alertBuilder) withAllowance(allowanceCalculator AlertTestAllowanceCalcu
 
 func (a *alertBuilder) pending() *alertBuilder {
 	a.alertState = AlertPending
+	return a
+}
+
+// inNamespace limits the alert test to a specific namespace.
+func (a *alertBuilder) inNamespace(namespace string) *alertBuilder {
+	a.alertNamespace = namespace
 	return a
 }
 

--- a/pkg/monitortestlibrary/allowedalerts/basic_alert.go
+++ b/pkg/monitortestlibrary/allowedalerts/basic_alert.go
@@ -181,11 +181,11 @@ func (a *alertBuilder) toTests() []AlertTest {
 func (a *basicAlertTest) InvariantTestName() string {
 	switch {
 	case len(a.namespace) == 0:
-		return fmt.Sprintf("[bz-%v][invariant] alert/%s should not be at or above %s", a.bugzillaComponent, a.alertName, a.alertState)
+		return fmt.Sprintf("[%v][invariant] alert/%s should not be at or above %s", a.bugzillaComponent, a.alertName, a.alertState)
 	case a.namespace == platformidentification2.NamespaceOther:
-		return fmt.Sprintf("[bz-%v][invariant] alert/%s should not be at or above %s in all the other namespaces", a.bugzillaComponent, a.alertName, a.alertState)
+		return fmt.Sprintf("[%v][invariant] alert/%s should not be at or above %s in all the other namespaces", a.bugzillaComponent, a.alertName, a.alertState)
 	default:
-		return fmt.Sprintf("[bz-%v][invariant] alert/%s should not be at or above %s in ns/%s", a.bugzillaComponent, a.alertName, a.alertState, a.namespace)
+		return fmt.Sprintf("[%v][invariant] alert/%s should not be at or above %s in ns/%s", a.bugzillaComponent, a.alertName, a.alertState, a.namespace)
 	}
 }
 

--- a/pkg/monitortestlibrary/allowedalerts/matches.go
+++ b/pkg/monitortestlibrary/allowedalerts/matches.go
@@ -6,6 +6,8 @@ import (
 	historicaldata2 "github.com/openshift/origin/pkg/monitortestlibrary/historicaldata"
 )
 
+// neverFailAllowance will ignore historical data and impose a FailAfter limit that should not be
+// reachable in a CI job run, so the test can never fail, only flake if beyond historical limits.
 type neverFailAllowance struct {
 	flakeDelegate AlertTestAllowanceCalculator
 }
@@ -70,4 +72,21 @@ func (d *alwaysFlakeAllowance) FailAfter(key historicaldata2.AlertDataKey) (time
 
 func (d *alwaysFlakeAllowance) FlakeAfter(key historicaldata2.AlertDataKey) time.Duration {
 	return 1 * time.Second
+}
+
+func failOnAny() AlertTestAllowanceCalculator {
+	return &alwaysFailAllowance{}
+}
+
+// alwaysFailAllowance is for alerts we want to fail a test if they occur at all.
+type alwaysFailAllowance struct {
+}
+
+func (d *alwaysFailAllowance) FailAfter(key historicaldata2.AlertDataKey) (time.Duration, error) {
+	return 1 * time.Second, nil
+}
+
+func (d *alwaysFailAllowance) FlakeAfter(key historicaldata2.AlertDataKey) time.Duration {
+	// flake is irrelevant here, we're going to fail on ANY duration
+	return 24 * time.Hour
 }


### PR DESCRIPTION
Adds ability to specify alerts that should fail a test if we see ANY
fire, regardless of historical data.

Also allows specifying alert tests for an alert in a specific namespace.
Previously we could just do all interesting namespaces. (hardcoded list)

Adds TargetDown in kube-system (likely a kubelet problem) as  an initial
use of both concepts.

I adjusted how alert tests define their component to stop prepending bz-, move that prefix to all pre-existing alert tests as these are already mapped, and then align this test with sig-node, previously there was no way to map from bz-something to Node / Kubelet without updating the mapping repo. Bugzilla is dead to us anyhow and we shouldn't be making these assumptions in components in this mini-framework.
