### PR TITLE
Live migration: if managed namespace doesnt exist, create it

### DIFF
--- a/test/extended/util/managed.go
+++ b/test/extended/util/managed.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const ManagedClusterNamespace = "dedicated-admin"
+
+// IsRunningInManagedCluster returns true if the operator is running in a managed cluster.
+// It checks for the existence of the dedicated-admin namespace
+func IsRunningInManagedCluster(ctx context.Context, c kubernetes.Interface) (bool, error) {
+	_, err := c.CoreV1().Namespaces().Get(ctx, ManagedClusterNamespace, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
Live migration has added an extra requirement that it may only begin if the cluster is a managed cluster (SD).
This is to prevent self managed clusters from using this func as we do not support it.

See PR: https://github.com/openshift/cluster-network-operator/pull/2225

and slack conversation https://redhat-internal.slack.com/archives/CFJD1NZFT/p1706207602864769?thread_ts=1706194037.470999&cid=CFJD1NZFT

/cc @pliurh 