### PR TITLE
TRT-1480: Fix disruption analysis on /payload jobs

### DIFF
--- a/e2echart/test-risk-analysis.html
+++ b/e2echart/test-risk-analysis.html
@@ -70,7 +70,7 @@ alarming.<p/>
     function buildRiskLevel(level) {
         td$ = $('<td/>')
         if (level.Level >= 10) {
-            td$.css("background-color", "lightred");
+            td$.css("background-color", "pink");
         } else if (level.Level >= 5) {
             td$.css("background-color", "lightyellow");
         } else {
@@ -82,6 +82,10 @@ alarming.<p/>
 
     // Build Test Case Table
     function buildTestCaseTable(selector) {
+        if (!testResult.hasOwnProperty('OverallRisk')) {
+            return;
+        }
+
         // Add table headers
         addColumnHeaders(selector);
 

--- a/pkg/riskanalysis/cmd.go
+++ b/pkg/riskanalysis/cmd.go
@@ -234,7 +234,7 @@ func runDisruptionAnalysis(opt *Options, jobType platformidentification.JobType)
 			analysis.Backends[i].RiskColor = "lightyellow"
 		}
 		if float64(analysis.Backends[i].ObservedDisruption) > analysis.Backends[i].P99 {
-			analysis.Backends[i].RiskColor = "lightred"
+			analysis.Backends[i].RiskColor = "pink"
 		}
 
 		logrus.WithField("backend", analysis.Backends[i]).Info("calculated total disruption")

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53960,7 +53960,7 @@ alarming.<p/>
     function buildRiskLevel(level) {
         td$ = $('<td/>')
         if (level.Level >= 10) {
-            td$.css("background-color", "lightred");
+            td$.css("background-color", "pink");
         } else if (level.Level >= 5) {
             td$.css("background-color", "lightyellow");
         } else {
@@ -53972,6 +53972,10 @@ alarming.<p/>
 
     // Build Test Case Table
     function buildTestCaseTable(selector) {
+        if (!testResult.hasOwnProperty('OverallRisk')) {
+            return;
+        }
+
         // Add table headers
         addColumnHeaders(selector);
 


### PR DESCRIPTION
Risk analysis doesn't work at all on these jobs, and attempting to
reference the OverallRisk field in those cases was causing the
disruption portion of the html (which did work) to not be populated.

Bail out early if it looks like we didn't get a real risk analysis, and
let the disruption table render normally.

Also switch from lightred (Which doesn't actually exist) to pink.
