### PR TITLE
OCPBUGS-26601: Re-enable test/extended/router/http2 tests on AWS

### DIFF
--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -576,11 +576,8 @@ func resolveHost(oc *exutil.CLI, interval, timeout time.Duration, host string) (
 // clients.
 func platformHasHTTP2LoadBalancerService(platformType configv1.PlatformType) bool {
 	switch platformType {
-	case configv1.AzurePlatformType, configv1.GCPPlatformType:
+	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType:
 		return true
-	case configv1.AWSPlatformType:
-		e2e.Logf("AWS support waiting on https://bugzilla.redhat.com/show_bug.cgi?id=1912413")
-		fallthrough
 	default:
 		return false
 	}


### PR DESCRIPTION
It's been a long time since we disabled these tests on AWS. I have been running the http2 tests on AWS all week and I haven't run into the issue once. Let's re-enable the http2 x AWS tests for better coverage.

This PR also addresses an intermittent issue encountered in AWS environments during the router's h2spec conformance tests. The challenge involved slower hostname resolution within the cluster, resulting in frequent timeouts. Notably, AWS exhibited slower resolution times compared to Azure or GCP, hinting at potential differences in DNS handling.

The solution implemented in this PR focuses on resolving the hostname on the test host before initiating the h2spec tests within the cluster. This adjustment has resulted in a remarkable improvement in test execution speed, with the h2spec test now completing in approximately 85 seconds, a significant reduction from the previous average of over 376 seconds (just above the 5-minute mark).

While the difference in resolution times suggests environmental variations, particularly in AWS, it's important to note that this PR does not definitively attribute the issue to negative caching. Instead, it prioritises the substantial improvement achieved through the new approach. As a precaution, the polling interval and overall test timeout have been adjusted to 2 seconds and 10 minutes, respectively, to enhance test success rates across diverse cloud environments.

This PR represents a practical win in terms of improved test efficiency, while acknowledging potential environmental differences for further investigation, if needed, in the future.

Original bug: https://bugzilla.redhat.com/show_bug.cgi?id=1912413
