### PR TITLE
NO-JIRA: enforce only stable CRD versions accessible by default

### DIFF
--- a/test/extended/operators/crd_must_be_stable.go
+++ b/test/extended/operators/crd_must_be_stable.go
@@ -8,7 +8,6 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/origin/pkg/test/ginkgo/result"
 	exutil "github.com/openshift/origin/test/extended/util"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,7 +76,7 @@ var _ = g.Describe("[sig-arch][Early]", func() {
 			}
 
 			if len(failures) > 0 {
-				result.Flakef(strings.Join(failures, "\n"))
+				g.Fail(strings.Join(failures, "\n"))
 			}
 		})
 	})


### PR DESCRIPTION
/hold

Reminder to merge this next week if https://search.ci.openshift.org/?search=has+an+unstable+version&maxAge=168h&context=1&type=bug%2Bissue%2Bjunit&name=4.16&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job is clean

/assign @JoelSpeed 