### PR TITLE
TRT-1445: Monitor test hangs during interrupt handling

### DIFF
--- a/pkg/monitortestframework/impl.go
+++ b/pkg/monitortestframework/impl.go
@@ -79,7 +79,7 @@ func (r *monitorTestRegistry) ListMonitorTests() sets.String {
 
 func (r *monitorTestRegistry) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) ([]*junitapi.JUnitTestCase, error) {
 	wg := sync.WaitGroup{}
-	junitCh := make(chan *junitapi.JUnitTestCase, len(r.monitorTests))
+	junitCh := make(chan *junitapi.JUnitTestCase, 2*len(r.monitorTests))
 	errCh := make(chan error, len(r.monitorTests))
 
 	for i := range r.monitorTests {
@@ -148,7 +148,7 @@ func (r *monitorTestRegistry) StartCollection(ctx context.Context, adminRESTConf
 func (r *monitorTestRegistry) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
 	wg := sync.WaitGroup{}
 	intervalsCh := make(chan monitorapi.Intervals, len(r.monitorTests))
-	junitCh := make(chan []*junitapi.JUnitTestCase, 2*len(r.monitorTests))
+	junitCh := make(chan []*junitapi.JUnitTestCase, 3*len(r.monitorTests))
 	errCh := make(chan error, len(r.monitorTests))
 
 	for i := range r.monitorTests {


### PR DESCRIPTION
This problem is caused by sending to a channel (junitch) that is full. That blocked the code from finishing up.

The junitch was created with a fix limit (2*len(monitortest) in the case of CollectData). It was not expected to create more than 2 junit per monitortest. But flake case is added, one monitortest could potentially add three junit (one created by the monitor test, one for a failure and one for a success) to the channel. The channel is not processed until all monitor tests finished collecting data. Therefore, some monitortest got stuck with a full junitch and blocked.






