### PR TITLE
OWNER_ALIASES: update CoreOS team leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -37,7 +37,7 @@ aliases:
   - jwmatthews # App Migration
   - kevinrizza # Operator Lifecycle Manager
   - mandre # Shift on Stack
-  - miabbott # CoreOS
+  - mike-nguyen # CoreOS
   - pedjak # App Services
   - jmguzik # Test Platform
   - romfreiman # Single Node OpenShift
@@ -50,5 +50,6 @@ aliases:
   - staebler # OpenShift Installer
   - stlaz # Authentication
   - sttts # API Server
+  - travier # CoreOS
   - trozet # Networking
   - umohnani8 # Container Engine Tools


### PR DESCRIPTION
I left the CoreOS team over a year ago, so there are new co-leads for the team.