### PR TITLE
TRT-1559:Remove two sets of logs to bring build-log.txt size down

### DIFF
--- a/pkg/monitortests/testframework/watchevents/event.go
+++ b/pkg/monitortests/testframework/watchevents/event.go
@@ -221,10 +221,6 @@ func recordAddOrUpdateEvent(
 	interval := intervalBuilder.Locator(locator).
 		Message(message).Build(pathoFrom, to)
 
-	logrus.WithField("event", *obj).Info("processed event")
-	logrus.WithField("locator", interval.StructuredLocator).Info("resulting interval locator")
-	logrus.WithField("message", interval.StructuredMessage).Info("resulting interval message")
-
 	recorder.AddIntervals(interval)
 }
 


### PR DESCRIPTION
I believe that a substantially failing job like https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-ovn-dualstack/1758641985364692992 yields a rather large (38M) `build-log.txt` and browsing to that job takes a long time and consumes an exorbitant amount of RAM (4.6G in my case on chrome) assuming you can successfully load it.  Removing these logs could help shrink that file and speed up the prow job loads in general.