### PR TITLE
OCPBUGS-48445: Ignore an error intentionally generated by a test case

### DIFF
--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -67,6 +67,7 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 		{by: " by ovn default network ready", substring: "have you checked that your default network is ready? still waiting for readinessindicatorfile"},
 		{by: " by adding pod to network", substring: "failed (add)"},
 		{by: " by initializing docker source", substring: `can't talk to a V1 container registry`},
+		{by: " by binding hostport", substring: "failed to add hostport"},
 		{by: " by other", substring: " "}, // always matches
 	}
 
@@ -170,6 +171,13 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 				flakes = append(flakes, fmt.Sprintf("%v - i/o timeout common flake when pinging container registry on azure - %v", event.Locator.OldLocator(), event.Message.OldMessage()))
 				continue
 			}
+		}
+		if strings.Contains(event.Message.HumanMessage, "cannot open hostport 21017") {
+			// The "Should recreate evicted statefulset" test intentionally
+			// causes a hostport conflict and then ensures that it gets
+			// resolved correctly when the conflict goes away, but in some
+			// cases, it will transiently hit this error.
+			continue
 		}
 
 		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.Locator)


### PR DESCRIPTION
There's a statefulset test that does:
- create a pod that binds hostport 21017
- create a StatefulSet that also binds that hostport
- ensure that the StatefulSet can't be deployed to the node with the pod from the first step
- kill the conflicting pod
- ensure that the StatefulSet now gets deployed to that node

The problem is that apparently it's possible for the new StatefulSet pod to get deployed before the conflicting pod is fully cleaned up, in which case the first attempt at CreatePodSandBox will fail because it can't bind the hostport, but then the second attempt a bit later will succeed, and the e2e test doesn't even notice anything unusual happened. But openshift-tests notices the CreatePodSandBox failure and complains (eg, https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-network-operator/2262/pull-ci-openshift-cluster-network-operator-master-e2e-metal-ipi-ovn-ipv6/1756963861908426752)

This fixes us to ignore that specific event. (I also added a new categorization for "pods should successfully create sandboxes" errors.)