### PR TITLE
AUTH-483: Add a monitor test to check the existence of required-scc annotation in platform workloads

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/monitortests/authentication/legacyauthenticationmonitortests"
+	"github.com/openshift/origin/pkg/monitortests/authentication/requiredsccmonitortests"
 	azuremetrics "github.com/openshift/origin/pkg/monitortests/cloud/azure/metrics"
 	"github.com/openshift/origin/pkg/monitortests/clusterversionoperator/legacycvomonitortests"
 	"github.com/openshift/origin/pkg/monitortests/clusterversionoperator/operatorstateanalyzer"
@@ -140,6 +141,7 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-cvo-invariants", "Cluster Version Operator", legacycvomonitortests.NewLegacyTests())
 	monitorTestRegistry.AddMonitorTestOrDie("operator-state-analyzer", "Cluster Version Operator", operatorstateanalyzer.NewAnalyzer())
+	monitorTestRegistry.AddMonitorTestOrDie("required-scc-annotation-checker", "Cluster Version Operator", requiredsccmonitortests.NewAnalyzer())
 
 	monitorTestRegistry.AddMonitorTestOrDie("etcd-log-analyzer", "etcd", etcdloganalyzer.NewEtcdLogAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-etcd-invariants", "etcd", legacyetcdmonitortests.NewLegacyTests())

--- a/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
+++ b/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
@@ -1,0 +1,149 @@
+package requiredsccmonitortests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var defaultSCCs = sets.NewString(
+	"anyuid",
+	"hostaccess",
+	"hostmount-anyuid",
+	"hostnetwork",
+	"hostnetwork-v2",
+	"nonroot",
+	"nonroot-v2",
+	"privileged",
+	"restricted",
+	"restricted-v2",
+)
+
+type requiredSCCAnnotationChecker struct {
+	kubeClient kubernetes.Interface
+}
+
+func NewAnalyzer() monitortestframework.MonitorTest {
+	return &requiredSCCAnnotationChecker{}
+}
+
+func (w *requiredSCCAnnotationChecker) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	var err error
+	w.kubeClient, err = kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *requiredSCCAnnotationChecker) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if w.kubeClient == nil {
+		return nil, nil, nil
+	}
+
+	namespaces, err := w.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	junits := []*junitapi.JUnitTestCase{}
+	for _, ns := range namespaces.Items {
+		if !strings.HasPrefix(ns.Name, "openshift") && !strings.HasPrefix(ns.Name, "kube-") && ns.Name != "default" {
+			continue
+		}
+
+		pods, err := w.kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		failures := make([]string, 0)
+		for _, pod := range pods.Items {
+			if _, exists := pod.Annotations[securityv1.RequiredSCCAnnotation]; exists {
+				continue
+			}
+
+			suggestedSCC := suggestSCC(&pod)
+			owners := ownerReferences(&pod)
+			failures = append(failures, fmt.Sprintf("annotation missing from pod '%s'%s; %s", pod.Name, owners, suggestedSCC))
+		}
+
+		testName := fmt.Sprintf("[sig-auth] all workloads in ns/%s must set the '%s' annotation", ns.Name, securityv1.RequiredSCCAnnotation)
+		if len(failures) == 0 {
+			junits = append(junits, &junitapi.JUnitTestCase{Name: testName})
+			continue
+		}
+
+		failureMsg := strings.Join(failures, "\n")
+		junits = append(junits,
+			&junitapi.JUnitTestCase{
+				Name:          testName,
+				SystemOut:     failureMsg,
+				FailureOutput: &junitapi.FailureOutput{Output: failureMsg},
+			},
+
+			// add a successful test with the same name to cause a flake
+			&junitapi.JUnitTestCase{
+				Name: testName,
+			},
+		)
+	}
+
+	return nil, junits, nil
+}
+
+func (w *requiredSCCAnnotationChecker) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+func (w *requiredSCCAnnotationChecker) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (w *requiredSCCAnnotationChecker) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (w *requiredSCCAnnotationChecker) Cleanup(ctx context.Context) error {
+	return nil
+}
+
+// suggestSCC suggests the assigned SCC only if it belongs to the default set of SCCs
+// pods in runlevel 0/1 namespaces won't have any assigned SCC as SCC admission is disabled
+func suggestSCC(pod *v1.Pod) string {
+	if len(pod.Annotations[securityv1.ValidatedSCCAnnotation]) == 0 {
+		return "cannot suggest required-scc, no validated SCC on pod"
+	}
+
+	if defaultSCCs.Has(pod.Annotations[securityv1.ValidatedSCCAnnotation]) {
+		return fmt.Sprintf("suggested required-scc: '%s'", pod.Annotations[securityv1.ValidatedSCCAnnotation])
+	}
+
+	return "cannot suggest required-scc, validated SCC is custom"
+}
+
+func ownerReferences(pod *v1.Pod) string {
+	ownerRefs := make([]string, len(pod.OwnerReferences))
+	for i, or := range pod.OwnerReferences {
+		ownerRefs[i] = fmt.Sprintf("%s/%s", strings.ToLower(or.Kind), or.Name)
+	}
+
+	if len(ownerRefs) > 0 {
+		return fmt.Sprintf(" (owners: %s)", strings.Join(ownerRefs, ", "))
+	}
+
+	return ""
+}


### PR DESCRIPTION
This PR adds a monitor test that requires the existence of the `openshift.io/required-scc` annotation on all platform workloads (workloads that belong to `openshift*`, `kube-*` and `default` namespaces).

If the annotation is missing, the test suggests an SCC to be pinned using the annotation, based on the following:
- suggested SCC is the one that was used to admit the workload, provided that it is a default SCC and not a custom one
- if it's a custom SCC, the test cannot suggest any; the developer must determine the appropriate SCC
- since SCC admission is disabled for runlevel 0/1 namespaces, the test won't suggest any SCC for their workloads; the developer must determine the appropriate one

At its current state, the test is implemented as a flake, until we've pinned SCCs to all platform workloads (see https://issues.redhat.com/browse/AUTH-482).