### PR TITLE
TRT-1493: Re-introduce the GCP liveness endpoint test

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -3,6 +3,7 @@ package defaultmonitortests
 import (
 	"fmt"
 
+	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/watchrequestcountscollector"
 	"github.com/sirupsen/logrus"
 
@@ -110,6 +111,7 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 
 	monitorTestRegistry.AddMonitorTestOrDie("alert-summary-serializer", "Test Framework", alertanalyzer.NewAlertSummarySerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("external-service-availability", "Test Framework", disruptionexternalservicemonitoring.NewAvailabilityInvariant())
+	monitorTestRegistry.AddMonitorTestOrDie("external-gcp-cloud-service-availability", "Test Framework", disruptionexternalgcpcloudservicemonitoring.NewCloudAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("pathological-event-analyzer", "Test Framework", pathologicaleventanalyzer.NewAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("disruption-summary-serializer", "Test Framework", disruptionserializer.NewDisruptionSummarySerializer())
 

--- a/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring/cloudmonitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring/cloudmonitortest.go
@@ -23,7 +23,7 @@ const (
 	//externalServiceURL = "https://us-east4-openshift-gce-devel.cloudfunctions.net/openshift-tests-endpoint"
 
 	// Load balancer URL
-	externalServiceURL = "http://35.212.77.212/health"
+	externalServiceURL = "http://35.212.33.188/health"
 )
 
 type cloudAvailability struct {

--- a/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring/cloudmonitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring/cloudmonitortest.go
@@ -23,7 +23,7 @@ const (
 	//externalServiceURL = "https://us-east4-openshift-gce-devel.cloudfunctions.net/openshift-tests-endpoint"
 
 	// Load balancer URL
-	externalServiceURL = "http://35.212.104.31/health"
+	externalServiceURL = "http://35.212.77.212/health"
 )
 
 type cloudAvailability struct {

--- a/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring/cloudmonitortest.go
+++ b/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring/cloudmonitortest.go
@@ -1,0 +1,94 @@
+package disruptionexternalgcpcloudservicemonitoring
+
+import (
+	"context"
+	_ "embed"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/monitor/backenddisruption"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+const (
+	newCloudConnectionTestName    = "[sig-trt] disruption/gcp-network-liveness connection/new should be available throughout the test"
+	reusedCloudConnectionTestName = "[sig-trt] disruption/gcp-network-liveness connection/reused should be available throughout the test"
+
+	// Cloud function URL
+	//externalServiceURL = "https://us-east4-openshift-gce-devel.cloudfunctions.net/openshift-tests-endpoint"
+
+	// Load balancer URL
+	externalServiceURL = "http://35.212.104.31/health"
+)
+
+type cloudAvailability struct {
+	disruptionChecker  *disruptionlibrary.Availability
+	notSupportedReason error
+	suppressJunit      bool
+}
+
+func NewCloudAvailabilityInvariant() monitortestframework.MonitorTest {
+	return &cloudAvailability{}
+}
+
+func NewRecordCloudAvailabilityOnly() monitortestframework.MonitorTest {
+	return &cloudAvailability{
+		suppressJunit: true,
+	}
+}
+
+func (w *cloudAvailability) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	newConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
+		externalServiceURL,
+		"gcp-network-liveness-new-connections",
+		"",
+		monitorapi.NewConnectionType)
+
+	reusedConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
+		externalServiceURL,
+		"gcp-network-liveness-reused-connections",
+		"",
+		monitorapi.ReusedConnectionType)
+
+	w.disruptionChecker = disruptionlibrary.NewAvailabilityInvariant(
+		newCloudConnectionTestName, reusedCloudConnectionTestName,
+		newConnectionDisruptionSampler, reusedConnectionDisruptionSampler,
+	)
+	if err := w.disruptionChecker.StartCollection(ctx, adminRESTConfig, recorder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *cloudAvailability) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
+	}
+	return w.disruptionChecker.CollectData(ctx)
+}
+
+func (w *cloudAvailability) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, w.notSupportedReason
+}
+
+func (w *cloudAvailability) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	if w.suppressJunit {
+		return nil, nil
+	}
+
+	return nil, w.notSupportedReason
+}
+
+func (w *cloudAvailability) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return w.notSupportedReason
+}
+
+func (w *cloudAvailability) Cleanup(ctx context.Context) error {
+	return w.notSupportedReason
+}


### PR DESCRIPTION
Revert of this revert: https://github.com/openshift/origin/pull/28586
Plus a commit to add the new GCP LB -- this one should not remain there.

- TODO
  - [x] confirm there is no junit for the endpoint liveness test
    - I do NOT see a test in the Passed section on the prow job for `gcp-network-liveness` (but I also didn't see one in the tests for https://github.com/openshift/origin/pull/28571)
  - [x] run /payload to ensure we don't take out payloads