### PR TITLE
pkg/monitortests/clusterversionoperator: Add an exception for ingress going Available=False on IngressUnavailable

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -67,6 +67,10 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals) []*junitap
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "UnavailableReplicas" {
 				return "https://issues.redhat.com/browse/OCPBUGS-20061", nil
 			}
+		case "ingress":
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "IngressUnavailable" {
+				return "https://issues.redhat.com/browse/OCPBUGS-25739", nil
+			}
 		case "kube-storage-version-migrator":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-20062", nil


### PR DESCRIPTION
It would be great if the ingress operator addressed this issue, but:

* We do not want to block pull requests from landing, or releases from being accepted, until they adjust their operator.  This behavior is likely longstanding, and we want to give folks time to gradually tighten operator logic without needing to rush.
* Even once the ingress folks adjust their operator, this test suite will be used for test-cases that touch older releases (e.g. update and rollback jobs), and the test case doesn't yet allow for distinctions like "the ingress operator at the time of the Available=False condition predates the bugfix landing, so that should still fall under the earlier exception".