### PR TITLE
[release-4.15] OCPBUGS-25724: Cherrypick Ruby 3.0 ImageStream Fix

### DIFF
--- a/examples/quickstarts/rails-postgresql-persistent.json
+++ b/examples/quickstarts/rails-postgresql-persistent.json
@@ -117,7 +117,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:2.7-ubi8",
+							"name": "ruby:3.0-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},

--- a/examples/quickstarts/rails-postgresql.json
+++ b/examples/quickstarts/rails-postgresql.json
@@ -117,7 +117,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:2.7-ubi8",
+							"name": "ruby:3.0-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -26,7 +26,7 @@ FROM %s
 USER 1001
 `, image.ShellImage())
 		testDockerfile2 = `
-FROM image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+FROM image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
 USER 1001
 `
 		testDockerfile3 = `
@@ -110,7 +110,7 @@ USER 1001
 				o.Expect(image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.User).To(o.Equal("1001"))
 
 				g.By("checking for the imported tag")
-				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(context.Background(), "ruby:2.7-ubi8", metav1.GetOptions{})
+				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(context.Background(), "ruby:3.0-ubi8", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 

--- a/test/extended/cli/setimage.go
+++ b/test/extended/cli/setimage.go
@@ -39,28 +39,28 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 
 		g.By("waiting for created resources to be ready for testing")
 		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("get").Args("imagestreamtags", "ruby:2.7-ubi8").Execute()
+			err := oc.Run("get").Args("imagestreamtags", "ruby:3.0-ubi8").Execute()
 			return err == nil, nil
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("testing --local flag validation")
-		out, err := oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:2.7-ubi8", "--local").Output()
+		out, err := oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--local").Output()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("you must specify resources by --filename when --local is set."))
 
 		g.By("testing --dry-run=client with -o flags")
-		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:2.7-ubi8", "--source=istag", "--dry-run=client").Output()
+		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag", "--dry-run=client").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("test-deployment-config"))
 		o.Expect(out).To(o.ContainSubstring("deploymentconfig.apps.openshift.io/test-deployment-config image updated (dry run)"))
 
-		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:2.7-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
+		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("deploymentconfig.apps.openshift.io/test-deployment-config"))
 
 		g.By("testing basic image updates")
-		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:2.7-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
@@ -69,7 +69,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
 
 		g.By("repeating basic image updates to ensure nothing changed")
-		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:2.7-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
@@ -109,7 +109,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 
 		g.By("setting a different, valid image on multiple resources")
 		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("set").Args("image", "pods,dc", "*=ruby:2.7-ubi8", "--all", "--source=imagestreamtag").Execute()
+			err := oc.Run("set").Args("image", "pods,dc", "*=ruby:3.0-ubi8", "--all", "--source=imagestreamtag").Execute()
 			if err != nil {
 				klog.Warningf("one of pods failed when setting image %v", err)
 				return false, nil

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -36706,6 +36706,93 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
       "spec": {
         "tags": [
           {
+            "name": "latest",
+            "annotations": {
+              "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.0/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+              "iconClass": "icon-ruby",
+              "openshift.io/display-name": "Ruby (Latest)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+              "supports": "ruby",
+              "tags": "builder,ruby"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "3.0-ubi8"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "name": "3.0-ubi9",
+            "annotations": {
+              "description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+              "iconClass": "icon-ruby",
+              "openshift.io/display-name": "Ruby 3.0 (UBI 9)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+              "supports": "ruby:3.0,ruby",
+              "tags": "builder,ruby",
+              "version": "3.0"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/ubi9/ruby-30:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "name": "3.0-ubi8",
+            "annotations": {
+              "description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+              "iconClass": "icon-ruby",
+              "openshift.io/display-name": "Ruby 3.0 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+              "supports": "ruby:3.0,ruby",
+              "tags": "builder,ruby",
+              "version": "3.0"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/ubi8/ruby-30:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "name": "3.0-ubi7",
+            "annotations": {
+              "description": "Build and run Ruby 3.0 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+              "iconClass": "icon-ruby",
+              "openshift.io/display-name": "Ruby 3.0 (UBI 7)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+              "supports": "ruby:3.0,ruby",
+              "tags": "builder,ruby",
+              "version": "3.0"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/ubi7/ruby-30:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
             "annotations": {
               "description": "Build and run Ruby applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
               "iconClass": "icon-ruby",

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -11805,7 +11805,7 @@ var _examplesQuickstartsRailsPostgresqlPersistentJson = []byte(`{
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:2.7-ubi8",
+							"name": "ruby:3.0-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -33455,9 +33455,9 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/merge-tags-on-apply"
 os::cmd::expect_success 'oc new-project merge-tags'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/image-streams/image-streams-centos7.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 latest'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi8 3.0-ubi9 latest'
 os::cmd::expect_success 'oc apply -f ${TEST_DATA}/modified-ruby-imagestream.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 latest newtag'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi8 3.0-ubi9 latest newtag'
 os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[0].annotations.version}' '2.7 patched'
 os::cmd::expect_success 'oc delete project merge-tags'
 echo "apply new imagestream tags: ok"

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -12432,7 +12432,7 @@ var _examplesQuickstartsRailsPostgresqlJson = []byte(`{
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:2.7-ubi8",
+							"name": "ruby:3.0-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -18470,7 +18470,7 @@ var _testExtendedTestdataBuildsIncrementalAuthBuildJson = []byte(`{
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5-ubi8"
             },
             "incremental": true
           }
@@ -20106,7 +20106,7 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
           "git": {
             "uri":"https://github.com/sclorg/s2i-ruby-container"
           },
-          "contextDir": "2.7/test/puma-test-app"
+          "contextDir": "3.0/test/puma-test-app"
         },
         "strategy": {
           "type": "Source",
@@ -20119,7 +20119,7 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
             }
           }
         },
@@ -20894,7 +20894,7 @@ items:
             value: "2"
         from:
           kind: ImageStreamTag
-          name: ruby:2.7-ubi8
+          name: ruby:3.0-ubi8
           namespace: openshift
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -29338,7 +29338,7 @@ var _testExtendedTestdataClusterQuickstartsRailsPostgresqlJson = []byte(`{
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:2.7-ubi8",
+							"name": "ruby:3.0-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -37433,12 +37433,12 @@ spec:
   tags:
   - from:
       kind: ImageStreamTag
-      name: "2.7"
+      name: "3.0"
     name: "latest"
   - from:
       kind: ImageStreamTag
-      name: ruby:2.7-ubi8
-    name: "2.7"
+      name: ruby:3.0-ubi8
+    name: "3.0"
 `)
 
 func testExtendedTestdataCmdTestCmdTestdataNewAppImagestreamRefYamlBytes() ([]byte, error) {
@@ -49984,7 +49984,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-            name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
 `)
 
 func testExtendedTestdataRun_policySerialBcYamlBytes() ([]byte, error) {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17851,7 +17851,7 @@ var _testExtendedTestdataBuildsBuildSecretsTestS2iBuildJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
         },
         "env": [
           {
@@ -18470,7 +18470,7 @@ var _testExtendedTestdataBuildsIncrementalAuthBuildJson = []byte(`{
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
             },
             "incremental": true
           }
@@ -18696,7 +18696,7 @@ spec:
         value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailBadcontextdirs2iYamlBytes() ([]byte, error) {
@@ -18796,7 +18796,7 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchimagecontentdockerYamlBytes() ([]byte, error) {
@@ -18830,7 +18830,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsourcedockerYamlBytes() ([]byte, error) {
@@ -18864,7 +18864,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsources2iYamlBytes() ([]byte, error) {
@@ -18896,7 +18896,7 @@ spec:
 
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy
@@ -18939,7 +18939,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
       forcePull: true
 `)
 
@@ -19450,7 +19450,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -19639,7 +19639,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -19668,7 +19668,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -19696,7 +19696,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -19725,7 +19725,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -19753,7 +19753,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -20521,38 +20521,38 @@ func testExtendedTestdataBuildsTestDockerNoOutputnameJson() (*asset, error) {
 }
 
 var _testExtendedTestdataBuildsTestEnvBuildJson = []byte(`{
-  "kind":"BuildConfig",
-  "apiVersion":"build.openshift.io/v1",
-  "metadata":{
-    "name":"test",
-    "labels":{
-      "name":"test"
+  "kind": "BuildConfig",
+  "apiVersion": "build.openshift.io/v1",
+  "metadata": {
+    "name": "test",
+    "labels": {
+      "name": "test"
     }
   },
-  "spec":{
-    "triggers":[],
-    "source":{
-      "type":"Binary"
+  "spec": {
+    "triggers": [],
+    "source": {
+      "type": "Binary"
     },
-    "strategy":{
-      "type":"Source",
-      "sourceStrategy":{
-        "env":[
+    "strategy": {
+      "type": "Source",
+      "sourceStrategy": {
+        "env": [
           {
-             "name":"BUILD_LOGLEVEL",
-             "value":"2"
+            "name": "BUILD_LOGLEVEL",
+            "value": "2"
           }
-       ],
-        "from":{
-          "kind":"DockerImage",
-          "name":"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+        ],
+        "from": {
+          "kind": "DockerImage",
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
         }
       }
     },
-    "output":{
-      "to":{
-        "kind":"ImageStreamTag",
-        "name":"test:latest"
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag",
+        "name": "test:latest"
       }
     }
   }
@@ -44233,7 +44233,7 @@ var _testExtendedTestdataImageTestImageJson = []byte(`{
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8",
+  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",
@@ -47791,7 +47791,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
                         }
                     }
                 }
@@ -47820,7 +47820,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
                         }
                     }
                 }
@@ -49917,7 +49917,7 @@ var _testExtendedTestdataRun_policyParallelBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
         resources: {}
       status:
         lastVersion: 0
@@ -49963,7 +49963,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
     -
       kind: "BuildConfig"
       apiVersion: "build.openshift.io/v1"
@@ -49984,7 +49984,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+            name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
 `)
 
 func testExtendedTestdataRun_policySerialBcYamlBytes() ([]byte, error) {
@@ -50027,7 +50027,7 @@ var _testExtendedTestdataRun_policySerialLatestOnlyBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
         resources: {}
       status:
         lastVersion: 0

--- a/test/extended/testdata/builds/build-secrets/test-s2i-build.json
+++ b/test/extended/testdata/builds/build-secrets/test-s2i-build.json
@@ -45,7 +45,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/incremental-auth-build.json
+++ b/test/extended/testdata/builds/incremental-auth-build.json
@@ -48,7 +48,7 @@
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
             },
             "incremental": true
           }

--- a/test/extended/testdata/builds/incremental-auth-build.json
+++ b/test/extended/testdata/builds/incremental-auth-build.json
@@ -48,7 +48,7 @@
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.5-ubi8"
             },
             "incremental": true
           }

--- a/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
+++ b/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
@@ -15,4 +15,4 @@ spec:
         value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
@@ -19,4 +19,4 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
@@ -14,4 +14,4 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
@@ -14,4 +14,4 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8

--- a/test/extended/testdata/builds/statusfail-genericreason.yaml
+++ b/test/extended/testdata/builds/statusfail-genericreason.yaml
@@ -12,7 +12,7 @@ spec:
 
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy

--- a/test/extended/testdata/builds/statusfail-oomkilled.yaml
+++ b/test/extended/testdata/builds/statusfail-oomkilled.yaml
@@ -17,5 +17,5 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
       forcePull: true

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -88,7 +88,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -48,7 +48,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -77,7 +77,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -105,7 +105,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -134,7 +134,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -162,7 +162,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue

--- a/test/extended/testdata/builds/test-context-build.json
+++ b/test/extended/testdata/builds/test-context-build.json
@@ -42,7 +42,7 @@
           "git": {
             "uri":"https://github.com/sclorg/s2i-ruby-container"
           },
-          "contextDir": "2.7/test/puma-test-app"
+          "contextDir": "3.0/test/puma-test-app"
         },
         "strategy": {
           "type": "Source",
@@ -55,7 +55,7 @@
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
             }
           }
         },

--- a/test/extended/testdata/builds/test-env-build.json
+++ b/test/extended/testdata/builds/test-env-build.json
@@ -1,36 +1,36 @@
 {
-  "kind":"BuildConfig",
-  "apiVersion":"build.openshift.io/v1",
-  "metadata":{
-    "name":"test",
-    "labels":{
-      "name":"test"
+  "kind": "BuildConfig",
+  "apiVersion": "build.openshift.io/v1",
+  "metadata": {
+    "name": "test",
+    "labels": {
+      "name": "test"
     }
   },
-  "spec":{
-    "triggers":[],
-    "source":{
-      "type":"Binary"
+  "spec": {
+    "triggers": [],
+    "source": {
+      "type": "Binary"
     },
-    "strategy":{
-      "type":"Source",
-      "sourceStrategy":{
-        "env":[
+    "strategy": {
+      "type": "Source",
+      "sourceStrategy": {
+        "env": [
           {
-             "name":"BUILD_LOGLEVEL",
-             "value":"2"
+            "name": "BUILD_LOGLEVEL",
+            "value": "2"
           }
-       ],
-        "from":{
-          "kind":"DockerImage",
-          "name":"image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+        ],
+        "from": {
+          "kind": "DockerImage",
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
         }
       }
     },
-    "output":{
-      "to":{
-        "kind":"ImageStreamTag",
-        "name":"test:latest"
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag",
+        "name": "test:latest"
       }
     }
   }

--- a/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
+++ b/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
@@ -26,7 +26,7 @@ items:
             value: "2"
         from:
           kind: ImageStreamTag
-          name: ruby:2.7-ubi8
+          name: ruby:3.0-ubi8
           namespace: openshift
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig

--- a/test/extended/testdata/cluster/quickstarts/rails-postgresql.json
+++ b/test/extended/testdata/cluster/quickstarts/rails-postgresql.json
@@ -117,7 +117,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:2.7-ubi8",
+							"name": "ruby:3.0-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},

--- a/test/extended/testdata/cmd/test/cmd/images.sh
+++ b/test/extended/testdata/cmd/test/cmd/images.sh
@@ -305,9 +305,9 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/merge-tags-on-apply"
 os::cmd::expect_success 'oc new-project merge-tags'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/image-streams/image-streams-centos7.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 latest'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi8 3.0-ubi9 latest'
 os::cmd::expect_success 'oc apply -f ${TEST_DATA}/modified-ruby-imagestream.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 latest newtag'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi8 3.0-ubi9 latest newtag'
 os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[0].annotations.version}' '2.7 patched'
 os::cmd::expect_success 'oc delete project merge-tags'
 echo "apply new imagestream tags: ok"

--- a/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
@@ -800,6 +800,93 @@
       "spec": {
         "tags": [
           {
+            "name": "latest",
+            "annotations": {
+              "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.0/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+              "iconClass": "icon-ruby",
+              "openshift.io/display-name": "Ruby (Latest)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+              "supports": "ruby",
+              "tags": "builder,ruby"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "3.0-ubi8"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "name": "3.0-ubi9",
+            "annotations": {
+              "description": "Build and run Ruby 3.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+              "iconClass": "icon-ruby",
+              "openshift.io/display-name": "Ruby 3.0 (UBI 9)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+              "supports": "ruby:3.0,ruby",
+              "tags": "builder,ruby",
+              "version": "3.0"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/ubi9/ruby-30:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "name": "3.0-ubi8",
+            "annotations": {
+              "description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+              "iconClass": "icon-ruby",
+              "openshift.io/display-name": "Ruby 3.0 (UBI 8)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+              "supports": "ruby:3.0,ruby",
+              "tags": "builder,ruby",
+              "version": "3.0"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/ubi8/ruby-30:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
+            "name": "3.0-ubi7",
+            "annotations": {
+              "description": "Build and run Ruby 3.0 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+              "iconClass": "icon-ruby",
+              "openshift.io/display-name": "Ruby 3.0 (UBI 7)",
+              "openshift.io/provider-display-name": "Red Hat, Inc.",
+              "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
+              "supports": "ruby:3.0,ruby",
+              "tags": "builder,ruby",
+              "version": "3.0"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/ubi7/ruby-30:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          },
+          {
             "annotations": {
               "description": "Build and run Ruby applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
               "iconClass": "icon-ruby",

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/imagestream-ref.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/imagestream-ref.yaml
@@ -6,9 +6,9 @@ spec:
   tags:
   - from:
       kind: ImageStreamTag
-      name: "2.7"
+      name: "3.0"
     name: "latest"
   - from:
       kind: ImageStreamTag
-      name: ruby:2.7-ubi8
-    name: "2.7"
+      name: ruby:3.0-ubi8
+    name: "3.0"

--- a/test/extended/testdata/image/test-image.json
+++ b/test/extended/testdata/image/test-image.json
@@ -5,7 +5,7 @@
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8",
+  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",

--- a/test/extended/testdata/long_names/fixture.json
+++ b/test/extended/testdata/long_names/fixture.json
@@ -26,7 +26,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
                         }
                     }
                 }
@@ -55,7 +55,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
                         }
                     }
                 }

--- a/test/extended/testdata/run_policy/parallel-bc.yaml
+++ b/test/extended/testdata/run_policy/parallel-bc.yaml
@@ -32,7 +32,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
         resources: {}
       status:
         lastVersion: 0

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
     -
       kind: "BuildConfig"
       apiVersion: "build.openshift.io/v1"
@@ -44,4 +44,4 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+            name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -44,4 +44,4 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-            name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"

--- a/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:2.7-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
         resources: {}
       status:
         lastVersion: 0


### PR DESCRIPTION
Ruby 2.7 ImageStreams were removed in 4.15, this PR back ports updates the image references to ruby 3.0

Pulls in fixes from #28471 and #28481
