### PR TITLE
update-tls-artifacts: add AnnotationRequirement

### DIFF
--- a/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadata/ownership/requirement.go
+++ b/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadata/ownership/requirement.go
@@ -1,74 +1,28 @@
 package ownership
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/openshift/api/annotations"
 	"github.com/openshift/origin/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces"
 
 	"github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type OwnerRequirement struct {
-	name string
+const annotationName string = annotations.OpenShiftComponent
+
+type OwnerRequirement struct{}
+
+func NewOwnerRequirement() tlsmetadatainterfaces.AnnotationRequirement {
+	return tlsmetadatainterfaces.NewAnnotationRequirement(
+		"ownership",
+		annotationName,
+		generateOwnerMarkdownFn,
+	)
 }
 
-func NewOwnerRequirement() tlsmetadatainterfaces.Requirement {
-	return OwnerRequirement{
-		name: "ownership",
-	}
-}
-
-func (o OwnerRequirement) InspectRequirement(rawData []*certgraphapi.PKIList) (tlsmetadatainterfaces.RequirementResult, error) {
-	pkiInfo, err := tlsmetadatainterfaces.ProcessByLocation(rawData)
-	if err != nil {
-		return nil, fmt.Errorf("transforming raw data %v: %w", o.GetName(), err)
-	}
-
-	ownershipJSONBytes, err := json.MarshalIndent(pkiInfo, "", "    ")
-	if err != nil {
-		return nil, fmt.Errorf("failure marshalling %v.json: %w", o.GetName(), err)
-	}
-	markdown, err := generateOwnershipMarkdown(pkiInfo)
-	if err != nil {
-		return nil, fmt.Errorf("failure marshalling %v.md: %w", o.GetName(), err)
-	}
-	violations := generateViolationJSON(pkiInfo)
-	violationJSONBytes, err := json.MarshalIndent(violations, "", "    ")
-	if err != nil {
-		return nil, fmt.Errorf("failure marshalling %v-violations.json: %w", o.GetName(), err)
-	}
-
-	return tlsmetadatainterfaces.NewRequirementResult(
-		o.GetName(),
-		ownershipJSONBytes,
-		markdown,
-		violationJSONBytes)
-}
-
-func generateViolationJSON(pkiInfo *certgraphapi.PKIRegistryInfo) *certgraphapi.PKIRegistryInfo {
-	ret := &certgraphapi.PKIRegistryInfo{}
-
-	for i := range pkiInfo.CertKeyPairs {
-		curr := pkiInfo.CertKeyPairs[i]
-		owner := curr.CertKeyInfo.OwningJiraComponent
-		if len(owner) == 0 || owner == tlsmetadatainterfaces.UnknownOwner {
-			ret.CertKeyPairs = append(ret.CertKeyPairs, curr)
-		}
-	}
-	for i := range pkiInfo.CertificateAuthorityBundles {
-		curr := pkiInfo.CertificateAuthorityBundles[i]
-		owner := curr.CABundleInfo.OwningJiraComponent
-		if len(owner) == 0 || owner == tlsmetadatainterfaces.UnknownOwner {
-			ret.CertificateAuthorityBundles = append(ret.CertificateAuthorityBundles, curr)
-		}
-	}
-
-	return ret
-}
-
-func generateOwnershipMarkdown(pkiInfo *certgraphapi.PKIRegistryInfo) ([]byte, error) {
+func generateOwnerMarkdownFn(pkiInfo *certgraphapi.PKIRegistryInfo) ([]byte, error) {
 	certsByOwner := map[string][]certgraphapi.PKIRegistryInClusterCertKeyPair{}
 	certsWithoutOwners := []certgraphapi.PKIRegistryInClusterCertKeyPair{}
 	caBundlesByOwner := map[string][]certgraphapi.PKIRegistryInClusterCABundle{}
@@ -157,8 +111,4 @@ func generateOwnershipMarkdown(pkiInfo *certgraphapi.PKIRegistryInfo) ([]byte, e
 	}
 
 	return md.Bytes(), nil
-}
-
-func (o OwnerRequirement) GetName() string {
-	return o.name
 }

--- a/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces/annotation_requirement.go
+++ b/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces/annotation_requirement.go
@@ -1,0 +1,83 @@
+package tlsmetadatainterfaces
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/certs/cert-inspection/certgraphapi"
+)
+
+type generateMarkdownFn func(pkiInfo *certgraphapi.PKIRegistryInfo) ([]byte, error)
+
+type annotationRequirement struct {
+	// requirementName is a unique name for metadata requirement
+	requirementName string
+	// annotationName is the annotation looked up in cert metadata
+	annotationName string
+	// markdownFn is a function which build markdown report from pkiInfo
+	markdownFn generateMarkdownFn
+}
+
+func NewAnnotationRequirement(requirementName, annotationName string, generateMarkdownFn generateMarkdownFn) AnnotationRequirement {
+	return annotationRequirement{
+		requirementName: requirementName,
+		annotationName:  annotationName,
+		markdownFn:      generateMarkdownFn,
+	}
+}
+
+func (o annotationRequirement) GetName() string {
+	return o.requirementName
+}
+
+func (o annotationRequirement) GetAnnotationName() string {
+	return o.annotationName
+}
+
+func (o annotationRequirement) InspectRequirement(rawData []*certgraphapi.PKIList) (RequirementResult, error) {
+	pkiInfo, err := ProcessByLocation(rawData)
+	if err != nil {
+		return nil, fmt.Errorf("transforming raw data %v: %w", o.GetName(), err)
+	}
+
+	ownershipJSONBytes, err := json.MarshalIndent(pkiInfo, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failure marshalling %v.json: %w", o.GetName(), err)
+	}
+	markdown, err := o.markdownFn(pkiInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failure marshalling %v.md: %w", o.GetName(), err)
+	}
+	violations := generateViolationJSONForAnnotationRequirement(o.GetAnnotationName(), pkiInfo)
+	violationJSONBytes, err := json.MarshalIndent(violations, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failure marshalling %v-violations.json: %w", o.GetName(), err)
+	}
+
+	return NewRequirementResult(
+		o.GetName(),
+		ownershipJSONBytes,
+		markdown,
+		violationJSONBytes)
+}
+
+func generateViolationJSONForAnnotationRequirement(annotationName string, pkiInfo *certgraphapi.PKIRegistryInfo) *certgraphapi.PKIRegistryInfo {
+	ret := &certgraphapi.PKIRegistryInfo{}
+
+	for i := range pkiInfo.CertKeyPairs {
+		curr := pkiInfo.CertKeyPairs[i]
+		regenerates, _ := AnnotationValue(curr.CertKeyInfo.SelectedCertMetadataAnnotations, annotationName)
+		if len(regenerates) == 0 {
+			ret.CertKeyPairs = append(ret.CertKeyPairs, curr)
+		}
+	}
+	for i := range pkiInfo.CertificateAuthorityBundles {
+		curr := pkiInfo.CertificateAuthorityBundles[i]
+		regenerates, _ := AnnotationValue(curr.CABundleInfo.SelectedCertMetadataAnnotations, annotationName)
+		if len(regenerates) == 0 {
+			ret.CertificateAuthorityBundles = append(ret.CertificateAuthorityBundles, curr)
+		}
+	}
+
+	return ret
+}

--- a/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces/types.go
+++ b/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces/types.go
@@ -13,6 +13,13 @@ type Requirement interface {
 	InspectRequirement(rawData []*certgraphapi.PKIList) (RequirementResult, error)
 }
 
+type AnnotationRequirement interface {
+	Requirement
+
+	// GetAnnotationName returns annotation name to use
+	GetAnnotationName() string
+}
+
 type RequirementResult interface {
 	GetName() string
 


### PR DESCRIPTION
This is a wrapper around tlsmetadatainterfaces.Requirement which helps users quickly create new requirements for secret/configmap annotations