### PR TITLE
TRT-1347: Add ability to indicate a monitor test was skipped

### DIFF
--- a/pkg/monitortestframework/errors.go
+++ b/pkg/monitortestframework/errors.go
@@ -1,0 +1,12 @@
+package monitortestframework
+
+import "fmt"
+
+// NotSupportedError represents an error when a monitor test is unsupported for the given environment.
+type NotSupportedError struct {
+	Reason string
+}
+
+func (e *NotSupportedError) Error() string {
+	return fmt.Sprintf("not supported: %s", e.Reason)
+}

--- a/pkg/monitortestframework/impl.go
+++ b/pkg/monitortestframework/impl.go
@@ -2,6 +2,7 @@ package monitortestframework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -94,6 +95,17 @@ func (r *monitorTestRegistry) StartCollection(ctx context.Context, adminRESTConf
 			end := time.Now()
 			duration := end.Sub(start)
 			if err != nil {
+				var nsErr *NotSupportedError
+				if errors.As(err, &nsErr) {
+					junitCh <- &junitapi.JUnitTestCase{
+						Name:     testName,
+						Duration: duration.Seconds(),
+						SkipMessage: &junitapi.SkipMessage{
+							Message: nsErr.Reason,
+						},
+					}
+					return
+				}
 				errCh <- err
 				junitCh <- &junitapi.JUnitTestCase{
 					Name:     testName,
@@ -149,6 +161,19 @@ func (r *monitorTestRegistry) CollectData(ctx context.Context, storageDir string
 			end := time.Now()
 			duration := end.Sub(start)
 			if err != nil {
+				var nsErr *NotSupportedError
+				if errors.As(err, &nsErr) {
+					junitCh <- []*junitapi.JUnitTestCase{
+						{
+							Name:     testName,
+							Duration: duration.Seconds(),
+							SkipMessage: &junitapi.SkipMessage{
+								Message: nsErr.Reason,
+							},
+						},
+					}
+					return
+				}
 				junitCh <- []*junitapi.JUnitTestCase{
 					{
 						Name:     testName,
@@ -206,6 +231,18 @@ func (r *monitorTestRegistry) ConstructComputedIntervals(ctx context.Context, st
 		end := time.Now()
 		duration := end.Sub(start)
 		if err != nil {
+			var nsErr *NotSupportedError
+			if errors.As(err, &nsErr) {
+				junits = append(junits, &junitapi.JUnitTestCase{
+					Name:     testName,
+					Duration: duration.Seconds(),
+					SkipMessage: &junitapi.SkipMessage{
+						Message: nsErr.Reason,
+					},
+				})
+				continue
+			}
+
 			errs = append(errs, err)
 			junits = append(junits, &junitapi.JUnitTestCase{
 				Name:     testName,
@@ -240,6 +277,18 @@ func (r *monitorTestRegistry) EvaluateTestsFromConstructedIntervals(ctx context.
 		end := time.Now()
 		duration := end.Sub(start)
 		if err != nil {
+			var nsErr *NotSupportedError
+			if errors.As(err, &nsErr) {
+				junits = append(junits, &junitapi.JUnitTestCase{
+					Name:     testName,
+					Duration: duration.Seconds(),
+					SkipMessage: &junitapi.SkipMessage{
+						Message: nsErr.Reason,
+					},
+				})
+				continue
+			}
+
 			errs = append(errs, err)
 			junits = append(junits, &junitapi.JUnitTestCase{
 				Name:     testName,
@@ -282,6 +331,18 @@ func (r *monitorTestRegistry) WriteContentToStorage(ctx context.Context, storage
 		end := time.Now()
 		duration := end.Sub(start)
 		if err != nil {
+			var nsErr *NotSupportedError
+			if errors.As(err, &nsErr) {
+				junits = append(junits, &junitapi.JUnitTestCase{
+					Name:     testName,
+					Duration: duration.Seconds(),
+					SkipMessage: &junitapi.SkipMessage{
+						Message: nsErr.Reason,
+					},
+				})
+				continue
+			}
+
 			errs = append(errs, err)
 			junits = append(junits, &junitapi.JUnitTestCase{
 				Name:     testName,
@@ -315,6 +376,18 @@ func (r *monitorTestRegistry) Cleanup(ctx context.Context) ([]*junitapi.JUnitTes
 		end := time.Now()
 		duration := end.Sub(start)
 		if err != nil {
+			var nsErr *NotSupportedError
+			if errors.As(err, &nsErr) {
+				junits = append(junits, &junitapi.JUnitTestCase{
+					Name:     testName,
+					Duration: duration.Seconds(),
+					SkipMessage: &junitapi.SkipMessage{
+						Message: nsErr.Reason,
+					},
+				})
+				continue
+			}
+
 			errs = append(errs, err)
 			junits = append(junits, &junitapi.JUnitTestCase{
 				Name:     testName,

--- a/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
+++ b/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
@@ -34,7 +34,7 @@ type availability struct {
 	imageRegistryRoute *routev1.Route
 
 	disruptionChecker  *disruptionlibrary.Availability
-	notSupportedReason *monitortestframework.NotSupportedError
+	notSupportedReason error
 	suppressJunit      bool
 }
 

--- a/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
+++ b/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
@@ -34,7 +34,7 @@ type availability struct {
 	imageRegistryRoute *routev1.Route
 
 	disruptionChecker  *disruptionlibrary.Availability
-	notSupportedReason string
+	notSupportedReason *monitortestframework.NotSupportedError
 	suppressJunit      bool
 }
 
@@ -61,8 +61,8 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 
 	_, err = w.kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		w.notSupportedReason = "namespace openshift-image-registry not present"
-		return nil
+		w.notSupportedReason = &monitortestframework.NotSupportedError{Reason: "namespace openshift-image-registry not present"}
+		return w.notSupportedReason
 	}
 	if err != nil {
 		return err
@@ -73,8 +73,8 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 		return err
 	}
 	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 1 {
-		w.notSupportedReason = "image-registry only has a single replica"
-		return nil
+		w.notSupportedReason = &monitortestframework.NotSupportedError{Reason: "image-registry only has a single replica"}
+		return w.notSupportedReason
 	}
 
 	w.routeClient, err = routeclient.NewForConfig(adminRESTConfig)
@@ -115,8 +115,8 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 }
 
 func (w *availability) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
-	if len(w.notSupportedReason) > 0 {
-		return nil, nil, nil
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
 	}
 	// we failed and indicated it during setup.
 	if w.disruptionChecker == nil {
@@ -131,8 +131,8 @@ func (*availability) ConstructComputedIntervals(ctx context.Context, startingInt
 }
 
 func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
-	if len(w.notSupportedReason) > 0 {
-		return nil, nil
+	if w.notSupportedReason != nil {
+		return nil, w.notSupportedReason
 	}
 	if w.suppressJunit {
 		return nil, nil
@@ -145,8 +145,8 @@ func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 	return w.disruptionChecker.EvaluateTestsFromConstructedIntervals(ctx, finalIntervals)
 }
 
-func (*availability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	return nil
+func (w *availability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return w.notSupportedReason
 }
 
 func (w *availability) Cleanup(ctx context.Context) error {
@@ -157,5 +157,5 @@ func (w *availability) Cleanup(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	return w.notSupportedReason
 }

--- a/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers/monitortest.go
@@ -22,7 +22,7 @@ import (
 type availability struct {
 	disruptionCheckers []*disruptionlibrary.Availability
 
-	notSupportedReason *monitortestframework.NotSupportedError
+	notSupportedReason error
 	suppressJunit      bool
 }
 

--- a/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers/monitortest.go
@@ -8,20 +8,21 @@ import (
 
 	"github.com/openshift/origin/pkg/monitortestframework"
 
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
-	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
-	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 )
 
 type availability struct {
 	disruptionCheckers []*disruptionlibrary.Availability
 
-	notSupportedReason string
+	notSupportedReason *monitortestframework.NotSupportedError
 	suppressJunit      bool
 }
 
@@ -157,16 +158,20 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 
 	_, err = kubeClient.CoreV1().Namespaces().Get(context.Background(), "openshift-apiserver", metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		w.notSupportedReason = "namespace openshift-apiserver not present"
-		return nil
+		w.notSupportedReason = &monitortestframework.NotSupportedError{
+			Reason: "namespace openshift-apiserver not present",
+		}
+		return w.notSupportedReason
 	}
 	if err != nil {
 		return err
 	}
 	_, err = kubeClient.CoreV1().Namespaces().Get(context.Background(), "openshift-oauth-apiserver", metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		w.notSupportedReason = "namespace openshift-oauth-apiserver not present"
-		return nil
+		w.notSupportedReason = &monitortestframework.NotSupportedError{
+			Reason: "namespace openshift-oauth-apiserver not present",
+		}
+		return w.notSupportedReason
 	}
 	if err != nil {
 		return err
@@ -217,6 +222,10 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 }
 
 func (w *availability) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
+	}
+
 	intervals := monitorapi.Intervals{}
 	junits := []*junitapi.JUnitTestCase{}
 	errs := []error{}
@@ -238,11 +247,15 @@ func (w *availability) CollectData(ctx context.Context, storageDir string, begin
 	return intervals, junits, utilerrors.NewAggregate(errs)
 }
 
-func (*availability) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
-	return nil, nil
+func (w *availability) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, w.notSupportedReason
 }
 
 func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	if w.notSupportedReason != nil {
+		return nil, w.notSupportedReason
+	}
+
 	if w.suppressJunit {
 		return nil, nil
 	}
@@ -266,10 +279,10 @@ func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 	return junits, utilerrors.NewAggregate(errs)
 }
 
-func (*availability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	return nil
+func (w *availability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return w.notSupportedReason
 }
 
 func (w *availability) Cleanup(ctx context.Context) error {
-	return nil
+	return w.notSupportedReason
 }

--- a/pkg/monitortests/kubeapiserver/disruptionnewapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptionnewapiserver/monitortest.go
@@ -19,7 +19,7 @@ import (
 
 type newAPIServerDisruptionChecker struct {
 	adminRESTConfig    *rest.Config
-	notSupportedReason *monitortestframework.NotSupportedError
+	notSupportedReason error
 }
 
 func NewDisruptionInvariant() monitortestframework.MonitorTest {

--- a/pkg/monitortests/kubeapiserver/disruptionnewapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptionnewapiserver/monitortest.go
@@ -7,18 +7,19 @@ import (
 
 	"github.com/openshift/origin/pkg/monitortestframework"
 
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
 	"github.com/openshift/origin/pkg/disruption/backend/sampler"
 	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	exutil "github.com/openshift/origin/test/extended/util"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 type newAPIServerDisruptionChecker struct {
 	adminRESTConfig    *rest.Config
-	notSupportedReason string
+	notSupportedReason *monitortestframework.NotSupportedError
 }
 
 func NewDisruptionInvariant() monitortestframework.MonitorTest {
@@ -37,15 +38,18 @@ func (w *newAPIServerDisruptionChecker) StartCollection(ctx context.Context, adm
 		return fmt.Errorf("unable to determine if cluster is MicroShift: %v", err)
 	}
 	if isMicroShift {
-		w.notSupportedReason = "platform MicroShift not supported"
+		w.notSupportedReason = &monitortestframework.NotSupportedError{
+			Reason: "platform MicroShift not supported",
+		}
 	}
-	return nil
+	return w.notSupportedReason
 }
 
 func (w *newAPIServerDisruptionChecker) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
-	if len(w.notSupportedReason) > 0 {
-		return nil, nil, nil
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
 	}
+
 	kubeClient, err := kubernetes.NewForConfig(w.adminRESTConfig)
 	if err != nil {
 		return nil, nil, err
@@ -55,21 +59,21 @@ func (w *newAPIServerDisruptionChecker) CollectData(ctx context.Context, storage
 	return apiserverAvailabilityIntervals, nil, err
 }
 
-func (*newAPIServerDisruptionChecker) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
-	return nil, nil
+func (w *newAPIServerDisruptionChecker) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, w.notSupportedReason
 }
 
-func (*newAPIServerDisruptionChecker) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
-	return nil, nil
+func (w *newAPIServerDisruptionChecker) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, w.notSupportedReason
 }
 
 func (w *newAPIServerDisruptionChecker) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	return nil
+	return w.notSupportedReason
 }
 
 func (w *newAPIServerDisruptionChecker) Cleanup(ctx context.Context) error {
-	if len(w.notSupportedReason) > 0 {
-		return nil
+	if w.notSupportedReason != nil {
+		return w.notSupportedReason
 	}
 
 	if err := sampler.TearDownInClusterMonitors(w.adminRESTConfig); err != nil {

--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -78,7 +78,7 @@ func init() {
 
 type podNetworkAvalibility struct {
 	payloadImagePullSpec string
-	notSupportedReason   *monitortestframework.NotSupportedError
+	notSupportedReason   error
 	namespaceName        string
 	targetService        *corev1.Service
 	kubeClient           kubernetes.Interface

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -53,7 +53,7 @@ func init() {
 
 type availability struct {
 	namespaceName      string
-	notSupportedReason *monitortestframework.NotSupportedError
+	notSupportedReason error
 	kubeClient         kubernetes.Interface
 
 	disruptionChecker *disruptionlibrary.Availability

--- a/pkg/monitortests/testframework/disruptionexternalservicemonitoring/monitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalservicemonitoring/monitortest.go
@@ -34,7 +34,7 @@ type availability struct {
 	imageRegistryRoute *routev1.Route
 
 	disruptionChecker  *disruptionlibrary.Availability
-	notSupportedReason *monitortestframework.NotSupportedError
+	notSupportedReason error
 	suppressJunit      bool
 }
 

--- a/pkg/monitortests/testframework/disruptionexternalservicemonitoring/monitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalservicemonitoring/monitortest.go
@@ -6,19 +6,19 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
-
 	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
 
 	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
-	"github.com/openshift/origin/pkg/monitor/backenddisruption"
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
-	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
-	"github.com/openshift/origin/test/extended/util/imageregistryutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"github.com/openshift/origin/test/extended/util/imageregistryutil"
 )
 
 const (
@@ -34,7 +34,7 @@ type availability struct {
 	imageRegistryRoute *routev1.Route
 
 	disruptionChecker  *disruptionlibrary.Availability
-	notSupportedReason string
+	notSupportedReason *monitortestframework.NotSupportedError
 	suppressJunit      bool
 }
 
@@ -62,7 +62,9 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 
 	_, err = w.kubeClient.CoreV1().Namespaces().Get(context.Background(), "openshift-image-registry", metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		w.notSupportedReason = "namespace openshift-image-registry not present"
+		w.notSupportedReason = &monitortestframework.NotSupportedError{
+			Reason: "namespace openshift-image-registry not present",
+		}
 		return nil
 	}
 	if err != nil {
@@ -97,14 +99,14 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 }
 
 func (w *availability) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
-	if len(w.notSupportedReason) > 0 {
-		return nil, nil, nil
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
 	}
 	return w.disruptionChecker.CollectData(ctx)
 }
 
-func (*availability) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
-	return nil, nil
+func (w *availability) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, w.notSupportedReason
 }
 
 func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
@@ -112,13 +114,13 @@ func (w *availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 		return nil, nil
 	}
 
-	return nil, nil
+	return nil, w.notSupportedReason
 }
 
-func (*availability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	return nil
+func (w *availability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return w.notSupportedReason
 }
 
 func (w *availability) Cleanup(ctx context.Context) error {
-	return nil
+	return w.notSupportedReason
 }


### PR DESCRIPTION
Currently when the image-registry is unavailable, the monitor tests all just come back successful with no additional data.  This is a bit confusing, since there's no indication that monitor didn't run other than the extremely short duration of the tests.  This introduces a NotSupportedError type that the monitor tests can return which will cause the tests to be skipped instead of faked success.
