### PR TITLE
NE-1444: test/extended/router: HAProxy 2.8 Compatibility Enhancements for h2spec tests

### DIFF
--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -500,8 +500,18 @@ BFNBRELPe53ZdLKWpf2Sr96vRPRNw
 			//
 			// 147 tests, 145 passed, 0 skipped, 2 failed
 			knownFailures := map[string]bool{
-				"http2/5.4.1.2": true,
-				"http2/6.9.1.2": true,
+				// In HAProxy 2.2 these two tests
+				// fail/flake:
+				//
+				//    "http2/5.4.1.2": true,
+				//    "http2/6.9.1.2": true,
+				//
+				// Using HAProxy 2.6 and 2.8 I have
+				// temporarily run this test setting
+				// ROUTER_H2SPEC_SAMPLE=100 (which
+				// would ordinarily be 1) and I have
+				// not observed either of these
+				// failures.
 			}
 			for _, f := range failures {
 				if _, exists := knownFailures[f.ID()]; exists {

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -108,7 +108,7 @@ global
 	log stdout local0
 	nbthread 4
 	tune.ssl.default-dh-param 2048
-	tune.ssl.capture-cipherlist-size 1
+	tune.ssl.capture-buffer-size 1
 defaults
 	mode http
 	timeout connect 5s


### PR DESCRIPTION
This PR introduces two updates to the HAProxy configuration and the associated test suite for the h2spec tests in test/extended/router.

1. **Update to HAProxy Configuration:**
   The HAProxy configuration in `test/extended/router/h2spec.go` is updated to replace the deprecated directive `tune.ssl.capture-cipherlist-size` with `tune.ssl.capture-buffer-size`. This change is in response to deprecation warnings from HAProxy versions 2.8.5 and 2.6.13, ensuring compatibility with both versions.

2. **Removal of Known h2spec Failures for HAProxy 2.6 and 2.8:**
   The h2spec tests "http2/5.4.1.2" and "http2/6.9.1.2", previously known to fail or flake in HAProxy 2.2, have been removed from the list of known failures. The removal is based on successful test runs with HAProxy versions 2.6 and 2.8, indicating that these issues have been resolved in these newer versions. I ran the h2spec tests with an increased sample size (ROUTER_H2SPEC_SAMPLE set to 100 instead of the usual 1) and these failures were not observed.

Requires openshift/router#551.