### PR TITLE
API-1802: watchevents: add cert rotation events

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -464,6 +464,7 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 	registry.AddPathologicalEventMatcherOrDie(FailedScheduling)
 	registry.AddPathologicalEventMatcherOrDie(ErrorUpdatingEndpointSlices)
 	registry.AddPathologicalEventMatcherOrDie(MarketplaceStartupProbeFailure)
+	registry.AddPathologicalEventMatcherOrDie(CertificateRotation)
 
 	// Inject the dynamic allowance for etcd readiness probe failures based on the number of
 	// etcd revisions the cluster went through.
@@ -685,6 +686,11 @@ var MarketplaceStartupProbeFailure = &SimplePathologicalEventMatcher{
 		monitorapi.LocatorPodKey:       regexp.MustCompile(`(community-operators|redhat-operators)-[a-z0-9-]+`),
 	},
 	messageHumanRegex: regexp.MustCompile(`Startup probe failed`),
+}
+
+var CertificateRotation = &SimplePathologicalEventMatcher{
+	name:               "CertificateRotation",
+	messageReasonRegex: regexp.MustCompile(`^(CABundleUpdateRequired|SignerUpdateRequired|TargetUpdateRequired|CertificateUpdated|CertificateRemoved|CertificateUpdateFailed)$`),
 }
 
 // IsEventAfterInstallation returns true if the monitorEvent represents an event that happened after installation.

--- a/pkg/monitortests/testframework/watchevents/event.go
+++ b/pkg/monitortests/testframework/watchevents/event.go
@@ -150,6 +150,8 @@ func recordAddOrUpdateEvent(
 				}
 			}
 		}
+	case "CABundleUpdateRequired", "SignerUpdateRequired", "TargetUpdateRequired", "CertificateUpdated", "CertificateRemoved", "CertificateUpdateFailed":
+		message = message.WithAnnotation(monitorapi.AnnotationInteresting, "true")
 	default:
 	}
 


### PR DESCRIPTION
library-go emits events when cert rotation happens, these should be displayed as interesting events.

[Example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/release-openshift-origin-installer-launch-gcp-modern/1780541177255170048/artifacts/launch/openshift-e2e-test/artifacts/junit/e2e-timelines_everything_20240417-115106.html), filter by Interesting Events