### PR TITLE
allow topology aware hints failures when pods are evicted

### DIFF
--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -22,6 +22,12 @@ func E2ETestFromLocator(l Locator) (string, bool) {
 	return test, ok
 }
 
+func E2ETestFromOldLocator(locator string) (string, bool) {
+	parts := LocatorParts(locator)
+	test, ok := parts[string(LocatorE2ETestKey)]
+	return test, ok
+}
+
 func NodeLocator(testName string) string {
 	return fmt.Sprintf("node/%v", testName)
 }


### PR DESCRIPTION
building a proper count is better, but this will allow us to get green component readiness signal since the events are expected when pods are evicted.