### PR TITLE
TRT-965: Add disruption to the risk analysis spyglass panel

### DIFF
--- a/e2echart/test-risk-analysis.html
+++ b/e2echart/test-risk-analysis.html
@@ -5,7 +5,7 @@
     <meta name="description"
           content="Risk analysis is performed by Sippy to attempt to determine if the failures in this job are abnormal when compared to results for similar jobs over the past week, and amidst on-going incidents in the CI infrastructure. Risk analysis API will not catch everything and is a relatively simple implementation today, please reach out to the Technical Release Team if you spot abnormalities or have suggestions.">
 </head>
-<body onLoad="buildTestCaseTable('#test_case_results')">
+<body onLoad="buildTestCaseTable('#test_case_results'); buildDisruptionTable('#disruption_results')">
 <p>
     <a target="_blank" href="TEST_RISK_ANALYSIS_SIPPY_URL_GOES_HERE">Link to Sippy</a>
 </p>
@@ -14,8 +14,27 @@
 </table>
 <p>&nbsp;</p>
 
+<h1>Disruption Analysis</h1>
+
+Disruption unit testing on individual job runs is relatively forgiving as it can generate a lot of noise.
+This table attempts to highlight
+risky results by color coding the observed disruption for this run against the percentiles over the past several
+weeks. Red indicates this job run exceeded the 99th percentile, yellow the 95th.<p/>
+
+If you're getting red results here, it might be a good idea to investigate the intervals chart for this job run,
+available in the spyglass panels on the prow job. This will show when the disruption occurred, the exact error
+messages returned, and what else was going on in the cluster at that time. Additional runs may help provide a clearer
+picture if the chart does not provide any insight. Feel free to reach out to TRT if you think you're seeing something
+alarming.<p/>
+
+
+<table id="disruption_results" border="1" width="100%">
+</table>
+<p>&nbsp;</p>
+
 <script>
     var testResult = TEST_RISK_ANALYSIS_JSON_GOES_HERE
+    var disruptionResult = TEST_DISRUPTION_ANALYSIS_JSON_GOES_HERE
     var testLinkPrefix = "https://sippy.dptools.openshift.org/sippy-ng/tests/"
     var testLinkSuffix = "/analysis?test="
 
@@ -51,11 +70,11 @@
     function buildRiskLevel(level) {
         td$ = $('<td/>')
         if (level.Level >= 10) {
-            td$.css("background-color", "red");
+            td$.css("background-color", "lightred");
         } else if (level.Level >= 5) {
-            td$.css("background-color", "yellow");
+            td$.css("background-color", "lightyellow");
         } else {
-            td$.css("background-color", "green");
+            td$.css("background-color", "lightgreen");
         }
         td$.append(level.Name)
         return td$
@@ -96,6 +115,42 @@
         headerTr$.append($('<th/>').html("Open Bugs"));
 
         $(selector).append(headerTr$);
+    }
+
+    function buildDisruptionTable(selector) {
+        addDisruptionColumnHeaders(selector);
+
+        for (var i = 0; i < disruptionResult.Backends.length; i++) {
+            var row$ = $('<tr/>');
+
+            row$.css("background-color", disruptionResult.Backends[i].RiskColor);
+            row$.append(addSimpleCell(disruptionResult.Backends[i].BackendName))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].ObservedDisruption))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].P50.toFixed(2)))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].P75.toFixed(2)))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].P95.toFixed(2)))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].P99.toFixed(2)))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].JobRuns))
+            $(selector).append(row$);
+        }
+    }
+    function addDisruptionColumnHeaders(selector) {
+        var headerTr$ = $('<tr/>');
+        headerTr$.append($('<th/>').html("Backend Name"));
+        headerTr$.append($('<th/>').html("Observed Disruption"));
+        headerTr$.append($('<th/>').html("P50"));
+        headerTr$.append($('<th/>').html("P75"));
+        headerTr$.append($('<th/>').html("P95"));
+        headerTr$.append($('<th/>').html("P99"));
+        headerTr$.append($('<th/>').html("JobRuns"));
+
+        $(selector).append(headerTr$);
+    }
+
+    function addSimpleCell(v) {
+        td$ = $('<td/>')
+        td$.append(v)
+        return td$
     }
 
 </script>

--- a/pkg/cmd/openshift-tests/risk-analysis/command.go
+++ b/pkg/cmd/openshift-tests/risk-analysis/command.go
@@ -1,8 +1,6 @@
 package risk_analysis
 
 import (
-	"os"
-
 	"github.com/openshift/origin/pkg/riskanalysis"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -11,10 +9,7 @@ import (
 const sippyDefaultURL = "https://sippy.dptools.openshift.org/api/jobs/runs/risk_analysis"
 
 func NewTestFailureRiskAnalysisCommand() *cobra.Command {
-	riskAnalysisOpts := &riskanalysis.Options{
-		Out:    os.Stdout,
-		ErrOut: os.Stderr,
-	}
+	riskAnalysisOpts := &riskanalysis.Options{}
 
 	cmd := &cobra.Command{
 		Use:   "risk-analysis",

--- a/pkg/monitortestlibrary/allowedbackenddisruption/matches.go
+++ b/pkg/monitortestlibrary/allowedbackenddisruption/matches.go
@@ -16,8 +16,9 @@ const (
 	allowedExternalDisruption = 600 * time.Second
 )
 
-// GetAllowedDisruption uses the backend and information about the cluster to choose the best historical p95 to operate against.
+// GetAllowedDisruption uses the backend and information about the cluster to choose the best historical p99 to
+// operate against.
 // We enforce "don't get worse" for disruption by watching the aggregate data in CI over many runs.
 func GetAllowedDisruption(backendName string, jobType platformidentification.JobType) (*time.Duration, string, error) {
-	return getCurrentResults().BestMatchP99(backendName, jobType)
+	return GetCurrentResults().BestMatchP99(backendName, jobType)
 }

--- a/pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go
+++ b/pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go
@@ -196,7 +196,7 @@ func TestGetClosestP95Value(t *testing.T) {
 // from bigquery and commit into origin. Test ensures we can parse it and the data looks sane.
 func TestDisruptionDataFileParsing(t *testing.T) {
 
-	disruptionMatcher := getCurrentResults()
+	disruptionMatcher := GetCurrentResults()
 
 	var dataOver100Runs int
 	var foundAWSOVN bool
@@ -247,7 +247,7 @@ func TestDisruptionDataFileParsing(t *testing.T) {
 		Topology:     "ha",
 	}
 
-	percentiles, _, err := disruptionMatcher.BestMatchDuration("kube-api-new-connections", jobType)
+	percentiles, _, err := disruptionMatcher.BestMatchDuration("kube-api-new-connections", jobType, 100)
 	// We can't really check a value here as it could very likely be 0,
 	// so instead we'll make sure we didn't get a msg complaining about no match with no fallback.
 	assert.NotEqual(t, percentiles, historicaldata.StatisticalDuration{}, "BestMatchDuration found no match and could not fall back for kube-api-new-connections aws amd64 ovn ha")

--- a/pkg/monitortestlibrary/allowedbackenddisruption/types.go
+++ b/pkg/monitortestlibrary/allowedbackenddisruption/types.go
@@ -57,7 +57,7 @@ var (
 	historicalData *historicaldata.DisruptionBestMatcher
 )
 
-func getCurrentResults() *historicaldata.DisruptionBestMatcher {
+func GetCurrentResults() *historicaldata.DisruptionBestMatcher {
 	readResults.Do(
 		func() {
 			var err error

--- a/pkg/monitortestlibrary/historicaldata/alert_types.go
+++ b/pkg/monitortestlibrary/historicaldata/alert_types.go
@@ -88,7 +88,7 @@ func (b *AlertBestMatcher) bestMatch(key AlertDataKey) (AlertStatisticalData, st
 		Debugf("searching for best match for %+v", key.JobType)
 
 	if percentiles, ok := b.HistoricalData[exactMatchKey]; ok {
-		if percentiles.JobRuns >= minJobRuns {
+		if percentiles.JobRuns >= defaultMinJobRuns {
 			logrus.Infof("found exact match: %+v", percentiles)
 			return percentiles, "", nil
 		}
@@ -135,7 +135,7 @@ func (b *AlertBestMatcher) evaluateBestGuesser(nextBestGuesser NextBestKey, exac
 
 		JobType: nextBestJobType,
 	}
-	if percentiles, ok := b.HistoricalData[nextBestMatchKey]; ok && percentiles.JobRuns >= minJobRuns {
+	if percentiles, ok := b.HistoricalData[nextBestMatchKey]; ok && percentiles.JobRuns >= defaultMinJobRuns {
 		return percentiles, fmt.Sprintf("(no exact match for %#v, fell back to %#v)", exactMatchKey, nextBestMatchKey), nil
 	}
 	return AlertStatisticalData{}, "", nil

--- a/pkg/riskanalysis/cmd.go
+++ b/pkg/riskanalysis/cmd.go
@@ -5,15 +5,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitortestlibrary/allowedbackenddisruption"
+	"github.com/openshift/origin/pkg/monitortestlibrary/historicaldata"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionserializer"
 	"github.com/openshift/origin/test/extended/testdata"
-	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -23,9 +27,8 @@ const (
 // Options is used to run a risk analysis to determine how severe or unusual
 // the test failures in an openshift-tests run were.
 type Options struct {
-	Out, ErrOut io.Writer
-	JUnitDir    string
-	SippyURL    string
+	JUnitDir string
+	SippyURL string
 }
 
 const testFailureSummaryFilePrefix = "test-failures-summary"
@@ -34,18 +37,18 @@ const sippyURL = "https://sippy.dptools.openshift.org/sippy-ng/"
 // Run performs the test risk analysis by reading the output files from the test run, submitting them to sippy,
 // and writing out the analysis result as a new artifact.
 func (opt *Options) Run() error {
-	fmt.Fprintf(opt.Out, "Scanning for %s files in: %s\n", testFailureSummaryFilePrefix, opt.JUnitDir)
+	logrus.Infof("Scanning for %s files in: %s", testFailureSummaryFilePrefix, opt.JUnitDir)
 
 	resultFiles, err := filepath.Glob(fmt.Sprintf("%s/%s*.json", opt.JUnitDir, testFailureSummaryFilePrefix))
 	if err != nil {
-		fmt.Fprintf(opt.Out, "Error scanning for test failure summary files: %v", err)
+		logrus.Infof("Error scanning for test failure summary files: %v", err)
 		return nil
 	}
-	fmt.Fprintf(opt.Out, "Found files: %v\n", resultFiles)
+	logrus.Infof("Found files: %v", resultFiles)
 
 	// we didn't find any files to process. log but don't return an error as  step may not have produced those files
 	if len(resultFiles) == 0 {
-		fmt.Fprintf(opt.Out, "Missing : %s file(s), exiting\n", testFailureSummaryFilePrefix)
+		logrus.Infof("Missing : %s file(s), exiting", testFailureSummaryFilePrefix)
 		return nil
 	}
 
@@ -54,13 +57,13 @@ func (opt *Options) Run() error {
 	for _, rf := range resultFiles {
 		data, err := os.ReadFile(rf)
 		if err != nil {
-			fmt.Fprintf(opt.Out, "Error reading test failure summary file: %s - %v", rf, err)
+			logrus.Infof("Error reading test failure summary file: %s - %v", rf, err)
 			return nil
 		}
 		jobRun := &ProwJobRun{}
 		err = json.Unmarshal(data, jobRun)
 		if err != nil {
-			fmt.Fprintf(opt.Out, "Error unmarshalling ProwJob json for: %s - %v", rf, err)
+			logrus.Infof("Error unmarshalling ProwJob json for: %s - %v", rf, err)
 			return nil
 		}
 		prowJobRuns = append(prowJobRuns, jobRun)
@@ -75,7 +78,7 @@ func (opt *Options) Run() error {
 			continue
 		}
 		if pjr.ProwJob.Name != finalProwJobRun.ProwJob.Name {
-			fmt.Fprintf(opt.Out, "Mismatched job names found in %s files, %s != %s",
+			logrus.Errorf("Mismatched job names found in %s files, %s != %s",
 				testFailureSummaryFilePrefix, finalProwJobRun.ProwJob.Name, pjr.ProwJob.Name)
 			return nil
 		}
@@ -85,13 +88,13 @@ func (opt *Options) Run() error {
 
 	inputBytes, err := json.Marshal(finalProwJobRun)
 	if err != nil {
-		fmt.Fprintf(opt.Out, "Error marshalling results: %v", err)
+		logrus.WithError(err).Error("Error marshalling results")
 		return nil
 	}
 
 	req, err := http.NewRequest("GET", opt.SippyURL, bytes.NewBuffer(inputBytes))
 	if err != nil {
-		fmt.Fprintf(opt.Out, "Error creating GET request during risk analysis: %v", err)
+		logrus.WithError(err).Error("Error creating GET request during risk analysis")
 		return nil
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -103,51 +106,159 @@ func (opt *Options) Run() error {
 		ctx, cancelFn := context.WithTimeout(req.Context(), 20*time.Second)
 		defer cancelFn()
 		startTime := time.Now()
-		fmt.Printf("%s: Requesting risk analysis (attempt %d/%d) from: %s\n", startTime.Format(time.RFC3339), i, maxRetries, sippyURL)
+		logrus.Infof("Requesting risk analysis (attempt %d/%d) from: %s", i, maxRetries, sippyURL)
 		resp, err = client.Do(req.WithContext(ctx))
 		endTime := time.Now()
 		duration := endTime.Sub(startTime)
-		fmt.Printf("%s: Call to sippy finished after: %s\n", endTime.Format(time.RFC3339), duration)
+		logrus.Infof("Call to sippy finished after: %s", duration)
 		if err == nil {
 			clientDoSuccess = true
 			break
 		}
-		fmt.Println(errors.Wrap(err, "error requesting risk analysis from sippy, sleeping 30s"))
+		logrus.WithError(err).Warn("error requesting risk analysis from sippy, sleeping 30s")
 
 		// cancel the context we just used.
 		cancelFn()
 		time.Sleep(time.Duration(i*30) * time.Second)
 	}
 	if !clientDoSuccess {
-		fmt.Fprintf(opt.Out, "Unable to obtain risk analysis from sippy after retries: %v", err)
+		logrus.WithError(err).Error("Unable to obtain risk analysis from sippy after retries")
 		return nil
 	}
 	defer resp.Body.Close()
 
 	riskAnalysisBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Fprintf(opt.Out, "Error reading risk analysis request body from sippy: %v", err)
+		logrus.WithError(err).Error("Error reading risk analysis request body from sippy")
 		return nil
 	}
-	fmt.Println("response Body:", string(riskAnalysisBytes))
+	logrus.Info("response Body:", string(riskAnalysisBytes))
 
 	outputFile := filepath.Join(opt.JUnitDir, "risk-analysis.json")
 	err = ioutil.WriteFile(outputFile, riskAnalysisBytes, 0644)
 	if err != nil {
-		fmt.Fprintf(opt.Out, "Error writing risk analysis json artifact: %v", err)
+		logrus.WithError(err).Error("Error writing risk analysis json artifact")
 		return nil
 	}
-	fmt.Fprintf(opt.Out, "Successfully wrote: %s\n", outputFile)
+	logrus.Infof("Successfully wrote: %s", outputFile)
+
+	disruptionBytes := []byte(`{Backends: []}`)
+	da, err := runDisruptionAnalysis(opt, finalProwJobRun.ClusterData.JobType)
+	if err != nil {
+		logrus.WithError(err).Error("error running disruption analysis locally")
+		return nil
+	}
+	disruptionBytes, err = json.Marshal(da)
+	if err != nil {
+		logrus.WithError(err).Error("Error marshalling disruption results")
+		return nil
+	}
 
 	// Write html file for spyglass
 	riskAnalysisHTMLTemplate := testdata.MustAsset("e2echart/test-risk-analysis.html")
 	html := bytes.ReplaceAll(riskAnalysisHTMLTemplate, []byte("TEST_RISK_ANALYSIS_SIPPY_URL_GOES_HERE"), []byte(sippyURL))
 	html = bytes.ReplaceAll(html, []byte("TEST_RISK_ANALYSIS_JSON_GOES_HERE"), riskAnalysisBytes)
+	html = bytes.ReplaceAll(html, []byte("TEST_DISRUPTION_ANALYSIS_JSON_GOES_HERE"), disruptionBytes)
 	path := filepath.Join(opt.JUnitDir, fmt.Sprintf("%s.html", "test-risk-analysis"))
 	if err := ioutil.WriteFile(path, html, 0644); err != nil {
-		fmt.Fprintf(opt.Out, "Error writing output file: %v", err)
+		logrus.WithError(err).Error("Error writing output file")
 		return nil
 	}
 
 	return nil
+}
+
+type disruptionBackendAnalysis struct {
+	BackendName        string
+	ObservedDisruption int
+	P50                float64
+	P75                float64
+	P95                float64
+	P99                float64
+	JobRuns            int64
+	RiskColor          string // red, yellow or green
+}
+
+type disruptionAnalysis struct {
+	Backends []disruptionBackendAnalysis
+}
+
+func runDisruptionAnalysis(opt *Options, jobType platformidentification.JobType) (*disruptionAnalysis, error) {
+	logrus.WithField("jobType", jobType).Infof("Checking disruption results for job type")
+	resultFiles, err := filepath.Glob(fmt.Sprintf("%s/backend-disruption*.json", opt.JUnitDir))
+	if err != nil {
+		return nil, err
+	}
+	logrus.Infof("Found files: %v", resultFiles)
+
+	// If we have multiple files we need to combine the disruption results into a single value for the
+	// overall job run, as we do when we submit to the database.
+	analysis := &disruptionAnalysis{}
+	for _, filename := range resultFiles {
+
+		var disruptList *disruptionserializer.BackendDisruptionList
+		f, err := os.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+		byteValue, _ := ioutil.ReadAll(f)
+		err = json.Unmarshal(byteValue, &disruptList)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, backend := range disruptList.BackendDisruptions {
+			tallyBackendInAnalysis(analysis, backend)
+		}
+	}
+
+	matcher := allowedbackenddisruption.GetCurrentResults()
+	for i, ba := range analysis.Backends {
+		// Inject the percentiles:
+		percentiles, details, err := matcher.BestMatchDuration(ba.BackendName, jobType, 1)
+		if err != nil {
+			logrus.WithError(err).Error("error looking up historical duration")
+		}
+		if percentiles == (historicaldata.StatisticalDuration{}) {
+			logrus.WithField("details", details).Warn("no historical data found for job run: ")
+			continue
+		}
+		analysis.Backends[i].P50 = percentiles.P50.Seconds()
+		analysis.Backends[i].P75 = percentiles.P75.Seconds()
+		analysis.Backends[i].P95 = percentiles.P95.Seconds()
+		analysis.Backends[i].P99 = percentiles.P99.Seconds()
+		analysis.Backends[i].JobRuns = percentiles.JobRuns
+
+		analysis.Backends[i].RiskColor = "lightgreen"
+		if float64(analysis.Backends[i].ObservedDisruption) > analysis.Backends[i].P95 {
+			analysis.Backends[i].RiskColor = "lightyellow"
+		}
+		if float64(analysis.Backends[i].ObservedDisruption) > analysis.Backends[i].P99 {
+			analysis.Backends[i].RiskColor = "lightred"
+		}
+
+		logrus.WithField("backend", analysis.Backends[i]).Info("calculated total disruption")
+	}
+
+	// Sort with highest disruption at top
+	sort.Slice(analysis.Backends, func(i, j int) bool {
+		return analysis.Backends[i].ObservedDisruption > analysis.Backends[j].ObservedDisruption
+	})
+
+	return analysis, nil
+}
+
+func tallyBackendInAnalysis(analysis *disruptionAnalysis, backendDisruption *disruptionserializer.BackendDisruption) {
+	for i, existing := range analysis.Backends {
+		if existing.BackendName == backendDisruption.BackendName {
+			analysis.Backends[i].ObservedDisruption = analysis.Backends[i].ObservedDisruption +
+				int(backendDisruption.DisruptedDuration.Seconds())
+			return
+		}
+	}
+	// Wasn't in the list, so we add it:
+	analysis.Backends = append(analysis.Backends, disruptionBackendAnalysis{
+		BackendName:        backendDisruption.BackendName,
+		ObservedDisruption: int(backendDisruption.DisruptedDuration.Seconds()),
+	})
 }

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53895,7 +53895,7 @@ var _e2echartTestRiskAnalysisHtml = []byte(`<html lang="en">
     <meta name="description"
           content="Risk analysis is performed by Sippy to attempt to determine if the failures in this job are abnormal when compared to results for similar jobs over the past week, and amidst on-going incidents in the CI infrastructure. Risk analysis API will not catch everything and is a relatively simple implementation today, please reach out to the Technical Release Team if you spot abnormalities or have suggestions.">
 </head>
-<body onLoad="buildTestCaseTable('#test_case_results')">
+<body onLoad="buildTestCaseTable('#test_case_results'); buildDisruptionTable('#disruption_results')">
 <p>
     <a target="_blank" href="TEST_RISK_ANALYSIS_SIPPY_URL_GOES_HERE">Link to Sippy</a>
 </p>
@@ -53904,8 +53904,27 @@ var _e2echartTestRiskAnalysisHtml = []byte(`<html lang="en">
 </table>
 <p>&nbsp;</p>
 
+<h1>Disruption Analysis</h1>
+
+Disruption unit testing on individual job runs is relatively forgiving as it can generate a lot of noise.
+This table attempts to highlight
+risky results by color coding the observed disruption for this run against the percentiles over the past several
+weeks. Red indicates this job run exceeded the 99th percentile, yellow the 95th.<p/>
+
+If you're getting red results here, it might be a good idea to investigate the intervals chart for this job run,
+available in the spyglass panels on the prow job. This will show when the disruption occurred, the exact error
+messages returned, and what else was going on in the cluster at that time. Additional runs may help provide a clearer
+picture if the chart does not provide any insight. Feel free to reach out to TRT if you think you're seeing something
+alarming.<p/>
+
+
+<table id="disruption_results" border="1" width="100%">
+</table>
+<p>&nbsp;</p>
+
 <script>
     var testResult = TEST_RISK_ANALYSIS_JSON_GOES_HERE
+    var disruptionResult = TEST_DISRUPTION_ANALYSIS_JSON_GOES_HERE
     var testLinkPrefix = "https://sippy.dptools.openshift.org/sippy-ng/tests/"
     var testLinkSuffix = "/analysis?test="
 
@@ -53941,11 +53960,11 @@ var _e2echartTestRiskAnalysisHtml = []byte(`<html lang="en">
     function buildRiskLevel(level) {
         td$ = $('<td/>')
         if (level.Level >= 10) {
-            td$.css("background-color", "red");
+            td$.css("background-color", "lightred");
         } else if (level.Level >= 5) {
-            td$.css("background-color", "yellow");
+            td$.css("background-color", "lightyellow");
         } else {
-            td$.css("background-color", "green");
+            td$.css("background-color", "lightgreen");
         }
         td$.append(level.Name)
         return td$
@@ -53986,6 +54005,42 @@ var _e2echartTestRiskAnalysisHtml = []byte(`<html lang="en">
         headerTr$.append($('<th/>').html("Open Bugs"));
 
         $(selector).append(headerTr$);
+    }
+
+    function buildDisruptionTable(selector) {
+        addDisruptionColumnHeaders(selector);
+
+        for (var i = 0; i < disruptionResult.Backends.length; i++) {
+            var row$ = $('<tr/>');
+
+            row$.css("background-color", disruptionResult.Backends[i].RiskColor);
+            row$.append(addSimpleCell(disruptionResult.Backends[i].BackendName))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].ObservedDisruption))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].P50.toFixed(2)))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].P75.toFixed(2)))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].P95.toFixed(2)))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].P99.toFixed(2)))
+            row$.append(addSimpleCell(disruptionResult.Backends[i].JobRuns))
+            $(selector).append(row$);
+        }
+    }
+    function addDisruptionColumnHeaders(selector) {
+        var headerTr$ = $('<tr/>');
+        headerTr$.append($('<th/>').html("Backend Name"));
+        headerTr$.append($('<th/>').html("Observed Disruption"));
+        headerTr$.append($('<th/>').html("P50"));
+        headerTr$.append($('<th/>').html("P75"));
+        headerTr$.append($('<th/>').html("P95"));
+        headerTr$.append($('<th/>').html("P99"));
+        headerTr$.append($('<th/>').html("JobRuns"));
+
+        $(selector).append(headerTr$);
+    }
+
+    function addSimpleCell(v) {
+        td$ = $('<td/>')
+        td$.append(v)
+        return td$
     }
 
 </script>


### PR DESCRIPTION
Display an additional table in the spyglass risk analysis view which shows the total observed disruption for every backend, as well as it's historical percentiles observed over the past several weeks. Rows which exceed the P95 are highlighted yellow, and P99 red.

Long term we'd like this in sippy in the actual risk analysis report, however this is logistically quite tricky. Sippy does not have disruption data in it's postgres, so we'd need to (a) submit to sippy live after openshift-tests runs now with disruption data observed, (b) update sippy to efficiently compare this to percentiles without blowing bigquery costs, (c) figure out how to fit it into the report and the pr commenter without breaking any assumptions about risk analysis formatting.

For now, origin knows the historical percentiles thanks to the weekly automated PR, and the observed disruption, so it was quite easy to include it in the table and get this info our to engineers quickly.