### PR TITLE
WRKLDS-1076: oc idle: Check idling annotation in services not endpoints

### DIFF
--- a/test/extended/cli/idle.go
+++ b/test/extended/cli/idle.go
@@ -116,7 +116,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring(expectedOutput))
 
-		out, err = oc.Run("get").Args("endpoints", "idling-echo", idledTemplate, "--output=go-template").Output()
+		out, err = oc.Run("get").Args("service", "idling-echo", idledTemplate, "--output=go-template").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).NotTo(o.BeEmpty())
 	})
@@ -126,7 +126,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring(expectedOutput))
 
-		out, err = oc.Run("get").Args("endpoints", "idling-echo", idledTemplate, "--output=go-template").Output()
+		out, err = oc.Run("get").Args("service", "idling-echo", idledTemplate, "--output=go-template").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).NotTo(o.BeEmpty())
 	})
@@ -136,7 +136,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring(expectedOutput))
 
-		out, err = oc.Run("get").Args("endpoints", "idling-echo", idledTemplate, "--output=go-template").Output()
+		out, err = oc.Run("get").Args("service", "idling-echo", idledTemplate, "--output=go-template").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).NotTo(o.BeEmpty())
 	})

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -130,20 +130,20 @@ func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]s
 
 	g.By("Fetching the service and checking the annotations are present")
 	serviceName := resources["service"][0]
-	endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(context.Background(), serviceName, metav1.GetOptions{})
+	services, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(context.Background(), serviceName, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	o.Expect(endpoints.Annotations).To(o.HaveKey(unidlingapi.IdledAtAnnotation))
-	o.Expect(endpoints.Annotations).To(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
+	o.Expect(services.Annotations).To(o.HaveKey(unidlingapi.IdledAtAnnotation))
+	o.Expect(services.Annotations).To(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
 
 	g.By("Checking the idled-at time")
-	idledAtAnnotation := endpoints.Annotations[unidlingapi.IdledAtAnnotation]
+	idledAtAnnotation := services.Annotations[unidlingapi.IdledAtAnnotation]
 	idledAtTime, err := time.Parse(time.RFC3339, idledAtAnnotation)
 	o.Expect(err).ToNot(o.HaveOccurred())
 	o.Expect(idledAtTime).To(o.BeTemporally("~", time.Now(), 5*time.Minute))
 
 	g.By("Checking the idle targets")
-	unidleTargetAnnotation := endpoints.Annotations[unidlingapi.UnidleTargetAnnotation]
+	unidleTargetAnnotation := services.Annotations[unidlingapi.UnidleTargetAnnotation]
 	unidleTargets := []unidlingapi.RecordedScaleReference{}
 	err = json.Unmarshal([]byte(unidleTargetAnnotation), &unidleTargets)
 	o.Expect(err).ToNot(o.HaveOccurred())

--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -184,21 +184,6 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 
 			var annotations map[string]string
 
-			g.By("Fetching the endpoints and checking the idle annotations are present")
-			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-				endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(context.Background(), "idle-test", metav1.GetOptions{})
-				if err != nil {
-					e2e.Logf("Error getting endpoints: %v", err)
-					return false, nil
-				}
-				annotations = endpoints.Annotations
-				_, idledAt := annotations[unidlingapi.IdledAtAnnotation]
-				_, unidleTarget := annotations[unidlingapi.UnidleTargetAnnotation]
-				return idledAt && unidleTarget, nil
-			})
-			o.Expect(err).NotTo(o.HaveOccurred(), "failed to fetch the endpoints")
-			mustVerifyIdleAnnotationValues(annotations)
-
 			g.By("Fetching the service and checking the idle annotations are present")
 			err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 				service, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(context.Background(), "idle-test", metav1.GetOptions{})


### PR DESCRIPTION
We have started fully relying on service's annotation instead of endpoints in oc idle. 

This PR is prerequisite of https://github.com/openshift/oc/pull/1692