### PR TITLE
SPLAT-1427: fix/sig-net: ignoring edge when listing worker nodes

### DIFF
--- a/test/extended/networking/tap.go
+++ b/test/extended/networking/tap.go
@@ -17,7 +17,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-const nodeLabelSelectorWorker = "node-role.kubernetes.io/worker"
+const nodeLabelSelectorWorker = "node-role.kubernetes.io/worker,!node-role.kubernetes.io/edge"
 
 var _ = g.Describe("[sig-network][Feature:tap]", func() {
 	oc := exutil.NewCLI("tap")


### PR DESCRIPTION
Test ` [sig-network][Feature:tap] should create a pod with a tap interface [apigroup:k8s.cni.cncf.io] [Suite:openshift/conformance/parallel] ` is failing when Local Zone node is present and the node is the first in when listing the worker node list.

All edge nodes requires toleration, as this job wants to select random worker node, and not test that feature, this change will make the test to nodes with edge label (`node-role.kubernetes.io/edge`)

Ref: https://github.com/openshift/release/pull/47066
Failed job: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/47066/rehearse-47066-pull-ci-openshift-installer-release-4.14-e2e-aws-ovn-localzones/1738304268001087488
Card: https://issues.redhat.com/browse/SPLAT-1427