### PR TITLE
OCPBUGS-26025: Do not apply master label to make sure SNO jobs pass

### DIFF
--- a/test/extended/security/labels.go
+++ b/test/extended/security/labels.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-node] [Conformance] Prevent openshift node labeling on 
 		o.Expect(len(workerNodes.Items)).NotTo(o.BeZero())
 		if len(workerNodes.Items) > 0 {
 			workerNode := &workerNodes.Items[0]
-			forbiddenLabels := []string{`node-role.kubernetes.io/etcd1=""`, `node-role.kubernetes.io/etcd=""`, `node-role.kubernetes.io/master=""`}
+			forbiddenLabels := []string{`node-role.kubernetes.io/etcd1=""`, `node-role.kubernetes.io/etcd=""`}
 			for _, forbiddenLabel := range forbiddenLabels {
 				result := testOpenshiftNodeLabeling(oc, workerNode, forbiddenLabel)
 				o.Expect(result).To(o.BeTrue())


### PR DESCRIPTION
The logic behind the `TestOpenshiftNodeLabeling` test was to pick up a worker node and apply the labels that the worker nodes is not allowed to have. While on a normal cluster the test worked fine, it started failing on the SNO clusters. This is because, on the SNO clusters the only available node is labelled with both `worker` and `master` labels. This would make this test pick up the (only available) node and apply the `master` label. However, since a node in SNO cluster already has `master` label, kubelet will fail that operation [during the validation](https://github.com/kubernetes/kubernetes/blob/6aac45ff1e99068e834ba3b93b673530cf62c007/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go#L391).  

Since the original intention of the test is to just apply labels that aren't allowed for the given node. IMO, even if we drop the `master` label from the test, it will still hold good as a test for forbidden labels. 