### PR TITLE
TRT-1440: Allow BestMatchDuration to pass even on fallback

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/matches_test.go
+++ b/pkg/monitortestlibrary/allowedalerts/matches_test.go
@@ -219,7 +219,7 @@ func TestAlertDataFileParsing(t *testing.T) {
 	}
 	hd, _, err := alertMatcher.BestMatchDuration(expectedKey)
 	assert.NoError(t, err)
-	assert.NotNil(t, hd)
+	assert.NotEqual(t, historicaldata.StatisticalDuration{}, hd, "AlertmanagerReceiversNotConfigured data not present for aws amd64 ovn ha")
 	// NOTE: when this test has failed, it's often been because the job key above doesn't have the
 	// required 100 runs to be returned, in the past week. Make sure we use a key above that has at
 	// least 100 runs.

--- a/pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go
+++ b/pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go
@@ -247,9 +247,9 @@ func TestDisruptionDataFileParsing(t *testing.T) {
 		Topology:     "ha",
 	}
 
-	_, msg, err := disruptionMatcher.BestMatchDuration("kube-api-new-connections", jobType)
+	percentiles, _, err := disruptionMatcher.BestMatchDuration("kube-api-new-connections", jobType)
 	// We can't really check a value here as it could very likely be 0,
-	// so instead we'll make sure we didn't get a msg complaining about no match:
-	assert.Equal(t, "", msg, "BestMatchDuration reported a problem finding data for kube-api-new-connections aws amd64 ovn ha")
+	// so instead we'll make sure we didn't get a msg complaining about no match with no fallback.
+	assert.NotEqual(t, percentiles, historicaldata.StatisticalDuration{}, "BestMatchDuration found no match and could not fall back for kube-api-new-connections aws amd64 ovn ha")
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
[TRT-1440](https://issues.redhat.com//browse/TRT-1440)

This unit test failed due to insufficient number of jobs (the number of jobs was 100 and we needed to be >= 101).  This makes it ok as long as we can fallback.