### PR TITLE
MULTIARCH-4352: Censor private key from pod dump logs

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -554,6 +554,11 @@ func DumpPodLogs(pods []corev1.Pod, oc *CLI) {
 	for _, pod := range pods {
 		descOutput, err := oc.AsAdmin().Run("describe").WithoutNamespace().Args("pod/"+pod.Name, "-n", pod.Namespace).Output()
 		if err == nil {
+			if strings.Contains(descOutput, "BEGIN PRIVATE KEY") {
+				// replace private key with XXXXX string
+				re := regexp.MustCompile(`BEGIN\s+PRIVATE\s+KEY.*END\s+PRIVATE\s+KEY`)
+				descOutput = re.ReplaceAllString(descOutput, "XXXXXXXXXXXXXX")
+			}
 			e2e.Logf("Describing pod %q\n%s\n\n", pod.Name, descOutput)
 		} else {
 			e2e.Logf("Error retrieving description for pod %q: %v\n\n", pod.Name, err)


### PR DESCRIPTION
Fix for [MULTIARCH-4352](https://issues.redhat.com/browse/MULTIARCH-4352). Private key was exposed in the e2e logs as part of the pod dump. Added code to replace the private key with XXXX