### PR TITLE
OCPBUGS-26603: e2e: fix malformed IPv6 URLs, use brackets

### DIFF
--- a/test/extended/router/certs.go
+++ b/test/extended/router/certs.go
@@ -238,7 +238,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 				defer t.Close()
 				t.Within(
 					time.Minute,
-					exurl.Expect("GET", url).Through(routerIP).SkipTLSVerification().HasStatusCode(200),
+					exurl.Expect("GET", url).Through(exutil.IPUrl(routerIP)).SkipTLSVerification().HasStatusCode(200),
 				)
 			})
 		})

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -516,15 +516,15 @@ http {
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, timeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), timeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid routes to respond")
-			err = waitForRouteToRespond(ns, execPod.Name, "http", "insecure.hapcm.test", "/", routerIP, 0)
+			err = waitForRouteToRespond(ns, execPod.Name, "http", "insecure.hapcm.test", "/", exutil.IPUrl(routerIP), 0)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			for _, host := range []string{"edge.allow.hapcm.test", "reencrypt.hapcm.test", "passthrough.hapcm.test"} {
-				err = waitForRouteToRespond(ns, execPod.Name, "https", host, "/", routerIP, 0)
+				err = waitForRouteToRespond(ns, execPod.Name, "https", host, "/", exutil.IPUrl(routerIP), 0)
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 
@@ -535,7 +535,7 @@ http {
 				err := oc.AsAdmin().Run("expose").Args("service", "insecure-service", "--name", name, "--hostname", hostName, "--labels", "select=haproxy-cfgmgr").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				err = waitForRouteToRespond(ns, execPod.Name, "http", hostName, "/", routerIP, 0)
+				err = waitForRouteToRespond(ns, execPod.Name, "http", hostName, "/", exutil.IPUrl(routerIP), 0)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				err = oc.AsAdmin().Run("delete").Args("route", name).Execute()
@@ -555,7 +555,7 @@ http {
 					err = oc.AsAdmin().Run("label").Args("route", name, "select=haproxy-cfgmgr").Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())
 
-					err = waitForRouteToRespond(ns, execPod.Name, "https", hostName, "/", routerIP, 0)
+					err = waitForRouteToRespond(ns, execPod.Name, "https", hostName, "/", exutil.IPUrl(routerIP), 0)
 					o.Expect(err).NotTo(o.HaveOccurred())
 
 					err = oc.AsAdmin().Run("delete").Args("route", name).Execute()

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -516,15 +516,15 @@ http {
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), timeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, timeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid routes to respond")
-			err = waitForRouteToRespond(ns, execPod.Name, "http", "insecure.hapcm.test", "/", exutil.IPUrl(routerIP), 0)
+			err = waitForRouteToRespond(ns, execPod.Name, "http", "insecure.hapcm.test", "/", routerIP, 0)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			for _, host := range []string{"edge.allow.hapcm.test", "reencrypt.hapcm.test", "passthrough.hapcm.test"} {
-				err = waitForRouteToRespond(ns, execPod.Name, "https", host, "/", exutil.IPUrl(routerIP), 0)
+				err = waitForRouteToRespond(ns, execPod.Name, "https", host, "/", routerIP, 0)
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 
@@ -535,7 +535,7 @@ http {
 				err := oc.AsAdmin().Run("expose").Args("service", "insecure-service", "--name", name, "--hostname", hostName, "--labels", "select=haproxy-cfgmgr").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				err = waitForRouteToRespond(ns, execPod.Name, "http", hostName, "/", exutil.IPUrl(routerIP), 0)
+				err = waitForRouteToRespond(ns, execPod.Name, "http", hostName, "/", routerIP, 0)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				err = oc.AsAdmin().Run("delete").Args("route", name).Execute()
@@ -555,7 +555,7 @@ http {
 					err = oc.AsAdmin().Run("label").Args("route", name, "select=haproxy-cfgmgr").Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())
 
-					err = waitForRouteToRespond(ns, execPod.Name, "https", hostName, "/", exutil.IPUrl(routerIP), 0)
+					err = waitForRouteToRespond(ns, execPod.Name, "https", hostName, "/", routerIP, 0)
 					o.Expect(err).NotTo(o.HaveOccurred())
 
 					err = oc.AsAdmin().Run("delete").Args("route", name).Execute()
@@ -567,6 +567,8 @@ http {
 })
 
 func waitForRouteToRespond(ns, execPodName, proto, host, abspath, ipaddr string, port int) error {
+	// bracket IPv6 IPs when used as URI
+	host = exutil.IPUrl(host)
 	if port == 0 {
 		switch proto {
 		case "http":

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -98,7 +98,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(metricsIP, "1936"))

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(metricsIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, metricsIP, changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(metricsIP), changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			host := "router-headers.example.com"

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(metricsIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(metricsIP), changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, metricsIP, changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			host := "router-headers.example.com"

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -164,7 +164,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 					}
 					// send a burst of traffic to the router
 					g.By("sending traffic to a weighted route")
-					err = expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", host), routeHost, http.StatusOK, times, proxyProtocol)
+					err = expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", exutil.IPUrl(host)), routeHost, http.StatusOK, times, proxyProtocol)
 					o.Expect(err).NotTo(o.HaveOccurred())
 				}
 				g.By("retrying metrics until all backend servers appear")

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][a
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should support reencrypt to services backed by a serving certificate automatically", func() {
-			routerURL := fmt.Sprintf("https://%s", ip)
+			routerURL := fmt.Sprintf("https://%s", exutil.IPUrl(ip))
 
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
 			defer func() {

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -22,6 +22,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 	defer g.GinkgoRecover()
 	var (
 		host, ns string
+		ipUrl    string
 		oc       *exutil.CLI
 
 		configPath = exutil.FixturePath("testdata", "router", "ingress.yaml")
@@ -52,6 +53,8 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 	g.BeforeEach(func() {
 		var err error
 		host, err = exutil.WaitForRouterServiceIP(oc)
+		// bracket IPv6
+		ipUrl = exutil.IPUrl(host)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		ns = oc.KubeFramework().Namespace.Name
@@ -63,8 +66,8 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 			defer t.Close()
 			t.Within(
 				time.Minute,
-				url.Expect("GET", "https://www.google.com").Through(host).SkipTLSVerification().HasStatusCode(503),
-				url.Expect("GET", "http://www.google.com").Through(host).HasStatusCode(503),
+				url.Expect("GET", "https://www.google.com").Through(ipUrl).SkipTLSVerification().HasStatusCode(503),
+				url.Expect("GET", "http://www.google.com").Through(ipUrl).HasStatusCode(503),
 			)
 		})
 
@@ -89,12 +92,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 			defer t.Close()
 			t.Within(
 				3*time.Minute,
-				url.Expect("GET", "http://1.ingress-test.com/test").Through(host).HasStatusCode(200),
-				url.Expect("GET", "http://1.ingress-test.com/other/deep").Through(host).HasStatusCode(200),
-				url.Expect("GET", "http://1.ingress-test.com/").Through(host).HasStatusCode(503),
-				url.Expect("GET", "http://2.ingress-test.com/").Through(host).HasStatusCode(200),
-				url.Expect("GET", "https://3.ingress-test.com/").Through(host).SkipTLSVerification().HasStatusCode(200),
-				url.Expect("GET", "http://3.ingress-test.com/").Through(host).RedirectsTo("https://3.ingress-test.com/", http.StatusFound),
+				url.Expect("GET", "http://1.ingress-test.com/test").Through(ipUrl).HasStatusCode(200),
+				url.Expect("GET", "http://1.ingress-test.com/other/deep").Through(ipUrl).HasStatusCode(200),
+				url.Expect("GET", "http://1.ingress-test.com/").Through(ipUrl).HasStatusCode(503),
+				url.Expect("GET", "http://2.ingress-test.com/").Through(ipUrl).HasStatusCode(200),
+				url.Expect("GET", "https://3.ingress-test.com/").Through(ipUrl).SkipTLSVerification().HasStatusCode(200),
+				url.Expect("GET", "http://3.ingress-test.com/").Through(ipUrl).RedirectsTo("https://3.ingress-test.com/", http.StatusFound),
 			)
 		})
 	})

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")
@@ -142,7 +142,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")
@@ -208,7 +208,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")
@@ -241,6 +241,8 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 })
 
 func waitForRouterOKResponseExec(ns, execPodName, url, host string, timeoutSeconds int) error {
+	// bracket IPv6 IPs when used as URI
+	host = exutil.IPUrl(host)
 	cmd := fmt.Sprintf(`
 		set -e
 		pass=%[4]d

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -91,7 +91,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
@@ -137,7 +137,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 			pattern := "%s-%s.myapps.mycompany.com"
 
 			g.By("waiting for the healthz endpoint to respond")
@@ -203,7 +203,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 			pattern := "%s-%s.apps.veto.test"
 
 			g.By("waiting for the healthz endpoint to respond")

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")
@@ -142,7 +142,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")
@@ -208,7 +208,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -82,7 +82,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -86,7 +86,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -86,7 +86,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -359,7 +359,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -363,7 +363,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			host := "weighted.example.com"

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -363,7 +363,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]",
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
-			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, exutil.IPUrl(routerIP), changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPod.Name, healthzURI, routerIP, changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			host := "weighted.example.com"

--- a/test/extended/util/net.go
+++ b/test/extended/util/net.go
@@ -1,0 +1,26 @@
+package util
+
+// This is copied from go/src/internal/bytealg, which includes versions
+// optimized for various platforms.  Those optimizations are elided here so we
+// don't have to maintain them.
+func IndexByteString(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// IPUrl safely converts a bare IPv4 or IPv6 into URL form with brackets
+//
+// This is copied from net.JoinHostPort, but without the port
+// Use  net.JoinHostPort if you have host and port.
+func IPUrl(host string) string {
+	// We assume that host is a literal IPv6 address if host has
+	// colons.
+	if IndexByteString(host, ':') >= 0 {
+		return "[" + host + "]"
+	}
+	return host
+}

--- a/test/extended/util/net.go
+++ b/test/extended/util/net.go
@@ -18,8 +18,8 @@ func IndexByteString(s string, c byte) int {
 // Use  net.JoinHostPort if you have host and port.
 func IPUrl(host string) string {
 	// We assume that host is a literal IPv6 address if host has
-	// colons.
-	if IndexByteString(host, ':') >= 0 {
+	// colons, and isn't already bracketed.
+	if len(host) > 0 && !(host[0] == '[' && host[len(host)-1] == ']') && IndexByteString(host, ':') >= 0 {
 		return "[" + host + "]"
 	}
 	return host


### PR DESCRIPTION
Fixes for pull-ci-openshift-cluster-network-operator-master-e2e-vsphere-ovn-dualstack-primaryv6

Grep all the e2e logs with the malformed IPv6 regex
```
rg  -o '.{0,20}https?://(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])).{0,20}'
```

```
 FIRST.example.com' http://fd65:10:128:3::331/Letter\n+ code=0
 FIRST.example.com' http://fd65:10:128:3::334/Letter\n+ code=0
4ck.apps.veto.test' http://fd65:10:128:4::41b/Letter\n+ code=0
FIRST.example.com' "http://fd65:10:128:3::331/Letter" ) || rc=
FIRST.example.com' "http://fd65:10:128:3::334/Letter" ) || rc=
apps.mycompany.com' http://fd65:10:128:3::2e1/Letter\n+ code=0
ck.apps.veto.test' "http://fd65:10:128:4::41b/Letter" ) || rc=
pps.mycompany.com' "http://fd65:10:128:3::2e1/Letter" ) || rc=
ster.openshift.com' http://fd65:a1a8:60ad:1207::a\n+ code=000\n+ rc=
ster.openshift.com' https://fd65:172:16::2837\n+ code=000\n+
ter.openshift.com' "http://fd65:a1a8:60ad:1207::a" ) || rc=$?
ter.openshift.com' "https://fd65:172:16::2837" ) || rc=$?
```

