### PR TITLE
trt-1538: additional timeout bumps

### DIFF
--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -184,7 +184,7 @@ func (o *RunMonitorOptions) Run() error {
 
 	<-ctx.Done()
 
-	fmt.Fprintf(o.Out, "Monitor shutting down, this may take up to five minutes...\n")
+	fmt.Fprintf(o.Out, "Monitor shutting down, this may take up to twenty minutes...\n")
 
 	cleanupContext, cleanupCancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cleanupCancel()

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -104,8 +104,8 @@ func (m *Monitor) Stop(ctx context.Context) (ResultState, error) {
 		ctx,
 		m.recorder.Intervals(time.Time{}, time.Time{}), // compute intervals based on *all* the intervals.
 		m.recorder.CurrentResourceState(),
-		m.startTime, // still allow computation to understand the begining and end for bounding.
-		m.stopTime)  // still allow computation to understand the begining and end for bounding.
+		m.startTime, // still allow computation to understand the beginning and end for bounding.
+		m.stopTime)  // still allow computation to understand the beginning and end for bounding.
 	if err != nil {
 		// these errors are represented as junit, always continue to the next step
 		fmt.Fprintf(os.Stderr, "Error computing intervals, continuing, junit will reflect this. %v\n", err)

--- a/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
+++ b/pkg/monitortests/imageregistry/disruptionimageregistry/monitortest.go
@@ -174,7 +174,7 @@ func (w *availability) Cleanup(ctx context.Context) error {
 		}
 
 		startTime := time.Now()
-		err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, w.routeDeleted)
+		err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 20*time.Minute, true, w.routeDeleted)
 		if err != nil {
 			return err
 		}

--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -366,7 +366,7 @@ func (pna *podNetworkAvalibility) Cleanup(ctx context.Context) error {
 		}
 
 		startTime := time.Now()
-		err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, pna.namespaceDeleted)
+		err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 20*time.Minute, true, pna.namespaceDeleted)
 		if err != nil {
 			return err
 		}

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -296,7 +296,7 @@ func (w *availability) Cleanup(ctx context.Context) error {
 		}
 
 		startTime := time.Now()
-		err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, w.namespaceDeleted)
+		err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 20*time.Minute, true, w.namespaceDeleted)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Additional timeout bumps for

`[Jira:"Networking / router"] monitor test service-type-load-balancer-availability cleanup `