### PR TITLE
TRT-1506: Restore the tests looking for excess single-second disruptions

### DIFF
--- a/pkg/cmd/openshift-tests/dev/dev.go
+++ b/pkg/cmd/openshift-tests/dev/dev.go
@@ -1,7 +1,6 @@
 package dev
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -11,6 +10,7 @@ import (
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 	"github.com/openshift/origin/pkg/monitortestlibrary/allowedalerts"
 	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+	"github.com/openshift/origin/pkg/monitortests/network/legacynetworkmonitortests"
 	"github.com/openshift/origin/pkg/monitortests/testframework/legacytestframeworkmonitortests"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -150,10 +150,7 @@ a running cluster.
 `),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if true {
-				return fmt.Errorf("this command got nerfed")
-			}
-			logrus.Info("running disruption invariant tests")
+			logrus.Info("running some disruption invariant tests (where possible)")
 
 			logrus.WithField("intervalsFile", opts.intervalsFile).Info("loading e2e intervals")
 			intervals, err := readIntervalsFromFile(opts.intervalsFile)
@@ -163,6 +160,17 @@ a running cluster.
 			logrus.Infof("loaded %d intervals", len(intervals))
 
 			logrus.Info("running tests")
+			junits := legacynetworkmonitortests.TestMultipleSingleSecondDisruptions(intervals)
+			for _, junit := range junits {
+				if junit.FailureOutput != nil {
+					logrus.Errorf("FAIL: %s", junit.Name)
+					logrus.Error(junit.FailureOutput.Output)
+				} else {
+					logrus.Infof("PASS: %s", junit.Name)
+				}
+			}
+
+			logrus.Warn("this command was nerfed, running only tests devs decide to include, not all disruption tests at this time")
 
 			return nil
 		},

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -1,7 +1,6 @@
 package monitorapi
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -22,10 +21,6 @@ func E2ETestFromLocator(l Locator) (string, bool) {
 	return test, ok
 }
 
-func NodeLocator(testName string) string {
-	return fmt.Sprintf("node/%v", testName)
-}
-
 func IsNode(locator string) bool {
 	_, ret := NodeFromLocator(locator)
 	return ret
@@ -34,10 +29,6 @@ func IsNode(locator string) bool {
 func NodeFromLocator(locator string) (string, bool) {
 	ret := NodeFrom(LocatorParts(locator))
 	return ret, len(ret) > 0
-}
-
-func OperatorLocator(operatorName string) string {
-	return fmt.Sprintf("clusteroperator/%v", operatorName)
 }
 
 func OperatorFromLocator(locator string) (string, bool) {
@@ -99,7 +90,7 @@ func AlertFrom(locatorParts map[string]string) string {
 }
 
 func ThisDisruptionInstanceFrom(locatorParts map[string]string) string {
-	return locatorParts[string(LocatorDisruptionKey)]
+	return locatorParts[string(LocatorBackendDisruptionNameKey)]
 }
 
 func BackendDisruptionNameFromLocator(locator Locator) string {
@@ -113,18 +104,6 @@ func BackendDisruptionNameFrom(locatorParts map[string]string) string {
 
 func DisruptionConnectionTypeFrom(locatorParts map[string]string) BackendConnectionType {
 	return BackendConnectionType(locatorParts[string(LocatorConnectionKey)])
-}
-
-func DisruptionLoadBalancerTypeFrom(locatorParts map[string]string) string {
-	return locatorParts["load-balancer"]
-}
-
-func DisruptionProtocolFrom(locatorParts map[string]string) string {
-	return locatorParts["protocol"]
-}
-
-func DisruptionTargetAPIFrom(locatorParts map[string]string) string {
-	return locatorParts["target"]
 }
 
 func IsEventForLocator(locator string) EventIntervalMatchesFunc {

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -534,6 +534,15 @@ func IsInE2ENamespace(eventInterval Interval) bool {
 	return false
 }
 
+func IsForDisruptionBackend(backend string) EventIntervalMatchesFunc {
+	return func(eventInterval Interval) bool {
+		if eventInterval.StructuredLocator.Keys[LocatorBackendDisruptionNameKey] == backend {
+			return true
+		}
+		return false
+	}
+}
+
 func IsInNamespaces(namespaces sets.String) EventIntervalMatchesFunc {
 	return func(eventInterval Interval) bool {
 		// For new, structured locators:

--- a/pkg/monitortests/network/legacynetworkmonitortests/monitortest.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/monitortest.go
@@ -42,7 +42,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	junits = append(junits, testNoOVSVswitchdUnreasonablyLongPollIntervals(finalIntervals)...)
 	junits = append(junits, testPodIPReuse(finalIntervals)...)
 	junits = append(junits, testErrorUpdatingEndpointSlices(finalIntervals)...)
-	junits = append(junits, testMultipleSingleSecondDisruptions(finalIntervals)...)
+	junits = append(junits, TestMultipleSingleSecondDisruptions(finalIntervals)...)
 	junits = append(junits, testDNSOverlapDisruption(finalIntervals)...)
 	junits = append(junits, testNoTooManyNetlinkEventLogs(finalIntervals)...)
 


### PR DESCRIPTION
These were mistakenly broken in the 4.14 release timeframe during the
monitortest refactor. The format of disruption intervals changed and the
way this test was looking for backend names was then broken. I've
modified the code to now better detect all disruption backends, pick the
ones we want to run these tests on (ingress and api backends), and fixed
the ordering of the case logic which was inverted and the > 50 check
could never run, because the > 20 would match first.

Dev command for running invariants against an intervals file is
partially restored, for these tests only.

`./openshift-tests dev  run-disruption-invariants --intervals-file e2e-timelines_spyglass_20240209-082358.json`

Bringing back as they will help us hunt for spatter disruption on gcp jobs.