### PR TITLE
TRT-1493: Add monitortest for cloud function on aws

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -3,6 +3,7 @@ package defaultmonitortests
 import (
 	"fmt"
 
+	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalawscloudservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/watchrequestcountscollector"
 	"github.com/sirupsen/logrus"
@@ -112,6 +113,7 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 	monitorTestRegistry.AddMonitorTestOrDie("alert-summary-serializer", "Test Framework", alertanalyzer.NewAlertSummarySerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("external-service-availability", "Test Framework", disruptionexternalservicemonitoring.NewAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("external-gcp-cloud-service-availability", "Test Framework", disruptionexternalgcpcloudservicemonitoring.NewCloudAvailabilityInvariant())
+	monitorTestRegistry.AddMonitorTestOrDie("external-aws-cloud-service-availability", "Test Framework", disruptionexternalawscloudservicemonitoring.NewCloudAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("pathological-event-analyzer", "Test Framework", pathologicaleventanalyzer.NewAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("disruption-summary-serializer", "Test Framework", disruptionserializer.NewDisruptionSummarySerializer())
 

--- a/pkg/monitortests/testframework/disruptionexternalawscloudservicemonitoring/cloudmonitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalawscloudservicemonitoring/cloudmonitortest.go
@@ -1,0 +1,91 @@
+package disruptionexternalawscloudservicemonitoring
+
+import (
+	"context"
+	_ "embed"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+const (
+	newCloudConnectionTestName    = "[sig-trt] disruption/aws-network-liveness connection/new should be available throughout the test"
+	reusedCloudConnectionTestName = "[sig-trt] disruption/aws-network-liveness connection/reused should be available throughout the test"
+
+	// Load balancer URL
+	externalServiceURL = "http://trt-openshift-tests-endpoint-lb-1161093811.us-east-1.elb.amazonaws.com/health"
+)
+
+type cloudAvailability struct {
+	disruptionChecker  *disruptionlibrary.Availability
+	notSupportedReason error
+	suppressJunit      bool
+}
+
+func NewCloudAvailabilityInvariant() monitortestframework.MonitorTest {
+	return &cloudAvailability{}
+}
+
+func NewRecordCloudAvailabilityOnly() monitortestframework.MonitorTest {
+	return &cloudAvailability{
+		suppressJunit: true,
+	}
+}
+
+func (w *cloudAvailability) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	newConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
+		externalServiceURL,
+		"aws-network-liveness-new-connections",
+		"",
+		monitorapi.NewConnectionType)
+
+	reusedConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
+		externalServiceURL,
+		"aws-network-liveness-reused-connections",
+		"",
+		monitorapi.ReusedConnectionType)
+
+	w.disruptionChecker = disruptionlibrary.NewAvailabilityInvariant(
+		newCloudConnectionTestName, reusedCloudConnectionTestName,
+		newConnectionDisruptionSampler, reusedConnectionDisruptionSampler,
+	)
+	if err := w.disruptionChecker.StartCollection(ctx, adminRESTConfig, recorder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *cloudAvailability) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
+	}
+	return w.disruptionChecker.CollectData(ctx)
+}
+
+func (w *cloudAvailability) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, w.notSupportedReason
+}
+
+func (w *cloudAvailability) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	if w.suppressJunit {
+		return nil, nil
+	}
+
+	return nil, w.notSupportedReason
+}
+
+func (w *cloudAvailability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return w.notSupportedReason
+}
+
+func (w *cloudAvailability) Cleanup(ctx context.Context) error {
+	return w.notSupportedReason
+}


### PR DESCRIPTION
TODO:

- [x] Ensure metal sdn test does not have disruption (this test should be skipped on metal)
- [x] Confirm 3 non-metal jobs have 0s disruption on aws-network-liveness

Hit an endpoint (on a VM behind a load-balancer in aws) to test aws connectivity during test runs in a way that (attempts to) mimic pods in an Openshift cluster.  This way we can compare disruption problems noted in TRT-1466.

Here's a test to see if the LB is working on AWS (should return 200):

```bash
url=http://trt-openshift-tests-endpoint-lb-1161093811.us-east-1.elb.amazonaws.com/health
echo $(curl -sk -w "%{http_code}" -o response.txt -H "Audit-ID: 12345" "$url")
```

The VM/LB has been up for days in the TRT aws account:

```
$ date
Sun Feb 18 19:28:25 EST 2024
$ url=http://trt-openshift-tests-endpoint-lb-1161093811.us-east-1.elb.amazonaws.com/health
$ echo $(curl -sk -w "%{http_code}" -o response.txt -H "Audit-ID: 12345" "$url")
200
```