### PR TITLE
AGENT-715: Add tests for baremetal hosts for agent installer

### DIFF
--- a/test/extended/agent_installer/baremetal_hosts.go
+++ b/test/extended/agent_installer/baremetal_hosts.go
@@ -1,0 +1,83 @@
+package baremetal
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openshift/origin/test/extended/baremetal"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform created by agent-installer should", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLI("baremetal")
+
+	g.BeforeEach(func() {
+		baremetal.SkipIfNotBaremetal(oc)
+	})
+
+	g.It("have baremetalhost resources", func() {
+		dc := oc.AdminDynamicClient()
+		bmc := baremetal.BaremetalClient(dc)
+
+		hosts, err := bmc.List(context.Background(), metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(hosts.Items).ToNot(o.BeEmpty())
+	})
+
+	g.It("have provisioned hosts when provisioning network set to managed", func() {
+		dc := oc.AdminDynamicClient()
+		bmc := baremetal.BaremetalClient(dc)
+
+		provisioningNetwork := baremetal.GetProvisioningNetwork(dc)
+		if provisioningNetwork == "Managed" {
+			hosts, _ := bmc.List(context.Background(), metav1.ListOptions{})
+
+			for _, h := range hosts.Items {
+				baremetal.ExpectStringField(h, "baremetalhost", "status.operationalStatus").To(o.BeEquivalentTo("OK"))
+				baremetal.ExpectStringField(h, "baremetalhost", "status.provisioning.state").To(o.Or(o.BeEquivalentTo("provisioned"), o.BeEquivalentTo("externally provisioned")))
+				baremetal.ExpectBoolField(h, "baremetalhost", "spec.online").To(o.BeTrue())
+
+			}
+		}
+	})
+
+	g.It("have hostfirmwaresetting resources when provisioning network set to managed", func() {
+		dc := oc.AdminDynamicClient()
+
+		bmc := baremetal.BaremetalClient(dc)
+		hosts, _ := bmc.List(context.Background(), metav1.ListOptions{})
+
+		hfsClient := baremetal.HostfirmwaresettingsClient(dc)
+
+		provisioningNetwork := baremetal.GetProvisioningNetwork(dc)
+		if provisioningNetwork == "Managed" {
+			for _, h := range hosts.Items {
+				hostName := baremetal.GetStringField(h, "baremetalhost", "metadata.name")
+
+				g.By(fmt.Sprintf("check that baremetalhost %s has a corresponding hostfirmwaresettings", hostName))
+				hfs, err := hfsClient.Get(context.Background(), hostName, metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(hfs).NotTo(o.Equal(nil))
+
+				g.By("check that hostfirmwaresettings conditions show resource is valid")
+				baremetal.CheckConditionStatus(*hfs, "Valid", "True")
+
+				g.By("check that hostfirmwaresettings reference a schema")
+				refName := baremetal.GetStringField(*hfs, "hostfirmwaresettings", "status.schema.name")
+				refNS := baremetal.GetStringField(*hfs, "hostfirmwaresettings", "status.schema.namespace")
+
+				schemaClient := dc.Resource(schema.GroupVersionResource{Group: "metal3.io", Resource: "firmwareschemas", Version: "v1alpha1"}).Namespace(refNS)
+				schema, err := schemaClient.Get(context.Background(), refName, metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(schema).NotTo(o.Equal(nil))
+			}
+		}
+	})
+})

--- a/test/extended/baremetal/common.go
+++ b/test/extended/baremetal/common.go
@@ -16,7 +16,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-func skipIfNotBaremetal(oc *exutil.CLI) {
+func SkipIfNotBaremetal(oc *exutil.CLI) {
 	g.By("checking platform type")
 
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
@@ -52,7 +52,7 @@ func skipIfUnsupportedPlatformOrConfig(oc *exutil.CLI, dc dynamic.Interface) {
 	case configv1.GCPPlatformType:
 		fallthrough
 	case configv1.NonePlatformType:
-		provisioningNetwork := getProvisioningNetwork(dc)
+		provisioningNetwork := GetProvisioningNetwork(dc)
 		if provisioningNetwork != "Disabled" {
 			e2eskipper.Skipf("Unsupported config in supported platform detected")
 		} else if provisioningNetwork == "" {
@@ -65,7 +65,7 @@ func skipIfUnsupportedPlatformOrConfig(oc *exutil.CLI, dc dynamic.Interface) {
 	}
 }
 
-func getProvisioningNetwork(dc dynamic.Interface) string {
+func GetProvisioningNetwork(dc dynamic.Interface) string {
 	provisioningGVR := schema.GroupVersionResource{Group: "metal3.io", Resource: "provisionings", Version: "v1alpha1"}
 	provisioningClient := dc.Resource(provisioningGVR)
 	provisioningConfig, err := provisioningClient.Get(context.Background(), "provisioning-configuration", metav1.GetOptions{})
@@ -83,12 +83,12 @@ func getProvisioningNetwork(dc dynamic.Interface) string {
 	return provisioningNetwork
 }
 
-func baremetalClient(dc dynamic.Interface) dynamic.ResourceInterface {
+func BaremetalClient(dc dynamic.Interface) dynamic.ResourceInterface {
 	baremetalClient := dc.Resource(schema.GroupVersionResource{Group: "metal3.io", Resource: "baremetalhosts", Version: "v1alpha1"})
 	return baremetalClient.Namespace("openshift-machine-api")
 }
 
-func hostfirmwaresettingsClient(dc dynamic.Interface) dynamic.ResourceInterface {
+func HostfirmwaresettingsClient(dc dynamic.Interface) dynamic.ResourceInterface {
 	hfsClient := dc.Resource(schema.GroupVersionResource{Group: "metal3.io", Resource: "hostfirmwaresettings", Version: "v1alpha1"})
 	return hfsClient.Namespace("openshift-machine-api")
 }
@@ -109,13 +109,13 @@ func expectField(object unstructured.Unstructured, resource string, nestedField 
 	return o.Expect(value)
 }
 
-func expectStringField(object unstructured.Unstructured, resource string, nestedField string) o.Assertion {
+func ExpectStringField(object unstructured.Unstructured, resource string, nestedField string) o.Assertion {
 	return expectField(object, resource, nestedField, func(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
 		return unstructured.NestedString(obj, fields...)
 	})
 }
 
-func expectBoolField(object unstructured.Unstructured, resource string, nestedField string) o.Assertion {
+func ExpectBoolField(object unstructured.Unstructured, resource string, nestedField string) o.Assertion {
 	return expectField(object, resource, nestedField, func(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
 		return unstructured.NestedBool(obj, fields...)
 	})
@@ -134,7 +134,7 @@ func expectSliceField(object unstructured.Unstructured, resource string, nestedF
 }
 
 // Conditions are stored as a slice of maps, check that the type has the correct status
-func checkConditionStatus(hfs unstructured.Unstructured, condType string, condStatus string) {
+func CheckConditionStatus(hfs unstructured.Unstructured, condType string, condStatus string) {
 
 	conditions, _, err := unstructured.NestedSlice(hfs.Object, "status", "conditions")
 	o.Expect(err).NotTo(o.HaveOccurred())
@@ -163,7 +163,7 @@ func getField(object unstructured.Unstructured, resource string, nestedField str
 	return value.(string)
 }
 
-func getStringField(object unstructured.Unstructured, resource string, nestedField string) string {
+func GetStringField(object unstructured.Unstructured, resource string, nestedField string) string {
 	return getField(object, resource, nestedField, func(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
 		return unstructured.NestedFieldNoCopy(obj, fields...)
 	})

--- a/test/extended/baremetal/helper.go
+++ b/test/extended/baremetal/helper.go
@@ -39,7 +39,7 @@ func NewBaremetalTestHelper(dc dynamic.Interface) *BaremetalTestHelper {
 
 	return &BaremetalTestHelper{
 		clientSet: clientSet,
-		bmcClient: baremetalClient(dc),
+		bmcClient: BaremetalClient(dc),
 	}
 }
 

--- a/test/extended/baremetal/high_availability.go
+++ b/test/extended/baremetal/high_availability.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal][Serial] Baremetal platfor
 	)
 
 	g.BeforeEach(func() {
-		skipIfNotBaremetal(oc)
+		SkipIfNotBaremetal(oc)
 		helper = NewBaremetalTestHelper(oc.AdminDynamicClient())
 		helper.Setup()
 	})
@@ -148,15 +148,15 @@ var _ = g.Describe("[sig-installer][Feature:baremetal][Serial] Baremetal platfor
 
 func checkMetal3DeploymentHealthy(oc *exutil.CLI) {
 	dc := oc.AdminDynamicClient()
-	bmc := baremetalClient(dc)
+	bmc := BaremetalClient(dc)
 
 	hosts, err := bmc.List(context.Background(), v1.ListOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(hosts.Items).ToNot(o.BeEmpty())
 
 	for _, h := range hosts.Items {
-		expectStringField(h, "baremetalhost", "status.operationalStatus").To(o.BeEquivalentTo("OK"))
-		expectStringField(h, "baremetalhost", "status.provisioning.state").To(o.Or(o.BeEquivalentTo("provisioned"), o.BeEquivalentTo("externally provisioned")))
-		expectBoolField(h, "baremetalhost", "spec.online").To(o.BeTrue())
+		ExpectStringField(h, "baremetalhost", "status.operationalStatus").To(o.BeEquivalentTo("OK"))
+		ExpectStringField(h, "baremetalhost", "status.provisioning.state").To(o.Or(o.BeEquivalentTo("provisioned"), o.BeEquivalentTo("externally provisioned")))
+		ExpectBoolField(h, "baremetalhost", "spec.online").To(o.BeTrue())
 	}
 }

--- a/test/extended/baremetal/hosts.go
+++ b/test/extended/baremetal/hosts.go
@@ -43,37 +43,37 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should
 	oc := exutil.NewCLI("baremetal")
 
 	g.BeforeEach(func() {
-		skipIfNotBaremetal(oc)
+		SkipIfNotBaremetal(oc)
 	})
 
 	g.It("have baremetalhost resources", func() {
 		dc := oc.AdminDynamicClient()
-		bmc := baremetalClient(dc)
+		bmc := BaremetalClient(dc)
 
 		hosts, err := bmc.List(context.Background(), metav1.ListOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts.Items).ToNot(o.BeEmpty())
 
 		for _, h := range hosts.Items {
-			expectStringField(h, "baremetalhost", "status.operationalStatus").To(o.BeEquivalentTo("OK"))
-			expectStringField(h, "baremetalhost", "status.provisioning.state").To(o.Or(o.BeEquivalentTo("provisioned"), o.BeEquivalentTo("externally provisioned")))
-			expectBoolField(h, "baremetalhost", "spec.online").To(o.BeTrue())
+			ExpectStringField(h, "baremetalhost", "status.operationalStatus").To(o.BeEquivalentTo("OK"))
+			ExpectStringField(h, "baremetalhost", "status.provisioning.state").To(o.Or(o.BeEquivalentTo("provisioned"), o.BeEquivalentTo("externally provisioned")))
+			ExpectBoolField(h, "baremetalhost", "spec.online").To(o.BeTrue())
 
 		}
 	})
 
 	g.It("have preprovisioning images for workers", func() {
 		dc := oc.AdminDynamicClient()
-		bmc := baremetalClient(dc)
+		bmc := BaremetalClient(dc)
 		ppiClient := preprovisioningImagesClient(dc)
 
 		hosts, err := bmc.List(context.Background(), metav1.ListOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		for _, h := range hosts.Items {
-			state := getStringField(h, "baremetalhost", "status.provisioning.state")
+			state := GetStringField(h, "baremetalhost", "status.provisioning.state")
 			if state != "externally provisioned" {
-				hostName := getStringField(h, "baremetalhost", "metadata.name")
+				hostName := GetStringField(h, "baremetalhost", "metadata.name")
 				_, err := ppiClient.Get(context.Background(), hostName, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
@@ -83,15 +83,15 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should
 	g.It("have hostfirmwaresetting resources", func() {
 		dc := oc.AdminDynamicClient()
 
-		bmc := baremetalClient(dc)
+		bmc := BaremetalClient(dc)
 		hosts, err := bmc.List(context.Background(), metav1.ListOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts.Items).ToNot(o.BeEmpty())
 
-		hfsClient := hostfirmwaresettingsClient(dc)
+		hfsClient := HostfirmwaresettingsClient(dc)
 
 		for _, h := range hosts.Items {
-			hostName := getStringField(h, "baremetalhost", "metadata.name")
+			hostName := GetStringField(h, "baremetalhost", "metadata.name")
 
 			g.By(fmt.Sprintf("check that baremetalhost %s has a corresponding hostfirmwaresettings", hostName))
 			hfs, err := hfsClient.Get(context.Background(), hostName, metav1.GetOptions{})
@@ -103,11 +103,11 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should
 			// expectStringMapField(*hfs, "hostfirmwaresettings", "status.settings").ToNot(o.BeEmpty())
 
 			g.By("check that hostfirmwaresettings conditions show resource is valid")
-			checkConditionStatus(*hfs, "Valid", "True")
+			CheckConditionStatus(*hfs, "Valid", "True")
 
 			g.By("check that hostfirmwaresettings reference a schema")
-			refName := getStringField(*hfs, "hostfirmwaresettings", "status.schema.name")
-			refNS := getStringField(*hfs, "hostfirmwaresettings", "status.schema.namespace")
+			refName := GetStringField(*hfs, "hostfirmwaresettings", "status.schema.name")
+			refNS := GetStringField(*hfs, "hostfirmwaresettings", "status.schema.namespace")
 
 			schemaClient := dc.Resource(schema.GroupVersionResource{Group: "metal3.io", Resource: "firmwareschemas", Version: "v1alpha1"}).Namespace(refNS)
 			schema, err := schemaClient.Get(context.Background(), refName, metav1.GetOptions{})
@@ -118,14 +118,14 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should
 
 	g.It("not allow updating BootMacAddress", func() {
 		dc := oc.AdminDynamicClient()
-		bmc := baremetalClient(dc)
+		bmc := BaremetalClient(dc)
 
 		hosts, err := bmc.List(context.Background(), metav1.ListOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(hosts.Items).ToNot(o.BeEmpty())
 
 		host := hosts.Items[0]
-		expectStringField(host, "baremetalhost", "spec.bootMACAddress").ShouldNot(o.BeNil())
+		ExpectStringField(host, "baremetalhost", "spec.bootMACAddress").ShouldNot(o.BeNil())
 		// Already verified that bootMACAddress exists
 		bootMACAddress, _, _ := unstructured.NestedString(host.Object, "spec", "bootMACAddress")
 		testMACAddress := "11:11:11:11:11:11"
@@ -156,7 +156,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal][Serial] Baremetal platfor
 	)
 
 	g.BeforeEach(func() {
-		skipIfNotBaremetal(oc)
+		SkipIfNotBaremetal(oc)
 		helper = NewBaremetalTestHelper(oc.AdminDynamicClient())
 		helper.Setup()
 	})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -8,6 +8,7 @@ import (
 
 	_ "github.com/openshift/origin/test/e2e/upgrade"
 	_ "github.com/openshift/origin/test/extended/adminack"
+	_ "github.com/openshift/origin/test/extended/agent_installer"
 	_ "github.com/openshift/origin/test/extended/apiserver"
 	_ "github.com/openshift/origin/test/extended/authentication"
 	_ "github.com/openshift/origin/test/extended/authorization"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1161,6 +1161,12 @@ var Annotations = map[string]string{
 
 	"[sig-imageregistry][Serial] Image signature workflow can push a signed image to openshift registry and verify it [apigroup:user.openshift.io][apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/serial]",
 
+	"[sig-installer][Feature:baremetal] Baremetal platform created by agent-installer should have baremetalhost resources": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-installer][Feature:baremetal] Baremetal platform created by agent-installer should have hostfirmwaresetting resources when provisioning network set to managed": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-installer][Feature:baremetal] Baremetal platform created by agent-installer should have provisioned hosts when provisioning network set to managed": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-installer][Feature:baremetal] Baremetal platform should have baremetalhost resources": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-installer][Feature:baremetal] Baremetal platform should have hostfirmwaresetting resources": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Add a new directory for agent-installer related tests with first set of tests to check baremetal hosts. The baremetal hosts tests will also check that the BMC configuration is set properly when the provisioning network is enabled.

In order to exercise this test in CI it depends on the conformance tests being added by:
https://github.com/openshift/release/pull/43917
In addition, an agent test must add this env variable in order to enable the provisioning network.
AGENT_BM_HOSTS_IN_INSTALL_CONFIG=true