### PR TITLE
NO-JIRA: Skip external cloud provider test for HyperShift clusters

### DIFF
--- a/test/extended/cloud_controller_manager/ccm.go
+++ b/test/extended/cloud_controller_manager/ccm.go
@@ -30,6 +30,10 @@ var _ = g.Describe("[sig-cloud-provider][Feature:OpenShiftCloudControllerManager
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+			g.Skip("Control plane is external")
+		}
+
 		if !isPlatformExternal(infra.Status.PlatformStatus.Type) {
 			g.Skip("Platform does not use external cloud provider")
 		}


### PR DESCRIPTION
The cloud provider runs externally to the cluster in HyperShift clusters, therefore it cannot be verified within the cluster.