### PR TITLE
NO-JIRA: watchpods: fix the collection logic for pending pods

### DIFF
--- a/pkg/monitortests/node/watchpods/collection.go
+++ b/pkg/monitortests/node/watchpods/collection.go
@@ -82,8 +82,10 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 				}
 			}
 
-			// check if container has exited
-			if containerStatus.LastTerminationState.Terminated != nil {
+			// if this container is terminated, then we don't need to compute an event for it.
+			lastTerminated := containerStatus.LastTerminationState.Terminated != nil
+			currentTerminated := containerStatus.State.Terminated != nil
+			if lastTerminated || currentTerminated {
 				continue
 			}
 

--- a/pkg/monitortests/node/watchpods/monitoring_reflector.go
+++ b/pkg/monitortests/node/watchpods/monitoring_reflector.go
@@ -94,10 +94,11 @@ func newMonitoringStore(
 
 	s.DeleteFunc = func(obj interface{}) error {
 		currentUID := uidOf(obj)
-		currentResourceVersion := resourceVersionAsInt(obj)
-		if s.processedResourceUIDs[currentUID] >= currentResourceVersion {
-			return nil
-		}
+		// currentResourceVersion := resourceVersionAsInt(obj)
+
+		// if s.processedResourceUIDs[currentUID] >= currentResourceVersion {
+		// 	return nil
+		// }
 
 		// clear values that have been deleted
 		defer func() {


### PR DESCRIPTION
[periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-remote-libvirt-ppc64le](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-remote-libvirt-ppc64le/1749182126944686080) is exhibiting a flake with pods transitioning to Pending state. I reviewed the kubelet, scheduler, and test logs, and everything seems to make sense.

The test itself though does not check to see if the 'Old' pod was in Pending state to check for the invalid state transition. The PR changes the test so an Old Pod Phase of `Pending` and a New Pod Phase of `Pending` are not considered bad transitions.