### PR TITLE
trt-1430: Pass watchdog InvariantCheck when cluster stability is disruptive

### DIFF
--- a/pkg/cmd/openshift-tests/dev/dev.go
+++ b/pkg/cmd/openshift-tests/dev/dev.go
@@ -78,6 +78,7 @@ a running cluster.
 			logrus.Info("running tests")
 			testCases := legacytestframeworkmonitortests.RunAlertTests(
 				jobType,
+				nil,
 				alerts.AllowedAlertsDuringUpgrade, // NOTE: may someway want a cli flag for conformance variant
 				configv1.Default,
 				allowedalerts.DefaultAllowances,

--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -75,7 +75,7 @@ func NewMonitorTestsFor(info monitortestframework.MonitorTestInitializationInfo)
 	case monitortestframework.Stable:
 		startingRegistry = newDefaultMonitorTests(info)
 	case monitortestframework.Disruptive:
-		startingRegistry = newDisruptiveMonitorTests()
+		startingRegistry = newDisruptiveMonitorTests(info)
 	default:
 		panic(fmt.Sprintf("unknown cluster stability level: %q", info.ClusterStabilityDuringTest))
 	}
@@ -96,7 +96,7 @@ func NewMonitorTestsFor(info monitortestframework.MonitorTestInitializationInfo)
 func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTestRegistry {
 	monitorTestRegistry := monitortestframework.NewMonitorTestRegistry()
 
-	monitorTestRegistry.AddRegistryOrDie(newUniversalMonitorTests())
+	monitorTestRegistry.AddRegistryOrDie(newUniversalMonitorTests(info))
 
 	monitorTestRegistry.AddMonitorTestOrDie("image-registry-availability", "Image Registry", disruptionimageregistry.NewAvailabilityInvariant())
 
@@ -115,10 +115,10 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 	return monitorTestRegistry
 }
 
-func newDisruptiveMonitorTests() monitortestframework.MonitorTestRegistry {
+func newDisruptiveMonitorTests(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTestRegistry {
 	monitorTestRegistry := monitortestframework.NewMonitorTestRegistry()
 
-	monitorTestRegistry.AddRegistryOrDie(newUniversalMonitorTests())
+	monitorTestRegistry.AddRegistryOrDie(newUniversalMonitorTests(info))
 
 	// this data would be interesting, but I'm betting we cannot scrub the data after the fact to exclude these.
 	// monitorTestRegistry.AddMonitorTestOrDie("image-registry-availability", "Image Registry", disruptionimageregistry.NewRecordAvailabilityOnly())
@@ -130,7 +130,7 @@ func newDisruptiveMonitorTests() monitortestframework.MonitorTestRegistry {
 	return monitorTestRegistry
 }
 
-func newUniversalMonitorTests() monitortestframework.MonitorTestRegistry {
+func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTestRegistry {
 	monitorTestRegistry := monitortestframework.NewMonitorTestRegistry()
 
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-authentication-invariants", "apiserver-auth", legacyauthenticationmonitortests.NewLegacyTests())
@@ -155,7 +155,7 @@ func newUniversalMonitorTests() monitortestframework.MonitorTestRegistry {
 
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-storage-invariants", "Storage", legacystoragemonitortests.NewLegacyTests())
 
-	monitorTestRegistry.AddMonitorTestOrDie("legacy-test-framework-invariants", "Test Framework", legacytestframeworkmonitortests.NewLegacyTests())
+	monitorTestRegistry.AddMonitorTestOrDie("legacy-test-framework-invariants", "Test Framework", legacytestframeworkmonitortests.NewLegacyTests(info))
 	monitorTestRegistry.AddMonitorTestOrDie("timeline-serializer", "Test Framework", timelineserializer.NewTimelineSerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("interval-serializer", "Test Framework", intervalserializer.NewIntervalSerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("tracked-resources-serializer", "Test Framework", trackedresourcesserializer.NewTrackedResourcesSerializer())

--- a/pkg/monitortestlibrary/allowedalerts/all.go
+++ b/pkg/monitortestlibrary/allowedalerts/all.go
@@ -1,6 +1,7 @@
 package allowedalerts
 
 import (
+	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 )
 
@@ -8,10 +9,10 @@ import (
 // etcdAllowance can be the DefaultAllowances, but the quality of testing will be better if it is set.
 // Some callers do not intend to run these tests (rather only to list alerts which have a test),
 // in which case JobType can be an empty struct.
-func AllAlertTests(jobType *platformidentification.JobType, etcdAllowance AlertTestAllowanceCalculator) []AlertTest {
+func AllAlertTests(jobType *platformidentification.JobType, clusterStability *monitortestframework.ClusterStabilityDuringTest, etcdAllowance AlertTestAllowanceCalculator) []AlertTest {
 
 	ret := []AlertTest{}
-	ret = append(ret, newWatchdogAlert(jobType))
+	ret = append(ret, newWatchdogAlert(jobType, clusterStability))
 	ret = append(ret, newAlertTestPerNamespace("KubePodNotReady", jobType).pending().neverFail().toTests()...)
 	ret = append(ret, newAlertTestPerNamespace("KubePodNotReady", jobType).firing().toTests()...)
 

--- a/pkg/monitortests/testframework/alertanalyzer/job_run_data.go
+++ b/pkg/monitortests/testframework/alertanalyzer/job_run_data.go
@@ -27,7 +27,7 @@ func writeAlertDataForJobRun(artifactDir string, _ monitorapi.ResourcesMap, even
 
 func addMissingAlertsForLevel(alertList *AlertList, level AlertLevel) {
 	wellKnownAlerts := sets.NewString()
-	for _, alertTest := range allowedalerts2.AllAlertTests(&platformidentification.JobType{}, allowedalerts2.DefaultAllowances) {
+	for _, alertTest := range allowedalerts2.AllAlertTests(&platformidentification.JobType{}, nil, allowedalerts2.DefaultAllowances) {
 		wellKnownAlerts.Insert(alertTest.AlertName())
 	}
 	alertsFound := sets.NewString()
@@ -159,7 +159,7 @@ func computeAlertData(events monitorapi.Intervals) *AlertList {
 				AlertKey: alertKey,
 			}
 		}
-		//the same alert can fire multiple times, so we add all the durations together
+		// the same alert can fire multiple times, so we add all the durations together
 		alert.Duration = metav1.Duration{Duration: alert.Duration.Duration + alertInterval.To.Sub(alertInterval.From)}
 		alertMap[alertKey] = alert
 	}

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -534,7 +534,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 		networking.InOpenShiftSDNContext(func() {
 			g.It("should be able to get the sdn ovs flows", func() {
 				tests := map[string]bool{
-					//something
+					// something
 					`openshift_sdn_ovs_flows >= 1`: true,
 				}
 				err := helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), tests, oc)
@@ -549,7 +549,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 
 			// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
 			// we exclude alerts that have their own separate tests.
-			for _, alertTest := range allowedalerts2.AllAlertTests(&platformidentification.JobType{}, allowedalerts2.DefaultAllowances) {
+			for _, alertTest := range allowedalerts2.AllAlertTests(&platformidentification.JobType{}, nil, allowedalerts2.DefaultAllowances) {
 				allowedAlertNames = append(allowedAlertNames, alertTest.AlertName())
 			}
 


### PR DESCRIPTION
For Disruptive suites we don't fetch promethues alerts
However we still test for watchdog alert when we shouldn't