### PR TITLE
OCPNODE-2099: add kube-rbac-proxy-crio toleration change

### DIFF
--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -35,6 +35,10 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 		// The kube-apiserver proxy exists only in Hypershift. It is used to proxy the kubelet->kube-apiserver connection, hence it must be a static pod
 		// which makes the kubelet add a keyless noExecution toleration, so we have to exclude it here.
 		whitelistPods.Insert("kube-apiserver-proxy")
+		// The kube-rbac-proxy-crio pod exists in the machine config operator
+		// namespace. It is a static pod which makes the kubelet add a keyless
+		// noExecution toleration, so we have to exclude it here.
+		whitelistPods.Insert("kube-rbac-proxy-crio")
 		for _, pod := range pods.Items {
 			// exclude non-control plane namespaces
 			if !hasPrefixSet(pod.Namespace, namespacePrefixes) {


### PR DESCRIPTION
`kube-rbac-proxy-crio` is a new static pod in the `openshift-machine-config-operator` namespace. Since it is a static pod, the tolerations test needs to ignore this pod due to it tolerating all taints.

```
openshift-machine-config-operator/kube-rbac-proxy-crio-ip-10-0-112-244.us-west-2.compute.internal tolerates all taints
```

### Merge information

* Allow static pod tolerations (this PR): 4.16/master : Backport to EUS 4.14
* MCO Kube-Rbac-Proxy Static pods 4.16/master : https://github.com/openshift/machine-config-operator/pull/4175 : Backport to EUS 4.14
* Create an upgrade edge after all backports merge

***After all the above backports are merged, then***

* Change the Monitoring Operator to use port 9637 (with client certificates) : https://github.com/openshift/cluster-monitoring-operator/pull/2257 : This PR is only for 4.16