### PR TITLE
TRT-1477: update IP for new gcp LB

### DIFF
--- a/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring/cloudmonitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring/cloudmonitortest.go
@@ -23,7 +23,7 @@ const (
 	//externalServiceURL = "https://us-east4-openshift-gce-devel.cloudfunctions.net/openshift-tests-endpoint"
 
 	// Load balancer URL
-	externalServiceURL = "http://34.150.152.77/health"
+	externalServiceURL = "http://35.212.104.31/health"
 )
 
 type cloudAvailability struct {


### PR DESCRIPTION
Just updating to a new IP given this is a new load balancer and the previous one's IP was reaped.

This LB worked on Feb 11, 2024 8:14pm EST

```
$ url=http://35.212.104.31/health
$ echo $(curl -sk -w "%{http_code}" -o response.txt -H "Audit-ID: 12345" "$url")
200```
