### PR TITLE
OCPBUGS-27892: fix panic in service-poller

### DIFF
--- a/pkg/cmd/openshift-tests/disruption/poll-service/service_controller.go
+++ b/pkg/cmd/openshift-tests/disruption/poll-service/service_controller.go
@@ -147,6 +147,11 @@ func (c *PollServiceController) removeAllWatchers() {
 	c.watcherLock.Lock()
 	defer c.watcherLock.Unlock()
 
+	if c.watcher == nil {
+		fmt.Fprintf(c.outFile, "No watchers running, skipping removal\n")
+		return
+	}
+
 	fmt.Fprintf(c.outFile, "Stopping and removing: %v for node/%v\n", c.watcher.address, c.nodeName)
 	c.watcher.newConnectionSampler.Stop()
 	c.watcher.reusedConnectionSampler.Stop()


### PR DESCRIPTION
observed in https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-remote-libvirt-ppc64le/1749182126944686080

/assign @JacobTanenbaum @dgoodwin 