### PR TITLE
NO-JIRA: Handle release info output streams separately

### DIFF
--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -42,7 +42,7 @@ var _ = Describe("[sig-arch] Managed cluster", func() {
 		}
 
 		// find out the current installed release info using the temp file
-		out, err := oc.Run("adm", "release", "info").Args("--pullspecs", "-o", "json", "--registry-config", imagePullFile.Name()).Output()
+		out, _, err := oc.Run("adm", "release", "info").Args("--pullspecs", "-o", "json", "--registry-config", imagePullFile.Name()).Outputs()
 		if err != nil {
 			// TODO need to determine why release tests are not having access to read payload
 			e2e.Logf("unable to read release payload with error: %v", err)


### PR DESCRIPTION
This PR handles release info command's output streams separately instead of merging them. Because
test does not need the data in `errOut`.