### PR TITLE
add requirement for hostname change

### DIFF
--- a/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadata/hostname_change/requirement.go
+++ b/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadata/hostname_change/requirement.go
@@ -1,0 +1,39 @@
+package hostname_change
+
+import "github.com/openshift/origin/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces"
+
+const annotationName string = "certificates.openshift.io/supports-offline-hostname-change"
+
+type SupportsOfflineHostnameChange struct{}
+
+func NewSupportsOfflineHostnameChange() tlsmetadatainterfaces.Requirement {
+
+	md := tlsmetadatainterfaces.NewMarkdown("")
+	md.Text("Offline hostname change is an SNO feature driven using tool (provide link here) while a cluster is not running.")
+	md.Text("")
+	md.Textf("Adding the %q annotation means that the cert/key pair or CA bundle has been verified to function properly", annotationName)
+	md.Text("after the regeneration with a new hostname happens.")
+	md.Text("The value of the annotation must be a link to the PR adding to the annotation.")
+	md.Text("This needs to cover not just serving certificate DNS and IPs, but some client certificates include hostname")
+	md.Text("embedded in names, and CA bundles need to be able to verify the new client and serving certificates as well.")
+	md.Text("")
+	md.Textf("Setting `.annotation[%q]=<URL to PR>` means that you have:", annotationName)
+	md.OrderedListStart()
+	md.NewOrderedListItem()
+	md.Text("Manually tested that this particular TLS artifact worked properly after a hostname is updated using this tool.")
+	md.Text("If the manual approach is taken, then QE must include this manual test in their \"must pass prior to ship\" bucket.  OR")
+	md.NewOrderedListItem()
+	md.Text("Written an automated e2e job that runs the tool AND has a test that explicitly checks the TLS artifact in question.")
+	md.Text("The generic bucket MAY test this, but before adding this annotation you MUST be able to indicate which precise")
+	md.Text("test ensures that this TLS artifact is functioning properly.")
+	md.OrderedListEnd()
+
+	return tlsmetadatainterfaces.NewAnnotationRequirement(
+		// requirement name
+		"offline-hostname-change",
+		// cert or configmap annotation
+		annotationName,
+		"Supports Offline Hostname Change",
+		string(md.ExactBytes()),
+	)
+}

--- a/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatadefaults/defaults.go
+++ b/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatadefaults/defaults.go
@@ -2,6 +2,7 @@ package tlsmetadatadefaults
 
 import (
 	"github.com/openshift/origin/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadata/autoregenerate_after_expiry"
+	"github.com/openshift/origin/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadata/hostname_change"
 	"github.com/openshift/origin/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadata/ownership"
 	"github.com/openshift/origin/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces"
 )
@@ -10,5 +11,6 @@ func GetDefaultTLSRequirements() []tlsmetadatainterfaces.Requirement {
 	return []tlsmetadatainterfaces.Requirement{
 		ownership.NewOwnerRequirement(),
 		autoregenerate_after_expiry.NewAutoRegenerateAfterOfflineExpiryRequirement(),
+		hostname_change.NewSupportsOfflineHostnameChange(),
 	}
 }

--- a/tls/offline-hostname-change/offline-hostname-change.json
+++ b/tls/offline-hostname-change/offline-hostname-change.json
@@ -1,0 +1,4368 @@
+{
+    "certificateAuthorityBundles": [
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-apiserver",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-apiserver",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-apiserver-operator",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-authentication",
+                "Name": "v4-0-config-system-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-authentication-operator",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cloud-controller-manager",
+                "Name": "ccm-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Cloud Compute / Cloud Controller Manager"
+                    }
+                ],
+                "owningJiraComponent": "Cloud Compute / Cloud Controller Manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cloud-credential-operator",
+                "Name": "cco-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cloud-network-config-controller",
+                "Name": "trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "aws-ebs-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "azure-disk-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "azure-file-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "gcp-pd-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "shared-resource-csi-driver-operator-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vmware-vsphere-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vsphere-csi-driver-operator-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-node-tuning-operator",
+                "Name": "trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "admin-kubeconfig-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-metric-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "initial-kube-apiserver-server-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Machine Config Operator"
+                    }
+                ],
+                "owningJiraComponent": "Machine Config Operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "user-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "End User"
+                    }
+                ],
+                "owningJiraComponent": "End User",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "csr-controller-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "default-ingress-cert"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-apiserver-aggregator-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-apiserver-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-apiserver-server-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kubelet-bootstrap-kubeconfig"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kubelet-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "oauth-serving-cert"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "apiserver-auth"
+                    }
+                ],
+                "owningJiraComponent": "apiserver-auth",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "service-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-console",
+                "Name": "default-ingress-cert"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-console",
+                "Name": "oauth-serving-cert"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "apiserver-auth"
+                    }
+                ],
+                "owningJiraComponent": "apiserver-auth",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-console",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-controller-manager",
+                "Name": "client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-controller-manager",
+                "Name": "openshift-global-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-metrics-proxy-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-metrics-proxy-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-peer-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-metric-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-image-registry",
+                "Name": "trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-ingress-operator",
+                "Name": "trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-insights",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "aggregator-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "kube-apiserver-server-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "kubelet-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-apiserver-to-kubelet-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-control-plane-signer-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "loadbalancer-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "localhost-recovery-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "localhost-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "node-system-admin-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "service-network-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "aggregator-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "service-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "serviceaccount-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-controller-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-controller-signer-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-signer-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-scheduler",
+                "Name": "serviceaccount-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-scheduler"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-scheduler",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "cbo-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "mao-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-marketplace",
+                "Name": "marketplace-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "alertmanager-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "alertmanager-trusted-ca-bundle-2ua4n9ob5qr8o"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "kubelet-serving-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-trusted-ca-bundle-2ua4n9ob5qr8o"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "telemeter-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "telemeter-trusted-ca-bundle-2ua4n9ob5qr8o"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "thanos-querier-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "thanos-querier-trusted-ca-bundle-2ua4n9ob5qr8o"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-network-node-identity",
+                "Name": "network-node-identity-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-oauth-apiserver",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "signer-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-route-controller-manager",
+                "Name": "client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-service-ca",
+                "Name": "signing-cabundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+            }
+        }
+    ],
+    "certKeyPairs": [
+        {
+            "secretLocation": {
+                "Namespace": "openshift-apiserver",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-apiserver",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-apiserver-operator",
+                "Name": "openshift-apiserver-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-apiserver-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-apiserver-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-authentication",
+                "Name": "v4-0-config-system-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/oauth-openshift with hostname oauth-openshift.openshift-authentication.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/oauth-openshift with hostname oauth-openshift.openshift-authentication.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-authentication-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-authentication-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-authentication-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cloud-credential-operator",
+                "Name": "cloud-credential-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cco-metrics with hostname cco-metrics.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cloud-credential-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cco-metrics with hostname cco-metrics.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cloud-credential-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cloud-credential-operator",
+                "Name": "pod-identity-webhook"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/pod-identity-webhook with hostname pod-identity-webhook.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: pod-identity-webhook'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/pod-identity-webhook with hostname pod-identity-webhook.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: pod-identity-webhook'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-api",
+                "Name": "capg-webhook-service-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capg-webhook-service with hostname capg-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capg-webhook-service-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capg-webhook-service with hostname capg-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capg-webhook-service-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-api",
+                "Name": "capi-webhook-service-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capi-webhook-service with hostname capi-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capi-webhook-service-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capi-webhook-service with hostname capi-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capi-webhook-service-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-api",
+                "Name": "cluster-capi-operator-webhook-service-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-capi-operator-webhook-service with hostname cluster-capi-operator-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-capi-operator-webhook-service-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-capi-operator-webhook-service with hostname cluster-capi-operator-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-capi-operator-webhook-service-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "aws-ebs-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/aws-ebs-csi-driver-controller-metrics with hostname aws-ebs-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: aws-ebs-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/aws-ebs-csi-driver-controller-metrics with hostname aws-ebs-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: aws-ebs-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "azure-disk-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-disk-csi-driver-controller-metrics with hostname azure-disk-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-disk-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-disk-csi-driver-controller-metrics with hostname azure-disk-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-disk-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "azure-file-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-file-csi-driver-controller-metrics with hostname azure-file-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-file-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-file-csi-driver-controller-metrics with hostname azure-file-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-file-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "gcp-pd-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/gcp-pd-csi-driver-controller-metrics with hostname gcp-pd-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: gcp-pd-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/gcp-pd-csi-driver-controller-metrics with hostname gcp-pd-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: gcp-pd-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "shared-resource-csi-driver-node-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-node-metrics with hostname shared-resource-csi-driver-node-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-node-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-node-metrics with hostname shared-resource-csi-driver-node-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-node-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "shared-resource-csi-driver-operator-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-operator-metrics with hostname shared-resource-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-operator-metrics with hostname shared-resource-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "shared-resource-csi-driver-webhook-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-webhook with hostname shared-resource-csi-driver-webhook.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-webhook-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-webhook with hostname shared-resource-csi-driver-webhook.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-webhook-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vmware-vsphere-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-controller-metrics with hostname vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-controller-metrics with hostname vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vmware-vsphere-csi-driver-operator-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-operator-metrics with hostname vmware-vsphere-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-operator-metrics with hostname vmware-vsphere-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vmware-vsphere-csi-driver-webhook-secret"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-webhook-svc with hostname vmware-vsphere-csi-driver-webhook-svc.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-webhook-secret'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-webhook-svc with hostname vmware-vsphere-csi-driver-webhook-svc.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-webhook-secret'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-machine-approver",
+                "Name": "machine-approver-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-approver with hostname machine-approver.openshift-cluster-machine-approver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-approver-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-approver with hostname machine-approver.openshift-cluster-machine-approver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-approver-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-node-tuning-operator",
+                "Name": "node-tuning-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-tuning-operator with hostname node-tuning-operator.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-tuning-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-tuning-operator with hostname node-tuning-operator.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-tuning-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-node-tuning-operator",
+                "Name": "performance-addon-operator-webhook-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/performance-addon-operator-service with hostname performance-addon-operator-service.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: performance-addon-operator-webhook-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/performance-addon-operator-service with hostname performance-addon-operator-service.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: performance-addon-operator-webhook-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-olm-operator",
+                "Name": "cluster-olm-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-olm-operator-metrics with hostname cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-olm-operator-metrics with hostname cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-samples-operator",
+                "Name": "samples-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-cluster-samples-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: samples-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-cluster-samples-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: samples-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "cluster-storage-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-storage-operator-metrics with hostname cluster-storage-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-storage-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-storage-operator-metrics with hostname cluster-storage-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-storage-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "csi-snapshot-webhook-secret"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-webhook with hostname csi-snapshot-webhook.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: csi-snapshot-webhook-secret'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-webhook with hostname csi-snapshot-webhook.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: csi-snapshot-webhook-secret'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-controller-operator-metrics with hostname csi-snapshot-controller-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-controller-operator-metrics with hostname csi-snapshot-controller-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "vsphere-problem-detector-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vsphere-problem-detector-metrics with hostname vsphere-problem-detector-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vsphere-problem-detector-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vsphere-problem-detector-metrics with hostname vsphere-problem-detector-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vsphere-problem-detector-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-version",
+                "Name": "cluster-version-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-version-operator with hostname cluster-version-operator.openshift-cluster-version.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-version-operator with hostname cluster-version-operator.openshift-cluster-version.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-metric-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-metric-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-controller-manager-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-scheduler-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config-operator",
+                "Name": "config-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: config-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: config-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-console",
+                "Name": "console-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/console with hostname console.openshift-console.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: console-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/console with hostname console.openshift-console.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: console-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-console-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-console-operator",
+                "Name": "webhook-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/webhook with hostname webhook.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: webhook-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/webhook with hostname webhook.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: webhook-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-controller-manager",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/controller-manager with hostname controller-manager.openshift-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/controller-manager with hostname controller-manager.openshift-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-controller-manager-operator",
+                "Name": "openshift-controller-manager-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-controller-manager-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-controller-manager-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-dns",
+                "Name": "dns-default-metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/dns-default with hostname dns-default.openshift-dns.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: dns-default-metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/dns-default with hostname dns-default.openshift-dns.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: dns-default-metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-dns-operator",
+                "Name": "metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-dns-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-dns-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-e2e-loki",
+                "Name": "proxy-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/promtail with hostname promtail.openshift-e2e-loki.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/promtail with hostname promtail.openshift-e2e-loki.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-peer-\u003cmaster-0\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-peer-\u003cmaster-1\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-peer-\u003cmaster-2\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-\u003cmaster-0\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-\u003cmaster-1\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-\u003cmaster-2\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-metrics-\u003cmaster-0\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-metrics-\u003cmaster-1\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-metrics-\u003cmaster-2\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/etcd with hostname etcd.openshift-etcd.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/etcd with hostname etcd.openshift-etcd.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-metric-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-etcd-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: etcd-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-etcd-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: etcd-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-image-registry",
+                "Name": "image-registry-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry-operator with hostname image-registry-operator.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry-operator with hostname image-registry-operator.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-image-registry",
+                "Name": "image-registry-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry with hostname image-registry.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry with hostname image-registry.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ingress",
+                "Name": "router-certs-default"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ingress",
+                "Name": "router-metrics-certs-default"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/router-internal-default with hostname router-internal-default.openshift-ingress.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: router-metrics-certs-default'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/router-internal-default with hostname router-internal-default.openshift-ingress.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: router-metrics-certs-default'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ingress-operator",
+                "Name": "metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-ingress-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-ingress-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ingress-operator",
+                "Name": "router-ca"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-insights",
+                "Name": "openshift-insights-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-insights.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-insights-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-insights.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-insights-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "aggregator-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "check-endpoints-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "control-plane-node-admin-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "external-loadbalancer-serving-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "internal-loadbalancer-serving-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "kubelet-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "localhost-recovery-serving-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "localhost-serving-cert-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "service-network-serving-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "aggregator-client-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-apiserver-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-apiserver-to-kubelet-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-control-plane-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "loadbalancer-serving-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "localhost-recovery-serving-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "localhost-serving-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "node-system-admin-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "node-system-admin-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "service-network-serving-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "csr-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "kube-controller-manager-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-controller-manager with hostname kube-controller-manager.openshift-kube-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-controller-manager with hostname kube-controller-manager.openshift-kube-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-signer-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "kube-controller-manager-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-scheduler",
+                "Name": "kube-scheduler-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-scheduler",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/scheduler with hostname scheduler.openshift-kube-scheduler.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/scheduler with hostname scheduler.openshift-kube-scheduler.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-scheduler-operator",
+                "Name": "kube-scheduler-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-scheduler-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-scheduler-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-scheduler-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-scheduler-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-storage-version-migrator-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-storage-version-migrator-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-storage-version-migrator-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "baremetal-operator-webhook-server-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/baremetal-operator-webhook-service with hostname baremetal-operator-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: baremetal-operator-webhook-server-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/baremetal-operator-webhook-service with hostname baremetal-operator-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: baremetal-operator-webhook-server-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "cluster-autoscaler-operator-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-autoscaler-operator with hostname cluster-autoscaler-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-autoscaler-operator-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-autoscaler-operator with hostname cluster-autoscaler-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-autoscaler-operator-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "cluster-baremetal-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-operator-service with hostname cluster-baremetal-operator-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-operator-service with hostname cluster-baremetal-operator-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "cluster-baremetal-webhook-server-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-webhook-service with hostname cluster-baremetal-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-webhook-server-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-webhook-service with hostname cluster-baremetal-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-webhook-server-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "control-plane-machine-set-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/control-plane-machine-set-operator with hostname control-plane-machine-set-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: control-plane-machine-set-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/control-plane-machine-set-operator with hostname control-plane-machine-set-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: control-plane-machine-set-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "machine-api-controllers-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-controllers with hostname machine-api-controllers.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-controllers-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-controllers with hostname machine-api-controllers.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-controllers-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "machine-api-operator-machine-webhook-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-machine-webhook with hostname machine-api-operator-machine-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-machine-webhook-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-machine-webhook with hostname machine-api-operator-machine-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-machine-webhook-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "machine-api-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator with hostname machine-api-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator with hostname machine-api-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "machine-api-operator-webhook-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-webhook with hostname machine-api-operator-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-webhook-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-webhook with hostname machine-api-operator-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-webhook-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "metal3-ironic-tls"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-config-operator",
+                "Name": "machine-config-server-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Machine Config Operator"
+                    }
+                ],
+                "owningJiraComponent": "Machine Config Operator",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-config-operator",
+                "Name": "mcc-proxy-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-controller with hostname machine-config-controller.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mcc-proxy-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-controller with hostname machine-config-controller.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mcc-proxy-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-config-operator",
+                "Name": "mco-proxy-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-operator with hostname machine-config-operator.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mco-proxy-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-operator with hostname machine-config-operator.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mco-proxy-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-config-operator",
+                "Name": "proxy-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-daemon with hostname machine-config-daemon.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-daemon with hostname machine-config-daemon.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-marketplace",
+                "Name": "marketplace-operator-metrics"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/marketplace-operator-metrics with hostname marketplace-operator-metrics.openshift-marketplace.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: marketplace-operator-metrics'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/marketplace-operator-metrics with hostname marketplace-operator-metrics.openshift-marketplace.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: marketplace-operator-metrics'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "alertmanager-main-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/alertmanager-main with hostname alertmanager-main.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: alertmanager-main-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/alertmanager-main with hostname alertmanager-main.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: alertmanager-main-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "cluster-monitoring-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-monitoring-operator with hostname cluster-monitoring-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-monitoring-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-monitoring-operator with hostname cluster-monitoring-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-monitoring-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "federate-client-certs"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "kube-state-metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-state-metrics with hostname kube-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-state-metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-state-metrics with hostname kube-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-state-metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "metrics-client-certs"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "metrics-server-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics-server with hostname metrics-server.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-server-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics-server with hostname metrics-server.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-server-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "monitoring-plugin-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/monitoring-plugin with hostname monitoring-plugin.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: monitoring-plugin-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/monitoring-plugin with hostname monitoring-plugin.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: monitoring-plugin-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "node-exporter-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-exporter with hostname node-exporter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-exporter-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-exporter with hostname node-exporter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-exporter-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "openshift-state-metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/openshift-state-metrics with hostname openshift-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-state-metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/openshift-state-metrics with hostname openshift-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-state-metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-1ehgs15tubhcc"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-1vcbbd485dtu8"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-2la6907ck7pse"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-4ho3dj3us2df4"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-56glf1mhs3bbm"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-5b3cu0f6s65i"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-5blo6a2jkr388"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-ba21034efmj7v"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-bo9ukpiqhr327"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-d6ej41uj54llt"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-adapter with hostname prometheus-adapter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-adapter-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-adapter with hostname prometheus-adapter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-adapter-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-k8s-thanos-sidecar-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s-thanos-sidecar with hostname prometheus-k8s-thanos-sidecar.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-thanos-sidecar-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s-thanos-sidecar with hostname prometheus-k8s-thanos-sidecar.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-thanos-sidecar-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-k8s-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s with hostname prometheus-k8s.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s with hostname prometheus-k8s.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-operator-admission-webhook-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator-admission-webhook with hostname prometheus-operator-admission-webhook.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-admission-webhook-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator-admission-webhook with hostname prometheus-operator-admission-webhook.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-admission-webhook-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator with hostname prometheus-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator with hostname prometheus-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "telemeter-client-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/telemeter-client with hostname telemeter-client.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: telemeter-client-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/telemeter-client with hostname telemeter-client.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: telemeter-client-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "thanos-querier-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/thanos-querier with hostname thanos-querier.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: thanos-querier-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/thanos-querier with hostname thanos-querier.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: thanos-querier-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-multus",
+                "Name": "metrics-daemon-secret"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/network-metrics-service with hostname network-metrics-service.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-daemon-secret'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/network-metrics-service with hostname network-metrics-service.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-daemon-secret'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-multus",
+                "Name": "multus-admission-controller-secret"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/multus-admission-controller with hostname multus-admission-controller.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: multus-admission-controller-secret'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/multus-admission-controller with hostname multus-admission-controller.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: multus-admission-controller-secret'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-network-node-identity",
+                "Name": "network-node-identity-ca"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-network-node-identity",
+                "Name": "network-node-identity-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-network-operator",
+                "Name": "metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-network-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-network-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-oauth-apiserver",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-oauth-apiserver",
+                "Name": "openshift-authenticator-certs"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "apiserver-auth"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "apiserver-auth",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-oauth-apiserver",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-oauth-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-oauth-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "catalog-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/catalog-operator-metrics with hostname catalog-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/catalog-operator-metrics with hostname catalog-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "olm-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/olm-operator-metrics with hostname olm-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: olm-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/olm-operator-metrics with hostname olm-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: olm-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "package-server-manager-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/package-server-manager-metrics with hostname package-server-manager-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/package-server-manager-metrics with hostname package-server-manager-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "packageserver-service-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "pprof-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-ca"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-control-plane-metrics-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-control-plane with hostname ovn-kubernetes-control-plane.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-control-plane-metrics-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-control-plane with hostname ovn-kubernetes-control-plane.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-control-plane-metrics-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-node-metrics-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-node with hostname ovn-kubernetes-node.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-node-metrics-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-node with hostname ovn-kubernetes-node.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-node-metrics-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "signer-ca"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "signer-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-route-controller-manager",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/route-controller-manager with hostname route-controller-manager.openshift-route-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/route-controller-manager with hostname route-controller-manager.openshift-route-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-rukpak",
+                "Name": "core-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/core with hostname core.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: core-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/core with hostname core.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: core-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-rukpak",
+                "Name": "helm-provisioner-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/helm-provisioner with hostname helm-provisioner.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: helm-provisioner-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/helm-provisioner with hostname helm-provisioner.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: helm-provisioner-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-rukpak",
+                "Name": "rukpak-webhook-certificate"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/rukpak-webhook-service with hostname rukpak-webhook-service.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: rukpak-webhook-certificate'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/rukpak-webhook-service with hostname rukpak-webhook-service.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: rukpak-webhook-certificate'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-sdn",
+                "Name": "sdn-controller-metrics-certs"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn-controller with hostname sdn-controller.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-controller-metrics-certs'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn-controller with hostname sdn-controller.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-controller-metrics-certs'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-sdn",
+                "Name": "sdn-metrics-certs"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn with hostname sdn.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-metrics-certs'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn with hostname sdn.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-metrics-certs'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-service-ca",
+                "Name": "signing-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Service CA secret contains a signing key that will be used to issue a signed serving certificate/key pair to services annotated with 'service.beta.openshift.io/serving-cert-secret-name'"
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Service CA secret contains a signing key that will be used to issue a signed serving certificate/key pair to services annotated with 'service.beta.openshift.io/serving-cert-secret-name'"
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-service-ca-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-service-ca-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-service-ca-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        }
+    ]
+}

--- a/tls/offline-hostname-change/offline-hostname-change.md
+++ b/tls/offline-hostname-change/offline-hostname-change.md
@@ -1,0 +1,1378 @@
+# Supports Offline Hostname Change
+
+## Table of Contents
+  - [Items Do NOT Meet the Requirement (252)](#Items-Do-NOT-Meet-the-Requirement-252)
+    - [ (39)](#-39)
+      - [Certificates (23)](#Certificates-23)
+      - [Certificate Authority Bundles (16)](#Certificate-Authority-Bundles-16)
+    - [Cloud Compute / Cloud Controller Manager (1)](#Cloud-Compute-/-Cloud-Controller-Manager-1)
+      - [Certificate Authority Bundles (1)](#Certificate-Authority-Bundles-1)
+    - [End User (1)](#End-User-1)
+      - [Certificate Authority Bundles (1)](#Certificate-Authority-Bundles-1)
+    - [Etcd (28)](#Etcd-28)
+      - [Certificates (19)](#Certificates-19)
+      - [Certificate Authority Bundles (9)](#Certificate-Authority-Bundles-9)
+    - [Machine Config Operator (2)](#Machine-Config-Operator-2)
+      - [Certificates (1)](#Certificates-1)
+      - [Certificate Authority Bundles (1)](#Certificate-Authority-Bundles-1)
+    - [Networking / cluster-network-operator (30)](#Networking-/-cluster-network-operator-30)
+      - [Certificate Authority Bundles (30)](#Certificate-Authority-Bundles-30)
+    - [apiserver-auth (3)](#apiserver-auth-3)
+      - [Certificates (1)](#Certificates-1)
+      - [Certificate Authority Bundles (2)](#Certificate-Authority-Bundles-2)
+    - [kube-apiserver (39)](#kube-apiserver-39)
+      - [Certificates (22)](#Certificates-22)
+      - [Certificate Authority Bundles (17)](#Certificate-Authority-Bundles-17)
+    - [kube-controller-manager (10)](#kube-controller-manager-10)
+      - [Certificates (3)](#Certificates-3)
+      - [Certificate Authority Bundles (7)](#Certificate-Authority-Bundles-7)
+    - [kube-scheduler (1)](#kube-scheduler-1)
+      - [Certificate Authority Bundles (1)](#Certificate-Authority-Bundles-1)
+    - [service-ca (98)](#service-ca-98)
+      - [Certificates (95)](#Certificates-95)
+      - [Certificate Authority Bundles (3)](#Certificate-Authority-Bundles-3)
+  - [Items That DO Meet the Requirement (0)](#Items-That-DO-Meet-the-Requirement-0)
+
+
+Offline hostname change is an SNO feature driven using tool (provide link here) while a cluster is not running.
+
+Adding the "certificates.openshift.io/supports-offline-hostname-change" annotation means that the cert/key pair or CA bundle has been verified to function properly
+after the regeneration with a new hostname happens.
+The value of the annotation must be a link to the PR adding to the annotation.
+This needs to cover not just serving certificate DNS and IPs, but some client certificates include hostname
+embedded in names, and CA bundles need to be able to verify the new client and serving certificates as well.
+
+Setting `.annotation["certificates.openshift.io/supports-offline-hostname-change"]=\<URL to PR>` means that you have:
+1. Manually tested that this particular TLS artifact worked properly after a hostname is updated using this tool.
+      If the manual approach is taken, then QE must include this manual test in their "must pass prior to ship" bucket.  OR
+2. Written an automated e2e job that runs the tool AND has a test that explicitly checks the TLS artifact in question.
+      The generic bucket MAY test this, but before adding this annotation you MUST be able to indicate which precise
+      test ensures that this TLS artifact is functioning properly.
+
+## Items Do NOT Meet the Requirement (252)
+###  (39)
+#### Certificates (23)
+1. ns/openshift-ingress secret/router-certs-default
+
+      **Description:** 
+      
+
+2. ns/openshift-ingress-operator secret/router-ca
+
+      **Description:** 
+      
+
+3. ns/openshift-machine-api secret/metal3-ironic-tls
+
+      **Description:** 
+      
+
+4. ns/openshift-monitoring secret/federate-client-certs
+
+      **Description:** 
+      
+
+5. ns/openshift-monitoring secret/metrics-client-certs
+
+      **Description:** 
+      
+
+6. ns/openshift-monitoring secret/prometheus-adapter-1ehgs15tubhcc
+
+      **Description:** 
+      
+
+7. ns/openshift-monitoring secret/prometheus-adapter-1vcbbd485dtu8
+
+      **Description:** 
+      
+
+8. ns/openshift-monitoring secret/prometheus-adapter-2la6907ck7pse
+
+      **Description:** 
+      
+
+9. ns/openshift-monitoring secret/prometheus-adapter-4ho3dj3us2df4
+
+      **Description:** 
+      
+
+10. ns/openshift-monitoring secret/prometheus-adapter-56glf1mhs3bbm
+
+      **Description:** 
+      
+
+11. ns/openshift-monitoring secret/prometheus-adapter-5b3cu0f6s65i
+
+      **Description:** 
+      
+
+12. ns/openshift-monitoring secret/prometheus-adapter-5blo6a2jkr388
+
+      **Description:** 
+      
+
+13. ns/openshift-monitoring secret/prometheus-adapter-ba21034efmj7v
+
+      **Description:** 
+      
+
+14. ns/openshift-monitoring secret/prometheus-adapter-bo9ukpiqhr327
+
+      **Description:** 
+      
+
+15. ns/openshift-monitoring secret/prometheus-adapter-d6ej41uj54llt
+
+      **Description:** 
+      
+
+16. ns/openshift-network-node-identity secret/network-node-identity-ca
+
+      **Description:** 
+      
+
+17. ns/openshift-network-node-identity secret/network-node-identity-cert
+
+      **Description:** 
+      
+
+18. ns/openshift-operator-lifecycle-manager secret/packageserver-service-cert
+
+      **Description:** 
+      
+
+19. ns/openshift-operator-lifecycle-manager secret/pprof-cert
+
+      **Description:** 
+      
+
+20. ns/openshift-ovn-kubernetes secret/ovn-ca
+
+      **Description:** 
+      
+
+21. ns/openshift-ovn-kubernetes secret/ovn-cert
+
+      **Description:** 
+      
+
+22. ns/openshift-ovn-kubernetes secret/signer-ca
+
+      **Description:** 
+      
+
+23. ns/openshift-ovn-kubernetes secret/signer-cert
+
+      **Description:** 
+      
+
+
+
+#### Certificate Authority Bundles (16)
+1. ns/openshift-config configmap/admin-kubeconfig-client-ca
+
+      **Description:** 
+      
+
+2. ns/openshift-config configmap/etcd-ca-bundle
+
+      **Description:** 
+      
+
+3. ns/openshift-config-managed configmap/default-ingress-cert
+
+      **Description:** 
+      
+
+4. ns/openshift-config-managed configmap/kubelet-bootstrap-kubeconfig
+
+      **Description:** 
+      
+
+5. ns/openshift-console configmap/default-ingress-cert
+
+      **Description:** 
+      
+
+6. ns/openshift-etcd configmap/etcd-ca-bundle
+
+      **Description:** 
+      
+
+7. ns/openshift-etcd configmap/etcd-peer-client-ca
+
+      **Description:** 
+      
+
+8. ns/openshift-etcd-operator configmap/etcd-ca-bundle
+
+      **Description:** 
+      
+
+9. ns/openshift-monitoring configmap/alertmanager-trusted-ca-bundle-2ua4n9ob5qr8o
+
+      **Description:** 
+      
+
+10. ns/openshift-monitoring configmap/kubelet-serving-ca-bundle
+
+      **Description:** 
+      
+
+11. ns/openshift-monitoring configmap/prometheus-trusted-ca-bundle-2ua4n9ob5qr8o
+
+      **Description:** 
+      
+
+12. ns/openshift-monitoring configmap/telemeter-trusted-ca-bundle-2ua4n9ob5qr8o
+
+      **Description:** 
+      
+
+13. ns/openshift-monitoring configmap/thanos-querier-trusted-ca-bundle-2ua4n9ob5qr8o
+
+      **Description:** 
+      
+
+14. ns/openshift-network-node-identity configmap/network-node-identity-ca
+
+      **Description:** 
+      
+
+15. ns/openshift-ovn-kubernetes configmap/ovn-ca
+
+      **Description:** 
+      
+
+16. ns/openshift-ovn-kubernetes configmap/signer-ca
+
+      **Description:** 
+      
+
+
+
+### Cloud Compute / Cloud Controller Manager (1)
+#### Certificate Authority Bundles (1)
+1. ns/openshift-cloud-controller-manager configmap/ccm-trusted-ca
+
+      **Description:** 
+      
+
+
+
+### End User (1)
+#### Certificate Authority Bundles (1)
+1. ns/openshift-config configmap/user-ca-bundle
+
+      **Description:** 
+      
+
+
+
+### Etcd (28)
+#### Certificates (19)
+1. ns/openshift-apiserver secret/etcd-client
+
+      **Description:** 
+      
+
+2. ns/openshift-config secret/etcd-client
+
+      **Description:** 
+      
+
+3. ns/openshift-config secret/etcd-metric-client
+
+      **Description:** 
+      
+
+4. ns/openshift-config secret/etcd-metric-signer
+
+      **Description:** 
+      
+
+5. ns/openshift-config secret/etcd-signer
+
+      **Description:** 
+      
+
+6. ns/openshift-etcd secret/etcd-client
+
+      **Description:** 
+      
+
+7. ns/openshift-etcd secret/etcd-peer-\<master-0>
+
+      **Description:** 
+      
+
+8. ns/openshift-etcd secret/etcd-peer-\<master-1>
+
+      **Description:** 
+      
+
+9. ns/openshift-etcd secret/etcd-peer-\<master-2>
+
+      **Description:** 
+      
+
+10. ns/openshift-etcd secret/etcd-serving-\<master-0>
+
+      **Description:** 
+      
+
+11. ns/openshift-etcd secret/etcd-serving-\<master-1>
+
+      **Description:** 
+      
+
+12. ns/openshift-etcd secret/etcd-serving-\<master-2>
+
+      **Description:** 
+      
+
+13. ns/openshift-etcd secret/etcd-serving-metrics-\<master-0>
+
+      **Description:** 
+      
+
+14. ns/openshift-etcd secret/etcd-serving-metrics-\<master-1>
+
+      **Description:** 
+      
+
+15. ns/openshift-etcd secret/etcd-serving-metrics-\<master-2>
+
+      **Description:** 
+      
+
+16. ns/openshift-etcd-operator secret/etcd-client
+
+      **Description:** 
+      
+
+17. ns/openshift-etcd-operator secret/etcd-metric-client
+
+      **Description:** 
+      
+
+18. ns/openshift-kube-apiserver secret/etcd-client
+
+      **Description:** 
+      
+
+19. ns/openshift-oauth-apiserver secret/etcd-client
+
+      **Description:** 
+      
+
+
+
+#### Certificate Authority Bundles (9)
+1. ns/openshift-apiserver configmap/etcd-serving-ca
+
+      **Description:** 
+      
+
+2. ns/openshift-config configmap/etcd-metric-serving-ca
+
+      **Description:** 
+      
+
+3. ns/openshift-config configmap/etcd-serving-ca
+
+      **Description:** 
+      
+
+4. ns/openshift-etcd configmap/etcd-metrics-proxy-client-ca
+
+      **Description:** 
+      
+
+5. ns/openshift-etcd configmap/etcd-metrics-proxy-serving-ca
+
+      **Description:** 
+      
+
+6. ns/openshift-etcd configmap/etcd-serving-ca
+
+      **Description:** 
+      
+
+7. ns/openshift-etcd-operator configmap/etcd-metric-serving-ca
+
+      **Description:** 
+      
+
+8. ns/openshift-kube-apiserver configmap/etcd-serving-ca
+
+      **Description:** 
+      
+
+9. ns/openshift-oauth-apiserver configmap/etcd-serving-ca
+
+      **Description:** 
+      
+
+
+
+### Machine Config Operator (2)
+#### Certificates (1)
+1. ns/openshift-machine-config-operator secret/machine-config-server-tls
+
+      **Description:** 
+      
+
+
+
+#### Certificate Authority Bundles (1)
+1. ns/openshift-config configmap/initial-kube-apiserver-server-ca
+
+      **Description:** 
+      
+
+
+
+### Networking / cluster-network-operator (30)
+#### Certificate Authority Bundles (30)
+1. ns/openshift-apiserver configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+2. ns/openshift-apiserver-operator configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+3. ns/openshift-authentication configmap/v4-0-config-system-trusted-ca-bundle
+
+      **Description:** 
+      
+
+4. ns/openshift-authentication-operator configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+5. ns/openshift-cloud-credential-operator configmap/cco-trusted-ca
+
+      **Description:** 
+      
+
+6. ns/openshift-cloud-network-config-controller configmap/trusted-ca
+
+      **Description:** 
+      
+
+7. ns/openshift-cluster-csi-drivers configmap/aws-ebs-csi-driver-trusted-ca-bundle
+
+      **Description:** 
+      
+
+8. ns/openshift-cluster-csi-drivers configmap/azure-disk-csi-driver-trusted-ca-bundle
+
+      **Description:** 
+      
+
+9. ns/openshift-cluster-csi-drivers configmap/azure-file-csi-driver-trusted-ca-bundle
+
+      **Description:** 
+      
+
+10. ns/openshift-cluster-csi-drivers configmap/gcp-pd-csi-driver-trusted-ca-bundle
+
+      **Description:** 
+      
+
+11. ns/openshift-cluster-csi-drivers configmap/shared-resource-csi-driver-operator-trusted-ca-bundle
+
+      **Description:** 
+      
+
+12. ns/openshift-cluster-csi-drivers configmap/vmware-vsphere-csi-driver-trusted-ca-bundle
+
+      **Description:** 
+      
+
+13. ns/openshift-cluster-csi-drivers configmap/vsphere-csi-driver-operator-trusted-ca-bundle
+
+      **Description:** 
+      
+
+14. ns/openshift-cluster-node-tuning-operator configmap/trusted-ca
+
+      **Description:** 
+      
+
+15. ns/openshift-cluster-storage-operator configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+16. ns/openshift-config-managed configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+17. ns/openshift-console configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+18. ns/openshift-controller-manager configmap/openshift-global-ca
+
+      **Description:** 
+      
+
+19. ns/openshift-image-registry configmap/trusted-ca
+
+      **Description:** 
+      
+
+20. ns/openshift-ingress-operator configmap/trusted-ca
+
+      **Description:** 
+      
+
+21. ns/openshift-insights configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+22. ns/openshift-kube-apiserver configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+23. ns/openshift-kube-controller-manager configmap/trusted-ca-bundle
+
+      **Description:** 
+      
+
+24. ns/openshift-machine-api configmap/cbo-trusted-ca
+
+      **Description:** 
+      
+
+25. ns/openshift-machine-api configmap/mao-trusted-ca
+
+      **Description:** 
+      
+
+26. ns/openshift-marketplace configmap/marketplace-trusted-ca
+
+      **Description:** 
+      
+
+27. ns/openshift-monitoring configmap/alertmanager-trusted-ca-bundle
+
+      **Description:** 
+      
+
+28. ns/openshift-monitoring configmap/prometheus-trusted-ca-bundle
+
+      **Description:** 
+      
+
+29. ns/openshift-monitoring configmap/telemeter-trusted-ca-bundle
+
+      **Description:** 
+      
+
+30. ns/openshift-monitoring configmap/thanos-querier-trusted-ca-bundle
+
+      **Description:** 
+      
+
+
+
+### apiserver-auth (3)
+#### Certificates (1)
+1. ns/openshift-oauth-apiserver secret/openshift-authenticator-certs
+
+      **Description:** 
+      
+
+
+
+#### Certificate Authority Bundles (2)
+1. ns/openshift-config-managed configmap/oauth-serving-cert
+
+      **Description:** 
+      
+
+2. ns/openshift-console configmap/oauth-serving-cert
+
+      **Description:** 
+      
+
+
+
+### kube-apiserver (39)
+#### Certificates (22)
+1. ns/openshift-config-managed secret/kube-controller-manager-client-cert-key
+
+      **Description:** 
+      
+
+2. ns/openshift-config-managed secret/kube-scheduler-client-cert-key
+
+      **Description:** 
+      
+
+3. ns/openshift-kube-apiserver secret/aggregator-client
+
+      **Description:** 
+      
+
+4. ns/openshift-kube-apiserver secret/check-endpoints-client-cert-key
+
+      **Description:** 
+      
+
+5. ns/openshift-kube-apiserver secret/control-plane-node-admin-client-cert-key
+
+      **Description:** 
+      
+
+6. ns/openshift-kube-apiserver secret/external-loadbalancer-serving-certkey
+
+      **Description:** 
+      
+
+7. ns/openshift-kube-apiserver secret/internal-loadbalancer-serving-certkey
+
+      **Description:** 
+      
+
+8. ns/openshift-kube-apiserver secret/kubelet-client
+
+      **Description:** 
+      
+
+9. ns/openshift-kube-apiserver secret/localhost-recovery-serving-certkey
+
+      **Description:** 
+      
+
+10. ns/openshift-kube-apiserver secret/localhost-serving-cert-certkey
+
+      **Description:** 
+      
+
+11. ns/openshift-kube-apiserver secret/service-network-serving-certkey
+
+      **Description:** 
+      
+
+12. ns/openshift-kube-apiserver-operator secret/aggregator-client-signer
+
+      **Description:** 
+      
+
+13. ns/openshift-kube-apiserver-operator secret/kube-apiserver-to-kubelet-signer
+
+      **Description:** 
+      
+
+14. ns/openshift-kube-apiserver-operator secret/kube-control-plane-signer
+
+      **Description:** 
+      
+
+15. ns/openshift-kube-apiserver-operator secret/loadbalancer-serving-signer
+
+      **Description:** 
+      
+
+16. ns/openshift-kube-apiserver-operator secret/localhost-recovery-serving-signer
+
+      **Description:** 
+      
+
+17. ns/openshift-kube-apiserver-operator secret/localhost-serving-signer
+
+      **Description:** 
+      
+
+18. ns/openshift-kube-apiserver-operator secret/node-system-admin-client
+
+      **Description:** 
+      
+
+19. ns/openshift-kube-apiserver-operator secret/node-system-admin-signer
+
+      **Description:** 
+      
+
+20. ns/openshift-kube-apiserver-operator secret/service-network-serving-signer
+
+      **Description:** 
+      
+
+21. ns/openshift-kube-controller-manager secret/kube-controller-manager-client-cert-key
+
+      **Description:** 
+      
+
+22. ns/openshift-kube-scheduler secret/kube-scheduler-client-cert-key
+
+      **Description:** 
+      
+
+
+
+#### Certificate Authority Bundles (17)
+1. ns/openshift-config-managed configmap/kube-apiserver-aggregator-client-ca
+
+      **Description:** 
+      
+
+2. ns/openshift-config-managed configmap/kube-apiserver-client-ca
+
+      **Description:** 
+      
+
+3. ns/openshift-config-managed configmap/kube-apiserver-server-ca
+
+      **Description:** 
+      
+
+4. ns/openshift-controller-manager configmap/client-ca
+
+      **Description:** 
+      
+
+5. ns/openshift-kube-apiserver configmap/aggregator-client-ca
+
+      **Description:** 
+      
+
+6. ns/openshift-kube-apiserver configmap/client-ca
+
+      **Description:** 
+      
+
+7. ns/openshift-kube-apiserver configmap/kube-apiserver-server-ca
+
+      **Description:** 
+      
+
+8. ns/openshift-kube-apiserver-operator configmap/kube-apiserver-to-kubelet-client-ca
+
+      **Description:** 
+      
+
+9. ns/openshift-kube-apiserver-operator configmap/kube-control-plane-signer-ca
+
+      **Description:** 
+      
+
+10. ns/openshift-kube-apiserver-operator configmap/loadbalancer-serving-ca
+
+      **Description:** 
+      
+
+11. ns/openshift-kube-apiserver-operator configmap/localhost-recovery-serving-ca
+
+      **Description:** 
+      
+
+12. ns/openshift-kube-apiserver-operator configmap/localhost-serving-ca
+
+      **Description:** 
+      
+
+13. ns/openshift-kube-apiserver-operator configmap/node-system-admin-ca
+
+      **Description:** 
+      
+
+14. ns/openshift-kube-apiserver-operator configmap/service-network-serving-ca
+
+      **Description:** 
+      
+
+15. ns/openshift-kube-controller-manager configmap/aggregator-client-ca
+
+      **Description:** 
+      
+
+16. ns/openshift-kube-controller-manager configmap/client-ca
+
+      **Description:** 
+      
+
+17. ns/openshift-route-controller-manager configmap/client-ca
+
+      **Description:** 
+      
+
+
+
+### kube-controller-manager (10)
+#### Certificates (3)
+1. ns/openshift-kube-controller-manager secret/csr-signer
+
+      **Description:** 
+      
+
+2. ns/openshift-kube-controller-manager-operator secret/csr-signer
+
+      **Description:** 
+      
+
+3. ns/openshift-kube-controller-manager-operator secret/csr-signer-signer
+
+      **Description:** 
+      
+
+
+
+#### Certificate Authority Bundles (7)
+1. ns/openshift-config-managed configmap/csr-controller-ca
+
+      **Description:** 
+      
+
+2. ns/openshift-config-managed configmap/kubelet-serving-ca
+
+      **Description:** 
+      
+
+3. ns/openshift-kube-apiserver configmap/kubelet-serving-ca
+
+      **Description:** 
+      
+
+4. ns/openshift-kube-controller-manager configmap/serviceaccount-ca
+
+      **Description:** 
+      
+
+5. ns/openshift-kube-controller-manager-operator configmap/csr-controller-ca
+
+      **Description:** 
+      
+
+6. ns/openshift-kube-controller-manager-operator configmap/csr-controller-signer-ca
+
+      **Description:** 
+      
+
+7. ns/openshift-kube-controller-manager-operator configmap/csr-signer-ca
+
+      **Description:** 
+      
+
+
+
+### kube-scheduler (1)
+#### Certificate Authority Bundles (1)
+1. ns/openshift-kube-scheduler configmap/serviceaccount-ca
+
+      **Description:** 
+      
+
+
+
+### service-ca (98)
+#### Certificates (95)
+1. ns/openshift-apiserver secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+2. ns/openshift-apiserver-operator secret/openshift-apiserver-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-apiserver-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+3. ns/openshift-authentication secret/v4-0-config-system-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/oauth-openshift with hostname oauth-openshift.openshift-authentication.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert'. The certificate is valid for 2 years.
+      
+
+4. ns/openshift-authentication-operator secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-authentication-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+5. ns/openshift-cloud-credential-operator secret/cloud-credential-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cco-metrics with hostname cco-metrics.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cloud-credential-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+6. ns/openshift-cloud-credential-operator secret/pod-identity-webhook
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/pod-identity-webhook with hostname pod-identity-webhook.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: pod-identity-webhook'. The certificate is valid for 2 years.
+      
+
+7. ns/openshift-cluster-api secret/capg-webhook-service-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capg-webhook-service with hostname capg-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capg-webhook-service-cert'. The certificate is valid for 2 years.
+      
+
+8. ns/openshift-cluster-api secret/capi-webhook-service-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capi-webhook-service with hostname capi-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capi-webhook-service-cert'. The certificate is valid for 2 years.
+      
+
+9. ns/openshift-cluster-api secret/cluster-capi-operator-webhook-service-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-capi-operator-webhook-service with hostname cluster-capi-operator-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-capi-operator-webhook-service-cert'. The certificate is valid for 2 years.
+      
+
+10. ns/openshift-cluster-csi-drivers secret/aws-ebs-csi-driver-controller-metrics-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/aws-ebs-csi-driver-controller-metrics with hostname aws-ebs-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: aws-ebs-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years.
+      
+
+11. ns/openshift-cluster-csi-drivers secret/azure-disk-csi-driver-controller-metrics-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-disk-csi-driver-controller-metrics with hostname azure-disk-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-disk-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years.
+      
+
+12. ns/openshift-cluster-csi-drivers secret/azure-file-csi-driver-controller-metrics-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-file-csi-driver-controller-metrics with hostname azure-file-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-file-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years.
+      
+
+13. ns/openshift-cluster-csi-drivers secret/gcp-pd-csi-driver-controller-metrics-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/gcp-pd-csi-driver-controller-metrics with hostname gcp-pd-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: gcp-pd-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years.
+      
+
+14. ns/openshift-cluster-csi-drivers secret/shared-resource-csi-driver-node-metrics-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-node-metrics with hostname shared-resource-csi-driver-node-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-node-metrics-serving-cert'. The certificate is valid for 2 years.
+      
+
+15. ns/openshift-cluster-csi-drivers secret/shared-resource-csi-driver-operator-metrics-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-operator-metrics with hostname shared-resource-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years.
+      
+
+16. ns/openshift-cluster-csi-drivers secret/shared-resource-csi-driver-webhook-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-webhook with hostname shared-resource-csi-driver-webhook.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-webhook-serving-cert'. The certificate is valid for 2 years.
+      
+
+17. ns/openshift-cluster-csi-drivers secret/vmware-vsphere-csi-driver-controller-metrics-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-controller-metrics with hostname vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years.
+      
+
+18. ns/openshift-cluster-csi-drivers secret/vmware-vsphere-csi-driver-operator-metrics-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-operator-metrics with hostname vmware-vsphere-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years.
+      
+
+19. ns/openshift-cluster-csi-drivers secret/vmware-vsphere-csi-driver-webhook-secret
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-webhook-svc with hostname vmware-vsphere-csi-driver-webhook-svc.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-webhook-secret'. The certificate is valid for 2 years.
+      
+
+20. ns/openshift-cluster-machine-approver secret/machine-approver-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-approver with hostname machine-approver.openshift-cluster-machine-approver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-approver-tls'. The certificate is valid for 2 years.
+      
+
+21. ns/openshift-cluster-node-tuning-operator secret/node-tuning-operator-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-tuning-operator with hostname node-tuning-operator.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-tuning-operator-tls'. The certificate is valid for 2 years.
+      
+
+22. ns/openshift-cluster-node-tuning-operator secret/performance-addon-operator-webhook-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/performance-addon-operator-service with hostname performance-addon-operator-service.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: performance-addon-operator-webhook-cert'. The certificate is valid for 2 years.
+      
+
+23. ns/openshift-cluster-olm-operator secret/cluster-olm-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-olm-operator-metrics with hostname cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+24. ns/openshift-cluster-samples-operator secret/samples-operator-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-cluster-samples-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: samples-operator-tls'. The certificate is valid for 2 years.
+      
+
+25. ns/openshift-cluster-storage-operator secret/cluster-storage-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-storage-operator-metrics with hostname cluster-storage-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-storage-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+26. ns/openshift-cluster-storage-operator secret/csi-snapshot-webhook-secret
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-webhook with hostname csi-snapshot-webhook.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: csi-snapshot-webhook-secret'. The certificate is valid for 2 years.
+      
+
+27. ns/openshift-cluster-storage-operator secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-controller-operator-metrics with hostname csi-snapshot-controller-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+28. ns/openshift-cluster-storage-operator secret/vsphere-problem-detector-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vsphere-problem-detector-metrics with hostname vsphere-problem-detector-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vsphere-problem-detector-serving-cert'. The certificate is valid for 2 years.
+      
+
+29. ns/openshift-cluster-version secret/cluster-version-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-version-operator with hostname cluster-version-operator.openshift-cluster-version.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+30. ns/openshift-config-operator secret/config-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: config-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+31. ns/openshift-console secret/console-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/console with hostname console.openshift-console.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: console-serving-cert'. The certificate is valid for 2 years.
+      
+
+32. ns/openshift-console-operator secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+33. ns/openshift-console-operator secret/webhook-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/webhook with hostname webhook.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: webhook-serving-cert'. The certificate is valid for 2 years.
+      
+
+34. ns/openshift-controller-manager secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/controller-manager with hostname controller-manager.openshift-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+35. ns/openshift-controller-manager-operator secret/openshift-controller-manager-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-controller-manager-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+36. ns/openshift-dns secret/dns-default-metrics-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/dns-default with hostname dns-default.openshift-dns.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: dns-default-metrics-tls'. The certificate is valid for 2 years.
+      
+
+37. ns/openshift-dns-operator secret/metrics-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-dns-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years.
+      
+
+38. ns/openshift-e2e-loki secret/proxy-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/promtail with hostname promtail.openshift-e2e-loki.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years.
+      
+
+39. ns/openshift-etcd secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/etcd with hostname etcd.openshift-etcd.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+40. ns/openshift-etcd-operator secret/etcd-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-etcd-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: etcd-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+41. ns/openshift-image-registry secret/image-registry-operator-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry-operator with hostname image-registry-operator.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-operator-tls'. The certificate is valid for 2 years.
+      
+
+42. ns/openshift-image-registry secret/image-registry-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry with hostname image-registry.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-tls'. The certificate is valid for 2 years.
+      
+
+43. ns/openshift-ingress secret/router-metrics-certs-default
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/router-internal-default with hostname router-internal-default.openshift-ingress.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: router-metrics-certs-default'. The certificate is valid for 2 years.
+      
+
+44. ns/openshift-ingress-operator secret/metrics-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-ingress-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years.
+      
+
+45. ns/openshift-insights secret/openshift-insights-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-insights.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-insights-serving-cert'. The certificate is valid for 2 years.
+      
+
+46. ns/openshift-kube-apiserver-operator secret/kube-apiserver-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+47. ns/openshift-kube-controller-manager secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-controller-manager with hostname kube-controller-manager.openshift-kube-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+48. ns/openshift-kube-controller-manager-operator secret/kube-controller-manager-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+49. ns/openshift-kube-scheduler secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/scheduler with hostname scheduler.openshift-kube-scheduler.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+50. ns/openshift-kube-scheduler-operator secret/kube-scheduler-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-scheduler-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-scheduler-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+51. ns/openshift-kube-storage-version-migrator-operator secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-storage-version-migrator-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+52. ns/openshift-machine-api secret/baremetal-operator-webhook-server-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/baremetal-operator-webhook-service with hostname baremetal-operator-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: baremetal-operator-webhook-server-cert'. The certificate is valid for 2 years.
+      
+
+53. ns/openshift-machine-api secret/cluster-autoscaler-operator-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-autoscaler-operator with hostname cluster-autoscaler-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-autoscaler-operator-cert'. The certificate is valid for 2 years.
+      
+
+54. ns/openshift-machine-api secret/cluster-baremetal-operator-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-operator-service with hostname cluster-baremetal-operator-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-operator-tls'. The certificate is valid for 2 years.
+      
+
+55. ns/openshift-machine-api secret/cluster-baremetal-webhook-server-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-webhook-service with hostname cluster-baremetal-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-webhook-server-cert'. The certificate is valid for 2 years.
+      
+
+56. ns/openshift-machine-api secret/control-plane-machine-set-operator-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/control-plane-machine-set-operator with hostname control-plane-machine-set-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: control-plane-machine-set-operator-tls'. The certificate is valid for 2 years.
+      
+
+57. ns/openshift-machine-api secret/machine-api-controllers-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-controllers with hostname machine-api-controllers.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-controllers-tls'. The certificate is valid for 2 years.
+      
+
+58. ns/openshift-machine-api secret/machine-api-operator-machine-webhook-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-machine-webhook with hostname machine-api-operator-machine-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-machine-webhook-cert'. The certificate is valid for 2 years.
+      
+
+59. ns/openshift-machine-api secret/machine-api-operator-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator with hostname machine-api-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-tls'. The certificate is valid for 2 years.
+      
+
+60. ns/openshift-machine-api secret/machine-api-operator-webhook-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-webhook with hostname machine-api-operator-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-webhook-cert'. The certificate is valid for 2 years.
+      
+
+61. ns/openshift-machine-config-operator secret/mcc-proxy-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-controller with hostname machine-config-controller.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mcc-proxy-tls'. The certificate is valid for 2 years.
+      
+
+62. ns/openshift-machine-config-operator secret/mco-proxy-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-operator with hostname machine-config-operator.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mco-proxy-tls'. The certificate is valid for 2 years.
+      
+
+63. ns/openshift-machine-config-operator secret/proxy-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-daemon with hostname machine-config-daemon.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years.
+      
+
+64. ns/openshift-marketplace secret/marketplace-operator-metrics
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/marketplace-operator-metrics with hostname marketplace-operator-metrics.openshift-marketplace.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: marketplace-operator-metrics'. The certificate is valid for 2 years.
+      
+
+65. ns/openshift-monitoring secret/alertmanager-main-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/alertmanager-main with hostname alertmanager-main.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: alertmanager-main-tls'. The certificate is valid for 2 years.
+      
+
+66. ns/openshift-monitoring secret/cluster-monitoring-operator-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-monitoring-operator with hostname cluster-monitoring-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-monitoring-operator-tls'. The certificate is valid for 2 years.
+      
+
+67. ns/openshift-monitoring secret/kube-state-metrics-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-state-metrics with hostname kube-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-state-metrics-tls'. The certificate is valid for 2 years.
+      
+
+68. ns/openshift-monitoring secret/metrics-server-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics-server with hostname metrics-server.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-server-tls'. The certificate is valid for 2 years.
+      
+
+69. ns/openshift-monitoring secret/monitoring-plugin-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/monitoring-plugin with hostname monitoring-plugin.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: monitoring-plugin-cert'. The certificate is valid for 2 years.
+      
+
+70. ns/openshift-monitoring secret/node-exporter-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-exporter with hostname node-exporter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-exporter-tls'. The certificate is valid for 2 years.
+      
+
+71. ns/openshift-monitoring secret/openshift-state-metrics-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/openshift-state-metrics with hostname openshift-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-state-metrics-tls'. The certificate is valid for 2 years.
+      
+
+72. ns/openshift-monitoring secret/prometheus-adapter-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-adapter with hostname prometheus-adapter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-adapter-tls'. The certificate is valid for 2 years.
+      
+
+73. ns/openshift-monitoring secret/prometheus-k8s-thanos-sidecar-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s-thanos-sidecar with hostname prometheus-k8s-thanos-sidecar.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-thanos-sidecar-tls'. The certificate is valid for 2 years.
+      
+
+74. ns/openshift-monitoring secret/prometheus-k8s-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s with hostname prometheus-k8s.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls'. The certificate is valid for 2 years.
+      
+
+75. ns/openshift-monitoring secret/prometheus-operator-admission-webhook-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator-admission-webhook with hostname prometheus-operator-admission-webhook.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-admission-webhook-tls'. The certificate is valid for 2 years.
+      
+
+76. ns/openshift-monitoring secret/prometheus-operator-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator with hostname prometheus-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-tls'. The certificate is valid for 2 years.
+      
+
+77. ns/openshift-monitoring secret/telemeter-client-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/telemeter-client with hostname telemeter-client.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: telemeter-client-tls'. The certificate is valid for 2 years.
+      
+
+78. ns/openshift-monitoring secret/thanos-querier-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/thanos-querier with hostname thanos-querier.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: thanos-querier-tls'. The certificate is valid for 2 years.
+      
+
+79. ns/openshift-multus secret/metrics-daemon-secret
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/network-metrics-service with hostname network-metrics-service.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-daemon-secret'. The certificate is valid for 2 years.
+      
+
+80. ns/openshift-multus secret/multus-admission-controller-secret
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/multus-admission-controller with hostname multus-admission-controller.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: multus-admission-controller-secret'. The certificate is valid for 2 years.
+      
+
+81. ns/openshift-network-operator secret/metrics-tls
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-network-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years.
+      
+
+82. ns/openshift-oauth-apiserver secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-oauth-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+83. ns/openshift-operator-lifecycle-manager secret/catalog-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/catalog-operator-metrics with hostname catalog-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+84. ns/openshift-operator-lifecycle-manager secret/olm-operator-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/olm-operator-metrics with hostname olm-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: olm-operator-serving-cert'. The certificate is valid for 2 years.
+      
+
+85. ns/openshift-operator-lifecycle-manager secret/package-server-manager-serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/package-server-manager-metrics with hostname package-server-manager-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert'. The certificate is valid for 2 years.
+      
+
+86. ns/openshift-ovn-kubernetes secret/ovn-control-plane-metrics-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-control-plane with hostname ovn-kubernetes-control-plane.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-control-plane-metrics-cert'. The certificate is valid for 2 years.
+      
+
+87. ns/openshift-ovn-kubernetes secret/ovn-node-metrics-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-node with hostname ovn-kubernetes-node.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-node-metrics-cert'. The certificate is valid for 2 years.
+      
+
+88. ns/openshift-route-controller-manager secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/route-controller-manager with hostname route-controller-manager.openshift-route-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+89. ns/openshift-rukpak secret/core-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/core with hostname core.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: core-cert'. The certificate is valid for 2 years.
+      
+
+90. ns/openshift-rukpak secret/helm-provisioner-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/helm-provisioner with hostname helm-provisioner.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: helm-provisioner-cert'. The certificate is valid for 2 years.
+      
+
+91. ns/openshift-rukpak secret/rukpak-webhook-certificate
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/rukpak-webhook-service with hostname rukpak-webhook-service.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: rukpak-webhook-certificate'. The certificate is valid for 2 years.
+      
+
+92. ns/openshift-sdn secret/sdn-controller-metrics-certs
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn-controller with hostname sdn-controller.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-controller-metrics-certs'. The certificate is valid for 2 years.
+      
+
+93. ns/openshift-sdn secret/sdn-metrics-certs
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn with hostname sdn.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-metrics-certs'. The certificate is valid for 2 years.
+      
+
+94. ns/openshift-service-ca secret/signing-key
+
+      **Description:** Service CA secret contains a signing key that will be used to issue a signed serving certificate/key pair to services annotated with 'service.beta.openshift.io/serving-cert-secret-name'
+      
+
+95. ns/openshift-service-ca-operator secret/serving-cert
+
+      **Description:** Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-service-ca-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years.
+      
+
+
+
+#### Certificate Authority Bundles (3)
+1. ns/openshift-config-managed configmap/service-ca
+
+      **Description:** Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'
+      
+
+2. ns/openshift-kube-controller-manager configmap/service-ca
+
+      **Description:** Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'
+      
+
+3. ns/openshift-service-ca configmap/signing-cabundle
+
+      **Description:** Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'
+      
+
+
+
+## Items That DO Meet the Requirement (0)

--- a/tls/violations/offline-hostname-change/offline-hostname-change-violations.json
+++ b/tls/violations/offline-hostname-change/offline-hostname-change-violations.json
@@ -1,0 +1,4368 @@
+{
+    "certificateAuthorityBundles": [
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-apiserver",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-apiserver",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-apiserver-operator",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-authentication",
+                "Name": "v4-0-config-system-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-authentication-operator",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cloud-controller-manager",
+                "Name": "ccm-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Cloud Compute / Cloud Controller Manager"
+                    }
+                ],
+                "owningJiraComponent": "Cloud Compute / Cloud Controller Manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cloud-credential-operator",
+                "Name": "cco-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cloud-network-config-controller",
+                "Name": "trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "aws-ebs-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "azure-disk-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "azure-file-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "gcp-pd-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "shared-resource-csi-driver-operator-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vmware-vsphere-csi-driver-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vsphere-csi-driver-operator-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-node-tuning-operator",
+                "Name": "trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "admin-kubeconfig-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-metric-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "initial-kube-apiserver-server-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Machine Config Operator"
+                    }
+                ],
+                "owningJiraComponent": "Machine Config Operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config",
+                "Name": "user-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "End User"
+                    }
+                ],
+                "owningJiraComponent": "End User",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "csr-controller-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "default-ingress-cert"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-apiserver-aggregator-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-apiserver-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-apiserver-server-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kubelet-bootstrap-kubeconfig"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kubelet-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "oauth-serving-cert"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "apiserver-auth"
+                    }
+                ],
+                "owningJiraComponent": "apiserver-auth",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "service-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-console",
+                "Name": "default-ingress-cert"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-console",
+                "Name": "oauth-serving-cert"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "apiserver-auth"
+                    }
+                ],
+                "owningJiraComponent": "apiserver-auth",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-console",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-controller-manager",
+                "Name": "client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-controller-manager",
+                "Name": "openshift-global-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-metrics-proxy-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-metrics-proxy-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-peer-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-metric-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-image-registry",
+                "Name": "trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-ingress-operator",
+                "Name": "trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-insights",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "aggregator-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "kube-apiserver-server-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "kubelet-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-apiserver-to-kubelet-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-control-plane-signer-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "loadbalancer-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "localhost-recovery-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "localhost-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "node-system-admin-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "service-network-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "aggregator-client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "service-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "serviceaccount-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-controller-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-controller-signer-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-signer-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-kube-scheduler",
+                "Name": "serviceaccount-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-scheduler"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-scheduler",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "cbo-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "mao-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-marketplace",
+                "Name": "marketplace-trusted-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "alertmanager-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "alertmanager-trusted-ca-bundle-2ua4n9ob5qr8o"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "kubelet-serving-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-trusted-ca-bundle-2ua4n9ob5qr8o"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "telemeter-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "telemeter-trusted-ca-bundle-2ua4n9ob5qr8o"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "thanos-querier-trusted-ca-bundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Networking / cluster-network-operator"
+                    }
+                ],
+                "owningJiraComponent": "Networking / cluster-network-operator",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "thanos-querier-trusted-ca-bundle-2ua4n9ob5qr8o"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-network-node-identity",
+                "Name": "network-node-identity-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-oauth-apiserver",
+                "Name": "etcd-serving-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "signer-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-route-controller-manager",
+                "Name": "client-ca"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "configMapLocation": {
+                "Namespace": "openshift-service-ca",
+                "Name": "signing-cabundle"
+            },
+            "certificateAuthorityBundleInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Service CA configmap contains the data for the PEM-encoded CA signing bundle which will be injected to resources annotated with 'service.beta.openshift.io/inject-cabundle=true'"
+            }
+        }
+    ],
+    "certKeyPairs": [
+        {
+            "secretLocation": {
+                "Namespace": "openshift-apiserver",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-apiserver",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-apiserver-operator",
+                "Name": "openshift-apiserver-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-apiserver-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-apiserver-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-authentication",
+                "Name": "v4-0-config-system-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/oauth-openshift with hostname oauth-openshift.openshift-authentication.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/oauth-openshift with hostname oauth-openshift.openshift-authentication.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: v4-0-config-system-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-authentication-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-authentication-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-authentication-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cloud-credential-operator",
+                "Name": "cloud-credential-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cco-metrics with hostname cco-metrics.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cloud-credential-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cco-metrics with hostname cco-metrics.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cloud-credential-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cloud-credential-operator",
+                "Name": "pod-identity-webhook"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/pod-identity-webhook with hostname pod-identity-webhook.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: pod-identity-webhook'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/pod-identity-webhook with hostname pod-identity-webhook.openshift-cloud-credential-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: pod-identity-webhook'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-api",
+                "Name": "capg-webhook-service-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capg-webhook-service with hostname capg-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capg-webhook-service-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capg-webhook-service with hostname capg-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capg-webhook-service-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-api",
+                "Name": "capi-webhook-service-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capi-webhook-service with hostname capi-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capi-webhook-service-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/capi-webhook-service with hostname capi-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: capi-webhook-service-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-api",
+                "Name": "cluster-capi-operator-webhook-service-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-capi-operator-webhook-service with hostname cluster-capi-operator-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-capi-operator-webhook-service-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-capi-operator-webhook-service with hostname cluster-capi-operator-webhook-service.openshift-cluster-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-capi-operator-webhook-service-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "aws-ebs-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/aws-ebs-csi-driver-controller-metrics with hostname aws-ebs-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: aws-ebs-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/aws-ebs-csi-driver-controller-metrics with hostname aws-ebs-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: aws-ebs-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "azure-disk-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-disk-csi-driver-controller-metrics with hostname azure-disk-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-disk-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-disk-csi-driver-controller-metrics with hostname azure-disk-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-disk-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "azure-file-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-file-csi-driver-controller-metrics with hostname azure-file-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-file-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/azure-file-csi-driver-controller-metrics with hostname azure-file-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: azure-file-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "gcp-pd-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/gcp-pd-csi-driver-controller-metrics with hostname gcp-pd-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: gcp-pd-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/gcp-pd-csi-driver-controller-metrics with hostname gcp-pd-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: gcp-pd-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "shared-resource-csi-driver-node-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-node-metrics with hostname shared-resource-csi-driver-node-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-node-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-node-metrics with hostname shared-resource-csi-driver-node-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-node-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "shared-resource-csi-driver-operator-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-operator-metrics with hostname shared-resource-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-operator-metrics with hostname shared-resource-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "shared-resource-csi-driver-webhook-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-webhook with hostname shared-resource-csi-driver-webhook.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-webhook-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/shared-resource-csi-driver-webhook with hostname shared-resource-csi-driver-webhook.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: shared-resource-csi-driver-webhook-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vmware-vsphere-csi-driver-controller-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-controller-metrics with hostname vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-controller-metrics with hostname vmware-vsphere-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-controller-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vmware-vsphere-csi-driver-operator-metrics-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-operator-metrics with hostname vmware-vsphere-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-operator-metrics with hostname vmware-vsphere-csi-driver-operator-metrics.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-operator-metrics-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-csi-drivers",
+                "Name": "vmware-vsphere-csi-driver-webhook-secret"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-webhook-svc with hostname vmware-vsphere-csi-driver-webhook-svc.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-webhook-secret'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vmware-vsphere-csi-driver-webhook-svc with hostname vmware-vsphere-csi-driver-webhook-svc.openshift-cluster-csi-drivers.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vmware-vsphere-csi-driver-webhook-secret'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-machine-approver",
+                "Name": "machine-approver-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-approver with hostname machine-approver.openshift-cluster-machine-approver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-approver-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-approver with hostname machine-approver.openshift-cluster-machine-approver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-approver-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-node-tuning-operator",
+                "Name": "node-tuning-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-tuning-operator with hostname node-tuning-operator.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-tuning-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-tuning-operator with hostname node-tuning-operator.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-tuning-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-node-tuning-operator",
+                "Name": "performance-addon-operator-webhook-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/performance-addon-operator-service with hostname performance-addon-operator-service.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: performance-addon-operator-webhook-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/performance-addon-operator-service with hostname performance-addon-operator-service.openshift-cluster-node-tuning-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: performance-addon-operator-webhook-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-olm-operator",
+                "Name": "cluster-olm-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-olm-operator-metrics with hostname cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-olm-operator-metrics with hostname cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-samples-operator",
+                "Name": "samples-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-cluster-samples-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: samples-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-cluster-samples-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: samples-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "cluster-storage-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-storage-operator-metrics with hostname cluster-storage-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-storage-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-storage-operator-metrics with hostname cluster-storage-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-storage-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "csi-snapshot-webhook-secret"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-webhook with hostname csi-snapshot-webhook.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: csi-snapshot-webhook-secret'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-webhook with hostname csi-snapshot-webhook.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: csi-snapshot-webhook-secret'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-controller-operator-metrics with hostname csi-snapshot-controller-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/csi-snapshot-controller-operator-metrics with hostname csi-snapshot-controller-operator-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-storage-operator",
+                "Name": "vsphere-problem-detector-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vsphere-problem-detector-metrics with hostname vsphere-problem-detector-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vsphere-problem-detector-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/vsphere-problem-detector-metrics with hostname vsphere-problem-detector-metrics.openshift-cluster-storage-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: vsphere-problem-detector-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-cluster-version",
+                "Name": "cluster-version-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-version-operator with hostname cluster-version-operator.openshift-cluster-version.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-version-operator with hostname cluster-version-operator.openshift-cluster-version.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-metric-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-metric-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config",
+                "Name": "etcd-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-controller-manager-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config-managed",
+                "Name": "kube-scheduler-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-config-operator",
+                "Name": "config-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: config-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: config-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-console",
+                "Name": "console-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/console with hostname console.openshift-console.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: console-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/console with hostname console.openshift-console.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: console-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-console-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-console-operator",
+                "Name": "webhook-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/webhook with hostname webhook.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: webhook-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/webhook with hostname webhook.openshift-console-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: webhook-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-controller-manager",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/controller-manager with hostname controller-manager.openshift-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/controller-manager with hostname controller-manager.openshift-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-controller-manager-operator",
+                "Name": "openshift-controller-manager-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-controller-manager-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-controller-manager-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-dns",
+                "Name": "dns-default-metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/dns-default with hostname dns-default.openshift-dns.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: dns-default-metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/dns-default with hostname dns-default.openshift-dns.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: dns-default-metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-dns-operator",
+                "Name": "metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-dns-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-dns-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-e2e-loki",
+                "Name": "proxy-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/promtail with hostname promtail.openshift-e2e-loki.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/promtail with hostname promtail.openshift-e2e-loki.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-peer-\u003cmaster-0\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-peer-\u003cmaster-1\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-peer-\u003cmaster-2\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-\u003cmaster-0\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-\u003cmaster-1\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-\u003cmaster-2\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-metrics-\u003cmaster-0\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-metrics-\u003cmaster-1\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "etcd-serving-metrics-\u003cmaster-2\u003e"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/etcd with hostname etcd.openshift-etcd.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/etcd with hostname etcd.openshift-etcd.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-metric-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-etcd-operator",
+                "Name": "etcd-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-etcd-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: etcd-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-etcd-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: etcd-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-image-registry",
+                "Name": "image-registry-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry-operator with hostname image-registry-operator.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry-operator with hostname image-registry-operator.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-image-registry",
+                "Name": "image-registry-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry with hostname image-registry.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/image-registry with hostname image-registry.openshift-image-registry.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: image-registry-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ingress",
+                "Name": "router-certs-default"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ingress",
+                "Name": "router-metrics-certs-default"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/router-internal-default with hostname router-internal-default.openshift-ingress.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: router-metrics-certs-default'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/router-internal-default with hostname router-internal-default.openshift-ingress.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: router-metrics-certs-default'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ingress-operator",
+                "Name": "metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-ingress-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-ingress-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ingress-operator",
+                "Name": "router-ca"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-insights",
+                "Name": "openshift-insights-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-insights.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-insights-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-insights.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-insights-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "aggregator-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "check-endpoints-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "control-plane-node-admin-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "external-loadbalancer-serving-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "internal-loadbalancer-serving-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "kubelet-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "localhost-recovery-serving-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "localhost-serving-cert-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver",
+                "Name": "service-network-serving-certkey"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "aggregator-client-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-apiserver-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-apiserver-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-apiserver-to-kubelet-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "kube-control-plane-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "loadbalancer-serving-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "localhost-recovery-serving-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "localhost-serving-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "node-system-admin-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "node-system-admin-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-apiserver-operator",
+                "Name": "service-network-serving-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "csr-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "kube-controller-manager-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-controller-manager with hostname kube-controller-manager.openshift-kube-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-controller-manager with hostname kube-controller-manager.openshift-kube-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "csr-signer-signer"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-controller-manager"
+                    }
+                ],
+                "owningJiraComponent": "kube-controller-manager",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-controller-manager-operator",
+                "Name": "kube-controller-manager-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-controller-manager-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-controller-manager-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-scheduler",
+                "Name": "kube-scheduler-client-cert-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "kube-apiserver"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "kube-apiserver",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-scheduler",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/scheduler with hostname scheduler.openshift-kube-scheduler.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/scheduler with hostname scheduler.openshift-kube-scheduler.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-scheduler-operator",
+                "Name": "kube-scheduler-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-scheduler-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-scheduler-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-scheduler-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-scheduler-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-kube-storage-version-migrator-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-storage-version-migrator-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-kube-storage-version-migrator-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "baremetal-operator-webhook-server-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/baremetal-operator-webhook-service with hostname baremetal-operator-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: baremetal-operator-webhook-server-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/baremetal-operator-webhook-service with hostname baremetal-operator-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: baremetal-operator-webhook-server-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "cluster-autoscaler-operator-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-autoscaler-operator with hostname cluster-autoscaler-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-autoscaler-operator-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-autoscaler-operator with hostname cluster-autoscaler-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-autoscaler-operator-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "cluster-baremetal-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-operator-service with hostname cluster-baremetal-operator-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-operator-service with hostname cluster-baremetal-operator-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "cluster-baremetal-webhook-server-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-webhook-service with hostname cluster-baremetal-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-webhook-server-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-baremetal-webhook-service with hostname cluster-baremetal-webhook-service.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-baremetal-webhook-server-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "control-plane-machine-set-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/control-plane-machine-set-operator with hostname control-plane-machine-set-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: control-plane-machine-set-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/control-plane-machine-set-operator with hostname control-plane-machine-set-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: control-plane-machine-set-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "machine-api-controllers-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-controllers with hostname machine-api-controllers.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-controllers-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-controllers with hostname machine-api-controllers.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-controllers-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "machine-api-operator-machine-webhook-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-machine-webhook with hostname machine-api-operator-machine-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-machine-webhook-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-machine-webhook with hostname machine-api-operator-machine-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-machine-webhook-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "machine-api-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator with hostname machine-api-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator with hostname machine-api-operator.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "machine-api-operator-webhook-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-webhook with hostname machine-api-operator-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-webhook-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-api-operator-webhook with hostname machine-api-operator-webhook.openshift-machine-api.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: machine-api-operator-webhook-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-api",
+                "Name": "metal3-ironic-tls"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-config-operator",
+                "Name": "machine-config-server-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Machine Config Operator"
+                    }
+                ],
+                "owningJiraComponent": "Machine Config Operator",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-config-operator",
+                "Name": "mcc-proxy-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-controller with hostname machine-config-controller.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mcc-proxy-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-controller with hostname machine-config-controller.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mcc-proxy-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-config-operator",
+                "Name": "mco-proxy-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-operator with hostname machine-config-operator.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mco-proxy-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-operator with hostname machine-config-operator.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: mco-proxy-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-machine-config-operator",
+                "Name": "proxy-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-daemon with hostname machine-config-daemon.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/machine-config-daemon with hostname machine-config-daemon.openshift-machine-config-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: proxy-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-marketplace",
+                "Name": "marketplace-operator-metrics"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/marketplace-operator-metrics with hostname marketplace-operator-metrics.openshift-marketplace.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: marketplace-operator-metrics'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/marketplace-operator-metrics with hostname marketplace-operator-metrics.openshift-marketplace.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: marketplace-operator-metrics'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "alertmanager-main-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/alertmanager-main with hostname alertmanager-main.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: alertmanager-main-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/alertmanager-main with hostname alertmanager-main.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: alertmanager-main-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "cluster-monitoring-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-monitoring-operator with hostname cluster-monitoring-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-monitoring-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/cluster-monitoring-operator with hostname cluster-monitoring-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: cluster-monitoring-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "federate-client-certs"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "kube-state-metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-state-metrics with hostname kube-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-state-metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/kube-state-metrics with hostname kube-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: kube-state-metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "metrics-client-certs"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "metrics-server-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics-server with hostname metrics-server.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-server-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics-server with hostname metrics-server.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-server-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "monitoring-plugin-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/monitoring-plugin with hostname monitoring-plugin.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: monitoring-plugin-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/monitoring-plugin with hostname monitoring-plugin.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: monitoring-plugin-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "node-exporter-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-exporter with hostname node-exporter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-exporter-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/node-exporter with hostname node-exporter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: node-exporter-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "openshift-state-metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/openshift-state-metrics with hostname openshift-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-state-metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/openshift-state-metrics with hostname openshift-state-metrics.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: openshift-state-metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-1ehgs15tubhcc"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-1vcbbd485dtu8"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-2la6907ck7pse"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-4ho3dj3us2df4"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-56glf1mhs3bbm"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-5b3cu0f6s65i"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-5blo6a2jkr388"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-ba21034efmj7v"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-bo9ukpiqhr327"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-d6ej41uj54llt"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-adapter-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-adapter with hostname prometheus-adapter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-adapter-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-adapter with hostname prometheus-adapter.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-adapter-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-k8s-thanos-sidecar-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s-thanos-sidecar with hostname prometheus-k8s-thanos-sidecar.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-thanos-sidecar-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s-thanos-sidecar with hostname prometheus-k8s-thanos-sidecar.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-thanos-sidecar-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-k8s-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s with hostname prometheus-k8s.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-k8s with hostname prometheus-k8s.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-k8s-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-operator-admission-webhook-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator-admission-webhook with hostname prometheus-operator-admission-webhook.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-admission-webhook-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator-admission-webhook with hostname prometheus-operator-admission-webhook.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-admission-webhook-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "prometheus-operator-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator with hostname prometheus-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/prometheus-operator with hostname prometheus-operator.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: prometheus-operator-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "telemeter-client-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/telemeter-client with hostname telemeter-client.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: telemeter-client-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/telemeter-client with hostname telemeter-client.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: telemeter-client-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-monitoring",
+                "Name": "thanos-querier-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/thanos-querier with hostname thanos-querier.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: thanos-querier-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/thanos-querier with hostname thanos-querier.openshift-monitoring.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: thanos-querier-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-multus",
+                "Name": "metrics-daemon-secret"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/network-metrics-service with hostname network-metrics-service.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-daemon-secret'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/network-metrics-service with hostname network-metrics-service.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-daemon-secret'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-multus",
+                "Name": "multus-admission-controller-secret"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/multus-admission-controller with hostname multus-admission-controller.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: multus-admission-controller-secret'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/multus-admission-controller with hostname multus-admission-controller.openshift-multus.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: multus-admission-controller-secret'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-network-node-identity",
+                "Name": "network-node-identity-ca"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-network-node-identity",
+                "Name": "network-node-identity-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-network-operator",
+                "Name": "metrics-tls"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-network-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-network-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: metrics-tls'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-oauth-apiserver",
+                "Name": "etcd-client"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "Etcd"
+                    }
+                ],
+                "owningJiraComponent": "Etcd",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-oauth-apiserver",
+                "Name": "openshift-authenticator-certs"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "apiserver-auth"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": ""
+                    }
+                ],
+                "owningJiraComponent": "apiserver-auth",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-oauth-apiserver",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-oauth-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/api with hostname api.openshift-oauth-apiserver.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "catalog-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/catalog-operator-metrics with hostname catalog-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/catalog-operator-metrics with hostname catalog-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: catalog-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "olm-operator-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/olm-operator-metrics with hostname olm-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: olm-operator-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/olm-operator-metrics with hostname olm-operator-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: olm-operator-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "package-server-manager-serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/package-server-manager-metrics with hostname package-server-manager-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/package-server-manager-metrics with hostname package-server-manager-metrics.openshift-operator-lifecycle-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: package-server-manager-serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "packageserver-service-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-operator-lifecycle-manager",
+                "Name": "pprof-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-ca"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-control-plane-metrics-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-control-plane with hostname ovn-kubernetes-control-plane.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-control-plane-metrics-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-control-plane with hostname ovn-kubernetes-control-plane.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-control-plane-metrics-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "ovn-node-metrics-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-node with hostname ovn-kubernetes-node.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-node-metrics-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/ovn-kubernetes-node with hostname ovn-kubernetes-node.openshift-ovn-kubernetes.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: ovn-node-metrics-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "signer-ca"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-ovn-kubernetes",
+                "Name": "signer-cert"
+            },
+            "certKeyInfo": {
+                "owningJiraComponent": "",
+                "description": ""
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-route-controller-manager",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/route-controller-manager with hostname route-controller-manager.openshift-route-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/route-controller-manager with hostname route-controller-manager.openshift-route-controller-manager.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-rukpak",
+                "Name": "core-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/core with hostname core.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: core-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/core with hostname core.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: core-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-rukpak",
+                "Name": "helm-provisioner-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/helm-provisioner with hostname helm-provisioner.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: helm-provisioner-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/helm-provisioner with hostname helm-provisioner.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: helm-provisioner-cert'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-rukpak",
+                "Name": "rukpak-webhook-certificate"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/rukpak-webhook-service with hostname rukpak-webhook-service.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: rukpak-webhook-certificate'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/rukpak-webhook-service with hostname rukpak-webhook-service.openshift-rukpak.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: rukpak-webhook-certificate'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-sdn",
+                "Name": "sdn-controller-metrics-certs"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn-controller with hostname sdn-controller.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-controller-metrics-certs'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn-controller with hostname sdn-controller.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-controller-metrics-certs'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-sdn",
+                "Name": "sdn-metrics-certs"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn with hostname sdn.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-metrics-certs'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/sdn with hostname sdn.openshift-sdn.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: sdn-metrics-certs'. The certificate is valid for 2 years."
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-service-ca",
+                "Name": "signing-key"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Service CA secret contains a signing key that will be used to issue a signed serving certificate/key pair to services annotated with 'service.beta.openshift.io/serving-cert-secret-name'"
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Service CA secret contains a signing key that will be used to issue a signed serving certificate/key pair to services annotated with 'service.beta.openshift.io/serving-cert-secret-name'"
+            }
+        },
+        {
+            "secretLocation": {
+                "Namespace": "openshift-service-ca-operator",
+                "Name": "serving-cert"
+            },
+            "certKeyInfo": {
+                "selectedCertMetadataAnnotations": [
+                    {
+                        "key": "openshift.io/owning-component",
+                        "value": "service-ca"
+                    },
+                    {
+                        "key": "openshift.io/description",
+                        "value": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-service-ca-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+                    }
+                ],
+                "owningJiraComponent": "service-ca",
+                "description": "Secret contains a pair signed serving certificate/key that is generated by Service CA operator for service/metrics with hostname metrics.openshift-service-ca-operator.svc and is annotated to the service with annotating a service resource with 'service.beta.openshift.io/serving-cert-secret-name: serving-cert'. The certificate is valid for 2 years."
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Keep track of which certificates support the SNO hostname change tool and prevent new certificates from being added that have not confirmed this capability to avoid accidental regressions.

After testing for a particular TLS artifact is complete (requirements noted in the markdown), adding the annotation to a particular secret or configmap indicates that certificate is complete.  Keep in mind that 
1. existing e2e testing does not necessarily cover every certificate and CA bundle
2. this mechanism adds an e2e test that ensures new certificates must work with a hostname change prior to coming into the payload.
3. acknowledgement is lightweight, see https://github.com/openshift/cluster-etcd-operator/pull/1159/files as a similar example.
4. this has the benefit of ensuring that teams are aware of exactly how the hostname changes impact their certificates

/hold

cc @cuppett @romfreiman 