### PR TITLE
OCPBUGS-25943:Adding test case for when exceed openshift.io/image-tags will ban to …

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -53,6 +53,8 @@ var Annotations = map[string]string{
 
 	"[sig-api-machinery][Feature:ResourceQuota] Object count should properly count the number of persistentvolumeclaims resources [Serial]": " [Suite:openshift/conformance/serial]",
 
+	"[sig-api-machinery][Feature:ResourceQuota] Object count when exceed openshift.io/image-tags will ban to create new image references in the project [Skipped:Disconnected]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-api-machinery][Feature:ServerSideApply] Server-Side Apply should work for apps.openshift.io/v1, Resource=deploymentconfigs [apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-api-machinery][Feature:ServerSideApply] Server-Side Apply should work for build.openshift.io/v1, Resource=buildconfigs [apigroup:build.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
@wangke19 @deepakpunia Please review this PR regarding adding test case OCP-12214 in upstream
```
 [sig-api-machinery][Feature:ResourceQuota] Object count when exceed openshift.io/image-tags will ban to create new image references in the project [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
  github.com/openshift/origin/test/extended/quota/resourcequota.go:221
    STEP: Creating a kubernetes client @ 12/19/23 10:52:27.387
  Dec 19 10:52:30.986: INFO: configPath is now "/var/folders/_h/gx71mkg16rz5ylj2xzz_t_hh0000gn/T/configfile1726019048"
  Dec 19 10:52:30.986: INFO: The user is now "e2e-test-object-count-rq-hbzlw-user"
  Dec 19 10:52:30.986: INFO: Creating project "e2e-test-object-count-rq-hbzlw"
  Dec 19 10:52:31.292: INFO: Waiting on permissions in project "e2e-test-object-count-rq-hbzlw" ...
  Dec 19 10:52:32.017: INFO: Waiting for ServiceAccount "default" to be provisioned...
  Dec 19 10:52:32.354: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
  Dec 19 10:52:32.713: INFO: Waiting for ServiceAccount "builder" to be provisioned...
  Dec 19 10:52:33.140: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
  Dec 19 10:52:33.597: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
  Dec 19 10:52:34.051: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
  Dec 19 10:52:35.006: INFO: Project "e2e-test-object-count-rq-hbzlw" has been fully provisioned.
  Dec 19 10:52:38.443: INFO: configPath is now "/var/folders/_h/gx71mkg16rz5ylj2xzz_t_hh0000gn/T/configfile1253462381"
  Dec 19 10:52:38.443: INFO: The user is now "e2e-test-object-count-rq-898xv-user"
  Dec 19 10:52:38.443: INFO: Creating project "e2e-test-object-count-rq-898xv"
  Dec 19 10:52:38.740: INFO: Waiting on permissions in project "e2e-test-object-count-rq-898xv" ...
  Dec 19 10:52:39.476: INFO: Waiting for ServiceAccount "default" to be provisioned...
  Dec 19 10:52:39.809: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
  Dec 19 10:52:40.139: INFO: Waiting for ServiceAccount "builder" to be provisioned...
  Dec 19 10:52:40.621: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
  Dec 19 10:52:41.085: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
  Dec 19 10:52:41.585: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
  Dec 19 10:52:42.651: INFO: Project "e2e-test-object-count-rq-898xv" has been fully provisioned.
    STEP: create the image-tags and checking the usage @ 12/19/23 10:52:42.652
Actual: [{openshift.io/ImageStream map[openshift.io/image-tags:{{1 0} {<nil>} 1 DecimalSI}] map[] map[] map[] map[]}]
Expected: [{openshift.io/ImageStream map[openshift.io/image-tags:{{1 0} {<nil>} 1 DecimalSI}] map[] map[] map[] map[]}]
    STEP: trying to tag a container image with v1 @ 12/19/23 10:52:43.246
  Dec 19 10:52:43.246: INFO: Running 'oc --kubeconfig=/Users/rahulgangwar/office-work/kubeconfig/kube.txt tag quay.io/openshifttest/base-alpine@sha256:3126e4eed4a3ebd8bf972b2453fa838200988ee07c01b2251e3ea47e4b1f245c --source=docker mystream:v1 -n e2e-test-object-count-rq-898xv'
  Tag mystream:v1 set to quay.io/openshifttest/base-alpine@sha256:3126e4eed4a3ebd8bf972b2453fa838200988ee07c01b2251e3ea47e4b1f245c.
    STEP: waiting for an is importer to import a tag v1 into a stream mystream @ 12/19/23 10:52:44.624
    STEP: trying to tag a container image with v2 @ 12/19/23 10:52:45.25
  Dec 19 10:52:45.251: INFO: Running 'oc --kubeconfig=/Users/rahulgangwar/office-work/kubeconfig/kube.txt tag openshift/hello-openshift --source=docker mystream:v3 -n e2e-test-object-count-rq-898xv'
  Dec 19 10:52:46.664: INFO: Error running /Users/rahulgangwar/office-work/kubeconfig/oc --kubeconfig=/Users/rahulgangwar/office-work/kubeconfig/kube.txt tag openshift/hello-openshift --source=docker mystream:v3 -n e2e-test-object-count-rq-898xv:
  StdOut>
  The ImageStream "mystream" is invalid: []: Internal error: ImageStream.image.openshift.io "mystream" is forbidden: requested usage of openshift.io/image-tags exceeds the maximum limit per openshift.io/ImageStream (2 > 1)
  StdErr>
  The ImageStream "mystream" is invalid: []: Internal error: ImageStream.image.openshift.io "mystream" is forbidden: requested usage of openshift.io/image-tags exceeds the maximum limit per openshift.io/ImageStream (2 > 1)

  The ImageStream "mystream" is invalid: []: Internal error: ImageStream.image.openshift.io "mystream" is forbidden: requested usage of openshift.io/image-tags exceeds the maximum limit per openshift.io/ImageStream (2 > 1)
  Dec 19 10:52:46.912: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-object-count-rq-hbzlw-user}, err: <nil>
  Dec 19 10:52:47.166: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-object-count-rq-hbzlw}, err: <nil>
  Dec 19 10:52:47.423: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~qkpipYoIPiu2-d4hMfk4b4PnGu2UbibGT6nKIPAv_R4}, err: <nil>
  Dec 19 10:52:47.670: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-object-count-rq-898xv-user}, err: <nil>
  Dec 19 10:52:47.918: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-object-count-rq-898xv}, err: <nil>
  Dec 19 10:52:48.163: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~PCyL0e6t1walJJ4r7ohgfKebsWLSy2sZ07EPtZF5RNk}, err: <nil>
    STEP: Destroying namespace "e2e-test-object-count-rq-hbzlw" for this suite. @ 12/19/23 10:52:48.163
    STEP: Destroying namespace "e2e-test-object-count-rq-898xv" for this suite. @ 12/19/23 10:52:48.409
  • [21.272 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 21.273 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```