### PR TITLE
Use ruby-27 from quay instead registry access due to removal

### DIFF
--- a/examples/image-streams/image-streams-centos7.json
+++ b/examples/image-streams/image-streams-centos7.json
@@ -1742,7 +1742,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             },
             "generation": null,
             "importPolicy": {},

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -90,7 +90,7 @@
           {
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             },
             "name": "latest"
           }

--- a/examples/sample-app/application-template-pullspecbuild.json
+++ b/examples/sample-app/application-template-pullspecbuild.json
@@ -86,7 +86,7 @@
         "name": "ruby-27"
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -134,7 +134,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             }
           }
         },

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -86,7 +86,7 @@
         "name": "ruby-27"
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""

--- a/test/extended/cli/builds.go
+++ b/test/extended/cli/builds.go
@@ -84,7 +84,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		o.Expect(oc.Run("delete").Args("bc,is", "--all").Execute()).NotTo(o.HaveOccurred())
 
 		g.By("build from git with output to ImageStreamTag")
-		out, err = oc.Run("new-build").Args("registry.access.redhat.com/ubi8/ruby-27", "https://github.com/openshift/ruby-hello-world.git").Output()
+		out, err = oc.Run("new-build").Args("quay.io/centos7/ruby-27-centos7", "https://github.com/openshift/ruby-hello-world.git").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(getExpectedBCOutputMatcher("ruby-hello-world", "ruby-hello-world"))
 		o.Expect(getBCSourceType(oc, "ruby-hello-world")).To(o.Equal("Git"))

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -4536,7 +4536,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             },
             "generation": null,
             "importPolicy": {},
@@ -5010,7 +5010,7 @@ var _examplesSampleAppApplicationTemplateDockerbuildJson = []byte(`{
           {
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             },
             "name": "latest"
           }
@@ -5466,7 +5466,7 @@ var _examplesSampleAppApplicationTemplatePullspecbuildJson = []byte(`{
         "name": "ruby-27"
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -5514,7 +5514,7 @@ var _examplesSampleAppApplicationTemplatePullspecbuildJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             }
           }
         },
@@ -5961,7 +5961,7 @@ var _examplesSampleAppApplicationTemplateStibuildJson = []byte(`{
         "name": "ruby-27"
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -17947,7 +17947,7 @@ func testExtendedTestdataBuildsBuildSecretsTestSecretJson() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsBuildTimingDockerfile = []byte(`FROM registry.access.redhat.com/ubi8/ruby-27
+var _testExtendedTestdataBuildsBuildTimingDockerfile = []byte(`FROM quay.io/centos7/ruby-27-centos7
 
 USER root
 `)
@@ -19167,7 +19167,7 @@ func testExtendedTestdataBuildsTestBcWithPrRefYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsTestBuildAppDockerfile = []byte(`FROM registry.access.redhat.com/ubi8/ruby-27
+var _testExtendedTestdataBuildsTestBuildAppDockerfile = []byte(`FROM quay.io/centos7/ruby-27-centos7
 USER default
 EXPOSE 8080
 ENV RACK_ENV production
@@ -19770,7 +19770,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM registry.access.redhat.com/ubi8/ruby-27
+        FROM quay.io/centos7/ruby-27-centos7
         ARG foofoo
         RUN echo $foofoo
     strategy:
@@ -19799,7 +19799,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM registry.access.redhat.com/ubi8/ruby-27
+        FROM quay.io/centos7/ruby-27-centos7
         ARG foofoo
         RUN echo $foofoo
     strategy:
@@ -35087,7 +35087,7 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateMixJson = []byte(`
         "name": "ruby-27"
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -35245,7 +35245,7 @@ var _testExtendedTestdataCmdTestCmdTestdataApplicationTemplateStibuildJson = []b
         "name": "ruby-27"
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -36737,7 +36737,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             },
             "generation": null,
             "importPolicy": {},
@@ -37178,14 +37178,14 @@ var _testExtendedTestdataCmdTestCmdTestdataModifiedRubyImagestreamJson = []byte(
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+          "name": "quay.io/centos7/ruby-27-centos7:latest"
         }
       },
       {
         "name": "newtag",
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+          "name": "quay.io/centos7/ruby-27-centos7:latest"
         }
       }
     ]
@@ -37322,7 +37322,7 @@ func testExtendedTestdataCmdTestCmdTestdataNewAppBcFromImagestreamimageJson() (*
 	return a, nil
 }
 
-var _testExtendedTestdataCmdTestCmdTestdataNewAppBuildArgDockerfileDockerfile = []byte(`FROM registry.access.redhat.com/ubi8/ruby-27
+var _testExtendedTestdataCmdTestCmdTestdataNewAppBuildArgDockerfileDockerfile = []byte(`FROM quay.io/centos7/ruby-27-centos7
 ARG foo
 RUN echo $foo
 `)
@@ -37707,7 +37707,7 @@ var _testExtendedTestdataCmdTestCmdTestdataNewAppTemplateWithAppLabelJson = []by
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -38370,7 +38370,7 @@ var _testExtendedTestdataCmdTestCmdTestdataNewAppTemplateWithoutAppLabelJson = [
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""
@@ -39693,7 +39693,7 @@ spec:
     spec:
       containers:
       - name: testapp
-        image: registry.access.redhat.com/ubi8/ruby-27:latest
+        image: quay.io/centos7/ruby-27-centos7:latest
         command:
         - /bin/sleep
         args:
@@ -40648,7 +40648,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/ubi8/ruby-27
+        name: quay.io/centos7/ruby-27-centos7
     type: Source
   triggers: []
 status:
@@ -41277,7 +41277,7 @@ project="$(oc project -q)"
 os::test::junit::declare_suite_start "cmd/triggers"
 # This test validates triggers
 
-os::cmd::expect_success 'oc new-app registry.access.redhat.com/ubi8/ruby-27~https://github.com/openshift/ruby-hello-world.git'
+os::cmd::expect_success 'oc new-app quay.io/centos7/ruby-27-centos7~https://github.com/openshift/ruby-hello-world.git'
 os::cmd::expect_success 'oc get bc/ruby-hello-world'
 
 os::cmd::expect_success "oc new-build --name=scratch --docker-image=scratch --dockerfile='FROM scratch'"
@@ -41599,7 +41599,7 @@ run Proc.new { |env|
 EOF
 
 cat > Dockerfile <<- EOF
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM quay.io/centos7/ruby-27-centos7
 ENV SECRET_FILE /opt/openshift/src/dockercfg
 COPY dockercfg ./
 COPY config.ru ./
@@ -47715,7 +47715,7 @@ func testExtendedTestdataLdapLdapserverServiceYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataLong_namesDockerfile = []byte(`FROM registry.access.redhat.com/ubi8/ruby-27
+var _testExtendedTestdataLong_namesDockerfile = []byte(`FROM quay.io/centos7/ruby-27-centos7
 
 CMD ["/bin/sh", "-c", "echo", "hello"]
 `)
@@ -50073,7 +50073,7 @@ func testExtendedTestdataS2iDropcapsRootAccessBuildYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataS2iDropcapsRootableRubyDockerfile = []byte(`FROM registry.access.redhat.com/ubi8/ruby-27:latest
+var _testExtendedTestdataS2iDropcapsRootableRubyDockerfile = []byte(`FROM quay.io/centos7/ruby-27-centos7:latest
 USER root
 RUN rm -f /usr/bin/ls
 RUN echo "root:redhat" | chpasswd

--- a/test/extended/testdata/builds/build-timing/Dockerfile
+++ b/test/extended/testdata/builds/build-timing/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM quay.io/centos7/ruby-27-centos7
 
 USER root

--- a/test/extended/testdata/builds/test-build-app/Dockerfile
+++ b/test/extended/testdata/builds/test-build-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM quay.io/centos7/ruby-27-centos7
 USER default
 EXPOSE 8080
 ENV RACK_ENV production

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -180,7 +180,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM registry.access.redhat.com/ubi8/ruby-27
+        FROM quay.io/centos7/ruby-27-centos7
         ARG foofoo
         RUN echo $foofoo
     strategy:
@@ -209,7 +209,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM registry.access.redhat.com/ubi8/ruby-27
+        FROM quay.io/centos7/ruby-27-centos7
         ARG foofoo
         RUN echo $foofoo
     strategy:

--- a/test/extended/testdata/cmd/test/cmd/testdata/application-template-mix.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/application-template-mix.json
@@ -86,7 +86,7 @@
         "name": "ruby-27"
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""

--- a/test/extended/testdata/cmd/test/cmd/testdata/application-template-stibuild.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/application-template-stibuild.json
@@ -86,7 +86,7 @@
         "name": "ruby-27"
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""

--- a/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
@@ -832,7 +832,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:latest"
             },
             "generation": null,
             "importPolicy": {},

--- a/test/extended/testdata/cmd/test/cmd/testdata/modified-ruby-imagestream.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/modified-ruby-imagestream.json
@@ -23,14 +23,14 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+          "name": "quay.io/centos7/ruby-27-centos7:latest"
         }
       },
       {
         "name": "newtag",
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
+          "name": "quay.io/centos7/ruby-27-centos7:latest"
         }
       }
     ]

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/build-arg-dockerfile/Dockerfile
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/build-arg-dockerfile/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM quay.io/centos7/ruby-27-centos7
 ARG foo
 RUN echo $foo

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/template-with-app-label.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/template-with-app-label.json
@@ -77,7 +77,7 @@
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/template-without-app-label.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/template-without-app-label.json
@@ -81,7 +81,7 @@
         "creationTimestamp": null
       },
       "spec": {
-        "dockerImageRepository": "registry.access.redhat.com/ubi8/ruby-27"
+        "dockerImageRepository": "quay.io/centos7/ruby-27-centos7"
       },
       "status": {
         "dockerImageRepository": ""

--- a/test/extended/testdata/cmd/test/cmd/testdata/statefulset.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: testapp
-        image: registry.access.redhat.com/ubi8/ruby-27:latest
+        image: quay.io/centos7/ruby-27-centos7:latest
         command:
         - /bin/sleep
         args:

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-bc.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-bc.yaml
@@ -14,7 +14,7 @@ spec:
     sourceStrategy:
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/ubi8/ruby-27
+        name: quay.io/centos7/ruby-27-centos7
     type: Source
   triggers: []
 status:

--- a/test/extended/testdata/cmd/test/cmd/triggers.sh
+++ b/test/extended/testdata/cmd/test/cmd/triggers.sh
@@ -16,7 +16,7 @@ project="$(oc project -q)"
 os::test::junit::declare_suite_start "cmd/triggers"
 # This test validates triggers
 
-os::cmd::expect_success 'oc new-app registry.access.redhat.com/ubi8/ruby-27~https://github.com/openshift/ruby-hello-world.git'
+os::cmd::expect_success 'oc new-app quay.io/centos7/ruby-27-centos7~https://github.com/openshift/ruby-hello-world.git'
 os::cmd::expect_success 'oc get bc/ruby-hello-world'
 
 os::cmd::expect_success "oc new-build --name=scratch --docker-image=scratch --dockerfile='FROM scratch'"

--- a/test/extended/testdata/custom-secret-builder/build.sh
+++ b/test/extended/testdata/custom-secret-builder/build.sh
@@ -35,7 +35,7 @@ run Proc.new { |env|
 EOF
 
 cat > Dockerfile <<- EOF
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM quay.io/centos7/ruby-27-centos7
 ENV SECRET_FILE /opt/openshift/src/dockercfg
 COPY dockercfg ./
 COPY config.ru ./

--- a/test/extended/testdata/long_names/Dockerfile
+++ b/test/extended/testdata/long_names/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ruby-27
+FROM quay.io/centos7/ruby-27-centos7
 
 CMD ["/bin/sh", "-c", "echo", "hello"]

--- a/test/extended/testdata/s2i-dropcaps/rootable-ruby/Dockerfile
+++ b/test/extended/testdata/s2i-dropcaps/rootable-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ruby-27:latest
+FROM quay.io/centos7/ruby-27-centos7:latest
 USER root
 RUN rm -f /usr/bin/ls
 RUN echo "root:redhat" | chpasswd


### PR DESCRIPTION
It seems that ruby-2.7 is removed from registery access and this PR
uses quay instead of it to unblock jobs to pass again.