### PR TITLE
TRT-1494: Add monitortest for cloud function on azure

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalawscloudservicemonitoring"
+	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalazurecloudservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/watchrequestcountscollector"
 	"github.com/sirupsen/logrus"
@@ -114,6 +115,7 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 	monitorTestRegistry.AddMonitorTestOrDie("external-service-availability", "Test Framework", disruptionexternalservicemonitoring.NewAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("external-gcp-cloud-service-availability", "Test Framework", disruptionexternalgcpcloudservicemonitoring.NewCloudAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("external-aws-cloud-service-availability", "Test Framework", disruptionexternalawscloudservicemonitoring.NewCloudAvailabilityInvariant())
+	monitorTestRegistry.AddMonitorTestOrDie("external-azure-cloud-service-availability", "Test Framework", disruptionexternalazurecloudservicemonitoring.NewCloudAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("pathological-event-analyzer", "Test Framework", pathologicaleventanalyzer.NewAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("disruption-summary-serializer", "Test Framework", disruptionserializer.NewDisruptionSummarySerializer())
 

--- a/pkg/monitortests/testframework/disruptionexternalazurecloudservicemonitoring/cloudmonitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalazurecloudservicemonitoring/cloudmonitortest.go
@@ -22,7 +22,7 @@ const (
 	reusedCloudConnectionTestName = "[sig-trt] disruption/azure-network-liveness connection/reused should be available throughout the test"
 
 	// Load balancer URL
-	externalServiceURL = "http://20.102.111.171/health"
+	externalServiceURL = "http://20.127.186.25/health"
 )
 
 type cloudAvailability struct {

--- a/pkg/monitortests/testframework/disruptionexternalazurecloudservicemonitoring/cloudmonitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalazurecloudservicemonitoring/cloudmonitortest.go
@@ -19,11 +19,8 @@ const (
 	newCloudConnectionTestName    = "[sig-trt] disruption/azure-network-liveness connection/new should be available throughout the test"
 	reusedCloudConnectionTestName = "[sig-trt] disruption/azure-network-liveness connection/reused should be available throughout the test"
 
-	// Cloud function URL
-	//externalServiceURL = "https://us-east4-openshift-gce-devel.cloudfunctions.net/openshift-tests-endpoint"
-
 	// Load balancer URL
-	externalServiceURL = "http://52.168.131.231/health"
+	externalServiceURL = "http://20.102.111.171/health"
 )
 
 type cloudAvailability struct {

--- a/pkg/monitortests/testframework/disruptionexternalazurecloudservicemonitoring/cloudmonitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalazurecloudservicemonitoring/cloudmonitortest.go
@@ -1,0 +1,94 @@
+package disruptionexternalazurecloudservicemonitoring
+
+import (
+	"context"
+	_ "embed"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+const (
+	newCloudConnectionTestName    = "[sig-trt] disruption/azure-network-liveness connection/new should be available throughout the test"
+	reusedCloudConnectionTestName = "[sig-trt] disruption/azure-network-liveness connection/reused should be available throughout the test"
+
+	// Cloud function URL
+	//externalServiceURL = "https://us-east4-openshift-gce-devel.cloudfunctions.net/openshift-tests-endpoint"
+
+	// Load balancer URL
+	externalServiceURL = "http://52.168.131.231/health"
+)
+
+type cloudAvailability struct {
+	disruptionChecker  *disruptionlibrary.Availability
+	notSupportedReason error
+	suppressJunit      bool
+}
+
+func NewCloudAvailabilityInvariant() monitortestframework.MonitorTest {
+	return &cloudAvailability{}
+}
+
+func NewRecordCloudAvailabilityOnly() monitortestframework.MonitorTest {
+	return &cloudAvailability{
+		suppressJunit: true,
+	}
+}
+
+func (w *cloudAvailability) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	newConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
+		externalServiceURL,
+		"azure-network-liveness-new-connections",
+		"",
+		monitorapi.NewConnectionType)
+
+	reusedConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
+		externalServiceURL,
+		"azure-network-liveness-reused-connections",
+		"",
+		monitorapi.ReusedConnectionType)
+
+	w.disruptionChecker = disruptionlibrary.NewAvailabilityInvariant(
+		newCloudConnectionTestName, reusedCloudConnectionTestName,
+		newConnectionDisruptionSampler, reusedConnectionDisruptionSampler,
+	)
+	if err := w.disruptionChecker.StartCollection(ctx, adminRESTConfig, recorder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *cloudAvailability) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
+	}
+	return w.disruptionChecker.CollectData(ctx)
+}
+
+func (w *cloudAvailability) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, w.notSupportedReason
+}
+
+func (w *cloudAvailability) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	if w.suppressJunit {
+		return nil, nil
+	}
+
+	return nil, w.notSupportedReason
+}
+
+func (w *cloudAvailability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return w.notSupportedReason
+}
+
+func (w *cloudAvailability) Cleanup(ctx context.Context) error {
+	return w.notSupportedReason
+}


### PR DESCRIPTION
Hit an endpoint (on a VM behind a load-balancer in azure) to test azure connectivity during test runs in a way that (attempts to) mimic pods in an Openshift cluster. This way we can compare disruption problems noted in TRT-1466.

This is just a test using an LB/VM in a personal Azure account.

TODO:

- [x] Move the endpoint to an LB/VM on an Openshift owned Azure account.
- [x] Ensure metal sdn test does not have disruption (this test should be skipped on metal)
- [x] Confirm 3 non-metal jobs have 0s disruption on aws-network-liveness

The new resource group is called `do-not-delete-trt-liveness` at portal.azure.com.