### PR TITLE
TRT-1539: Do not let loki alerts fail tests

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -551,7 +551,8 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			}
 
 			tests := map[string]bool{
-				fmt.Sprintf(`ALERTS{alertname!~"%s",alertstate="firing",severity!="info"} >= 1`, strings.Join(allowedAlertNames, "|")): false,
+				// openshift-e2e-loki alerts should never fail this test, we've seen this happen on daemon set rollout stuck when CI loki was down.
+				fmt.Sprintf(`ALERTS{alertname!~"%s",alertstate="firing",severity!="info",namespace!="openshift-e2e-loki"} >= 1`, strings.Join(allowedAlertNames, "|")): false,
 			}
 			err := helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), tests, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
We saw yesterday with loki in full outage, this single test would fail
reporting an alert firing in openshift-e2e-loki due to daemon set
rollout stuck. Promtail pods would run but would never go ready because they
couldn't communicate with loki.

Filter out any alerts from openshift-e2e-loki in this test so we can
pass all tests even when loki is down. We were very close otherwise as
no other problems popped up.
