### PR TITLE
OCPBUGS-29858: Only extract node role from properly formatted node-role label

### DIFF
--- a/pkg/monitortests/node/watchnodes/node.go
+++ b/pkg/monitortests/node/watchnodes/node.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 
 	corev1 "k8s.io/api/core/v1"
@@ -205,11 +207,16 @@ func startNodeMonitoring(ctx context.Context, m monitorapi.RecorderWriter, clien
 }
 
 func nodeRoles(node *corev1.Node) string {
-	const roleLabel = "node-role.kubernetes.io"
+	const roleLabel = "node-role.kubernetes.io/"
 	var roles []string
 	for label := range node.Labels {
 		if strings.Contains(label, roleLabel) {
-			roles = append(roles, label[len(roleLabel)+1:])
+			role := label[len(roleLabel):]
+			if role == "" {
+				logrus.Warningf("ignoring blank role label %s", roleLabel)
+				continue
+			}
+			roles = append(roles, role)
 		}
 	}
 


### PR DESCRIPTION
The convention is a format like `node-role.kubernetes.io/role: ""`, not `node-role.kubernetes.io: role`, however ROSA uses the latter format to indicate the `infra` role. This changes the node watch code to ignore it, as well as other potential variations like `node-role.kubernetes.io/`.

The current code panics when run against a ROSA cluster:

```
  E0209 18:10:55.533265      78 runtime.go:79] Observed a panic: runtime.boundsError{x:24, y:23, signed:true, code:0x3} (runtime error: slice bounds out of range [24:23])
  goroutine 233 [running]:
  k8s.io/apimachinery/pkg/util/runtime.logPanic({0x7a71840?, 0xc0018e2f48})
  	k8s.io/apimachinery@v0.27.2/pkg/util/runtime/runtime.go:75 +0x99
  k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x1000251f9fe?})
  	k8s.io/apimachinery@v0.27.2/pkg/util/runtime/runtime.go:49 +0x75
  panic({0x7a71840, 0xc0018e2f48})
  	runtime/panic.go:884 +0x213
  github.com/openshift/origin/pkg/monitortests/node/watchnodes.nodeRoles(0x7ecd7b3?)
  	github.com/openshift/origin/pkg/monitortests/node/watchnodes/node.go:187 +0x1e5
  github.com/openshift/origin/pkg/monitortests/node/watchnodes.startNodeMonitoring.func1(0
```