### PR TITLE
OCPNODE-1892: Conditionally skip tests to help with k8s 1.29

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -614,6 +614,7 @@ func (o *GinkgoRunSuiteOptions) filterOutRebaseTests(restConfig *rest.Config, te
 	exclusions := []string{
 		// compare https://github.com/kubernetes/kubernetes/pull/119454
 		`[sig-network] Services should complete a service status lifecycle`,
+		`[sig-storage] In-tree Volumes [Driver: vsphere]`,
 	}
 
 	matches := make([]*testCase, 0, len(tests))


### PR DESCRIPTION
Based on the following conversation[1], this test would be skipped until a fix to the blocker bug[2] is added 

[1] - https://redhat-internal.slack.com/archives/C065R4NCLGM/p1702558716657289?thread_ts=1702481324.774039&cid=C065R4NCLGM 
[2] - https://issues.redhat.com/browse/OCPBUGS-25402

/cc @soltysh