### PR TITLE
NO-JIRA: fix the static pod lifecycle failure test for more revisions

### DIFF
--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/static_pod.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/static_pod.go
@@ -17,7 +17,7 @@ import (
 // staticPodFailureRegex trying to pull out information from messages like
 // `static pod lifecycle failure - static pod: "etcd" in namespace: "openshift-etcd" for revision: 6 on node: "ovirt10-gh8t5-master-2" didn't show up, waited: 2m30s`
 var staticPodFailureRegex = regexp.MustCompile(
-	`static pod lifecycle failure - static pod: ".*" in namespace: ".*" for revision: (\d) on node: "(.*)" didn't show up, waited: .*`)
+	`static pod lifecycle failure - static pod: ".*" in namespace: ".*" for revision: (\d+) on node: "(.*)" didn't show up, waited: .*`)
 
 type staticPodFailure struct {
 	operatorNamespace string
@@ -29,7 +29,7 @@ type staticPodFailure struct {
 func staticPodFailureFromMessage(message string) (*staticPodFailure, error) {
 	matches := staticPodFailureRegex.FindStringSubmatch(message)
 	if len(matches) != 3 {
-		return nil, fmt.Errorf("wrong number of matches: %v", matches)
+		return nil, fmt.Errorf("wrong number of matches: %v from: %q", matches, message)
 	}
 	revision, err := strconv.ParseInt(matches[1], 0, 64)
 	if err != nil {

--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/static_pod_test.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/static_pod_test.go
@@ -24,6 +24,18 @@ func Test_staticPodFailureFromMessage(t *testing.T) {
 				failureMessage: `static pod lifecycle failure - static pod: "etcd" in namespace: "openshift-etcd" for revision: 6 on node: "ovirt10-gh8t5-master-2" didn't show up, waited: 2m30s`,
 			},
 		},
+		{
+			name: "I hate regex: metal string",
+			args: args{
+				message: `static pod lifecycle failure - static pod: "kube-controller-manager" in namespace: "openshift-kube-controller-manager" for revision: 30 on node: "master-1.ostest.test.metalkube.org" didn't show up, waited: 3m0s`,
+			},
+			want: &staticPodFailure{
+				node:           "master-1.ostest.test.metalkube.org",
+				revision:       30,
+				failureMessage: `static pod lifecycle failure - static pod: "kube-controller-manager" in namespace: "openshift-kube-controller-manager" for revision: 30 on node: "master-1.ostest.test.metalkube.org" didn't show up, waited: 3m0s`,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Found in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-baremetal-operator/399/pull-ci-openshift-cluster-baremetal-operator-master-e2e-metal-ipi-ovn-ipv6/1750255824447475712

/assign @ingvagabund 