### PR TITLE
OCPBUGS-14057: Removes HAProxyDown critical alert exception.

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -73,10 +73,6 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		"MCDRebootError",
 		"ExtremelyHighIndividualControlPlaneMemory",
 
-		// Repository: https://github.com/openshift/cluster-ingress-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14057
-		"HAProxyDown",
-
 		// Repository: https://github.com/openshift/cluster-version-operator
 		// Issue: https://issues.redhat.com/browse/OCPBUGS-14246
 		"ClusterOperatorDown",


### PR DESCRIPTION
Removes HAProxyDown critical alert exception.
Ticket: https://issues.redhat.com/browse/OCPBUGS-14057