### PR TITLE
NOJIRA: collect certificate data: use SkipHashed option

### DIFF
--- a/test/extended/operators/certs.go
+++ b/test/extended/operators/certs.go
@@ -57,6 +57,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 
 		currentPKIContent, err := certgraphanalysis.GatherCertsFromPlatformNamespaces(ctx, kubeClient,
 			certgraphanalysis.SkipRevisioned,
+			certgraphanalysis.SkipHashed,
 			certgraphanalysis.ElideProxyCADetails,
 			certgraphanalysis.RewriteNodeIPs(masters),
 			certgraphanalysis.CollectAnnotations(


### PR DESCRIPTION
Skip hashed certs generated by monitoring operator. This has probably been accidentally removed in one of rebases.