### PR TITLE
trt-1538: Bump context timeout to 20 minutes

### DIFF
--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -186,7 +186,7 @@ func (o *RunMonitorOptions) Run() error {
 
 	fmt.Fprintf(o.Out, "Monitor shutting down, this may take up to five minutes...\n")
 
-	cleanupContext, cleanupCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	cleanupContext, cleanupCancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cleanupCancel()
 	// ignore the ResultState because we're interested in whether we collected, not whether what we collected passed.
 	if _, err := m.Stop(cleanupContext); err != nil {


### PR DESCRIPTION
Need additional time to cleanup based on [observed failures](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-azure-sdn-upgrade/1765435689505132544/artifacts/e2e-azure-sdn-upgrade/gather-extra/artifacts/pods/openshift-cloud-controller-manager_azure-cloud-controller-manager-54cd8d5744-8f8nb_cloud-controller-manager.log)

`I0306 20:22:36.751700       1 azure_metrics.go:115] "Observed Request Latency" latency_seconds=1057.030765794 request="services_ensure_loadbalancer_deleted" resource_group="ci-op-mjrwbm2m-9d969-9z25b-rg" subscription_id="72e3a972-58b0-4afc-bd4f-da89b39ccebd" source="e2e-service-lb-test-j4ggk/service-test" result_code="succeeded"`