### PR TITLE
NO-JIRA: Pass tail flag in adm node-logs to reduce log size

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 			}
 		}
 
-		o.Expect(oc.Run("adm", "node-logs").Args(randomNode(oc), "--boot=0").Execute()).To(o.Succeed())
+		o.Expect(oc.Run("adm", "node-logs").Args(randomNode(oc), "--boot=0", "--tail=100").Execute()).To(o.Succeed())
 
 		o.Expect(oc.Run("adm", "node-logs").Args(randomNode(oc), "--since=-2m", "--until=-1m").Execute()).To(o.Succeed())
 


### PR DESCRIPTION
This PR adds `--tail=100` flag in `adm node-logs --boot=0` test to reduce the generated log size that
may put a pressure on CI pod's memory.