### PR TITLE
AUTH-480: Add monitor tests for PSa labels of openshift prefixed namespaces

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -18,6 +18,7 @@ import (
 	azuremetrics "github.com/openshift/origin/pkg/monitortests/cloud/azure/metrics"
 	"github.com/openshift/origin/pkg/monitortests/clusterversionoperator/legacycvomonitortests"
 	"github.com/openshift/origin/pkg/monitortests/clusterversionoperator/operatorstateanalyzer"
+	"github.com/openshift/origin/pkg/monitortests/clusterversionoperator/psalabelsmonitortests"
 	"github.com/openshift/origin/pkg/monitortests/etcd/etcdloganalyzer"
 	"github.com/openshift/origin/pkg/monitortests/etcd/legacyetcdmonitortests"
 	"github.com/openshift/origin/pkg/monitortests/imageregistry/disruptionimageregistry"
@@ -140,6 +141,7 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-cvo-invariants", "Cluster Version Operator", legacycvomonitortests.NewLegacyTests())
 	monitorTestRegistry.AddMonitorTestOrDie("operator-state-analyzer", "Cluster Version Operator", operatorstateanalyzer.NewAnalyzer())
+	monitorTestRegistry.AddMonitorTestOrDie("namespace-psa-labels-analyzer", "Custer Version Operator", psalabelsmonitortests.NewAnalyzer())
 
 	monitorTestRegistry.AddMonitorTestOrDie("etcd-log-analyzer", "etcd", etcdloganalyzer.NewEtcdLogAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-etcd-invariants", "etcd", legacyetcdmonitortests.NewLegacyTests())

--- a/pkg/monitortests/clusterversionoperator/psalabelsmonitortests/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/psalabelsmonitortests/monitortest.go
@@ -1,0 +1,89 @@
+package psalabelsmonitortests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	psapi "k8s.io/pod-security-admission/api"
+)
+
+type namespacePSaLabelsChecker struct {
+	kubeClient kubernetes.Interface
+}
+
+func NewAnalyzer() monitortestframework.MonitorTest {
+	return &namespacePSaLabelsChecker{}
+}
+
+func (w *namespacePSaLabelsChecker) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	var err error
+	w.kubeClient, err = kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *namespacePSaLabelsChecker) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if w.kubeClient == nil {
+		return nil, nil, nil
+	}
+
+	namespaces, err := w.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	junits := []*junitapi.JUnitTestCase{}
+	for _, ns := range namespaces.Items {
+		if !strings.HasPrefix(ns.Name, "openshift") {
+			continue
+		}
+
+		failureMessages := make([]string, 0)
+		for _, requiredLabel := range []string{psapi.EnforceLevelLabel, psapi.AuditLevelLabel, psapi.WarnLevelLabel} {
+			if len(ns.Labels[requiredLabel]) == 0 {
+				failureMessages = append(failureMessages, fmt.Sprintf("missing label '%s'", requiredLabel))
+			}
+		}
+
+		junit := &junitapi.JUnitTestCase{Name: fmt.Sprintf("ns/%s must have all PSa labels defined", ns.Name)}
+		if len(failureMessages) > 0 {
+			msg := strings.Join(failureMessages, "\n")
+			junit.SystemOut = msg
+			junit.FailureOutput = &junitapi.FailureOutput{
+				Output: msg,
+			}
+		}
+
+		junits = append(junits, junit)
+	}
+
+	return nil, junits, nil
+}
+
+func (w *namespacePSaLabelsChecker) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+func (w *namespacePSaLabelsChecker) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (w *namespacePSaLabelsChecker) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (w *namespacePSaLabelsChecker) Cleanup(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
This PR adds a monitor test that checks all `openshift` prefixed namespaces and requires that all 3 PSa labels are defined.