### PR TITLE
OCPBUGS-31032 Decrease memory request for pods

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -41010,7 +41010,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 3Gi
+            memory: 200Mi
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:
@@ -42565,7 +42565,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 3Gi
+            memory: 200Mi
 `)
 
 func testExtendedTestdataDeploymentsTagImagesDeploymentYamlBytes() ([]byte, error) {
@@ -52083,7 +52083,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 3Gi
+            memory: 200Mi
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-deployment-config.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-deployment-config.yaml
@@ -32,7 +32,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 3Gi
+            memory: 200Mi
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/test/extended/testdata/deployments/tag-images-deployment.yaml
+++ b/test/extended/testdata/deployments/tag-images-deployment.yaml
@@ -35,4 +35,4 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 3Gi
+            memory: 200Mi

--- a/test/extended/testdata/test-deployment-config.yaml
+++ b/test/extended/testdata/test-deployment-config.yaml
@@ -32,7 +32,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 3Gi
+            memory: 200Mi
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:


### PR DESCRIPTION
Reduce memory requests for pods in tag images tests

The test "[sig-apps][Feature:DeploymentConfig] deploymentconfigs when tagging images should successfully tag the deployed image [apigroup:apps.openshift.io][apigroup:authorization.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]" fails when not having enough resources.

This PR decreases the memory request.