### PR TITLE
TRT-1452: Separate excessive Back-off restarting tests via namespace

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
@@ -141,20 +141,16 @@ func generateJUnitTestCasesCoreNamespaces(testName string, nsResults map[string]
 	for namespace := range namespaces {
 		jUnitName := getJUnitName(testName, namespace)
 		if result, ok := nsResults[namespace]; ok {
-			if len(result.failures) == 0 && len(result.flakes) == 0 {
+			output := generateFailureOutput(result.failures, result.flakes)
+			tests = append(tests, &junitapi.JUnitTestCase{
+				Name: jUnitName,
+				FailureOutput: &junitapi.FailureOutput{
+					Output: output,
+				},
+			})
+			// Add a success for flakes
+			if len(result.failures) == 0 && len(result.flakes) > 0 {
 				tests = append(tests, &junitapi.JUnitTestCase{Name: jUnitName})
-			} else {
-				output := generateFailureOutput(result.failures, result.flakes)
-				tests = append(tests, &junitapi.JUnitTestCase{
-					Name: jUnitName,
-					FailureOutput: &junitapi.FailureOutput{
-						Output: output,
-					},
-				})
-				// Add a success for flakes
-				if len(result.failures) == 0 && len(result.flakes) > 0 {
-					tests = append(tests, &junitapi.JUnitTestCase{Name: jUnitName})
-				}
 			}
 		} else {
 			tests = append(tests, &junitapi.JUnitTestCase{Name: jUnitName})

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
@@ -141,16 +141,20 @@ func generateJUnitTestCasesCoreNamespaces(testName string, nsResults map[string]
 	for namespace := range namespaces {
 		jUnitName := getJUnitName(testName, namespace)
 		if result, ok := nsResults[namespace]; ok {
-			output := generateFailureOutput(result.failures, result.flakes)
-			tests = append(tests, &junitapi.JUnitTestCase{
-				Name: jUnitName,
-				FailureOutput: &junitapi.FailureOutput{
-					Output: output,
-				},
-			})
-			// Add a success for flakes
-			if len(result.failures) == 0 && len(result.flakes) > 0 {
+			if len(result.failures) == 0 && len(result.flakes) == 0 {
 				tests = append(tests, &junitapi.JUnitTestCase{Name: jUnitName})
+			} else {
+				output := generateFailureOutput(result.failures, result.flakes)
+				tests = append(tests, &junitapi.JUnitTestCase{
+					Name: jUnitName,
+					FailureOutput: &junitapi.FailureOutput{
+						Output: output,
+					},
+				})
+				// Add a success for flakes
+				if len(result.failures) == 0 && len(result.flakes) > 0 {
+					tests = append(tests, &junitapi.JUnitTestCase{Name: jUnitName})
+				}
 			}
 		} else {
 			tests = append(tests, &junitapi.JUnitTestCase{Name: jUnitName})

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special.go
@@ -90,6 +90,13 @@ func (s *singleEventThresholdCheck) NamespacedTest(events monitorapi.Intervals) 
 		}
 	}
 
+	for ns, result := range nsResults {
+		if len(result.failures) == 0 && len(result.flakes) == 0 {
+			// delete the entry for ns
+			delete(nsResults, ns)
+		}
+	}
+
 	return generateJUnitTestCasesCoreNamespaces(s.testName, nsResults)
 }
 

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special_test.go
@@ -1,0 +1,81 @@
+package pathologicaleventlibrary
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_singleEventThresholdCheck_getNamespacedFailuresAndFlakes(t *testing.T) {
+	namespace := "openshift-etcd-operator"
+	samplePod := "etcd-operator-6f9b4d9d4f-4q9q8"
+
+	testName := "[sig-cluster-lifecycle] pathological event should not see excessive Back-off restarting failed containers"
+	backoffMatcher := NewSingleEventThresholdCheck(testName, AllowBackOffRestartingFailedContainer,
+		DuplicateEventThreshold, BackoffRestartingFlakeThreshold)
+	type fields struct {
+		testName       string
+		matcher        *SimplePathologicalEventMatcher
+		failThreshold  int
+		flakeThreshold int
+	}
+	type args struct {
+		events monitorapi.Intervals
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		args             args
+		expectedKeyCount int
+	}{
+		{
+			name: "Successful test yields no keys",
+			fields: fields{
+				testName:       testName,
+				matcher:        backoffMatcher.matcher,
+				failThreshold:  DuplicateEventThreshold,
+				flakeThreshold: BackoffRestartingFlakeThreshold,
+			},
+			args: args{
+				events: monitorapi.Intervals{
+					BuildTestDupeKubeEvent(namespace, samplePod,
+						"BackOff",
+						"Back-off restarting failed container",
+						5),
+				},
+			},
+			expectedKeyCount: 0,
+		},
+		{
+			name: "Failing test yields one key",
+			fields: fields{
+				testName:       testName,
+				matcher:        backoffMatcher.matcher,
+				failThreshold:  DuplicateEventThreshold,
+				flakeThreshold: BackoffRestartingFlakeThreshold,
+			},
+			args: args{
+				events: monitorapi.Intervals{
+					BuildTestDupeKubeEvent(namespace, samplePod,
+						"BackOff",
+						"Back-off restarting failed container",
+						21),
+				},
+			},
+			expectedKeyCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &singleEventThresholdCheck{
+				testName:       tt.fields.testName,
+				matcher:        tt.fields.matcher,
+				failThreshold:  tt.fields.failThreshold,
+				flakeThreshold: tt.fields.flakeThreshold,
+			}
+			got := s.getNamespacedFailuresAndFlakes(tt.args.events)
+			assert.Equal(t, tt.expectedKeyCount, len(got))
+		})
+	}
+}

--- a/pkg/monitortests/node/legacynodemonitortests/pathological_events.go
+++ b/pkg/monitortests/node/legacynodemonitortests/pathological_events.go
@@ -60,7 +60,7 @@ func testBackoffStartingFailedContainer(events monitorapi.Intervals) []*junitapi
 
 	return pathologicaleventlibrary.NewSingleEventThresholdCheck(testName, pathologicaleventlibrary.AllowBackOffRestartingFailedContainer,
 		pathologicaleventlibrary.DuplicateEventThreshold, pathologicaleventlibrary.BackoffRestartingFlakeThreshold).
-		Test(events.Filter(monitorapi.Not(monitorapi.IsInE2ENamespace)))
+		NamespacedTest(events.Filter(monitorapi.Not(monitorapi.IsInE2ENamespace)))
 }
 
 func testConfigOperatorReadinessProbe(events monitorapi.Intervals) []*junitapi.JUnitTestCase {


### PR DESCRIPTION
This introduces `NamespacedTest()` which can be used where the `Test()` method is used if we want to split out more pathological tests by namespace.

To test, we need this test to fail on multiple namespaces:

```
[sig-cluster-lifecycle] pathological event should not see excessive Back-off restarting failed containers
```