### PR TITLE
TRT-786: Relax the per-job disruption tests and fix bugs/improve consistency

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/matches_test.go
+++ b/pkg/monitortestlibrary/allowedalerts/matches_test.go
@@ -107,23 +107,6 @@ func TestGetClosestP99Value(t *testing.T) {
 			expectedDuration: mustDuration("7.9s"),
 		},
 		{
-			name: "choose different arch",
-			key: historicaldata.AlertDataKey{
-				AlertName:      "etcdGRPCRequestsSlow",
-				AlertNamespace: "",
-				AlertLevel:     "warning",
-				JobType: platformidentification.JobType{
-					Release:      "4.12",
-					FromRelease:  "4.12",
-					Platform:     "aws",
-					Architecture: "not-real",
-					Network:      "sdn",
-					Topology:     "ha",
-				},
-			},
-			expectedDuration: mustDuration("120.458s"),
-		},
-		{
 			name: "missing",
 			key: historicaldata.AlertDataKey{
 				AlertName:      "notARealAlert",

--- a/pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go
+++ b/pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go
@@ -153,53 +153,6 @@ func TestGetClosestP95Value(t *testing.T) {
 			expectedDuration: mustDuration("2.987s"),
 		},
 		{
-			name: "fuzzy match single ovn fallback to sdn",
-			args: args{
-				backendName: "kube-api-new-connections",
-				jobType: platformidentification.JobType{
-					Release:      "4.12",
-					FromRelease:  "4.12",
-					Platform:     "aws",
-					Architecture: "amd64",
-					Network:      "ovn", // we only defined sdn above, should fall back to it's value
-					Topology:     "single",
-				},
-			},
-			expectedDuration: mustDuration("120.458s"),
-		},
-		{
-			name: "fuzzy match single ovn fallback to sdn previous",
-			args: args{
-				// switching to openshift-api backend, defined above we only have from 4.11->4.11 and sdn
-				backendName: "openshift-api-new-connections",
-				jobType: platformidentification.JobType{
-					Release:      "4.12",
-					FromRelease:  "4.12",
-					Platform:     "aws",
-					Network:      "ovn",
-					Architecture: "amd64",
-					Topology:     "single",
-				},
-			},
-			expectedDuration: mustDuration("70.381s"),
-		},
-		{
-			name: "fuzzy match single ovn fallback to sdn previous micro",
-			args: args{
-				// For oauth backend ovn single don't have 4.12 minor, but we have 4.11->4.12 sdn above:
-				backendName: "oauth-api-new-connections",
-				jobType: platformidentification.JobType{
-					Release:      "4.12",
-					FromRelease:  "4.11",
-					Platform:     "aws",
-					Network:      "ovn",
-					Architecture: "amd64",
-					Topology:     "single",
-				},
-			},
-			expectedDuration: mustDuration("35.917s"),
-		},
-		{
 			name: "no exact or fuzzy match",
 			args: args{
 				backendName: "kube-api-reused-connections",

--- a/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
@@ -99,7 +99,24 @@ func (w *Availability) CollectData(ctx context.Context) (monitorapi.Intervals, [
 	return nil, nil, utilerrors.NewAggregate([]error{newRecoverErr, reusedRecoverErr})
 }
 
-func createDisruptionJunit(testName string, allowedDisruption *time.Duration, disruptionDetails string, locator monitorapi.Locator, disruptedIntervals monitorapi.Intervals) *junitapi.JUnitTestCase {
+func createDisruptionJunit(
+	testName string,
+	allowedDisruption *time.Duration,
+	disruptionDetails string,
+	locator monitorapi.Locator,
+	disruptedIntervals monitorapi.Intervals,
+	jobType *platformidentification.JobType) *junitapi.JUnitTestCase {
+
+	// Not sure what these are, but this will help find them, and we don't get any value from testing these:
+	if jobType.Platform == "" {
+		return &junitapi.JUnitTestCase{
+			Name: testName,
+			SkipMessage: &junitapi.SkipMessage{
+				Message: "Unknown platform, skipping disruption testing",
+			},
+		}
+	}
+
 	// Indicates there is no entry in the query_results.json data file, nor a valid fallback,
 	// we do not wish to run the test. (this likely implies we do not have the required number of
 	// runs in 3 weeks to do a reliable P99)
@@ -177,6 +194,7 @@ func (w *Availability) junitForNewConnections(ctx context.Context, finalInterval
 					monitorapi.IsErrorEvent,
 				),
 			),
+			jobType,
 		),
 		nil
 }
@@ -194,6 +212,7 @@ func (w *Availability) junitForReusedConnections(ctx context.Context, finalInter
 					monitorapi.IsErrorEvent,
 				),
 			),
+			jobType,
 		),
 		nil
 }

--- a/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -111,17 +112,37 @@ func createDisruptionJunit(testName string, allowedDisruption *time.Duration, di
 		}
 	}
 
+	disruptionDuration := disruptedIntervals.Duration(1 * time.Second)
+	roundedDisruptionDuration := disruptionDuration.Round(time.Second)
+
+	// Determine what amount of disruption we're willing to tolerate before we fail the test. We previously just
+	// enforced being over a P99 over the past 3 weeks, however the P99 fluctuates wildly even under these
+	// conditions, and the tests fail excessively on very low numbers. Thus we now also allow a grace amount to try to
+	// establish this as a first line of defence to detect egregious regressions before they merge.
+	//roundedAllowedDisruption, additionalDetails := calculateAllowedDisruptionWithGrace(*allowedDisruption)
+	allowedDetails := []string{}
+	allowedDetails = append(allowedDetails, fmt.Sprintf("P99 from historical data for similar jobs over past 3 weeks: %s",
+		*allowedDisruption))
 	if *allowedDisruption < 1*time.Second {
 		t := 1 * time.Second
 		allowedDisruption = &t
-		disruptionDetails = "always allow at least one second"
+		allowedDetails = append(allowedDetails, "rounded P99 up to always allow one second")
 	}
 
-	disruptionDuration := disruptedIntervals.Duration(1 * time.Second)
-	roundedAllowedDisruption := allowedDisruption.Round(time.Second)
-	roundedDisruptionDuration := disruptionDuration.Round(time.Second)
+	// Allow grace of 5s or 20%, at this layer, with one sample, we're only hoping to find really severe disruption:
+	allowedSecs := allowedDisruption.Seconds()
+	allowedSecsWithGrace := allowedSecs + 5.0
+	allowedSecsPlus20Percent := allowedSecs * 1.2
+	if allowedSecsPlus20Percent > allowedSecsWithGrace {
+		allowedSecsWithGrace = allowedSecsPlus20Percent
+		allowedDetails = append(allowedDetails, "added an additional 20% of grace")
+	} else {
+		allowedDetails = append(allowedDetails, "added an additional 5s of grace")
+	}
+	roundedFinal := int64(math.Round(allowedSecsWithGrace))
+	finalAllowedDisruption := time.Duration(roundedFinal) * time.Second
 
-	if roundedDisruptionDuration <= roundedAllowedDisruption {
+	if roundedDisruptionDuration <= finalAllowedDisruption {
 		return &junitapi.JUnitTestCase{
 			Name: testName,
 		}
@@ -129,7 +150,10 @@ func createDisruptionJunit(testName string, allowedDisruption *time.Duration, di
 
 	reason := fmt.Sprintf("%v was unreachable during disruption: %v", locator.OldLocator(), disruptionDetails)
 	describe := disruptedIntervals.Strings()
-	failureMessage := fmt.Sprintf("%s for at least %s (maxAllowed=%s):\n\n%s", reason, roundedDisruptionDuration, roundedAllowedDisruption, strings.Join(describe, "\n"))
+	failureMessage := fmt.Sprintf("%s for at least %s (maxAllowed=%s):\n%s\n\n%s", reason,
+		roundedDisruptionDuration, finalAllowedDisruption,
+		strings.Join(allowedDetails, "\n"),
+		strings.Join(describe, "\n"))
 
 	return &junitapi.JUnitTestCase{
 		Name: testName,

--- a/pkg/monitortestlibrary/historicaldata/next_best_guess.go
+++ b/pkg/monitortestlibrary/historicaldata/next_best_guess.go
@@ -10,94 +10,17 @@ import (
 )
 
 // nextBestGuessers is the order in which to attempt to lookup other alternative matches that are close to this job type.
-// TODO building a cross multiply would likely be beneficial
 var nextBestGuessers = []NextBestKey{
-	MicroReleaseUpgrade,
-	//	MinorReleaseUpgrade,
+	// The only guesser we try not is falling back to previous release. Otherwise if we don't have enough data, we don't
+	// run the test. This was implemented after finding that we fail every attempt at a fallback.
+	// Continuing with previous release helps us in the transition between major releases, so we kept this fallback.
 	PreviousReleaseUpgrade,
-
-	combine(PreviousReleaseUpgrade, MicroReleaseUpgrade),
-	//	combine(PreviousReleaseUpgrade, MinorReleaseUpgrade),
-
-	OnArchitecture("amd64"),
-	OnArchitecture("ppc64le"),
-	OnArchitecture("s390x"),
-	OnArchitecture("arm64"),
-
-	combine(OnArchitecture("amd64"), MicroReleaseUpgrade),
-	combine(OnArchitecture("ppc64le"), MicroReleaseUpgrade),
-	combine(OnArchitecture("s390x"), MicroReleaseUpgrade),
-	combine(OnArchitecture("arm64"), MicroReleaseUpgrade),
-
-	//	combine(OnArchitecture("amd64"), MinorReleaseUpgrade),
-	//	combine(OnArchitecture("ppc64le"), MinorReleaseUpgrade),
-	//	combine(OnArchitecture("s390x"), MinorReleaseUpgrade),
-	//	combine(OnArchitecture("arm64"), MinorReleaseUpgrade),
-
-	combine(OnArchitecture("amd64"), PreviousReleaseUpgrade),
-	combine(OnArchitecture("ppc64le"), PreviousReleaseUpgrade),
-	combine(OnArchitecture("s390x"), PreviousReleaseUpgrade),
-	combine(OnArchitecture("arm64"), PreviousReleaseUpgrade),
-
-	combine(OnArchitecture("amd64"), PreviousReleaseUpgrade, MicroReleaseUpgrade),
-	combine(OnArchitecture("ppc64le"), PreviousReleaseUpgrade, MicroReleaseUpgrade),
-	combine(OnArchitecture("s390x"), PreviousReleaseUpgrade, MicroReleaseUpgrade),
-	combine(OnArchitecture("arm64"), PreviousReleaseUpgrade, MicroReleaseUpgrade),
-
-	//	combine(OnArchitecture("amd64"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
-	//	combine(OnArchitecture("ppc64le"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
-	//	combine(OnArchitecture("s390x"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
-	//	combine(OnArchitecture("arm64"), PreviousReleaseUpgrade, MinorReleaseUpgrade),
-
-	combine(ForTopology("single"), OnSDN),
-	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade),
-	combine(ForTopology("single"), OnSDN, PreviousReleaseUpgrade, MicroReleaseUpgrade),
 }
 
 // NextBestKey returns the next best key in the query_results.json generated from BigQuery and a bool indicating whether this guesser has an opinion.
 // If the bool is false, the key should not be used.
 // Returning true doesn't mean the key exists, it just means that the key is worth trying.
 type NextBestKey func(in platformidentification.JobType) (platformidentification.JobType, bool)
-
-// MinorReleaseUpgrade if we don't have data for the current fromRelease and it's a micro upgrade, perhaps we have data
-// for a minor upgrade.  A 4.11 to 4.11 upgrade will attempt a 4.10 to 4.11 upgrade.
-func MinorReleaseUpgrade(in platformidentification.JobType) (platformidentification.JobType, bool) {
-	if len(in.FromRelease) == 0 {
-		return platformidentification.JobType{}, false
-	}
-
-	fromReleaseMinor := getMinor(in.FromRelease)
-	toReleaseMajor := getMajor(in.Release)
-	toReleaseMinor := getMinor(in.Release)
-	// if we're already a minor upgrade, this doesn't apply
-	if fromReleaseMinor == (toReleaseMinor - 1) {
-		return platformidentification.JobType{}, false
-	}
-
-	ret := platformidentification.CloneJobType(in)
-	ret.FromRelease = fmt.Sprintf("%d.%d", toReleaseMajor, toReleaseMinor-1)
-	return ret, true
-}
-
-// MicroReleaseUpgrade if we don't have data for the current fromRelease and it's a minor upgrade, perhaps we have data
-// for a micro upgrade.  A 4.10 to 4.11 upgrade will attempt a 4.11 to 4.11 upgrade.
-func MicroReleaseUpgrade(in platformidentification.JobType) (platformidentification.JobType, bool) {
-	if len(in.FromRelease) == 0 {
-		return platformidentification.JobType{}, false
-	}
-
-	fromReleaseMinor := getMinor(in.FromRelease)
-	toReleaseMajor := getMajor(in.Release)
-	toReleaseMinor := getMinor(in.Release)
-	// if we're already a micro upgrade, this doesn't apply
-	if fromReleaseMinor == toReleaseMinor {
-		return platformidentification.JobType{}, false
-	}
-
-	ret := platformidentification.CloneJobType(in)
-	ret.FromRelease = fmt.Sprintf("%d.%d", toReleaseMajor, toReleaseMinor)
-	return ret, true
-}
 
 // PreviousReleaseUpgrade if we don't have data for the current toRelease, perhaps we have data for the congruent test
 // on the prior release.   A 4.11 to 4.11 upgrade will attempt a 4.10 to 4.10 upgrade.  A 4.11 no upgrade, will attempt a 4.10 no upgrade.
@@ -128,68 +51,6 @@ func getMinor(in string) int {
 		panic(err)
 	}
 	return int(minor)
-}
-
-// OnOVN maybe we have data on OVN
-func OnOVN(in platformidentification.JobType) (platformidentification.JobType, bool) {
-	if in.Network == "ovn" {
-		return platformidentification.JobType{}, false
-	}
-
-	ret := platformidentification.CloneJobType(in)
-	ret.Network = "ovn"
-	return ret, true
-}
-
-// OnSDN maybe we have data on SDN
-func OnSDN(in platformidentification.JobType) (platformidentification.JobType, bool) {
-	if in.Network == "sdn" {
-		return platformidentification.JobType{}, false
-	}
-
-	ret := platformidentification.CloneJobType(in)
-	ret.Network = "sdn"
-	return ret, true
-}
-
-// OnArchitecture maybe we match a different architecture
-func OnArchitecture(architecture string) func(in platformidentification.JobType) (platformidentification.JobType, bool) {
-	return func(in platformidentification.JobType) (platformidentification.JobType, bool) {
-		if in.Architecture == architecture {
-			return platformidentification.JobType{}, false
-		}
-
-		ret := platformidentification.CloneJobType(in)
-		ret.Architecture = architecture
-		return ret, true
-	}
-}
-
-// ForTopology we match on exact topology
-func ForTopology(topology string) func(in platformidentification.JobType) (platformidentification.JobType, bool) {
-	return func(in platformidentification.JobType) (platformidentification.JobType, bool) {
-		if in.Topology != topology {
-			return platformidentification.JobType{}, false
-		}
-		return in, true
-	}
-}
-
-// combine will start with the input and call each guess in order.  It uses the output of the previous NextBestKeyFn
-// as the input to the next.  This allows combinations like "previous release upgrade micro" without writing custom
-// functions for each.
-func combine(nextBestKeys ...NextBestKey) NextBestKey {
-	return func(in platformidentification.JobType) (platformidentification.JobType, bool) {
-		curr := in
-		for _, nextBestKey := range nextBestKeys {
-			var ok bool
-			curr, ok = nextBestKey(curr)
-			if !ok {
-				return curr, false
-			}
-		}
-		return curr, true
-	}
 }
 
 func CurrentReleaseFromMap(releasesInQueryResults map[string]bool) string {

--- a/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
+++ b/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	newConnectionTestName    = "[sig-imageregistry] Image registry remains available using new connections"
-	reusedConnectionTestName = "[sig-imageregistry] Image registry remains available using reused connections"
+	newConnectionTestName    = "[sig-imageregistry] disruption/image-registry connection/new should be available throughout the test"
+	reusedConnectionTestName = "[sig-imageregistry] disruption/image-registry connection/reused should be available throughout the test"
 )
 
 type availability struct {

--- a/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers/monitortest.go
@@ -36,8 +36,8 @@ func NewRecordAvailabilityOnly() monitortestframework.MonitorTest {
 	}
 }
 func testNames(owner, disruptionBackendName string) (string, string) {
-	return fmt.Sprintf("[%s] disruption/%s should be available throughout the test", owner, disruptionBackendName),
-		fmt.Sprintf("[%s] disruption/%s should be available throughout the test", owner, disruptionBackendName)
+	return fmt.Sprintf("[%s] disruption/%s connection/new should be available throughout the test", owner, disruptionBackendName),
+		fmt.Sprintf("[%s] disruption/%s connection/reused should be available throughout the test", owner, disruptionBackendName)
 }
 
 func newDisruptionCheckerForKubeAPI(adminRESTConfig *rest.Config) (*disruptionlibrary.Availability, error) {

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -43,8 +43,8 @@ var (
 )
 
 const (
-	newConnectionTestName    = "[sig-network-edge] Application behind service load balancer with PDB remains available using new connections"
-	reusedConnectionTestName = "[sig-network-edge] Application behind service load balancer with PDB remains available using reused connections"
+	newConnectionTestName    = "[sig-network-edge] disruption/service-load-balancer-with-pdb connection/new should be available throughout the test"
+	reusedConnectionTestName = "[sig-network-edge] disruption/service-load-balancer-with-pdb connection/reused should be available throughout the test"
 )
 
 func init() {


### PR DESCRIPTION
Details for the why available in the linked jira.

- Allow 5s or 20% grace on per-job disruption testing
- Drop all disruption/alert matcher fallbacks except previous release
- Stop disruption testing when platform is unknown
- Fix broken new/reused disruption test names causing inaccurate flakes
- Update image registry and PDB disruption test names for consistency
