### PR TITLE
NO-JIRA: add kubernetes level to openshift tests image for payload

### DIFF
--- a/hack/verify-kube-version.sh
+++ b/hack/verify-kube-version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+KUBE_GO_MOD_VERSION=$(grep "k8s.io/kubernetes v1" go.mod | sed 's/[\t]k8s.io\/kubernetes v//')
+
+KUBE_DOCKER_VERSION=$(grep "kubernetes-tests=" images/tests/Dockerfile.rhel | sed 's/      io.openshift.build.versions="kubernetes-tests=//' | sed 's/" \\//')
+if [[ "${KUBE_GO_MOD_VERSION}" != "${KUBE_DOCKER_VERSION}" ]]; then
+  os::log::warning "kubernetes version (${KUBE_GO_MOD_VERSION}) and kubernetes-tests version (${KUBE_DOCKER_VERSION}) in images/tests/Dockerfile.rhel must be equal, please update Dockerfile"
+  exit 1
+fi

--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -18,4 +18,5 @@ RUN PACKAGES="git gzip util-linux" && \
     chmod g+w /etc/passwd
 LABEL io.k8s.display-name="OpenShift End-to-End Tests" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
+      io.openshift.build.versions="kubernetes-tests=1.29.0" \
       io.openshift.tags="openshift,tests,e2e"


### PR DESCRIPTION
This adds a kubectl version to the Dockerfile so that the release controller can better represent what level of kube is present in our payloads. As our mismatch times extend, this makes certain classes of failures obvious and ensure we don't have an accident shipping.

/assign @soltysh @wking
