### PR TITLE
OCPBUGS-23115: Test builds with subscription content

### DIFF
--- a/test/extended/builds/subscription_content.go
+++ b/test/extended/builds/subscription_content.go
@@ -1,0 +1,93 @@
+package builds
+
+import (
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-builds][Feature:Builds][subscription-content] builds installing subscription content", func() {
+
+	defer g.GinkgoRecover()
+
+	var (
+		oc               = exutil.NewCLIWithPodSecurityLevel("build-subscription-content", admissionapi.LevelBaseline)
+		baseDir          = exutil.FixturePath("testdata", "builds", "subscription-content")
+		secretTemplate   = filepath.Join(baseDir, "secret-template.txt")
+		imageStream      = filepath.Join(baseDir, "build-imagestream.yaml")
+		rhel7BuildConfig = filepath.Join(baseDir, "buildconfig-subscription-content-rhel7.yaml")
+		rhel8BuildConfig = filepath.Join(baseDir, "buildconfig-subscription-content-rhel8.yaml")
+		rhel9BuildConfig = filepath.Join(baseDir, "buildconfig-subscription-content-rhel9.yaml")
+	)
+
+	g.Context("[apigroup:build.openshift.io]", func() {
+
+		g.BeforeEach(func() {
+			exutil.PreTestDump()
+		})
+
+		g.JustBeforeEach(func(ctx g.SpecContext) {
+			g.By("copying entitlement keys to namespace")
+			// The Insights Operator is responsible for retrieving the entitlement keys for the
+			// cluster and syncing them to the openshift-config-managed namespace.
+			// If this secret is not present, it means the cluster is not a Red Hat subscribed
+			// cluster and is not eligible to include entitled RHEL content in builds.
+			_, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-config-managed").Get(ctx, "etc-pki-entitlement", metav1.GetOptions{})
+			if kerrors.IsNotFound(err) {
+				g.Skip("cluster entitlements not found")
+			}
+			// We should not expect an error other than "not found"
+			o.Expect(err).NotTo(o.HaveOccurred(), "getting secret openshift-config-managed/etc-pki-entitlement")
+			// Without the shared resoruces CSI driver, we must manually copy the entitlement keys
+			// to the build namespace.
+
+			// Run oc commands as per the openshift documentation
+			stdOut, _, err := oc.AsAdmin().Run("get").Args("secret", "etc-pki-entitlement", "-n", "openshift-config-managed", "-o=go-template-file", "--template", secretTemplate).Outputs()
+			o.Expect(err).NotTo(o.HaveOccurred(), "getting secret openshift-config-managed/etc-pki-entitlement")
+			err = oc.Run("apply").Args("-f", "-").InputString(stdOut).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred(), "creating secret etc-pki-entitlement")
+
+			g.By("setting up build outputs")
+			err = oc.Run("apply").Args("-f", imageStream).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred(), "creating build output imagestream")
+		})
+
+		g.AfterEach(func() {
+			if g.CurrentSpecReport().Failed() {
+				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
+				exutil.DumpPodLogsStartingWith("", oc)
+			}
+		})
+
+		g.It("should succeed for RHEL 7 base images", func() {
+			err := oc.Run("apply").Args("-f", rhel7BuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred(), "creating BuildConfig")
+			br, _ := exutil.StartBuildAndWait(oc, "subscription-content-rhel7")
+			br.AssertSuccess()
+		})
+
+		g.It("should succeed for RHEL 8 base images", func() {
+			err := oc.Run("apply").Args("-f", rhel8BuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred(), "creating BuildConfig")
+			br, _ := exutil.StartBuildAndWait(oc, "subscription-content-rhel8")
+			br.AssertSuccess()
+		})
+
+		g.It("should succeed for RHEL 9 base images", func() {
+			err := oc.Run("apply").Args("-f", rhel9BuildConfig).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred(), "creating BuildConfig")
+			br, _ := exutil.StartBuildAndWait(oc, "subscription-content-rhel9")
+			br.AssertSuccess()
+		})
+
+	})
+
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -108,6 +108,11 @@
 // test/extended/testdata/builds/statusfail-oomkilled.yaml
 // test/extended/testdata/builds/statusfail-postcommithook.yaml
 // test/extended/testdata/builds/statusfail-pushtoregistry.yaml
+// test/extended/testdata/builds/subscription-content/build-imagestream.yaml
+// test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel7.yaml
+// test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel8.yaml
+// test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel9.yaml
+// test/extended/testdata/builds/subscription-content/secret-template.txt
 // test/extended/testdata/builds/test-auth-build.yaml
 // test/extended/testdata/builds/test-bc-with-pr-ref.yaml
 // test/extended/testdata/builds/test-build-app/Dockerfile
@@ -19030,6 +19035,221 @@ func testExtendedTestdataBuildsStatusfailPushtoregistryYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/builds/statusfail-pushtoregistry.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsSubscriptionContentBuildImagestreamYaml = []byte(`apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: subscription-content
+`)
+
+func testExtendedTestdataBuildsSubscriptionContentBuildImagestreamYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsSubscriptionContentBuildImagestreamYaml, nil
+}
+
+func testExtendedTestdataBuildsSubscriptionContentBuildImagestreamYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsSubscriptionContentBuildImagestreamYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/subscription-content/build-imagestream.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel7Yaml = []byte(`` + "\xEF\xBB\xBF" + `kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: subscription-content-rhel7
+spec:
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'subscription-content:rhel7'
+  resources: {}
+  successfulBuildsHistoryLimit: 5
+  failedBuildsHistoryLimit: 5
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: 'registry.access.redhat.com/ubi7/ubi:latest'
+      volumes:
+        - name: etc-pki-entitlement
+          source:
+            type: Secret
+            secret:
+              secretName: etc-pki-entitlement
+              defaultMode: 420
+          mounts:
+            - destinationPath: /etc/pki/entitlement
+  postCommit: {}
+  source:
+    type: Dockerfile
+    dockerfile: |
+      FROM registry.access.redhat.com/ubi7/ubi:latest
+      RUN rm -rf /etc/rhsm-host
+      RUN yum --enablerepo=rhel-server-rhscl-7-rpms install \
+          nss_wrapper -y && \
+          yum clean all -y
+      RUN ln -s /run/secrets/rhsm /etc/rhsm-host
+  runPolicy: Serial
+`)
+
+func testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel7YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel7Yaml, nil
+}
+
+func testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel7Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel7YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel7.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel8Yaml = []byte(`` + "\xEF\xBB\xBF" + `kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: subscription-content-rhel8
+spec:
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'subscription-content:rhel8'
+  resources: {}
+  successfulBuildsHistoryLimit: 5
+  failedBuildsHistoryLimit: 5
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: 'registry.access.redhat.com/ubi8/ubi:latest'
+      volumes:
+        - name: etc-pki-entitlement
+          source:
+            type: Secret
+            secret:
+              secretName: etc-pki-entitlement
+              defaultMode: 420
+          mounts:
+            - destinationPath: /etc/pki/entitlement
+  postCommit: {}
+  source:
+    type: Dockerfile
+    dockerfile: |
+      FROM registry.access.redhat.com/ubi8/ubi:latest
+      RUN rm -rf /etc/rhsm-host
+      RUN yum --enablerepo=codeready-builder-for-rhel-8-x86_64-rpms install \
+          nss_wrapper \
+          uid_wrapper -y && \
+          yum clean all -y
+      RUN ln -s /run/secrets/rhsm /etc/rhsm-host
+  runPolicy: Serial
+`)
+
+func testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel8YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel8Yaml, nil
+}
+
+func testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel8Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel8YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel8.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel9Yaml = []byte(`` + "\xEF\xBB\xBF" + `kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: subscription-content-rhel9
+spec:
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'subscription-content:rhel9'
+  resources: {}
+  successfulBuildsHistoryLimit: 5
+  failedBuildsHistoryLimit: 5
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: 'registry.access.redhat.com/ubi9/ubi:latest'
+      volumes:
+        - name: etc-pki-entitlement
+          source:
+            type: Secret
+            secret:
+              secretName: etc-pki-entitlement
+              defaultMode: 420
+          mounts:
+            - destinationPath: /etc/pki/entitlement
+  postCommit: {}
+  source:
+    type: Dockerfile
+    dockerfile: |
+      FROM registry.access.redhat.com/ubi9/ubi:latest
+      RUN rm -rf /etc/rhsm-host
+      RUN yum --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms install \
+          nss_wrapper \
+          uid_wrapper -y && \
+          yum clean all -y
+      RUN ln -s /run/secrets/rhsm /etc/rhsm-host
+  runPolicy: Serial
+`)
+
+func testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel9YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel9Yaml, nil
+}
+
+func testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel9Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel9YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel9.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsSubscriptionContentSecretTemplateTxt = []byte(`kind: Secret
+apiVersion: v1
+metadata:
+  name: etc-pki-entitlement
+type: Opaque
+data: {{ range $key, $value := .data }}
+  {{ $key }}: {{ $value }} {{ end }}
+`)
+
+func testExtendedTestdataBuildsSubscriptionContentSecretTemplateTxtBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsSubscriptionContentSecretTemplateTxt, nil
+}
+
+func testExtendedTestdataBuildsSubscriptionContentSecretTemplateTxt() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsSubscriptionContentSecretTemplateTxtBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/subscription-content/secret-template.txt", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -54169,6 +54389,11 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/builds/statusfail-oomkilled.yaml":                                                testExtendedTestdataBuildsStatusfailOomkilledYaml,
 	"test/extended/testdata/builds/statusfail-postcommithook.yaml":                                           testExtendedTestdataBuildsStatusfailPostcommithookYaml,
 	"test/extended/testdata/builds/statusfail-pushtoregistry.yaml":                                           testExtendedTestdataBuildsStatusfailPushtoregistryYaml,
+	"test/extended/testdata/builds/subscription-content/build-imagestream.yaml":                              testExtendedTestdataBuildsSubscriptionContentBuildImagestreamYaml,
+	"test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel7.yaml":         testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel7Yaml,
+	"test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel8.yaml":         testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel8Yaml,
+	"test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel9.yaml":         testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel9Yaml,
+	"test/extended/testdata/builds/subscription-content/secret-template.txt":                                 testExtendedTestdataBuildsSubscriptionContentSecretTemplateTxt,
 	"test/extended/testdata/builds/test-auth-build.yaml":                                                     testExtendedTestdataBuildsTestAuthBuildYaml,
 	"test/extended/testdata/builds/test-bc-with-pr-ref.yaml":                                                 testExtendedTestdataBuildsTestBcWithPrRefYaml,
 	"test/extended/testdata/builds/test-build-app/Dockerfile":                                                testExtendedTestdataBuildsTestBuildAppDockerfile,
@@ -54765,8 +54990,15 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"statusfail-oomkilled.yaml":               {testExtendedTestdataBuildsStatusfailOomkilledYaml, map[string]*bintree{}},
 					"statusfail-postcommithook.yaml":          {testExtendedTestdataBuildsStatusfailPostcommithookYaml, map[string]*bintree{}},
 					"statusfail-pushtoregistry.yaml":          {testExtendedTestdataBuildsStatusfailPushtoregistryYaml, map[string]*bintree{}},
-					"test-auth-build.yaml":                    {testExtendedTestdataBuildsTestAuthBuildYaml, map[string]*bintree{}},
-					"test-bc-with-pr-ref.yaml":                {testExtendedTestdataBuildsTestBcWithPrRefYaml, map[string]*bintree{}},
+					"subscription-content": {nil, map[string]*bintree{
+						"build-imagestream.yaml":                      {testExtendedTestdataBuildsSubscriptionContentBuildImagestreamYaml, map[string]*bintree{}},
+						"buildconfig-subscription-content-rhel7.yaml": {testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel7Yaml, map[string]*bintree{}},
+						"buildconfig-subscription-content-rhel8.yaml": {testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel8Yaml, map[string]*bintree{}},
+						"buildconfig-subscription-content-rhel9.yaml": {testExtendedTestdataBuildsSubscriptionContentBuildconfigSubscriptionContentRhel9Yaml, map[string]*bintree{}},
+						"secret-template.txt":                         {testExtendedTestdataBuildsSubscriptionContentSecretTemplateTxt, map[string]*bintree{}},
+					}},
+					"test-auth-build.yaml":     {testExtendedTestdataBuildsTestAuthBuildYaml, map[string]*bintree{}},
+					"test-bc-with-pr-ref.yaml": {testExtendedTestdataBuildsTestBcWithPrRefYaml, map[string]*bintree{}},
 					"test-build-app": {nil, map[string]*bintree{
 						"Dockerfile": {testExtendedTestdataBuildsTestBuildAppDockerfile, map[string]*bintree{}},
 						"Gemfile":    {testExtendedTestdataBuildsTestBuildAppGemfile, map[string]*bintree{}},

--- a/test/extended/testdata/builds/subscription-content/build-imagestream.yaml
+++ b/test/extended/testdata/builds/subscription-content/build-imagestream.yaml
@@ -1,0 +1,4 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: subscription-content

--- a/test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel7.yaml
+++ b/test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel7.yaml
@@ -1,0 +1,39 @@
+﻿kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: subscription-content-rhel7
+spec:
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'subscription-content:rhel7'
+  resources: {}
+  successfulBuildsHistoryLimit: 5
+  failedBuildsHistoryLimit: 5
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: 'registry.access.redhat.com/ubi7/ubi:latest'
+      volumes:
+        - name: etc-pki-entitlement
+          source:
+            type: Secret
+            secret:
+              secretName: etc-pki-entitlement
+              defaultMode: 420
+          mounts:
+            - destinationPath: /etc/pki/entitlement
+  postCommit: {}
+  source:
+    type: Dockerfile
+    dockerfile: |
+      FROM registry.access.redhat.com/ubi7/ubi:latest
+      RUN rm -rf /etc/rhsm-host
+      RUN yum --enablerepo=rhel-server-rhscl-7-rpms install \
+          nss_wrapper -y && \
+          yum clean all -y
+      RUN ln -s /run/secrets/rhsm /etc/rhsm-host
+  runPolicy: Serial

--- a/test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel8.yaml
+++ b/test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel8.yaml
@@ -1,0 +1,40 @@
+﻿kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: subscription-content-rhel8
+spec:
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'subscription-content:rhel8'
+  resources: {}
+  successfulBuildsHistoryLimit: 5
+  failedBuildsHistoryLimit: 5
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: 'registry.access.redhat.com/ubi8/ubi:latest'
+      volumes:
+        - name: etc-pki-entitlement
+          source:
+            type: Secret
+            secret:
+              secretName: etc-pki-entitlement
+              defaultMode: 420
+          mounts:
+            - destinationPath: /etc/pki/entitlement
+  postCommit: {}
+  source:
+    type: Dockerfile
+    dockerfile: |
+      FROM registry.access.redhat.com/ubi8/ubi:latest
+      RUN rm -rf /etc/rhsm-host
+      RUN yum --enablerepo=codeready-builder-for-rhel-8-x86_64-rpms install \
+          nss_wrapper \
+          uid_wrapper -y && \
+          yum clean all -y
+      RUN ln -s /run/secrets/rhsm /etc/rhsm-host
+  runPolicy: Serial

--- a/test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel9.yaml
+++ b/test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel9.yaml
@@ -1,0 +1,40 @@
+﻿kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: subscription-content-rhel9
+spec:
+  nodeSelector: null
+  output:
+    to:
+      kind: ImageStreamTag
+      name: 'subscription-content:rhel9'
+  resources: {}
+  successfulBuildsHistoryLimit: 5
+  failedBuildsHistoryLimit: 5
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: 'registry.access.redhat.com/ubi9/ubi:latest'
+      volumes:
+        - name: etc-pki-entitlement
+          source:
+            type: Secret
+            secret:
+              secretName: etc-pki-entitlement
+              defaultMode: 420
+          mounts:
+            - destinationPath: /etc/pki/entitlement
+  postCommit: {}
+  source:
+    type: Dockerfile
+    dockerfile: |
+      FROM registry.access.redhat.com/ubi9/ubi:latest
+      RUN rm -rf /etc/rhsm-host
+      RUN yum --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms install \
+          nss_wrapper \
+          uid_wrapper -y && \
+          yum clean all -y
+      RUN ln -s /run/secrets/rhsm /etc/rhsm-host
+  runPolicy: Serial

--- a/test/extended/testdata/builds/subscription-content/secret-template.txt
+++ b/test/extended/testdata/builds/subscription-content/secret-template.txt
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: etc-pki-entitlement
+type: Opaque
+data: {{ range $key, $value := .data }}
+  {{ $key }}: {{ $value }} {{ end }}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -603,6 +603,12 @@ var Annotations = map[string]string{
 
 	"[sig-builds][Feature:Builds][pullsecret] docker build using a pull secret Building from a template should create a docker build that pulls using a secret run it [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-builds][Feature:Builds][subscription-content] builds installing subscription content [apigroup:build.openshift.io] should succeed for RHEL 7 base images": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-builds][Feature:Builds][subscription-content] builds installing subscription content [apigroup:build.openshift.io] should succeed for RHEL 8 base images": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-builds][Feature:Builds][subscription-content] builds installing subscription content [apigroup:build.openshift.io] should succeed for RHEL 9 base images": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-builds][Feature:Builds][timing] capture build stages and durations should record build stages and durations for docker [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-builds][Feature:Builds][timing] capture build stages and durations should record build stages and durations for s2i [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Add end to end tests to verify we can build images that install
RHEL subscription content via `yum/dnf install`. These tests
need a fully subscribed cluster to function properly - for example,
a ROSA cluster. If the cluster is not subscribed/does not have its
SCA certificates synced via the Insights Operator, the tests are
skipped.

The test verifies the instructions in the official OpenShift
documentation, which includes copying the entitlement keys to
the build's namespace. Docs are currently being drafted in https://github.com/openshift/openshift-docs/pull/70897