### PR TITLE
update SA checking when creating a project

### DIFF
--- a/test/extended/cpu_partitioning/managed.go
+++ b/test/extended/cpu_partitioning/managed.go
@@ -170,7 +170,7 @@ func createNamespace(oc *exutil.CLI, name string, annotations map[string]string)
 	if err != nil {
 		return err
 	}
-	return exutil.WaitForServiceAccountWithSecret(oc.AdminKubeClient().CoreV1().ServiceAccounts(name), "builder")
+	return exutil.WaitForServiceAccountWithSecret(oc.AdminKubeClient().CoreV1().ServiceAccounts(name), "builder", false)
 }
 
 func createDeployment(oc *exutil.CLI, name, namespace string, depLabels map[string]string, podAnnotations map[string]string) error {

--- a/test/extended/cpu_partitioning/managed.go
+++ b/test/extended/cpu_partitioning/managed.go
@@ -170,7 +170,7 @@ func createNamespace(oc *exutil.CLI, name string, annotations map[string]string)
 	if err != nil {
 		return err
 	}
-	return exutil.WaitForServiceAccountWithSecret(oc.AdminKubeClient().CoreV1().ServiceAccounts(name), "builder", false)
+	return exutil.WaitForServiceAccountWithSecret(oc, oc.AdminKubeClient().CoreV1().ServiceAccounts(name), "builder")
 }
 
 func createDeployment(oc *exutil.CLI, name, namespace string, depLabels map[string]string, podAnnotations map[string]string) error {

--- a/test/extended/pods/graceful-shutdown.go
+++ b/test/extended/pods/graceful-shutdown.go
@@ -338,9 +338,9 @@ func createTestBed(ctx context.Context, oc *exutil.CLI) {
 	Expect(err).NotTo(HaveOccurred())
 	err = callRBAC(ctx, oc, true)
 	Expect(err).NotTo(HaveOccurred())
-	err = exutil.WaitForServiceAccountWithSecret(
+	err = exutil.WaitForServiceAccountWithSecret(oc,
 		oc.AdminKubeClient().CoreV1().ServiceAccounts(namespace),
-		serviceAccountName, true)
+		serviceAccountName)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/test/extended/pods/graceful-shutdown.go
+++ b/test/extended/pods/graceful-shutdown.go
@@ -340,7 +340,7 @@ func createTestBed(ctx context.Context, oc *exutil.CLI) {
 	Expect(err).NotTo(HaveOccurred())
 	err = exutil.WaitForServiceAccountWithSecret(
 		oc.AdminKubeClient().CoreV1().ServiceAccounts(namespace),
-		serviceAccountName)
+		serviceAccountName, true)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1063,7 +1063,7 @@ func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string) 
 
 // WaitForServiceAccountWithSecret waits until the named service account gets fully
 // provisioned, including dockercfg secrets
-func WaitForServiceAccountWithSecret(c corev1client.ServiceAccountInterface, name string) error {
+func WaitForServiceAccountWithSecret(c corev1client.ServiceAccountInterface, name string, checkSecret bool) error {
 	waitFn := func() (bool, error) {
 		sa, err := c.Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
@@ -1083,7 +1083,7 @@ func WaitForServiceAccountWithSecret(c corev1client.ServiceAccountInterface, nam
 			}
 			secretNames = append(secretNames, s.Name)
 		}
-		if hasDockercfg {
+		if hasDockercfg || !checkSecret {
 			return true, nil
 		}
 		e2e.Logf("Waiting for service account %q secrets (%s) to include dockercfg ...", name, strings.Join(secretNames, ","))


### PR DESCRIPTION
The `deployer` and `builder` SAs are not a must when creating a project since OCP 4.14. 
For `no-capabilities` cluster, only `default` SA generated, no any secrets.
```yaml
MacBook-Pro:~ jianzhang$ oc get clusterversion version -o=jsonpath='{.spec.capabilities}'
{"additionalEnabledCapabilities":["MachineAPI","CloudCredential"],"baselineCapabilitySet":"None"}MacBook-Pro:~ jianzhang$ 
MacBook-Pro:~ jianzhang$ 
MacBook-Pro:~ jianzhang$ oc get sa 
NAME      SECRETS   AGE
default   0         5m22s
MacBook-Pro:~ jianzhang$ oc get secret 
No resources found in jian namespace.
```
For `ImageRegistry` capability disabled cluster, no `*-dockercfg-*` secret generated. So, updated `WaitForServiceAccountWithSecret` func.
```yaml
MacBook-Pro:~ jianzhang$ oc get clusterversion version -o=jsonpath='{.spec.capabilities}'
{"additionalEnabledCapabilities":["MachineAPI","CloudCredential","Build"],"baselineCapabilitySet":"None"}
MacBook-Pro:~ jianzhang$ oc get sa 
NAME      SECRETS   AGE
builder   0         2m5s
default   0         2m5s
MacBook-Pro:~ jianzhang$ oc get secret 
No resources found in jian namespace.
```
The `ImageRegistry` capability enabled cluster, the relevant secrets generated.
```yaml
MacBook-Pro:~ jianzhang$ oc get clusterversion version -o=jsonpath='{.spec.capabilities}'
{"additionalEnabledCapabilities":["MachineAPI","CloudCredential","Build","ImageRegistry"],"baselineCapabilitySet":"None"}
MacBook-Pro:~ jianzhang$ oc get sa 
NAME      SECRETS   AGE
builder   1         82s
default   1         82s
MacBook-Pro:~ jianzhang$ oc get secret 
NAME                      TYPE                                  DATA   AGE
builder-dockercfg-t55j4   kubernetes.io/dockercfg               1      86s
builder-token-mqkmd       kubernetes.io/service-account-token   4      86s
default-dockercfg-g8727   kubernetes.io/dockercfg               1      86s
default-token-mp229       kubernetes.io/service-account-token   4      86s
```

To address https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/46958/rehearse-46958-periodic-ci-openshift-release-master-ci-4.15-e2e-aws-ovn-no-capabilities/1737365378285178880 
```go
[sig-instrumentation] Prometheus [apigroup:image.openshift.io] when installed on the cluster should have important platform topology metrics [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
  github.com/openshift/origin/test/extended/prometheus/prometheus.go:493
    STEP: Creating a kubernetes client @ 12/20/23 08:40:24.519
  Dec 20 08:40:25.630: INFO: configPath is now "/tmp/configfile4283986400"
  Dec 20 08:40:25.630: INFO: The user is now "e2e-test-prometheus-bmnqc-user"
  Dec 20 08:40:25.630: INFO: Creating project "e2e-test-prometheus-bmnqc"
  Dec 20 08:40:25.754: INFO: Waiting on permissions in project "e2e-test-prometheus-bmnqc" ...
  Dec 20 08:40:25.982: INFO: Waiting for ServiceAccount "default" to be provisioned...
  Dec 20 08:40:26.150: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:26.250: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:26.352: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:26.448: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:26.553: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:26.649: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:26.[74](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/46958/rehearse-46958-periodic-ci-openshift-release-master-ci-4.15-e2e-aws-ovn-no-capabilities/1737365378285178880#1:build-log.txt%3A74)8: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:26.[84](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/46958/rehearse-46958-periodic-ci-openshift-release-master-ci-4.15-e2e-aws-ovn-no-capabilities/1737365378285178880#1:build-log.txt%3A84)8: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:26.950: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:27.049: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:27.148: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:27.248: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:27.349: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:27.448: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:27.548: INFO: Waiting for service account "default" secrets () to include dockercfg ...
  Dec 20 08:40:27.648: INFO: Waiting for service account "default" secrets () to include dockercfg ...
...
```