### PR TITLE
TRT-1545: Complete removal of non-structured locator/message use

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -77,68 +77,59 @@
     });
 
     function isOperatorAvailable(eventInterval) {
-        if (eventInterval.locator.includes("clusteroperator/") && eventInterval.message.includes("condition/Available") && eventInterval.message.includes("status/False")) {
-            return true
-        }
-        return false
+        return eventInterval.tempStructuredLocator.type === "ClusterOperator" &&
+            eventInterval.tempStructuredMessage.annotations["condition"] === "Available" &&
+            eventInterval.tempStructuredMessage.annotations["status"] === "False";
     }
 
     function isOperatorDegraded(eventInterval) {
-        if (eventInterval.locator.includes("clusteroperator/") && eventInterval.message.includes("condition/Degraded") && eventInterval.message.includes("status/True")) {
-            return true
-        }
-        return false
+        return eventInterval.tempStructuredLocator.type === "ClusterOperator" &&
+            eventInterval.tempStructuredMessage.annotations["condition"] === "Degraded" &&
+            eventInterval.tempStructuredMessage.annotations["status"] === "True";
     }
 
     function isOperatorProgressing(eventInterval) {
-        if (eventInterval.locator.includes("clusteroperator/") && eventInterval.message.includes("condition/Progressing") && eventInterval.message.includes("status/True")) {
-            return true
-        }
-        return false
+        return eventInterval.tempStructuredLocator.type === "ClusterOperator" &&
+            eventInterval.tempStructuredMessage.annotations["condition"] === "Progressing" &&
+            eventInterval.tempStructuredMessage.annotations["status"] === "True";
     }
 
     // When an interval in the openshift-etcd namespace had a reason of LeaderFound, LeaderLost,
     // LeaderElected, or LeaderMissing, tempSource was set to 'EtcdLeadership'.
     function isEtcdLeadership(eventInterval) {
-        if (eventInterval.tempSource == 'EtcdLeadership') {
-            return true
-        }
-        return false
+        return eventInterval.tempSource === 'EtcdLeadership';
+
     }
 
     function isPodLog(eventInterval) {
-        if (eventInterval.tempSource == 'PodLog') {
+        if (eventInterval.tempSource === 'PodLog') {
             return true
         }
-        if (eventInterval.tempSource == 'EtcdLog') {
-            return true
-        }
-        return false
+        return eventInterval.tempSource === 'EtcdLog';
+
     }
 
     function isInterestingOrPathological(eventInterval) {
-        if (eventInterval.tempSource == 'KubeEvent' && eventInterval.message.includes("pathological/true")) {
-            return true
-        }
-        return false
+        return !!(eventInterval.tempSource === 'KubeEvent' && eventInterval.tempStructuredMessage.annotations["pathological"] === "true");
+
     }
 
     function isE2EFailed(eventInterval) {
-        if (eventInterval.locator.includes("e2e-test/") && eventInterval.message.includes("finished As \"Failed")) {
+        if (eventInterval.tempSource === "E2ETest" && eventInterval.tempStructuredMessage.annotations["status"] === "Failed") {
             return true
         }
         return false
     }
 
     function isE2EFlaked(eventInterval) {
-        if (eventInterval.locator.includes("e2e-test/") && eventInterval.message.includes("finished As \"Flaked")) {
+        if (eventInterval.tempSource === "E2ETest" && eventInterval.tempStructuredMessage.annotations["status"] === "Flaked") {
             return true
         }
         return false
     }
 
     function isE2EPassed(eventInterval) {
-        if (eventInterval.locator.includes("e2e-test/") && eventInterval.message.includes("finished As \"Passed")) {
+        if (eventInterval.tempSource === "E2ETest" && eventInterval.tempStructuredMessage.annotations["status"] === "Passed") {
             return true
         }
         return false
@@ -149,16 +140,16 @@
     }
 
     function isEndpointConnectivity(eventInterval) {
-        if (!eventInterval.message.includes("reason/DisruptionBegan") && !eventInterval.message.includes("reason/DisruptionSamplerOutageBegan")){
+        if (eventInterval.tempStructuredMessage.reason !== "DisruptionBegan" && eventInterval.tempStructuredMessage.reason !== "DisruptionSamplerOutageBegan") {
             return false
         }
-        if (eventInterval.locator.includes("disruption/")) {
+        if (eventInterval.tempSource === "Disruption") {
             return true
         }
-        if (eventInterval.locator.includes("ns/e2e-k8s-service-lb-available")) {
+        if (eventInterval.tempStructuredLocator.keys["namespace"] === "e2e-k8s-service-lb-available") {
             return true
         }
-        if (eventInterval.locator.includes(" route/")) {
+        if (eventInterval.tempStructuredLocator.keys.has("route")) {
             return true
         }
 
@@ -166,9 +157,7 @@
     }
 
     function isNodeState(eventInterval) {
-        return eventInterval.tempStructuredLocator.type === "Node" &&
-            (eventInterval.tempStructuredMessage.reason === "NodeUpdate" ||
-                eventInterval.tempStructuredMessage.reason === "NotReady");
+        return eventInterval.tempSource === "NodeState"
     }
 
     function isCloudMetrics(eventInterval) {
@@ -176,34 +165,32 @@
     }
 
     function isAlert(eventInterval) {
-        if (eventInterval.locator.includes("alert/")) {
-            return true
-        }
-        return false
+        return eventInterval.tempSource === "Alert"
     }
 
     function pathologicalEvents(item) {
-        if (item.message.includes("pathological/true")) {
-            if (item.message.includes("interesting/true")) {
-                return [item.locator, ` (pathological known)`, "PathologicalKnown"];
+        if (item.tempStructuredMessage.annotations["pathological"] === "true") {
+            if (item.tempStructuredMessage.annotations["interesting"] === "true") {
+                return [buildLocatorDisplayString(item.tempStructuredLocator), ` (pathological known)`, "PathologicalKnown"];
             } else {
-                return [item.locator, ` (pathological new)`, "PathologicalNew"];
+                return [buildLocatorDisplayString(item.tempStructuredLocator), ` (pathological new)`, "PathologicalNew"];
             }
         }
         // TODO: hack that can likely be removed when we get to structured intervals for these
-        if (item.message.includes("interesting/true") && item.message.includes("pod sandbox")) {
-            return [item.locator, ` (pod sandbox)`, "PodSandbox"];
+        // Always show pod sandbox events even if they didn't make it to pathological
+        if (item.tempStructuredMessage.annotations["interesting"] === "true" && item.tempStructuredMessage.humanMessage.includes("pod sandbox")) {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), ` (pod sandbox)`, "PodSandbox"];
         }
 	}
 
     function podLogs(item) {
         if (item.level == "Warning") {
-            return [item.locator, ` (pod log)`, "PodLogWarning"];
+            return [buildLocatorDisplayString(item.tempStructuredLocator), ` (pod log)`, "PodLogWarning"];
         }
         if (item.level == "Error") {
-            return [item.locator, ` (pod log)`, "PodLogError"];
+            return [buildLocatorDisplayString(item.tempStructuredLocator), ` (pod log)`, "PodLogError"];
         }
-        return [item.locator, ` (pod log)`, "PodLogInfo"];
+        return [buildLocatorDisplayString(item.tempStructuredLocator), ` (pod log)`, "PodLogInfo"];
     }
 
 
@@ -215,10 +202,10 @@
         }
 
         if (item.tempStructuredMessage.reason === 'NotReady') {
-            return [item.locator, ` (${roles})`, "NodeNotReady"]
+            return [buildLocatorDisplayString(item.tempStructuredLocator), ` (${roles})`, "NodeNotReady"]
         }
         let m = item.tempStructuredMessage.annotations.phase;
-        return [item.locator, ` (${roles})`, m];
+        return [buildLocatorDisplayString(item.tempStructuredLocator), ` (${roles})`, m];
     }
 
     function etcdLeadershipLogsValue(item) {
@@ -245,57 +232,52 @@
     }
 
     function cloudMetricsValue(item) {
-        return [item.locator, "", "CloudMetric"];
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "CloudMetric"];
     }
 
     function alertSeverity(item) {
         // the other types can be pending, so check pending first
-        let pendingIndex = item.message.indexOf("pending")
-        if (pendingIndex != -1) {
-            return [item.locator, "", "AlertPending"]
+        if (item.tempStructuredMessage.annotations["alertstate"] === "pending") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertPending"]
         }
 
-        let infoIndex = item.message.indexOf("info")
-        if (infoIndex != -1) {
-            return [item.locator, "", "AlertInfo"]
+        if (item.tempStructuredMessage.annotations["severity"] === "info") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertInfo"]
         }
-        let warningIndex = item.message.indexOf("warning")
-        if (warningIndex != -1) {
-            return [item.locator, "", "AlertWarning"]
+        if (item.tempStructuredMessage.annotations["severity"] === "warning") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertWarning"]
         }
-        let criticalIndex = item.message.indexOf("critical")
-        if (criticalIndex != -1) {
-            return [item.locator, "", "AlertCritical"]
+        if (item.tempStructuredMessage.annotations["severity"] === "critical") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertCritical"]
         }
 
         // color as critical if nothing matches so that we notice that something has gone wrong
-        return [item.locator, "", "AlertCritical"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertCritical"]
     }
 
     function apiserverDisruptionValue(item) {
         // TODO: isolate DNS error into CIClusterDisruption
-        return [item.locator, "", "Disruption"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "Disruption"]
     }
 
     function apiserverShutdownValue(item) {
         // TODO: isolate DNS error into CIClusterDisruption
-        return [item.locator, "", "GracefulShutdownInterval"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "GracefulShutdownInterval"]
     }
 
     function disruptionValue(item) {
         // We classify these disruption samples with this message if it thinks
         // it looks like a problem in the CI cluster running the tests, not the cluster under test.
         // (typically DNS lookup problems)
-        let ciClusterDisruption = item.message.indexOf("likely a problem in cluster running tests")
-        if (ciClusterDisruption != -1) {
-            return [item.locator, "", "CIClusterDisruption"]
+        if (item.tempStructuredMessage.reason === "DisruptionSamplerOutageBegan") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "CIClusterDisruption"]
         }
-        return [item.locator, "", "Disruption"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "Disruption"]
     }
 
     function apiserverShutdownEventsValue(item) {
         // TODO: isolate DNS error into CIClusterDisruption
-        return [item.locator, "", "GracefulShutdownWindow"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "GracefulShutdownWindow"]
     }
 
     function getDurationString(durationSeconds) {
@@ -310,15 +292,84 @@
     }
 
     function defaultToolTip(item) {
-        let tt = item.message
-        if ('tempSource' in item) {
-            tt = tt + " source/" + item.tempSource
+        if (!item.tempStructuredMessage || !item.tempStructuredMessage.annotations) {
+            return '';
         }
+
+        const structuredMessage = item.tempStructuredMessage;
+        const annotations = structuredMessage.annotations;
+
+        const keyValuePairs = Object.entries(annotations).map(([key, value]) => {
+            return `${key}/${value}`;
+        });
+
+        let tt = keyValuePairs.join(' ') + ' ' + structuredMessage.humanMessage;
+
+        // TODO: can probably remove this once we're confident all displayed intervals have it set
         if ('display' in item) {
-            tt = tt + " display/" + item.display
+            tt = "display/" + item.display + " " + tt
+        }
+        if ('tempSource' in item) {
+            tt = "source/" + item.tempSource + " " + tt
         }
         tt = tt + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
         return tt
+    }
+
+
+    // Used for the actual locators displayed on the right hand side of the chart. Based on the origin go code that does
+    // similar for whenever we serialize a locator to display.
+    function buildLocatorDisplayString(i) {
+        let keys = Object.keys(i.keys);
+        keys = sortKeys(keys);
+
+        let annotations = [];
+        for (let k of keys) {
+            let v = i.keys[k];
+            if (k === 'LocatorE2ETestKey') {
+                annotations.push(`${k}/${JSON.stringify(v)}`);
+            } else {
+                annotations.push(`${k}/${v}`);
+            }
+        }
+
+        return annotations.join(' ');
+    }
+
+    function sortKeys(keys) {
+        // Ensure these keys appear in this order. Other keys can be mixed in and will appear at the end in alphabetical order.
+        const orderedKeys = ["namespace", "node", "pod", "uid", "server", "container", "shutdown", "row"];
+
+        // Create a map to store the indices of keys in the orderedKeys array.
+        // This will allow us to efficiently check if a key is in orderedKeys and find its position.
+        const orderedKeyIndices = {};
+        orderedKeys.forEach((key, index) => {
+            orderedKeyIndices[key] = index;
+        });
+
+        // Define a custom sorting function that orders the keys based on the orderedKeys array.
+        keys.sort((a, b) => {
+            // Get the indices of keys a and b in orderedKeys.
+            const indexA = orderedKeyIndices[a];
+            const indexB = orderedKeyIndices[b];
+
+            // If both keys exist in orderedKeys, sort them based on their order.
+            if (indexA !== undefined && indexB !== undefined) {
+                return indexA - indexB;
+            }
+
+            // If only one of the keys exists in orderedKeys, move it to the front.
+            if (indexA !== undefined) {
+                return -1;
+            } else if (indexB !== undefined) {
+                return 1;
+            }
+
+            // If neither key is in orderedKeys, sort alphabetically so we have predictable ordering.
+            return a.localeCompare(b);
+        });
+
+        return keys;
     }
 
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc, regex) {
@@ -344,7 +395,7 @@
             if (!item.to) {
                 endDate = latest
             }
-            let label = item.locator
+            let label = buildLocatorDisplayString(item.tempStructuredLocator)
             let sub = ""
             let val = timelineVal
             if (typeof val === "function") {

--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -110,8 +110,7 @@
     }
 
     function isInterestingOrPathological(eventInterval) {
-        return !!(eventInterval.tempSource === 'KubeEvent' && eventInterval.tempStructuredMessage.annotations["pathological"] === "true");
-
+        return eventInterval.tempSource === 'KubeEvent' && eventInterval.tempStructuredMessage.annotations["pathological"] === "true";
     }
 
     function isE2EFailed(eventInterval) {

--- a/pkg/clioptions/clusterinfo/write_job_run_data.go
+++ b/pkg/clioptions/clusterinfo/write_job_run_data.go
@@ -21,7 +21,7 @@ func WasMasterNodeUpdated(events monitorapi.Intervals) string {
 		// vs
 		// "locator": "node/ip-10-0-228-209.us-west-1.compute.internal",
 		//            "message": "reason/NodeUpdate phase/Update config/rendered-worker-722803a00bad408ee94572ab244ad3bc roles/worker reached desired config roles/worker",
-		if strings.Contains(i.Message, "master") {
+		if strings.Contains(i.StructuredMessage.Annotations[monitorapi.AnnotationRoles], "master") {
 			return "Y"
 		}
 	}
@@ -29,7 +29,7 @@ func WasMasterNodeUpdated(events monitorapi.Intervals) string {
 	return "N"
 }
 
-// TODO this should be taking a client, not a kubeconfig. Can't test a client.
+// TODO this should be taking a client, not a kubeconfig. Can't test a kubeconfig.
 func CollectClusterData(adminKubeConfig *rest.Config, masterNodeUpdated string) platformidentification.ClusterData {
 	clusterData := platformidentification.ClusterData{}
 	var errs *[]error

--- a/pkg/cmd/openshift-tests/monitor/timeline/timeline_command.go
+++ b/pkg/cmd/openshift-tests/monitor/timeline/timeline_command.go
@@ -51,7 +51,7 @@ func NewTimelineOptions(ioStreams genericclioptions.IOStreams) *TimelineOptions 
 			"operators":     timelineserializer.BelongsInOperatorRollout,
 			"apiserver":     timelineserializer.BelongsInKubeAPIServer,
 			"spyglass":      timelineserializer.BelongsInSpyglass,
-			"pod-lifecycle": timelineserializer.IsOriginalPodEvent,
+			"pod-lifecycle": timelineserializer.IsOriginalPodEvent, // TODO: may not be used?
 		},
 	}
 }

--- a/pkg/cmd/openshift-tests/run-disruption/disruption.go
+++ b/pkg/cmd/openshift-tests/run-disruption/disruption.go
@@ -135,7 +135,7 @@ func (opt *RunAPIDisruptionMonitorOptions) Run() error {
 	if len(opt.ExtraMessage) > 0 {
 		fmt.Fprintf(opt.Out, "\nAppending %s to recorded event message\n", opt.ExtraMessage)
 		for i, event := range intervals {
-			intervals[i].Message = fmt.Sprintf("%s user-provided-message=%s", event.Message, opt.ExtraMessage)
+			intervals[i].StructuredMessage.HumanMessage = fmt.Sprintf("%s user-provided-message=%s", event.StructuredMessage.HumanMessage, opt.ExtraMessage)
 		}
 	}
 

--- a/pkg/disruption/backend/disruption/handler.go
+++ b/pkg/disruption/backend/disruption/handler.go
@@ -77,6 +77,7 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 		nil, v1.EventTypeWarning, string(eventReason), "detected", message.BuildString())
 
 	interval := monitorapi.NewInterval(monitorapi.SourceDisruption, level).Locator(h.descriptor.DisruptionLocator()).
+		Display().
 		Message(message).Build(fs.StartedAt, time.Time{})
 	openIntervalID := h.monitorRecorder.StartInterval(interval)
 	// TODO: unlikely in the real world, if from == to for some reason,

--- a/pkg/disruption/backend/sampler/remote.go
+++ b/pkg/disruption/backend/sampler/remote.go
@@ -387,7 +387,7 @@ func fetchEventsFromFileOnNode(ctx context.Context, clientset *kubernetes.Client
 	fmt.Fprintf(os.Stdout, "Fetched %d events from node %s\n", len(allEvents), nodeName)
 	// Keep only disruption events
 	for _, event := range allEvents {
-		backendDisruptionName := monitorapi.BackendDisruptionNameFrom(monitorapi.LocatorParts(event.Locator))
+		backendDisruptionName := monitorapi.BackendDisruptionNameFromLocator(event.StructuredLocator)
 		if len(backendDisruptionName) == 0 {
 			continue
 		}

--- a/pkg/disruption/ci/factory.go
+++ b/pkg/disruption/ci/factory.go
@@ -103,7 +103,7 @@ func (t TestDescriptor) DisruptionLocator() monitorapi.Locator {
 }
 
 func (t TestDescriptor) ShutdownLocator() monitorapi.Locator {
-	return monitorapi.NewLocator().APIServerShutdown(string(t.LoadBalancerType))
+	return monitorapi.NewLocator().KubeAPIServerWithLB(string(t.LoadBalancerType))
 }
 
 func (t TestDescriptor) Validate() error {

--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -625,6 +625,7 @@ func (b *disruptionSampler) consumeSamples(ctx context.Context, consumerDoneCh c
 				v1.EventTypeWarning, string(eventReason), "detected", message.BuildString())
 			currInterval := monitorapi.NewInterval(monitorapi.SourceDisruption, level).
 				Locator(b.backendSampler.GetLocator()).
+				Display().
 				Message(message).Build(currSample.startTime, time.Time{})
 			previousIntervalID = monitorRecorder.StartInterval(currInterval)
 
@@ -656,7 +657,7 @@ func (b *disruptionSampler) consumeSamples(ctx context.Context, consumerDoneCh c
 				v1.EventTypeWarning, string(eventReason), "detected", message.BuildString())
 			currInterval := monitorapi.NewInterval(monitorapi.SourceDisruption, level).
 				Locator(b.backendSampler.GetLocator()).
-				Message(message).Build(currSample.startTime, time.Time{})
+				Message(message).Display().Build(currSample.startTime, time.Time{})
 			previousIntervalID = monitorRecorder.StartInterval(currInterval)
 
 		default:

--- a/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler_test.go
@@ -192,13 +192,13 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 				if duration := eventIntervals[0].To.Sub(eventIntervals[0].From); duration != 2*time.Second {
 					t.Error(eventIntervals[0])
 				}
-				if !strings.Contains(eventIntervals[0].Message, "started responding") {
+				if !strings.Contains(eventIntervals[0].StructuredMessage.HumanMessage, "started responding") {
 					t.Error(eventIntervals[0])
 				}
 				if duration := eventIntervals[1].To.Sub(eventIntervals[1].From); duration != 2*time.Second {
 					t.Error(eventIntervals[0])
 				}
-				if !strings.Contains(eventIntervals[1].Message, "now fail") {
+				if !strings.Contains(eventIntervals[1].StructuredMessage.HumanMessage, "now fail") {
 					t.Error(eventIntervals[1])
 				}
 				return nil
@@ -237,13 +237,13 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 				if duration := eventIntervals[0].To.Sub(eventIntervals[0].From); duration != 2*time.Second {
 					t.Error(eventIntervals[0])
 				}
-				if !strings.Contains(eventIntervals[0].Message, "started responding") {
+				if !strings.Contains(eventIntervals[0].StructuredMessage.HumanMessage, "started responding") {
 					t.Error(eventIntervals[0])
 				}
 				if duration := eventIntervals[1].To.Sub(eventIntervals[1].From); duration != 2*time.Second {
 					t.Error(eventIntervals[0])
 				}
-				if !strings.Contains(eventIntervals[1].Message, "now fail") {
+				if !strings.Contains(eventIntervals[1].StructuredMessage.HumanMessage, "now fail") {
 					t.Error(eventIntervals[1])
 				}
 				return nil
@@ -282,13 +282,13 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 				if duration := eventIntervals[0].To.Sub(eventIntervals[0].From); duration != 2*time.Second {
 					t.Error(eventIntervals[0])
 				}
-				if !strings.Contains(eventIntervals[0].Message, "early") {
+				if !strings.Contains(eventIntervals[0].StructuredMessage.HumanMessage, "early") {
 					t.Error(eventIntervals[0])
 				}
 				if duration := eventIntervals[1].To.Sub(eventIntervals[1].From); duration != 2*time.Second {
 					t.Error(eventIntervals[0])
 				}
-				if !strings.Contains(eventIntervals[1].Message, "late") {
+				if !strings.Contains(eventIntervals[1].StructuredMessage.HumanMessage, "late") {
 					t.Error(eventIntervals[1])
 				}
 				return nil
@@ -326,8 +326,8 @@ func Test_disruptionSampler_consumeSamples(t *testing.T) {
 				assert.Equal(t, 1*time.Second, eventIntervals[1].To.Sub(eventIntervals[1].From))
 				assert.Equal(t, monitorapi.Warning, eventIntervals[1].Level,
 					"DNS lookup i/o timeout should be warning level, not error")
-				assert.Contains(t, eventIntervals[1].Message, "DNS lookup timeouts began")
-				assert.Contains(t, eventIntervals[1].Message, "i/o timeout") // make sure the orig message is also preserved
+				assert.Contains(t, eventIntervals[1].StructuredMessage.HumanMessage, "DNS lookup timeouts began")
+				assert.Contains(t, eventIntervals[1].StructuredMessage.HumanMessage, "i/o timeout") // make sure the orig message is also preserved
 				return nil
 			},
 		},

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 func TestMonitor_Newlines(t *testing.T) {
-	evt := &monitorapi.Interval{Condition: monitorapi.Condition{Message: "a\nb\n"}}
-	expected := "Jan 01 00:00:00.000 I  a\\nb\\n"
+	evt := &monitorapi.Interval{Condition: monitorapi.Condition{StructuredMessage: monitorapi.Message{HumanMessage: "a\nb\n"}}}
+	// this originally expected preservation of the trailing newline, that gets trimmed somewhere in the new intervals,
+	// which seems ok as far as I can tell
+	expected := "Jan 01 00:00:00.000 I  a\\nb"
 	if evt.String() != expected {
 		t.Fatalf("unexpected:\n%s\n%s", expected, evt.String())
 	}

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -339,6 +339,12 @@ func (b *LocatorBuilder) APIServerShutdown(loadBalancer string) Locator {
 	return b.Build()
 }
 
+func (b *LocatorBuilder) KubeAPIServer() Locator {
+	b.targetType = LocatorTypeKubeAPIServer
+	b.annotations[LocatorServerKey] = "kube-apiserver"
+	return b.Build()
+}
+
 func (b *LocatorBuilder) ContainerFromPod(pod *corev1.Pod, containerName string) Locator {
 	b.PodFromPod(pod)
 	b.targetType = LocatorTypeContainer

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -266,16 +266,7 @@ func (b *LocatorBuilder) LocateDisruptionCheck(backendDisruptionName, thisInstan
 		Build()
 }
 
-func (b *LocatorBuilder) LocateServer(serverName, nodeName, namespace, podName string, isShutdown bool) Locator {
-	if isShutdown {
-		return b.
-			withShutdown().
-			withServer(serverName).
-			withNode(nodeName).
-			withNamespace(namespace).
-			withPodName(podName).
-			Build()
-	}
+func (b *LocatorBuilder) LocateServer(serverName, nodeName, namespace, podName string) Locator {
 	return b.
 		withServer(serverName).
 		withNode(nodeName).
@@ -284,15 +275,18 @@ func (b *LocatorBuilder) LocateServer(serverName, nodeName, namespace, podName s
 		Build()
 }
 
-// TODO remove this once we know what all breaks.
-func (b *LocatorBuilder) withShutdown() *LocatorBuilder {
-	b.annotations[LocatorShutdown] = "apiserver"
-	return b
-}
-
 func (b *LocatorBuilder) withServer(serverName string) *LocatorBuilder {
 	b.annotations[LocatorServerKey] = serverName
 	return b
+}
+
+func (b *LocatorBuilder) KubeAPIServerWithLB(loadBalancer string) Locator {
+	b.targetType = LocatorTypeAPIServer
+	b.annotations[LocatorServerKey] = "kube-apiserver"
+	if len(loadBalancer) > 0 {
+		b.annotations[LocatorLoadBalancerKey] = loadBalancer
+	}
+	return b.Build()
 }
 
 // TODO decide whether we want to allow "random" locator keys.  deads2k is -1 on random locator keys and thinks we should enumerate every possible key we special case.
@@ -326,22 +320,6 @@ func (b *LocatorBuilder) KubeEvent(event *corev1.Event) Locator {
 	if len(event.InvolvedObject.Namespace) > 0 {
 		b.annotations[LocatorNamespaceKey] = event.InvolvedObject.Namespace
 	}
-	return b.Build()
-}
-
-func (b *LocatorBuilder) APIServerShutdown(loadBalancer string) Locator {
-	b.targetType = LocatorTypeAPIServerShutdown
-	b.annotations[LocatorShutdownKey] = "graceful"
-	b.annotations[LocatorServerKey] = "kube-apiserver"
-	if len(loadBalancer) > 0 {
-		b.annotations[LocatorLoadBalancerKey] = loadBalancer
-	}
-	return b.Build()
-}
-
-func (b *LocatorBuilder) KubeAPIServer() Locator {
-	b.targetType = LocatorTypeKubeAPIServer
-	b.annotations[LocatorServerKey] = "kube-apiserver"
 	return b.Build()
 }
 

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -411,9 +411,12 @@ func NewMessage() *MessageBuilder {
 
 // ExpandMessage parses a message that was collapsed into a string to extract each annotation
 // and the original message.
-func ExpandMessage(prevMessage string) *MessageBuilder {
-	prevAnnotations := AnnotationsFromMessage(prevMessage)
-	prevNonAnnotationMessage := NonAnnotationMessage(prevMessage)
+func ExpandMessage(prevMessage Message) *MessageBuilder {
+	prevAnnotations := prevMessage.Annotations
+	prevNonAnnotationMessage := prevMessage.HumanMessage
+	if prevAnnotations == nil {
+		prevAnnotations = map[AnnotationKey]string{}
+	}
 	return &MessageBuilder{
 		annotations:  prevAnnotations,
 		humanMessage: prevNonAnnotationMessage,

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -345,12 +345,17 @@ func (b *LocatorBuilder) ContainerFromNames(namespace, podName, uid, containerNa
 }
 
 func (b *LocatorBuilder) PodFromNames(namespace, podName, uid string) Locator {
-	return b.
-		withTargetType(LocatorTypePod).
-		withNamespace(namespace).
-		withPodName(podName).
-		withUID(uid).
-		Build()
+	bldr := b.withTargetType(LocatorTypePod)
+	if len(namespace) > 0 {
+		bldr = bldr.withNamespace(namespace)
+	}
+	if len(podName) > 0 {
+		bldr = bldr.withPodName(podName)
+	}
+	if len(uid) > 0 {
+		bldr = bldr.withUID(uid)
+	}
+	return bldr.Build()
 }
 
 func (b *LocatorBuilder) withPodName(podName string) *LocatorBuilder {

--- a/pkg/monitor/monitorapi/disruption.go
+++ b/pkg/monitor/monitorapi/disruption.go
@@ -21,8 +21,5 @@ func BackendDisruptionSeconds(backendDisruptionName string, events Intervals) (t
 }
 
 func IsDisruptionEvent(eventInterval Interval) bool {
-	if disruptionBackend := BackendDisruptionNameFrom(LocatorParts(eventInterval.Locator)); len(disruptionBackend) > 0 {
-		return true
-	}
-	return false
+	return eventInterval.Source == SourceDisruption
 }

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -88,11 +88,6 @@ func BackendDisruptionNameFromLocator(locator Locator) string {
 	return locator.Keys[LocatorBackendDisruptionNameKey]
 }
 
-// BackendDisruptionNameFrom holds the value used to store and locate historical data related to the amount of disruption.
-func BackendDisruptionNameFrom(locatorParts map[string]string) string {
-	return locatorParts[string(LocatorBackendDisruptionNameKey)]
-}
-
 func DisruptionConnectionTypeFrom(locatorParts map[string]string) BackendConnectionType {
 	return BackendConnectionType(locatorParts[string(LocatorConnectionKey)])
 }

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -1,6 +1,7 @@
 package monitorapi
 
 import (
+	"reflect"
 	"strings"
 )
 
@@ -36,21 +37,11 @@ func OperatorFromLocator(locator string) (string, bool) {
 	return ret, len(ret) > 0
 }
 
-func NamespaceFromLocator(locator string) string {
-	locatorParts := LocatorParts(locator)
-	if ns, ok := locatorParts["ns"]; ok {
-		return ns
-	}
-	if ns, ok := locatorParts["namespace"]; ok {
-		return ns
-	}
-	return ""
+func NamespaceFromLocator(locator Locator) string {
+	return locator.Keys[LocatorNamespaceKey]
 }
 
-func AlertFromLocator(locator string) string {
-	return AlertFrom(LocatorParts(locator))
-}
-
+// TODO: remove all uses
 func LocatorParts(locator string) map[string]string {
 	parts := map[string]string{}
 
@@ -106,18 +97,15 @@ func DisruptionConnectionTypeFrom(locatorParts map[string]string) BackendConnect
 	return BackendConnectionType(locatorParts[string(LocatorConnectionKey)])
 }
 
-func IsEventForLocator(locator string) EventIntervalMatchesFunc {
+func IsEventForLocator(locator Locator) EventIntervalMatchesFunc {
 	return func(eventInterval Interval) bool {
-		if eventInterval.Locator == locator {
-			return true
-		}
-		return false
+		return reflect.DeepEqual(eventInterval.StructuredLocator, locator)
 	}
 }
 
 func IsEventForBackendDisruptionName(backendDisruptionName string) EventIntervalMatchesFunc {
 	return func(eventInterval Interval) bool {
-		if BackendDisruptionNameFrom(LocatorParts(eventInterval.Locator)) == backendDisruptionName {
+		if BackendDisruptionNameFromLocator(eventInterval.StructuredLocator) == backendDisruptionName {
 			return true
 		}
 		return false

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -22,8 +22,8 @@ func E2ETestFromLocator(l Locator) (string, bool) {
 	return test, ok
 }
 
-func IsNode(locator string) bool {
-	_, ret := NodeFromLocator(locator)
+func IsNode(locator Locator) bool {
+	_, ret := locator.Keys[LocatorNodeKey]
 	return ret
 }
 

--- a/pkg/monitor/monitorapi/identification.go
+++ b/pkg/monitor/monitorapi/identification.go
@@ -32,11 +32,6 @@ func NodeFromLocator(locator string) (string, bool) {
 	return ret, len(ret) > 0
 }
 
-func OperatorFromLocator(locator string) (string, bool) {
-	ret := OperatorFrom(LocatorParts(locator))
-	return ret, len(ret) > 0
-}
-
 func NamespaceFromLocator(locator Locator) string {
 	return locator.Keys[LocatorNamespaceKey]
 }

--- a/pkg/monitor/monitorapi/identification_node.go
+++ b/pkg/monitor/monitorapi/identification_node.go
@@ -1,18 +1,6 @@
 package monitorapi
 
-import (
-	"strings"
-)
-
 // GetNodeRoles extract the node roles from the event message.
 func GetNodeRoles(event Interval) string {
-	var roles string
-	if i := strings.Index(event.Message, "roles/"); i != -1 {
-		roles = event.Message[i+len("roles/"):]
-		if j := strings.Index(roles, " "); j != -1 {
-			roles = roles[:j]
-		}
-	}
-
-	return roles
+	return event.StructuredMessage.Annotations[AnnotationRoles]
 }

--- a/pkg/monitor/monitorapi/identification_node_test.go
+++ b/pkg/monitor/monitorapi/identification_node_test.go
@@ -9,16 +9,14 @@ func TestGetNodeRoles(t *testing.T) {
 	}{
 		{
 			event: Interval{
-				Condition: Condition{
-					Message: "",
-				},
+				Condition: Condition{},
 			},
 			expected: "",
 		},
 		{
 			event: Interval{
 				Condition: Condition{
-					Message: "roles/master",
+					StructuredMessage: Message{Annotations: map[AnnotationKey]string{AnnotationRoles: "master"}},
 				},
 			},
 			expected: "master",
@@ -26,7 +24,7 @@ func TestGetNodeRoles(t *testing.T) {
 		{
 			event: Interval{
 				Condition: Condition{
-					Message: "roles/worker",
+					StructuredMessage: Message{Annotations: map[AnnotationKey]string{AnnotationRoles: "worker"}},
 				},
 			},
 			expected: "worker",
@@ -34,7 +32,7 @@ func TestGetNodeRoles(t *testing.T) {
 		{
 			event: Interval{
 				Condition: Condition{
-					Message: "roles/master,worker",
+					StructuredMessage: Message{Annotations: map[AnnotationKey]string{AnnotationRoles: "master,worker"}},
 				},
 			},
 			expected: "master,worker",

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -9,8 +9,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func LocatePod(pod *corev1.Pod) string {
-	return fmt.Sprintf("ns/%s pod/%s node/%s uid/%s", pod.Namespace, pod.Name, pod.Spec.NodeName, pod.UID)
+func LocatePod(pod *corev1.Pod) Locator {
+	return Locator{
+		Type: LocatorTypePod,
+		Keys: map[LocatorKey]string{
+			LocatorNamespaceKey: pod.Namespace,
+			LocatorPodKey:       pod.Name,
+			LocatorNodeKey:      pod.Spec.NodeName,
+			LocatorUIDKey:       string(pod.UID),
+		},
+	}
 }
 
 // NonUniquePodLocatorFrom produces an inexact locator based on namespace and name.  This is useful when dealing with events

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -165,8 +165,8 @@ var (
 type ByTimeWithNamespacedPods []Interval
 
 func (intervals ByTimeWithNamespacedPods) Less(i, j int) bool {
-	lhsIsPodConstructed := strings.Contains(intervals[i].Message, "constructed") && len(intervals[i].StructuredLocator.Keys[LocatorPodKey]) > 0
-	rhsIsPodConstructed := strings.Contains(intervals[j].Message, "constructed") && len(intervals[j].StructuredLocator.Keys[LocatorPodKey]) > 0
+	lhsIsPodConstructed := len(intervals[i].StructuredMessage.Annotations[AnnotationConstructed]) > 0 && len(intervals[i].StructuredLocator.Keys[LocatorPodKey]) > 0
+	rhsIsPodConstructed := len(intervals[j].StructuredMessage.Annotations[AnnotationConstructed]) > 0 && len(intervals[j].StructuredLocator.Keys[LocatorPodKey]) > 0
 	switch {
 	case lhsIsPodConstructed && rhsIsPodConstructed:
 		lhsNamespace := NamespaceFromLocator(intervals[i].StructuredLocator)
@@ -198,7 +198,7 @@ func (intervals ByTimeWithNamespacedPods) Less(i, j int) bool {
 	case d > 0:
 		return false
 	}
-	return intervals[i].Message < intervals[j].Message
+	return intervals[i].StructuredMessage.HumanMessage < intervals[j].StructuredMessage.HumanMessage
 }
 
 func (intervals ByTimeWithNamespacedPods) Len() int { return len(intervals) }

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -22,26 +22,9 @@ func NonUniquePodLocatorFrom(locator string) string {
 	return fmt.Sprintf("ns/%s pod/%s", namespace, parts["pod"])
 }
 
-// TODO:  all callers should eventuall be using structured locator variant below:
-func PodFrom(locator Locator) PodReference {
-	namespace := locator.Keys[LocatorNamespaceKey]
-	name := locator.Keys[LocatorPodKey]
-	uid := locator.Keys[LocatorUIDKey]
-	if len(namespace) == 0 || len(name) == 0 {
-		return PodReference{}
-	}
-	return PodReference{
-		NamespacedReference: NamespacedReference{
-			Namespace: namespace,
-			Name:      name,
-			UID:       uid,
-		},
-	}
-}
-
-// PodFromLocator is used to strip down a locator to just a pod. (as it may contain additional keys like container or node)
+// PodFrom is used to strip down a locator to just a pod. (as it may contain additional keys like container or node)
 // that we do not want for some uses.
-func PodFromLocator(locator Locator) PodReference {
+func PodFrom(locator Locator) PodReference {
 	namespace := locator.Keys[LocatorNamespaceKey]
 	name := locator.Keys[LocatorPodKey]
 	uid := locator.Keys[LocatorUIDKey]

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -23,11 +23,10 @@ func NonUniquePodLocatorFrom(locator string) string {
 }
 
 // TODO:  all callers should eventuall be using structured locator variant below:
-func PodFrom(locator string) PodReference {
-	parts := LocatorParts(locator)
-	namespace := NamespaceFrom(parts)
-	name := parts[string(LocatorPodKey)]
-	uid := parts[string(LocatorUIDKey)]
+func PodFrom(locator Locator) PodReference {
+	namespace := locator.Keys[LocatorNamespaceKey]
+	name := locator.Keys[LocatorPodKey]
+	uid := locator.Keys[LocatorUIDKey]
 	if len(namespace) == 0 || len(name) == 0 {
 		return PodReference{}
 	}
@@ -59,7 +58,7 @@ func PodFromLocator(locator Locator) PodReference {
 }
 
 func ContainerFrom(locator Locator) ContainerReference {
-	pod := PodFrom(locator.OldLocator())
+	pod := PodFrom(locator)
 	name := locator.Keys[LocatorContainerKey]
 	if len(name) == 0 || len(pod.UID) == 0 {
 		return ContainerReference{}
@@ -175,12 +174,12 @@ var (
 type ByTimeWithNamespacedPods []Interval
 
 func (intervals ByTimeWithNamespacedPods) Less(i, j int) bool {
-	lhsIsPodConstructed := strings.Contains(intervals[i].Message, "constructed") && strings.Contains(intervals[i].Locator, "pod/")
-	rhsIsPodConstructed := strings.Contains(intervals[j].Message, "constructed") && strings.Contains(intervals[j].Locator, "pod/")
+	lhsIsPodConstructed := strings.Contains(intervals[i].Message, "constructed") && len(intervals[i].StructuredLocator.Keys[LocatorPodKey]) > 0
+	rhsIsPodConstructed := strings.Contains(intervals[j].Message, "constructed") && len(intervals[j].StructuredLocator.Keys[LocatorPodKey]) > 0
 	switch {
 	case lhsIsPodConstructed && rhsIsPodConstructed:
-		lhsNamespace := NamespaceFromLocator(intervals[i].Locator)
-		rhsNamespace := NamespaceFromLocator(intervals[j].Locator)
+		lhsNamespace := NamespaceFromLocator(intervals[i].StructuredLocator)
+		rhsNamespace := NamespaceFromLocator(intervals[j].StructuredLocator)
 		if lhsNamespace < rhsNamespace {
 			return true
 		} else if lhsNamespace > rhsNamespace {

--- a/pkg/monitor/monitorapi/identification_pod.go
+++ b/pkg/monitor/monitorapi/identification_pod.go
@@ -16,10 +16,10 @@ func LocatePod(pod *corev1.Pod) string {
 // NonUniquePodLocatorFrom produces an inexact locator based on namespace and name.  This is useful when dealing with events
 // that are produced that do not contain UIDs.  Ultimately, we should use UIDs everywhere, but this is will keep some our
 // matching working until then.
-func NonUniquePodLocatorFrom(locator string) string {
-	parts := LocatorParts(locator)
-	namespace := NamespaceFrom(parts)
-	return fmt.Sprintf("ns/%s pod/%s", namespace, parts["pod"])
+func NonUniquePodLocatorFrom(locator Locator) string {
+	namespace := locator.Keys[LocatorNamespaceKey]
+	pod := locator.Keys[LocatorPodKey]
+	return fmt.Sprintf("ns/%s pod/%s", namespace, pod)
 }
 
 // PodFrom is used to strip down a locator to just a pod. (as it may contain additional keys like container or node)

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -523,15 +523,7 @@ func IsInfoEvent(eventInterval Interval) bool {
 
 // IsInE2ENamespace returns true if the eventInterval is in an e2e namespace
 func IsInE2ENamespace(eventInterval Interval) bool {
-	// Old style
-	if strings.Contains(eventInterval.Locator, "ns/e2e-") {
-		return true
-	}
-	// New style
-	if strings.Contains(eventInterval.Locator, "namespace/e2e-") {
-		return true
-	}
-	return false
+	return strings.HasPrefix(NamespaceFromLocator(eventInterval.StructuredLocator), "e2e-")
 }
 
 func IsForDisruptionBackend(backend string) EventIntervalMatchesFunc {
@@ -549,9 +541,7 @@ func IsInNamespaces(namespaces sets.String) EventIntervalMatchesFunc {
 		if ns, ok := eventInterval.StructuredLocator.Keys[LocatorNamespaceKey]; ok {
 			return namespaces.Has(ns)
 		}
-		// TODO: For legacy locators, can be removed soon
-		ns := NamespaceFromLocator(eventInterval.Locator)
-		return namespaces.Has(ns)
+		return false
 	}
 }
 

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -98,34 +98,29 @@ type Condition struct {
 type LocatorType string
 
 const (
-	LocatorTypePod               LocatorType = "Pod"
-	LocatorTypeContainer         LocatorType = "Container"
-	LocatorTypeNode              LocatorType = "Node"
-	LocatorTypeAlert             LocatorType = "Alert"
-	LocatorTypeClusterOperator   LocatorType = "ClusterOperator"
-	LocatorTypeKubeAPIServer     LocatorType = "KubeAPIServer"
-	LocatorTypeOther             LocatorType = "Other"
-	LocatorTypeDisruption        LocatorType = "Disruption"
-	LocatorTypeKubeEvent         LocatorType = "KubeEvent"
-	LocatorTypeE2ETest           LocatorType = "E2ETest"
-	LocatorTypeAPIServerShutdown LocatorType = "APIServerShutdown"
-	LocatorTypeClusterVersion    LocatorType = "ClusterVersion"
-	LocatorTypeKind              LocatorType = "Kind"
-	LocatorTypeCloudMetrics      LocatorType = "CloudMetrics"
+	LocatorTypePod             LocatorType = "Pod"
+	LocatorTypeContainer       LocatorType = "Container"
+	LocatorTypeNode            LocatorType = "Node"
+	LocatorTypeAlert           LocatorType = "Alert"
+	LocatorTypeClusterOperator LocatorType = "ClusterOperator"
+	LocatorTypeDisruption      LocatorType = "Disruption"
+	LocatorTypeKubeEvent       LocatorType = "KubeEvent"
+	LocatorTypeE2ETest         LocatorType = "E2ETest"
+	LocatorTypeAPIServer       LocatorType = "APIServer"
+	LocatorTypeClusterVersion  LocatorType = "ClusterVersion"
+	LocatorTypeKind            LocatorType = "Kind"
+	LocatorTypeCloudMetrics    LocatorType = "CloudMetrics"
 )
 
 type LocatorKey string
 
 const (
-	LocatorServer             LocatorKey = "server"   // TODO this looks like a bad name.  Aggregated apiserver?  Do we even need it?
-	LocatorShutdown           LocatorKey = "shutdown" // TODO this should not exist.  This is a reason and message
 	LocatorClusterOperatorKey LocatorKey = "clusteroperator"
 	LocatorClusterVersionKey  LocatorKey = "clusterversion"
 	LocatorNamespaceKey       LocatorKey = "namespace"
 	LocatorDeploymentKey      LocatorKey = "deployment"
 	LocatorNodeKey            LocatorKey = "node"
 	LocatorEtcdMemberKey      LocatorKey = "etcd-member"
-	LocatorKindKey            LocatorKey = "kind"
 	LocatorNameKey            LocatorKey = "name"
 	LocatorHmsgKey            LocatorKey = "hmsg"
 	LocatorPodKey             LocatorKey = "pod"
@@ -143,7 +138,6 @@ const (
 	LocatorProtocolKey              LocatorKey = "protocol"
 	LocatorTargetKey                LocatorKey = "target"
 	LocatorRowKey                   LocatorKey = "row"
-	LocatorShutdownKey              LocatorKey = "shutdown"
 	LocatorServerKey                LocatorKey = "server"
 	LocatorMetricKey                LocatorKey = "metric"
 )
@@ -163,7 +157,8 @@ const (
 	DisruptionBeganEventReason              IntervalReason = "DisruptionBegan"
 	DisruptionEndedEventReason              IntervalReason = "DisruptionEnded"
 	DisruptionSamplerOutageBeganEventReason IntervalReason = "DisruptionSamplerOutageBegan"
-	GracefulAPIServerShutdown               IntervalReason = "GracefulShutdownWindow"
+	GracefulAPIServerShutdown               IntervalReason = "GracefulAPIServerShutdown"
+	IncompleteAPIServerShutdown             IntervalReason = "IncompleteAPIServerShutdown"
 
 	HttpClientConnectionLost IntervalReason = "HttpClientConnectionLost"
 
@@ -207,6 +202,7 @@ const (
 	CloudMetricsExtrenuous                IntervalReason = "CloudMetricsExtrenuous"
 	FailedToDeleteCGroupsPath             IntervalReason = "FailedToDeleteCGroupsPath"
 	FailedToAuthenticateWithOpenShiftUser IntervalReason = "FailedToAuthenticateWithOpenShiftUser"
+	FailedContactingAPIReason             IntervalReason = "FailedContactingAPI"
 )
 
 type AnnotationKey string
@@ -271,19 +267,21 @@ type Message struct {
 type IntervalSource string
 
 const (
-	SourceAlert                   IntervalSource = "Alert"
-	SourceAPIServerShutdown       IntervalSource = "APIServerShutdown"
-	SourceDisruption              IntervalSource = "Disruption"
-	SourceE2ETest                 IntervalSource = "E2ETest"
-	SourceKubeEvent               IntervalSource = "KubeEvent"
-	SourceNetworkManagerLog       IntervalSource = "NetworkMangerLog"
-	SourceNodeMonitor             IntervalSource = "NodeMonitor"
-	SourceKubeletLog              IntervalSource = "KubeletLog"
-	SourcePodLog                  IntervalSource = "PodLog"
-	SourceEtcdLog                 IntervalSource = "EtcdLog"
-	SourceEtcdLeadership          IntervalSource = "EtcdLeadership"
-	SourcePodMonitor              IntervalSource = "PodMonitor"
-	APIServerGracefulShutdown     IntervalSource = "APIServerGracefulShutdown"
+	SourceAlert                     IntervalSource = "Alert"
+	SourceAPIServerShutdown         IntervalSource = "APIServerShutdown"
+	SourceDisruption                IntervalSource = "Disruption"
+	SourceE2ETest                   IntervalSource = "E2ETest"
+	SourceKubeEvent                 IntervalSource = "KubeEvent"
+	SourceNetworkManagerLog         IntervalSource = "NetworkMangerLog"
+	SourceNodeMonitor               IntervalSource = "NodeMonitor"
+	SourceKubeletLog                IntervalSource = "KubeletLog"
+	SourcePodLog                    IntervalSource = "PodLog"
+	SourceEtcdLog                   IntervalSource = "EtcdLog"
+	SourceEtcdLeadership            IntervalSource = "EtcdLeadership"
+	SourcePodMonitor                IntervalSource = "PodMonitor"
+	APIServerGracefulShutdown       IntervalSource = "APIServerGracefulShutdown"
+	APIServerClusterOperatorWatcher IntervalSource = "APIServerClusterOperatorWatcher"
+
 	SourceTestData                IntervalSource = "TestData" // some tests have no real source to assign
 	SourceOVSVswitchdLog          IntervalSource = "OVSVswitchdLog"
 	SourcePathologicalEventMarker IntervalSource = "PathologicalEventMarker" // not sure if this is really helpful since the events all have a different origin

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -103,6 +103,7 @@ const (
 	LocatorTypeNode              LocatorType = "Node"
 	LocatorTypeAlert             LocatorType = "Alert"
 	LocatorTypeClusterOperator   LocatorType = "ClusterOperator"
+	LocatorTypeKubeAPIServer     LocatorType = "KubeAPIServer"
 	LocatorTypeOther             LocatorType = "Other"
 	LocatorTypeDisruption        LocatorType = "Disruption"
 	LocatorTypeKubeEvent         LocatorType = "KubeEvent"

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -308,7 +308,7 @@ type Interval struct {
 
 func (i Interval) String() string {
 	if i.From.Equal(i.To) {
-		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), i.Level.String()[:1], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
+		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), i.Level.String()[:1], i.StructuredLocator.OldLocator(), strings.Replace(i.Message, "\n", "\\n", -1))
 	}
 	duration := i.To.Sub(i.From)
 	if duration < time.Second {
@@ -317,14 +317,14 @@ func (i Interval) String() string {
 			i.From.Nanosecond()/int(time.Millisecond),
 			strconv.Itoa(int(duration/time.Millisecond))+"ms",
 			i.Level.String()[:1],
-			i.Locator,
+			i.StructuredLocator.OldLocator(),
 			strings.Replace(i.Message, "\n", "\\n", -1))
 	}
 	return fmt.Sprintf("%s.%03d - %-5s %s %s %s",
 		i.From.Format("Jan 02 15:04:05"),
 		i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(duration/time.Second))+"s",
 		i.Level.String()[:1],
-		i.Locator,
+		i.StructuredLocator.OldLocator(),
 		strings.Replace(i.Message, "\n", "\\n", -1))
 }
 
@@ -369,6 +369,11 @@ func (i Locator) OldLocator() string {
 	annotationString := strings.Join(annotations, " ")
 
 	return annotationString
+}
+
+func (i Locator) HasKey(k LocatorKey) bool {
+	_, ok := i.Keys[k]
+	return ok
 }
 
 // sortKeys ensures that some keys appear in the order we require (least specific to most), so rows with locators
@@ -461,7 +466,9 @@ func (intervals Intervals) Less(i, j int) bool {
 		return intervals[i].Message < intervals[j].Message
 	}
 
-	return intervals[i].Locator < intervals[j].Locator
+	// TODO: this could be a bit slow, but leaving it simple if we can get away with it. Sorting structured locators
+	// that use keys is trickier than the old flat string method.
+	return intervals[i].StructuredLocator.OldLocator() < intervals[j].StructuredLocator.OldLocator()
 }
 func (intervals Intervals) Len() int { return len(intervals) }
 func (intervals Intervals) Swap(i, j int) {
@@ -548,9 +555,9 @@ func IsInNamespaces(namespaces sets.String) EventIntervalMatchesFunc {
 // ContainsAllParts ensures that all listed key match at least one of the values.
 func ContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatchesFunc {
 	return func(eventInterval Interval) bool {
-		actualParts := LocatorParts(eventInterval.Locator)
+		actualParts := eventInterval.StructuredLocator.Keys
 		for key, possibleValues := range matchers {
-			actualValue := actualParts[key]
+			actualValue := actualParts[LocatorKey(key)]
 
 			found := false
 			for _, possibleValue := range possibleValues {
@@ -571,9 +578,9 @@ func ContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatches
 // NotContainsAllParts returns a function that returns false if any key matches.
 func NotContainsAllParts(matchers map[string][]*regexp.Regexp) EventIntervalMatchesFunc {
 	return func(eventInterval Interval) bool {
-		actualParts := LocatorParts(eventInterval.Locator)
+		actualParts := eventInterval.StructuredLocator.Keys
 		for key, possibleValues := range matchers {
-			actualValue := actualParts[key]
+			actualValue := actualParts[LocatorKey(key)]
 
 			for _, possibleValue := range possibleValues {
 				if possibleValue.MatchString(actualValue) {

--- a/pkg/monitor/monitorapi/types_test.go
+++ b/pkg/monitor/monitorapi/types_test.go
@@ -31,63 +31,49 @@ func TestIntervals_Duration(t *testing.T) {
 			intervals: Intervals{
 				Interval{
 					Condition: Condition{
-						Level:   Info,
-						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
-						Message: "started responding to GET requests over new connections",
+						Level: Info,
 					},
 					From: start1,
 					To:   start2,
 				},
 				Interval{
 					Condition: Condition{
-						Level:   Error,
-						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
-						Message: "stopped responding to GET requests over new connections: Get \"https://api.ci-op-n37nl0in-c1303.ci2.azure.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthclients\": context deadline exceeded",
+						Level: Error,
 					},
 					From: start2,
 					To:   start3,
 				},
 				Interval{
 					Condition: Condition{
-						Level:   Info,
-						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
-						Message: "started responding to GET requests over new connections",
+						Level: Info,
 					},
 					From: start3,
 					To:   start4,
 				},
 				Interval{
 					Condition: Condition{
-						Level:   Error,
-						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
-						Message: "stopped responding to GET requests over new connections: Get \"https://api.ci-op-n37nl0in-c1303.ci2.azure.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthclients\": context deadline exceeded",
+						Level: Error,
 					},
 					From: start4,
 					To:   start5,
 				},
 				Interval{
 					Condition: Condition{
-						Level:   Info,
-						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
-						Message: "started responding to GET requests over new connections",
+						Level: Info,
 					},
 					From: start5,
 					To:   start6,
 				},
 				Interval{
 					Condition: Condition{
-						Level:   Error,
-						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
-						Message: "stopped responding to GET requests over new connections: Get \"https://api.ci-op-n37nl0in-c1303.ci2.azure.devcluster.openshift.com:6443/apis/oauth.openshift.io/v1/oauthclients\": context deadline exceeded",
+						Level: Error,
 					},
 					From: start6,
 					To:   start7,
 				},
 				Interval{
 					Condition: Condition{
-						Level:   Info,
-						Locator: "disruption/oauth-api connection/new disruption/oauth-api connection/new",
-						Message: "started responding to GET requests over new connections",
+						Level: Info,
 					},
 					From: start7,
 					To:   start8,

--- a/pkg/monitor/serialization/serialize.go
+++ b/pkg/monitor/serialization/serialize.go
@@ -162,7 +162,8 @@ func EventsIntervalsToJSON(events monitorapi.Intervals) ([]byte, error) {
 
 func monitorEventIntervalToEventInterval(interval monitorapi.Interval) EventInterval {
 	ret := EventInterval{
-		Level:             fmt.Sprintf("%v", interval.Level),
+		Level: fmt.Sprintf("%v", interval.Level),
+		// TODO: remove this when we're ready to fully ditch the legacy flat string locator
 		Locator:           interval.Locator,
 		Message:           interval.Message,
 		StructuredLocator: interval.StructuredLocator,

--- a/pkg/monitortestlibrary/allowedalerts/basic_alert.go
+++ b/pkg/monitortestlibrary/allowedalerts/basic_alert.go
@@ -431,10 +431,8 @@ func AlertFiringInNamespace(alertName, namespace string) monitorapi.EventInterva
 				if eventAlertName != alertName {
 					return false
 				}
-				if strings.Contains(eventInterval.Message, `alertstate="firing"`) {
-					return true
-				}
-				return false
+
+				return eventInterval.StructuredMessage.Annotations[monitorapi.AnnotationAlertState] == "firing"
 			},
 			InNamespace(namespace),
 		)(eventInterval)
@@ -449,10 +447,7 @@ func AlertPendingInNamespace(alertName, namespace string) monitorapi.EventInterv
 				if eventAlertName != alertName {
 					return false
 				}
-				if strings.Contains(eventInterval.Message, `alertstate="pending"`) {
-					return true
-				}
-				return false
+				return eventInterval.StructuredMessage.Annotations[monitorapi.AnnotationAlertState] == "pending"
 			},
 			InNamespace(namespace),
 		)(eventInterval)

--- a/pkg/monitortestlibrary/allowedalerts/basic_alert.go
+++ b/pkg/monitortestlibrary/allowedalerts/basic_alert.go
@@ -270,7 +270,7 @@ func kubePodNotReadyDueToImagePullBackoff(trackedEventResources monitorapi.Insta
 func kubePodNotReadyDueToRegExMatch(trackedEventResources monitorapi.InstanceMap, firingIntervals monitorapi.Intervals, regexp *regexp.Regexp) bool {
 	// Run the check for all firing intervals.
 	for _, firingInterval := range firingIntervals {
-		relatedPodRef := monitorapi.PodFrom(firingInterval.Locator)
+		relatedPodRef := monitorapi.PodFrom(firingInterval.StructuredLocator)
 
 		// Find an event
 		foundRegexMatchEvent := false
@@ -427,8 +427,7 @@ func AlertFiringInNamespace(alertName, namespace string) monitorapi.EventInterva
 	return func(eventInterval monitorapi.Interval) bool {
 		return monitorapi.And(
 			func(eventInterval monitorapi.Interval) bool {
-				locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
-				eventAlertName := monitorapi.AlertFrom(locatorParts)
+				eventAlertName := eventInterval.StructuredLocator.Keys[monitorapi.LocatorAlertKey]
 				if eventAlertName != alertName {
 					return false
 				}
@@ -446,8 +445,7 @@ func AlertPendingInNamespace(alertName, namespace string) monitorapi.EventInterv
 	return func(eventInterval monitorapi.Interval) bool {
 		return monitorapi.And(
 			func(eventInterval monitorapi.Interval) bool {
-				locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
-				eventAlertName := monitorapi.AlertFrom(locatorParts)
+				eventAlertName := eventInterval.StructuredLocator.Keys[monitorapi.LocatorAlertKey]
 				if eventAlertName != alertName {
 					return false
 				}
@@ -469,10 +467,10 @@ func InNamespace(namespace string) func(event monitorapi.Interval) bool {
 			return true
 
 		case namespace == platformidentification.NamespaceOther:
-			eventNamespace := monitorapi.NamespaceFromLocator(event.Locator)
+			eventNamespace := monitorapi.NamespaceFromLocator(event.StructuredLocator)
 			return !platformidentification.KnownNamespaces.Has(eventNamespace)
 		default:
-			eventNamespace := monitorapi.NamespaceFromLocator(event.Locator)
+			eventNamespace := monitorapi.NamespaceFromLocator(event.StructuredLocator)
 			return eventNamespace == namespace
 		}
 	}

--- a/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
@@ -190,7 +190,7 @@ func (w *Availability) junitForNewConnections(ctx context.Context, finalInterval
 			w.newConnectionTestName, newConnectionAllowed, newConnectionDisruptionDetails, w.newConnectionDisruptionSampler.GetLocator(),
 			finalIntervals.Filter(
 				monitorapi.And(
-					monitorapi.IsEventForLocator(w.newConnectionDisruptionSampler.GetLocator().OldLocator()),
+					monitorapi.IsEventForLocator(w.newConnectionDisruptionSampler.GetLocator()),
 					monitorapi.IsErrorEvent,
 				),
 			),
@@ -208,7 +208,7 @@ func (w *Availability) junitForReusedConnections(ctx context.Context, finalInter
 			w.reusedConnectionTestName, reusedConnectionAllowed, reusedConnectionDisruptionDetails, w.reusedConnectionDisruptionSampler.GetLocator(),
 			finalIntervals.Filter(
 				monitorapi.And(
-					monitorapi.IsEventForLocator(w.reusedConnectionDisruptionSampler.GetLocator().OldLocator()),
+					monitorapi.IsEventForLocator(w.reusedConnectionDisruptionSampler.GetLocator()),
 					monitorapi.IsErrorEvent,
 				),
 			),

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -79,18 +79,19 @@ func (ade *SimplePathologicalEventMatcher) Name() string {
 func (ade *SimplePathologicalEventMatcher) Matches(i monitorapi.Interval) bool {
 	l := i.StructuredLocator
 	msg := i.StructuredMessage
+	log := logrus.WithField("allower", ade.Name())
 	for lk, r := range ade.locatorKeyRegexes {
 		if !r.MatchString(l.Keys[lk]) {
-			logrus.WithField("allower", ade.Name).Debugf("key %s did not match", lk)
+			log.Debugf("%s: key %s did not match", ade.Name(), lk)
 			return false
 		}
 	}
 	if ade.messageHumanRegex != nil && !ade.messageHumanRegex.MatchString(msg.HumanMessage) {
-		logrus.WithField("allower", ade.Name).Debugf("human message did not match")
+		log.Debugf("%s: human message did not match", ade.Name())
 		return false
 	}
 	if ade.messageReasonRegex != nil && !ade.messageReasonRegex.MatchString(string(msg.Reason)) {
-		logrus.WithField("allower", ade.Name).Debugf("message reason did not match")
+		log.Debugf("%s: message reason did not match", ade.Name())
 		return false
 	}
 

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
@@ -206,7 +206,7 @@ func (d *duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOn
 
 			// key used in a map to identify the common interval that is repeating and we may
 			// encounter multiple times.
-			eventDisplayMessage := fmt.Sprintf("%s - reason/%s %s", event.Locator,
+			eventDisplayMessage := fmt.Sprintf("%s - reason/%s %s", event.StructuredLocator.OldLocator(),
 				event.StructuredMessage.Reason, event.StructuredMessage.HumanMessage)
 
 			if _, ok := displayToCount[eventDisplayMessage]; !ok {

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
@@ -312,17 +312,7 @@ func getBiggestRevisionForEtcdOperator(ctx context.Context, operatorClient opera
 // BuildTestDupeKubeEvent is a test utility to make the process of creating these specific intervals a little
 // more brief.
 func BuildTestDupeKubeEvent(namespace, pod, reason, msg string, count int) monitorapi.Interval {
-
-	l := monitorapi.Locator{
-		Type: monitorapi.LocatorTypePod,
-		Keys: map[monitorapi.LocatorKey]string{},
-	}
-	if namespace != "" {
-		l.Keys[monitorapi.LocatorNamespaceKey] = namespace
-	}
-	if pod != "" {
-		l.Keys[monitorapi.LocatorPodKey] = pod
-	}
+	l := monitorapi.NewLocator().PodFromNames(namespace, pod, "")
 
 	i := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
 		Locator(l).

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special.go
@@ -25,7 +25,7 @@ func (s *singleEventThresholdCheck) Test(events monitorapi.Intervals) []*junitap
 	var failureOutput, flakeOutput []string
 	for _, e := range events {
 		if s.matcher.Allows(e, "") {
-			msg := fmt.Sprintf("%s - %s", e.Locator, e.StructuredMessage.HumanMessage)
+			msg := fmt.Sprintf("%s - %s", e.StructuredLocator.OldLocator(), e.StructuredMessage.HumanMessage)
 			times := GetTimesAnEventHappened(e.StructuredMessage)
 			switch {
 			case s.failThreshold > 0 && times > s.failThreshold:

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special.go
@@ -76,7 +76,7 @@ func (s *singleEventThresholdCheck) getNamespacedFailuresAndFlakes(events monito
 
 		var failPresent, flakePresent bool
 		if s.matcher.Allows(e, "") {
-			msg := fmt.Sprintf("%s - %s", e.Locator, e.StructuredMessage.HumanMessage)
+			msg := fmt.Sprintf("%s - %s", e.StructuredLocator.OldLocator(), e.StructuredMessage.HumanMessage)
 			times := GetTimesAnEventHappened(e.StructuredMessage)
 
 			failPresent = false

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -173,9 +173,22 @@ func TestAllowedRepeatedEvents(t *testing.T) {
 			expectedAllowName: "",
 			expectedMatchName: "EtcdReadinessProbeFailuresPerRevisionChange",
 		},
+		{
+			name: "multiple versions found probably in transition",
+			locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey:  "openshift-kube-scheduler-operator",
+					monitorapi.LocatorDeploymentKey: "openshift-kube-scheduler-operator",
+				},
+			},
+
+			msg: monitorapi.NewMessage().HumanMessage("multiple versions found, probably in transition: registry.build05.ci.openshift.org/ci-op-322dfkrq/stable-initial@sha256:c5a14ed931427603ac0cc4f342c59e9d63ed66ef4fa16f4c9c3a6ae7bc3307a7,registry.build05.ci.openshift.org/ci-op-322dfkrq/stable@sha256:c5a14ed931427603ac0cc4f342c59e9d63ed66ef4fa16f4c9c3a6ae7bc3307a7").
+				Reason("MultipleVersions").Build(),
+			expectedAllowName: "OperatorMultipleVersions",
+		},
 	}
 	for _, test := range tests {
-		registry := NewUniversalPathologicalEventMatchers(nil, nil)
+		registry := NewUpgradePathologicalEventMatchers(nil, nil)
 		t.Run(test.name, func(t *testing.T) {
 			i := monitorapi.Interval{
 				Condition: monitorapi.Condition{

--- a/pkg/monitortestlibrary/platformidentification/upgrade.go
+++ b/pkg/monitortestlibrary/platformidentification/upgrade.go
@@ -10,7 +10,7 @@ func DidUpgradeHappenDuringCollection(intervals monitorapi.Intervals, beginning,
 	pertinentIntervals := intervals.Slice(beginning, end)
 
 	for _, event := range pertinentIntervals {
-		if event.StructuredLocator.Type != monitorapi.LocatorTypeKubeEvent || event.StructuredLocator.Keys[monitorapi.LocatorClusterVersionKey] != "cluster" {
+		if event.Source != monitorapi.SourceKubeEvent || event.StructuredLocator.Keys[monitorapi.LocatorClusterVersionKey] != "cluster" {
 			continue
 		}
 		reason := string(event.StructuredMessage.Reason)

--- a/pkg/monitortestlibrary/platformidentification/upgrade.go
+++ b/pkg/monitortestlibrary/platformidentification/upgrade.go
@@ -10,10 +10,10 @@ func DidUpgradeHappenDuringCollection(intervals monitorapi.Intervals, beginning,
 	pertinentIntervals := intervals.Slice(beginning, end)
 
 	for _, event := range pertinentIntervals {
-		if monitorapi.LocatorParts(event.Locator)["clusterversion"] != "cluster" {
+		if event.StructuredLocator.Type != monitorapi.LocatorTypeKubeEvent || event.StructuredLocator.Keys[monitorapi.LocatorClusterVersionKey] != "cluster" {
 			continue
 		}
-		reason := monitorapi.ReasonFrom(event.Message)
+		reason := string(event.StructuredMessage.Reason)
 		if reason == "UpgradeStarted" || reason == "UpgradeRollback" {
 			return true
 		}

--- a/pkg/monitortestlibrary/podaccess/location.go
+++ b/pkg/monitortestlibrary/podaccess/location.go
@@ -24,7 +24,7 @@ func NonUniquePodToNode(intervals monitorapi.Intervals) map[NonUniquePodKey]stri
 			continue
 		}
 
-		pod := monitorapi.PodFrom(interval.Locator)
+		pod := monitorapi.PodFrom(interval.StructuredLocator)
 		if len(pod.Name) == 0 {
 			continue
 		}
@@ -54,7 +54,7 @@ func NonUniqueEtcdMemberToPod(intervals monitorapi.Intervals) map[string]NonUniq
 			continue
 		}
 
-		pod := monitorapi.PodFrom(interval.Locator)
+		pod := monitorapi.PodFrom(interval.StructuredLocator)
 		if len(pod.Name) == 0 {
 			continue
 		}
@@ -72,29 +72,4 @@ func NonUniqueEtcdMemberToPod(intervals monitorapi.Intervals) map[string]NonUniq
 	}
 
 	return ret
-}
-
-func UniquePodToNode(intervals monitorapi.Intervals) map[PodKey]string {
-	ret := map[PodKey]string{}
-	for _, interval := range intervals {
-		pod := monitorapi.PodFrom(interval.Locator)
-		if len(pod.UID) == 0 {
-			continue
-		}
-		node, _ := monitorapi.NodeFromLocator(interval.Locator)
-		if len(node) == 0 {
-			continue
-		}
-
-		key := PodKey{
-			Namespace: pod.Namespace,
-			Name:      pod.Name,
-			UID:       pod.UID,
-		}
-		ret[key] = node
-
-	}
-
-	return ret
-
 }

--- a/pkg/monitortestlibrary/statetracker/state_tracker.go
+++ b/pkg/monitortestlibrary/statetracker/state_tracker.go
@@ -150,7 +150,7 @@ func (t *stateTracker) CloseInterval(locator monitorapi.Locator, state StateInfo
 	if !hasCondition {
 		return nil
 	}
-	return []monitorapi.Interval{ib.Build(from, to)}
+	return []monitorapi.Interval{ib.Display().Build(from, to)}
 }
 
 func (t *stateTracker) CloseAllIntervals(locatorToMessageAnnotations map[string]map[string]string, end time.Time) []monitorapi.Interval {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -371,7 +371,7 @@ func testOperatorOSUpdateStartedEventRecorded(events monitorapi.Intervals, clien
 	// Scan all OSUpdateStarted and OSUpdateStaged events, sort by node.
 	nodeOSUpdateTimes := map[string]*startedStaged{}
 	for _, e := range events {
-		if strings.Contains(e.Message, "reason/OSUpdateStarted") {
+		if e.StructuredMessage.Reason == "OSUpdateStarted" {
 			// locator will be of the form: node/ci-op-j34hmfqt-253f3-cq852-master-1
 			_, ok := nodeOSUpdateTimes[e.StructuredLocator.OldLocator()]
 			if !ok {
@@ -380,7 +380,7 @@ func testOperatorOSUpdateStartedEventRecorded(events monitorapi.Intervals, clien
 			// for this type of event, the from/to time are identical as this is a point in time event.
 			ss := nodeOSUpdateTimes[e.StructuredLocator.OldLocator()]
 			ss.OSUpdateStarted = e.To
-		} else if strings.Contains(e.Message, "reason/OSUpdateStaged") {
+		} else if e.StructuredMessage.Reason == "OSUpdateStaged" {
 			// locator will be of the form: node/ci-op-j34hmfqt-253f3-cq852-master-1
 			_, ok := nodeOSUpdateTimes[e.StructuredLocator.OldLocator()]
 			if !ok {

--- a/pkg/monitortests/clusterversionoperator/operatorstateanalyzer/operator_test.go
+++ b/pkg/monitortests/clusterversionoperator/operatorstateanalyzer/operator_test.go
@@ -23,8 +23,7 @@ func TestIntervalsFromEvents_OperatorProgressing(t *testing.T) {
 		monitorapi.Interval{
 			Source: monitorapi.SourceClusterOperatorMonitor,
 			Condition: monitorapi.Condition{
-				Level:   monitorapi.Info,
-				Locator: "clusteroperator/network",
+				Level: monitorapi.Info,
 				StructuredLocator: monitorapi.Locator{
 					Type: monitorapi.LocatorTypeClusterOperator,
 					Keys: map[monitorapi.LocatorKey]string{
@@ -78,8 +77,7 @@ func TestIntervalsFromEvents_OperatorProgressing2(t *testing.T) {
 		monitorapi.Interval{
 			Source: monitorapi.SourceClusterOperatorMonitor,
 			Condition: monitorapi.Condition{
-				Level:   monitorapi.Warning,
-				Locator: "clusteroperator/kube-apiserver",
+				Level: monitorapi.Warning,
 				StructuredLocator: monitorapi.Locator{
 					Type: monitorapi.LocatorTypeClusterOperator,
 					Keys: map[monitorapi.LocatorKey]string{
@@ -102,8 +100,7 @@ func TestIntervalsFromEvents_OperatorProgressing2(t *testing.T) {
 		monitorapi.Interval{
 			Source: monitorapi.SourceClusterOperatorMonitor,
 			Condition: monitorapi.Condition{
-				Level:   monitorapi.Warning,
-				Locator: "clusteroperator/kube-apiserver",
+				Level: monitorapi.Warning,
 				StructuredLocator: monitorapi.Locator{
 					Type: monitorapi.LocatorTypeClusterOperator,
 					Keys: map[monitorapi.LocatorKey]string{

--- a/pkg/monitortests/etcd/etcdloganalyzer/monitortest.go
+++ b/pkg/monitortests/etcd/etcdloganalyzer/monitortest.go
@@ -91,12 +91,12 @@ func (*etcdLogAnalyzer) ConstructComputedIntervals(ctx context.Context, starting
 	etcdMemberIDToPod := podaccess.NonUniqueEtcdMemberToPod(startingIntervals)
 
 	for _, currInterval := range startingIntervals {
-		reason := monitorapi.ReasonFrom(currInterval.Message)
+		reason := currInterval.StructuredMessage.Reason
 		if !interestingReasons.Has(string(reason)) {
 			continue
 		}
 
-		annotations := monitorapi.AnnotationsFromMessage(currInterval.Message)
+		annotations := currInterval.StructuredMessage.Annotations
 		newLeader := annotations[monitorapi.AnnotationEtcdLeader]
 		newTerm := annotations[monitorapi.AnnotationEtcdTerm]
 

--- a/pkg/monitortests/etcd/legacyetcdmonitortests/etcd.go
+++ b/pkg/monitortests/etcd/legacyetcdmonitortests/etcd.go
@@ -14,8 +14,8 @@ func testEtcdShouldNotLogSlowFdataSyncs(events monitorapi.Intervals) []*junitapi
 
 	var failures []string
 	for _, event := range events {
-		if strings.Contains(event.Message, "slow fdatasync") {
-			failures = append(failures, fmt.Sprintf("%v - %v", event.StructuredLocator.OldLocator(), event.Message))
+		if strings.Contains(event.StructuredMessage.HumanMessage, "slow fdatasync") {
+			failures = append(failures, fmt.Sprintf("%v - %v", event.StructuredLocator.OldLocator(), event.StructuredMessage.OldMessage()))
 		}
 	}
 
@@ -41,8 +41,8 @@ func testEtcdShouldNotLogDroppedRaftMessages(events monitorapi.Intervals) []*jun
 
 	var failures []string
 	for _, event := range events {
-		if strings.Contains(event.Message, "dropped internal Raft message since sending buffer is full") {
-			failures = append(failures, fmt.Sprintf("%v - %v", event.StructuredLocator.OldLocator(), event.Message))
+		if strings.Contains(event.StructuredMessage.HumanMessage, "dropped internal Raft message since sending buffer is full") {
+			failures = append(failures, fmt.Sprintf("%v - %v", event.StructuredLocator.OldLocator(), event.StructuredMessage.OldMessage()))
 		}
 	}
 

--- a/pkg/monitortests/etcd/legacyetcdmonitortests/etcd.go
+++ b/pkg/monitortests/etcd/legacyetcdmonitortests/etcd.go
@@ -15,7 +15,7 @@ func testEtcdShouldNotLogSlowFdataSyncs(events monitorapi.Intervals) []*junitapi
 	var failures []string
 	for _, event := range events {
 		if strings.Contains(event.Message, "slow fdatasync") {
-			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
+			failures = append(failures, fmt.Sprintf("%v - %v", event.StructuredLocator.OldLocator(), event.Message))
 		}
 	}
 
@@ -42,7 +42,7 @@ func testEtcdShouldNotLogDroppedRaftMessages(events monitorapi.Intervals) []*jun
 	var failures []string
 	for _, event := range events {
 		if strings.Contains(event.Message, "dropped internal Raft message since sending buffer is full") {
-			failures = append(failures, fmt.Sprintf("%v - %v", event.Locator, event.Message))
+			failures = append(failures, fmt.Sprintf("%v - %v", event.StructuredLocator.OldLocator(), event.Message))
 		}
 	}
 

--- a/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest.go
@@ -89,7 +89,7 @@ func (*apiserverGracefulShutdownAnalyzer) ConstructComputedIntervals(ctx context
 			computedIntervals = append(computedIntervals,
 				monitorapi.NewInterval(monitorapi.APIServerGracefulShutdown, monitorapi.Info).
 					Locator(monitorapi.NewLocator().
-						LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name, true),
+						LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name),
 					).
 					Message(monitorapi.NewMessage().
 						Constructed("graceful-shutdown-analyzer").
@@ -109,11 +109,11 @@ func (*apiserverGracefulShutdownAnalyzer) ConstructComputedIntervals(ctx context
 		computedIntervals = append(computedIntervals,
 			monitorapi.NewInterval(monitorapi.APIServerGracefulShutdown, monitorapi.Error).
 				Locator(monitorapi.NewLocator().
-					LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name, true),
+					LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name),
 				).
 				Message(monitorapi.NewMessage().
 					Constructed("graceful-shutdown-analyzer").
-					Reason("incomplete shutdown"),
+					Reason(monitorapi.IncompleteAPIServerShutdown),
 				).
 				Display().
 				Build(startTime, time.Time{}),
@@ -158,7 +158,7 @@ func (*apiserverGracefulShutdownAnalyzer) Cleanup(ctx context.Context) error {
 }
 
 func interesting(interval monitorapi.Interval) (monitorapi.IntervalReason, bool) {
-	reason := monitorapi.ReasonFrom(interval.Message)
+	reason := interval.StructuredMessage.Reason
 	switch reason {
 	// openshift-apiserver still is using the old event name TerminationStart
 	case "ShutdownInitiated", "TerminationStart", "TerminationGracefulTerminationFinished":

--- a/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest.go
@@ -71,7 +71,7 @@ func (*apiserverGracefulShutdownAnalyzer) ConstructComputedIntervals(ctx context
 		//    to that of the start event.
 		// TODO: With the above approach, finding the pair will be more deterministic
 		podRef := monitorapi.PodFrom(currInterval.StructuredLocator)
-		nodeName, _ := monitorapi.NodeFromLocator(currInterval.Locator)
+		nodeName, _ := currInterval.StructuredLocator.Keys[monitorapi.LocatorNodeKey]
 		key := fmt.Sprintf("ns/%s pod/%s node/%s", podRef.Namespace, podRef.Name, nodeName)
 
 		switch reason {

--- a/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest_test.go
+++ b/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest_test.go
@@ -14,7 +14,7 @@ func TestBuilder(t *testing.T) {
 
 	interval := monitorapi.NewInterval(monitorapi.APIServerGracefulShutdown, monitorapi.Info).
 		Locator(monitorapi.NewLocator().
-			LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name, true),
+			LocateServer(namespaceToServer[podRef.Namespace], nodeName, podRef.Namespace, podRef.Name),
 		).
 		Message(monitorapi.NewMessage().
 			Constructed("graceful-shutdown-analyzer").
@@ -23,7 +23,7 @@ func TestBuilder(t *testing.T) {
 		Display().
 		Build(time.Time{}, time.Time{})
 
-	if interval.StructuredLocator.OldLocator() != "namespace/openshift-kube-apiserver node/node-name pod/pod-name server/kube-apiserver shutdown/apiserver" {
+	if interval.StructuredLocator.OldLocator() != "namespace/openshift-kube-apiserver node/node-name pod/pod-name server/kube-apiserver" {
 		t.Fatal(interval.StructuredLocator.OldLocator())
 	}
 }

--- a/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest_test.go
+++ b/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest_test.go
@@ -23,7 +23,7 @@ func TestBuilder(t *testing.T) {
 		Display().
 		Build(time.Time{}, time.Time{})
 
-	if interval.Locator != "namespace/openshift-kube-apiserver node/node-name pod/pod-name server/kube-apiserver shutdown/apiserver" {
-		t.Fatal(interval.Locator)
+	if interval.StructuredLocator.OldLocator() != "namespace/openshift-kube-apiserver node/node-name pod/pod-name server/kube-apiserver shutdown/apiserver" {
+		t.Fatal(interval.StructuredLocator.OldLocator())
 	}
 }

--- a/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest_test.go
+++ b/pkg/monitortests/kubeapiserver/apiservergracefulrestart/monitortest_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBuilder(t *testing.T) {
 	oldLocator := "node/node-name ns/openshift-kube-apiserver pod/pod-name"
-	podRef := monitorapi.PodFrom(oldLocator)
+	podRef := podFrom(oldLocator)
 	nodeName, _ := monitorapi.NodeFromLocator(oldLocator)
 
 	interval := monitorapi.NewInterval(monitorapi.APIServerGracefulShutdown, monitorapi.Info).

--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/apiserver.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/apiserver.go
@@ -14,7 +14,7 @@ func testPodNodeNameIsImmutable(events monitorapi.Intervals) []*junitapi.JUnitTe
 	failures := []string{}
 	for _, event := range events {
 		if strings.Contains(event.Message, "pod once assigned to a node must stay on it") {
-			failures = append(failures, fmt.Sprintf("%v %v", event.Locator, event.Message))
+			failures = append(failures, fmt.Sprintf("%v %v", event.StructuredLocator.OldLocator(), event.Message))
 		}
 	}
 	if len(failures) == 0 {

--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/apiserver.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/apiserver.go
@@ -13,8 +13,8 @@ func testPodNodeNameIsImmutable(events monitorapi.Intervals) []*junitapi.JUnitTe
 
 	failures := []string{}
 	for _, event := range events {
-		if strings.Contains(event.Message, "pod once assigned to a node must stay on it") {
-			failures = append(failures, fmt.Sprintf("%v %v", event.StructuredLocator.OldLocator(), event.Message))
+		if strings.Contains(event.StructuredMessage.HumanMessage, "pod once assigned to a node must stay on it") {
+			failures = append(failures, fmt.Sprintf("%v %v", event.StructuredLocator.OldLocator(), event.StructuredMessage.OldMessage()))
 		}
 	}
 	if len(failures) == 0 {

--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/disruption.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/disruption.go
@@ -18,7 +18,7 @@ func testAPIServerIPTablesAccessDisruption(events monitorapi.Intervals) []*junit
 		if reason != "iptables-operation-not-permitted" {
 			continue
 		}
-		ns := monitorapi.NamespaceFromLocator(event.Locator)
+		ns := monitorapi.NamespaceFromLocator(event.StructuredLocator)
 		namespacesToCount[ns] = namespacesToCount[ns] + 1
 		messages = append(messages, event.String())
 	}

--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/disruption.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/disruption.go
@@ -14,7 +14,7 @@ func testAPIServerIPTablesAccessDisruption(events monitorapi.Intervals) []*junit
 	namespacesToCount := map[string]int{}
 	messages := []string{}
 	for _, event := range events {
-		reason := monitorapi.ReasonFrom(event.Message)
+		reason := event.StructuredMessage.Reason
 		if reason != "iptables-operation-not-permitted" {
 			continue
 		}

--- a/pkg/monitortests/network/legacynetworkmonitortests/disruption.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/disruption.go
@@ -127,11 +127,11 @@ func testDNSOverlapDisruption(events monitorapi.Intervals) []*junitapi.JUnitTest
 	disruptionIntervals := []monitorapi.Interval{}
 	for _, event := range events {
 		// DNS outage
-		if reason := monitorapi.ReasonFrom(event.Message); reason == "DisruptionSamplerOutageBegan" {
+		if event.StructuredMessage.Reason == "DisruptionSamplerOutageBegan" {
 			dnsIntervals = append(dnsIntervals, event)
 		}
 		// real disruption
-		if reason := monitorapi.ReasonFrom(event.Message); reason == "DisruptionBegan" {
+		if event.StructuredMessage.Reason == "DisruptionBegan" {
 			disruptionIntervals = append(disruptionIntervals, event)
 		}
 	}

--- a/pkg/monitortests/network/legacynetworkmonitortests/disruption_test.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/disruption_test.go
@@ -12,48 +12,102 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 	events := []monitorapi.Interval{
 		{
 			Condition: monitorapi.Condition{
-				Locator: "disruption/openshift-api connection/new",
-				Message: "reason/DisruptionSamplerOutageBegan DNS lookup timeouts began",
+				StructuredLocator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeDisruption,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorDisruptionKey: "openshift-api",
+						monitorapi.LocatorConnectionKey: "new",
+					},
+				},
+				StructuredMessage: monitorapi.Message{
+					Reason:       "DisruptionSamplerOutageBegan",
+					HumanMessage: "DNS lookup timeouts began",
+				},
 			},
 			From: time.Now(),
 			To:   time.Now().Add(1 * time.Minute),
 		},
 		{
 			Condition: monitorapi.Condition{
-				Locator: "disruption/openshift-api connection/new",
-				Message: "reason/DisruptionSamplerOutageBegan DNS lookup timeouts began",
+				StructuredLocator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeDisruption,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorDisruptionKey: "openshift-api",
+						monitorapi.LocatorConnectionKey: "new",
+					},
+				},
+				StructuredMessage: monitorapi.Message{
+					Reason:       "DisruptionSamplerOutageBegan",
+					HumanMessage: "DNS lookup timeouts began",
+				},
 			},
 			From: time.Now().Add(2 * time.Minute),
 			To:   time.Now().Add(3 * time.Minute),
 		},
 		{
 			Condition: monitorapi.Condition{
-				Locator: "disruption/openshift-api connection/new",
-				Message: "reason/DisruptionSamplerOutageBegan DNS lookup timeouts began",
+				StructuredLocator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeDisruption,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorDisruptionKey: "openshift-api",
+						monitorapi.LocatorConnectionKey: "new",
+					},
+				},
+				StructuredMessage: monitorapi.Message{
+					Reason:       "DisruptionSamplerOutageBegan",
+					HumanMessage: "DNS lookup timeouts began",
+				},
 			},
 			From: time.Now().Add(4 * time.Minute),
 			To:   time.Now().Add(5 * time.Minute),
 		},
 		{
 			Condition: monitorapi.Condition{
-				Locator: "disruption/openshift-api connection/new",
-				Message: "reason/DisruptionBegan disruption",
+				StructuredLocator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeDisruption,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorDisruptionKey: "openshift-api",
+						monitorapi.LocatorConnectionKey: "new",
+					},
+				},
+				StructuredMessage: monitorapi.Message{
+					Reason:       "DisruptionBegan",
+					HumanMessage: "disruption",
+				},
 			},
 			From: time.Now().Add(6 * time.Minute),
 			To:   time.Now().Add(7 * time.Minute),
 		},
 		{
 			Condition: monitorapi.Condition{
-				Locator: "disruption/openshift-api connection/new",
-				Message: "reason/DisruptionBegan disruption",
+				StructuredLocator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeDisruption,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorDisruptionKey: "openshift-api",
+						monitorapi.LocatorConnectionKey: "new",
+					},
+				},
+				StructuredMessage: monitorapi.Message{
+					Reason:       "DisruptionBegan",
+					HumanMessage: "disruption",
+				},
 			},
 			From: time.Now().Add(8 * time.Minute),
 			To:   time.Now().Add(9 * time.Minute),
 		},
 		{
 			Condition: monitorapi.Condition{
-				Locator: "disruption/openshift-api connection/new",
-				Message: "reason/DisruptionBegan disruption",
+				StructuredLocator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeDisruption,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorDisruptionKey: "openshift-api",
+						monitorapi.LocatorConnectionKey: "new",
+					},
+				},
+				StructuredMessage: monitorapi.Message{
+					Reason:       "DisruptionBegan",
+					HumanMessage: "disruption",
+				},
 			},
 			From: time.Now().Add(6 * time.Minute),
 			To:   time.Now().Add(8 * time.Minute),
@@ -74,7 +128,17 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 			name: "Partial Overlap between DNS and disruption",
 			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Message: "reason/DisruptionBegan disruption",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeDisruption,
+						Keys: map[monitorapi.LocatorKey]string{
+							monitorapi.LocatorDisruptionKey: "openshift-api",
+							monitorapi.LocatorConnectionKey: "new",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "DisruptionBegan",
+						HumanMessage: "disruption",
+					},
 				},
 				From: time.Now().Add(3*time.Minute + 50*time.Second),
 				To:   time.Now().Add(4*time.Minute + 5*time.Second),
@@ -85,7 +149,17 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 			name: "Complete Overlap between DNS and disruption",
 			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Message: "reason/DisruptionSamplerOutageBegan DNS lookup timeouts began",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeDisruption,
+						Keys: map[monitorapi.LocatorKey]string{
+							monitorapi.LocatorDisruptionKey: "openshift-api",
+							monitorapi.LocatorConnectionKey: "new",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "DisruptionBegan",
+						HumanMessage: "disruption",
+					},
 				},
 				From: time.Now().Add(5 * time.Minute),
 				To:   time.Now().Add(6 * time.Minute),
@@ -96,7 +170,17 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 			name: "Overlap within 10 seconds between DNS and disruption",
 			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Message: "reason/DisruptionSamplerOutageBegan DNS lookup timeouts began",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeDisruption,
+						Keys: map[monitorapi.LocatorKey]string{
+							monitorapi.LocatorDisruptionKey: "openshift-api",
+							monitorapi.LocatorConnectionKey: "new",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "DisruptionSamplerOutageBegan",
+						HumanMessage: "DNS lookup timeouts began",
+					},
 				},
 				From: time.Now().Add(6*time.Minute + 5*time.Second),
 				To:   time.Now().Add(6*time.Minute + 15*time.Second),
@@ -107,7 +191,17 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 			name: "Overlap between DNS and disruption with same start time",
 			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Message: "reason/DisruptionBegan disruption",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeDisruption,
+						Keys: map[monitorapi.LocatorKey]string{
+							monitorapi.LocatorDisruptionKey: "openshift-api",
+							monitorapi.LocatorConnectionKey: "new",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "DisruptionBegan",
+						HumanMessage: "disruption",
+					},
 				},
 				From: time.Now().Add(4 * time.Minute),
 				To:   time.Now().Add(4*time.Minute + 10*time.Second),
@@ -118,7 +212,17 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 			name: "Overlap between DNS and disruption with same end time",
 			events: append(events, monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Message: "reason/DisruptionBegan disruption",
+					StructuredLocator: monitorapi.Locator{
+						Type: monitorapi.LocatorTypeDisruption,
+						Keys: map[monitorapi.LocatorKey]string{
+							monitorapi.LocatorDisruptionKey: "openshift-api",
+							monitorapi.LocatorConnectionKey: "new",
+						},
+					},
+					StructuredMessage: monitorapi.Message{
+						Reason:       "DisruptionBegan",
+						HumanMessage: "disruption",
+					},
 				},
 				From: time.Now().Add(2*time.Minute + 45*time.Second),
 				To:   time.Now().Add(3 * time.Minute),

--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -284,7 +284,7 @@ func categorizeBySubset(categorizers []testCategorizer, failures, flakes []strin
 func getEventsByPodName(events monitorapi.Intervals) map[string]monitorapi.Intervals {
 	eventsByPods := map[string]monitorapi.Intervals{}
 	for _, event := range events {
-		if !strings.Contains(event.Locator, "pod/") {
+		if !event.StructuredLocator.HasKey(monitorapi.LocatorPodKey) {
 			continue
 		}
 		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.Locator)

--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -3,6 +3,7 @@ package legacynetworkmonitortests
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -76,9 +77,8 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 		if annotations[monitorapi.AnnotationCondition] != string(configv1.OperatorProgressing) {
 			return false
 		}
-		locatorParts := monitorapi.LocatorParts(ev.Locator)
-		isNetwork := locatorParts[string(monitorapi.LocatorClusterOperatorKey)] == "network"
-		isMCO := locatorParts[string(monitorapi.LocatorClusterOperatorKey)] == "machine-config"
+		isNetwork := ev.StructuredLocator.Keys[monitorapi.LocatorClusterOperatorKey] == "network"
+		isMCO := ev.StructuredLocator.Keys[monitorapi.LocatorClusterOperatorKey] == "machine-config"
 		if isNetwork || isMCO {
 			return true
 		}
@@ -119,10 +119,10 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 			continue
 		}
 
-		if strings.Contains(event.Locator, "pod/simpletest-rc-to-be-deleted") &&
-			(strings.Contains(event.Message, "not found") ||
-				strings.Contains(event.Message, "pod was already deleted") ||
-				strings.Contains(event.Message, "error adding container to network")) {
+		if strings.Contains(event.StructuredLocator.Keys[monitorapi.LocatorPodKey], "simpletest-rc-to-be-deleted") &&
+			(strings.Contains(event.StructuredMessage.HumanMessage, "not found") ||
+				strings.Contains(event.StructuredMessage.HumanMessage, "pod was already deleted") ||
+				strings.Contains(event.StructuredMessage.HumanMessage, "error adding container to network")) {
 			// This FailedCreatePodSandBox might happen because of an upstream Garbage Collector test. This test creates at least 10 pods controlled
 			// by a ReplicationController. Then proceeds to create a second ReplicationController and sets half of the pods owned by both RCs. Tries
 			// deleting all pods owned by the first RC and checks if the half having 2 owners is not deleted. Test doesnt wait for
@@ -131,43 +131,43 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 			// https://github.com/kubernetes/kubernetes/blob/70ca1dbb81d8b8c6a2ac88d62480008780d4db79/test/e2e/apimachinery/garbage_collector.go#L735
 			continue
 		}
-		if strings.Contains(event.Locator, "ns/e2e-test-tuning-") &&
-			strings.Contains(event.Message, "IFNAME") {
+		if strings.Contains(event.StructuredLocator.Keys[monitorapi.LocatorNamespaceKey], "e2e-test-tuning-") &&
+			strings.Contains(event.StructuredMessage.HumanMessage, "IFNAME") {
 			// These tests are trying to cause pod sandbox failures, so the errors are intended.
 			continue
 		}
 		if strings.Contains(event.Message, "Multus") &&
-			strings.Contains(event.Message, "error getting pod") &&
-			(strings.Contains(event.Message, "connection refused") || strings.Contains(event.Message, "i/o timeout")) {
-			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to get pods due to LB disruption https://bugzilla.redhat.com/show_bug.cgi?id=1927264 - %v", event.Locator, event.Message))
+			strings.Contains(event.StructuredMessage.HumanMessage, "error getting pod") &&
+			(strings.Contains(event.StructuredMessage.HumanMessage, "connection refused") || strings.Contains(event.Message, "i/o timeout")) {
+			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to get pods due to LB disruption https://bugzilla.redhat.com/show_bug.cgi?id=1927264 - %v", event.StructuredLocator.OldLocator(), event.Message))
 			continue
 		}
-		if strings.Contains(event.Message, "Multus") && strings.Contains(event.Message, "error getting pod: Unauthorized") {
-			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to get pods due to authorization https://bugzilla.redhat.com/show_bug.cgi?id=1972490 - %v", event.Locator, event.Message))
+		if strings.Contains(event.StructuredMessage.HumanMessage, "Multus") && strings.Contains(event.StructuredMessage.HumanMessage, "error getting pod: Unauthorized") {
+			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to get pods due to authorization https://bugzilla.redhat.com/show_bug.cgi?id=1972490 - %v", event.StructuredLocator.OldLocator(), event.Message))
 			continue
 		}
-		if strings.Contains(event.Message, "Multus") &&
-			strings.Contains(event.Message, "have you checked that your default network is ready? still waiting for readinessindicatorfile") {
-			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to get pods as ovnkube-node pod has not yet written readinessindicatorfile (possibly not running due to image pull delays) https://bugzilla.redhat.com/show_bug.cgi?id=20671320 - %v", event.Locator, event.Message))
+		if strings.Contains(event.StructuredMessage.HumanMessage, "Multus") &&
+			strings.Contains(event.StructuredMessage.HumanMessage, "have you checked that your default network is ready? still waiting for readinessindicatorfile") {
+			flakes = append(flakes, fmt.Sprintf("%v - multus is unable to get pods as ovnkube-node pod has not yet written readinessindicatorfile (possibly not running due to image pull delays) https://bugzilla.redhat.com/show_bug.cgi?id=20671320 - %v", event.StructuredLocator.OldLocator(), event.Message))
 			continue
 		}
-		if strings.Contains(event.Locator, "pod/whereabouts-pod") &&
-			strings.Contains(event.Message, "error adding container to network") &&
-			strings.Contains(event.Message, "Error at storage engine: Could not allocate IP in range: ip: 192.168.2.225 / - 192.168.2.230 ") {
+		if strings.Contains(event.StructuredLocator.Keys[monitorapi.LocatorPodKey], "whereabouts-pod") &&
+			strings.Contains(event.StructuredMessage.HumanMessage, "error adding container to network") &&
+			strings.Contains(event.StructuredMessage.HumanMessage, "Error at storage engine: Could not allocate IP in range: ip: 192.168.2.225 / - 192.168.2.230 ") {
 			// This failed to create sandbox case is expected due to the whereabouts-e2e test which creates a pod that is expected to
 			// not come up due to IP range exhausted.
 			// See https://github.com/openshift/origin/blob/93eb467cc8d293ba977549b05ae2e4b818c64327/test/extended/networking/whereabouts.go#L52
 			continue
 		}
-		if strings.Contains(event.Message, "pinging container registry") && strings.Contains(event.Message, "i/o timeout") {
+		if strings.Contains(event.StructuredMessage.HumanMessage, "pinging container registry") && strings.Contains(event.Message, "i/o timeout") {
 			if platform == configv1.AzurePlatformType {
-				flakes = append(flakes, fmt.Sprintf("%v - i/o timeout common flake when pinging container registry on azure - %v", event.Locator, event.Message))
+				flakes = append(flakes, fmt.Sprintf("%v - i/o timeout common flake when pinging container registry on azure - %v", event.StructuredLocator.OldLocator(), event.Message))
 				continue
 			}
 		}
 
-		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.Locator)
-		if deletionTime := getPodDeletionTime(eventsForPods[partialLocator], event.Locator); deletionTime == nil {
+		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.StructuredLocator)
+		if deletionTime := getPodDeletionTime(eventsForPods[partialLocator], event.StructuredLocator); deletionTime == nil {
 			// mark sandboxes errors as flakes if networking is being updated
 			match := -1
 			for i := range networkOperatorProgressing {
@@ -179,9 +179,9 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 				}
 			}
 			if match != -1 {
-				flakes = append(flakes, fmt.Sprintf("%v - never deleted - network rollout - %v", event.Locator, event.Message))
+				flakes = append(flakes, fmt.Sprintf("%v - never deleted - network rollout - %v", event.StructuredLocator.OldLocator(), event.Message))
 			} else {
-				failures = append(failures, fmt.Sprintf("%v - never deleted - %v", event.Locator, event.Message))
+				failures = append(failures, fmt.Sprintf("%v - never deleted - %v", event.StructuredLocator.OldLocator(), event.Message))
 			}
 
 		} else {
@@ -191,13 +191,13 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 				// nothing here, one second is close enough to be ok, the kubelet and CNI just didn't know
 			case timeBetweenDeleteAndFailure < 5*time.Second:
 				// withing five seconds, it ought to be long enough to know, but it's close enough to flake and not fail
-				flakes = append(flakes, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator, timeBetweenDeleteAndFailure.Seconds(), event.Message))
+				flakes = append(flakes, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.StructuredLocator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), event.Message))
 			case deletionTime.Before(event.From):
 				// something went wrong.  More than five seconds after the pod ws deleted, the CNI is trying to set up pod sandboxes and can't
-				failures = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator, timeBetweenDeleteAndFailure.Seconds(), event.Message))
+				failures = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.StructuredLocator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), event.Message))
 			default:
 				// something went wrong.  deletion happend after we had a failure to create the pod sandbox
-				failures = append(failures, fmt.Sprintf("%v - deletion came AFTER sandbox failure - %v", event.Locator, event.Message))
+				failures = append(failures, fmt.Sprintf("%v - deletion came AFTER sandbox failure - %v", event.StructuredLocator.OldLocator(), event.Message))
 			}
 		}
 	}
@@ -287,17 +287,17 @@ func getEventsByPodName(events monitorapi.Intervals) map[string]monitorapi.Inter
 		if !event.StructuredLocator.HasKey(monitorapi.LocatorPodKey) {
 			continue
 		}
-		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.Locator)
+		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.StructuredLocator)
 		eventsByPods[partialLocator] = append(eventsByPods[partialLocator], event)
 	}
 	return eventsByPods
 }
 
-func getPodDeletionTime(events monitorapi.Intervals, podLocator string) *time.Time {
+func getPodDeletionTime(events monitorapi.Intervals, podLocator monitorapi.Locator) *time.Time {
 	partialLocator := monitorapi.NonUniquePodLocatorFrom(podLocator)
 	for _, event := range events {
-		currPartialLocator := monitorapi.NonUniquePodLocatorFrom(event.Locator)
-		if currPartialLocator == partialLocator && strings.Contains(event.Message, "reason/Deleted") {
+		currPartialLocator := monitorapi.NonUniquePodLocatorFrom(event.StructuredLocator)
+		if reflect.DeepEqual(currPartialLocator, partialLocator) && event.StructuredMessage.Reason == "Deleted" {
 			return &event.From
 		}
 	}
@@ -313,7 +313,7 @@ func testOvnNodeReadinessProbe(events monitorapi.Intervals, kubeClientConfig *re
 	msgMap := map[string]bool{}
 
 	for _, event := range events {
-		msg := fmt.Sprintf("%s - %s", event.Locator, event.Message)
+		msg := fmt.Sprintf("%s - %s", event.StructuredLocator.OldLocator(), event.Message)
 		if pathologicaleventlibrary.AllowOVNReadiness.Allows(event, "") {
 
 			if _, ok := msgMap[msg]; !ok {
@@ -415,7 +415,7 @@ func testNoOVSVswitchdUnreasonablyLongPollIntervals(events monitorapi.Intervals)
 	var maxDur time.Duration
 	for _, event := range events {
 		if strings.Contains(event.Message, "Unreasonably long") && strings.Contains(event.Message, "ovs-vswitchd") {
-			msg := fmt.Sprintf("%v - %v", event.Locator, event.Message)
+			msg := fmt.Sprintf("%v - %v", event.StructuredLocator.OldLocator(), event.Message)
 			failures = append(failures, msg)
 
 			dur := event.To.Sub(event.From)
@@ -451,7 +451,7 @@ func testNoTooManyNetlinkEventLogs(events monitorapi.Intervals) []*junitapi.JUni
 	var failures []string
 	for _, event := range events {
 		if strings.Contains(event.Message, "read: too many netlink events. Need to resynchronize platform cache") && strings.Contains(event.Message, "NetworkManager") {
-			msg := fmt.Sprintf("%v - %v", event.Locator, event.Message)
+			msg := fmt.Sprintf("%v - %v", event.StructuredLocator.OldLocator(), event.Message)
 			failures = append(failures, msg)
 		}
 	}

--- a/pkg/monitortests/node/kubeletlogcollector/node_test.go
+++ b/pkg/monitortests/node/kubeletlogcollector/node_test.go
@@ -25,9 +25,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: eventsFromKubeletLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: "ns/openshift-monitoring pod/prometheus-k8s-0 uid/a1947638-25c2-4fd8-b3c8-4dbaa666bc61 container/",
-					Message: "reason/HttpClientConnectionLost ",
+					Level: monitorapi.Info,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeContainer,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -56,9 +54,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: eventsFromKubeletLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: "ns/openshift-monitoring pod/prometheus-adapter-7m6srg4dfreoi uid/ container/",
-					Message: "reason/HttpClientConnectionLost unable to decode an event from the watch stream: http2: client connection lost",
+					Level: monitorapi.Info,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeContainer,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -87,9 +83,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: eventsFromKubeletLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: "node/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s",
-					Message: "reason/HttpClientConnectionLost error getting node \"ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s\": Get \"https://api-int.ci-op-747jjqn3-b3af3.ci2.azure.devcluster.openshift.com:6443/api/v1/nodes/ci-op-747jjqn3-b3af3-f45pk-worker-centralus2-bdp5s?timeout=10s\": http2: client connection lost",
+					Level: monitorapi.Info,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeNode,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -115,9 +109,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: eventsFromKubeletLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: "node/testName",
-					Message: "reason/FailedToUpdateLease https://api-int.ci-op-6clh576g-0dd98.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-6clh576g-0dd98-xz4pt-master-2?timeout=10s - net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
+					Level: monitorapi.Info,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeNode,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -142,9 +134,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: eventsFromKubeletLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: "node/testName",
-					Message: "reason/FailedToUpdateLease https://api-int.ci-op-cyqgzj4w-ed5cd.ci2.azure.devcluster.openshift.com:6443/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/ci-op-cyqgzj4w-ed5cd-ll5md-master-0?timeout=10s - http2: client connection lost",
+					Level: monitorapi.Info,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeNode,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -169,9 +159,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: eventsFromKubeletLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: "ns/openshift-authentication pod/oauth-openshift-77f7b95df5-r4xf7 uid/1af660b3-ac3a-4182-86eb-2f74725d8415 container/oauth-openshift",
-					Message: "reason/ReadinessFailed Get \"https://10.129.0.12:6443/healthz\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)",
+					Level: monitorapi.Info,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeContainer,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -200,9 +188,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: eventsFromKubeletLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: "ns/openshift-marketplace pod/redhat-operators-4jpg4 uid/0bac4741-a3bd-483c-b119-e97663d64024 container/registry-server",
-					Message: "reason/ReadinessErrored rpc error: code = NotFound desc = container is not created or running: checking if PID of 645437acbb2ca429c04d5a2628924e2e10d44c681c824dddc7c82ffa30a936be is running failed: container process not found",
+					Level: monitorapi.Info,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeContainer,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -231,9 +217,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: eventsFromKubeletLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Info,
-					Locator: "ns/openshift-e2e-loki pod/loki-promtail-plm74 uid/59b26cbf-3421-407c-98ee-986b5a091ef4 container/oauth-proxy",
-					Message: "cause/UnrecognizedSignatureFormat reason/ErrImagePull",
+					Level: monitorapi.Info,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeContainer,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -264,9 +248,7 @@ func TestMonitorApiIntervals(t *testing.T) {
 			generatorFunc: intervalsFromNetworkManagerLogs,
 			want: monitorapi.Interval{
 				Condition: monitorapi.Condition{
-					Level:   monitorapi.Warning,
-					Locator: "node/ci-op-xs3rnrtc-2d4c7-4mhm7-worker-b-dwc7w",
-					Message: "[1155]: <info> [1681300187.8326] platform-linux: netlink[rtnl]: read: too many netlink events. Need to resynchronize platform cache",
+					Level: monitorapi.Warning,
 					StructuredLocator: monitorapi.Locator{
 						Type: monitorapi.LocatorTypeNode,
 						Keys: map[monitorapi.LocatorKey]string{
@@ -518,8 +500,7 @@ func Test_readinessFailure(t *testing.T) {
 			want: monitorapi.Intervals{
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: `ns/openshift-authentication pod/oauth-openshift-77f7b95df5-r4xf7 uid/1af660b3-ac3a-4182-86eb-2f74725d8415 container/oauth-openshift`,
+						Level: monitorapi.Info,
 						StructuredLocator: monitorapi.Locator{
 							Type: monitorapi.LocatorTypeContainer,
 							Keys: map[monitorapi.LocatorKey]string{
@@ -529,7 +510,6 @@ func Test_readinessFailure(t *testing.T) {
 								"container": "oauth-openshift",
 							},
 						},
-						Message: `reason/ReadinessFailed Get "https://10.129.0.12:6443/healthz": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)`,
 						StructuredMessage: monitorapi.Message{
 							Reason:       "ReadinessFailed",
 							Cause:        "",

--- a/pkg/monitortests/node/kubeletlogcollector/node_test.go
+++ b/pkg/monitortests/node/kubeletlogcollector/node_test.go
@@ -60,7 +60,6 @@ func TestMonitorApiIntervals(t *testing.T) {
 						Keys: map[monitorapi.LocatorKey]string{
 							"namespace": "openshift-monitoring",
 							"pod":       "prometheus-adapter-7m6srg4dfreoi",
-							"uid":       "",
 							"container": "",
 						},
 					},
@@ -328,7 +327,6 @@ func TestRegexToContainerReference(t *testing.T) {
 					monitorapi.LocatorContainerKey: "",
 					monitorapi.LocatorNamespaceKey: "openshift-monitoring",
 					monitorapi.LocatorPodKey:       "prometheus-adapter-7m6srg4dfreoi",
-					monitorapi.LocatorUIDKey:       "",
 				},
 			},
 		},

--- a/pkg/monitortests/node/nodestateanalyzer/node.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node.go
@@ -24,11 +24,11 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 		// ready events because they have a node in the locator, and a reason of "Ready".
 		// Once the reasons marked "not ported" in the comments below are ported, we could filter here on
 		// event.Source to ensure we only look at what we intend.
-		node, ok := monitorapi.NodeFromLocator(event.Locator)
+		node, ok := event.StructuredLocator.Keys[monitorapi.LocatorNodeKey]
 		if !ok {
 			continue
 		}
-		reason := monitorapi.ReasonFrom(event.Message)
+		reason := event.StructuredMessage.Reason
 		if len(reason) == 0 {
 			continue
 		}

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/expected.json
@@ -5,6 +5,7 @@
             "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7 row/NodeUpdatePhases",
             "message": "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
             "tempSource": "NodeState",
+            "display": true,
             "tempStructuredLocator": {
                 "type": "Node",
                 "keys": {
@@ -31,6 +32,7 @@
             "locator": "node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7 row/NodeUpdatePhases",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate roles/worker state/OperatingSystemUpdate never completed",
             "tempSource": "NodeState",
+            "display": true,
             "tempStructuredLocator": {
                 "type": "Node",
                 "keys": {

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/startingEvents.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-01/startingEvents.json
@@ -2,8 +2,25 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-machine-config-operator node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
+      "locator": "ns/openshift-machine-config-operator node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7 hmsg/502676ccb6",
       "message": "reason/Drain roles/worker Draining node to update config.",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "502676ccb6",
+          "node": "ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Drain",
+        "cause": "",
+        "humanMessage": "Draining node to update config.",
+        "annotations": {
+          "reason": "Drain",
+          "roles": "worker"
+        }
+      },
       "from": "2023-07-17T22:58:52Z",
       "to": "2023-07-17T22:58:52Z"
     },
@@ -11,6 +28,23 @@
       "level": "Info",
       "locator": "ns/openshift-machine-config-operator node/ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7",
       "message": "reason/OSUpdateStarted roles/worker Upgrading OS",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "873e8ad5d9",
+          "node": "ci-op-3zwth0s8-03fd1-bcssj-worker-a-2lcx7"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "OSUpdateStarted",
+        "cause": "",
+        "humanMessage": "Upgrading OS",
+        "annotations": {
+          "reason": "OSUpdateStarted",
+          "roles": "worker"
+        }
+      },
       "from": "2023-07-17T23:00:24Z",
       "to": "2023-07-17T23:00:24Z"
     }

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/expected.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/expected.json
@@ -5,6 +5,7 @@
             "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm row/NodeUpdatePhases",
             "message": "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
             "tempSource": "NodeState",
+            "display": true,
             "tempStructuredLocator": {
                 "type": "Node",
                 "keys": {
@@ -31,6 +32,7 @@
             "locator": "node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm row/NodeUpdatePhases",
             "message": "constructed/node-lifecycle-constructor reason/NodeUpdate roles/worker state/OperatingSystemUpdate never completed",
             "tempSource": "NodeState",
+            "display": true,
             "tempStructuredLocator": {
                 "type": "Node",
                 "keys": {

--- a/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/startingEvents.json
+++ b/pkg/monitortests/node/nodestateanalyzer/nodeTest/drain-02/startingEvents.json
@@ -2,8 +2,25 @@
   "items": [
     {
       "level": "Info",
-      "locator": "ns/openshift-machine-config-operator node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
+      "locator": "ns/openshift-machine-config-operator node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm hmsg/94b2a62d8a",
       "message": "reason/Cordon roles/worker Cordoned node to apply update",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "94b2a62d8a",
+          "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Cordon",
+        "cause": "",
+        "humanMessage": "Cordoned node to apply update",
+        "annotations": {
+          "reason": "Cordon",
+          "roles": "worker"
+        }
+      },
       "from": "2023-07-18T16:40:16Z",
       "to": "2023-07-18T16:40:16Z"
     },
@@ -11,6 +28,24 @@
       "level": "Info",
       "locator": "ns/openshift-machine-config-operator node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
       "message": "reason/Drain roles/worker Draining node to update config.",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "502676ccb6",
+          "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Drain",
+        "cause": "",
+        "humanMessage": "Draining node to update config.",
+        "annotations": {
+          "reason": "Drain",
+          "roles": "worker"
+        }
+      },
+
       "from": "2023-07-18T16:40:16Z",
       "to": "2023-07-18T16:40:16Z"
     },
@@ -18,6 +53,24 @@
       "level": "Info",
       "locator": "ns/openshift-machine-config-operator node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
       "message": "reason/InClusterUpgrade roles/worker Updating from oscontainer registry.build04.ci.openshift.org/ci-op-wh7nq7n4/stable@sha256:42fef51c3f19f40f5573f1ba6a393c3e8fbe53b78eb977aea957f60b85b1458a",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "0294347a34",
+          "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "InClusterUpgrade",
+        "cause": "",
+        "humanMessage": "Updating from oscontainer registry.build04.ci.openshift.org/ci-op-wh7nq7n4/stable@sha256:42fef51c3f19f40f5573f1ba6a393c3e8fbe53b78eb977aea957f60b85b1458a",
+        "annotations": {
+          "reason": "InClusterUpgrade",
+          "roles": "worker"
+        }
+      },
+
       "from": "2023-07-18T16:41:49Z",
       "to": "2023-07-18T16:41:49Z"
     },
@@ -25,6 +78,23 @@
       "level": "Info",
       "locator": "ns/openshift-machine-config-operator node/ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm",
       "message": "reason/OSUpdateStarted roles/worker Upgrading OS",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "873e8ad5d9",
+          "node": "ci-op-wh7nq7n4-206af-q9jvw-worker-a-rdxtm"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "OSUpdateStarted",
+        "cause": "",
+        "humanMessage": "Upgrading OS",
+        "annotations": {
+          "reason": "OSUpdateStarted",
+          "roles": "worker"
+        }
+      },
       "from": "2023-07-18T16:41:49Z",
       "to": "2023-07-18T16:41:49Z"
     }

--- a/pkg/monitortests/node/nodestateanalyzer/node_test.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,7 @@ import (
 
 func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 	// regenerate this file if schema changes by getting an updated e2e-events file, finding a worker node, and running:
-	// cat e2e-events_20240308-085144.json | jq '.items [] | select(.tempStructuredLocator.keys.node == "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q") | select(.tempStructuredMessage.reason? | match("RegisteredNode|Starting|Cordon|Drain|NodeNotSchedulable|OSUpdateStarted|InClusterUpgrade|OSUpdateStaged|PendingConfig|Reboot|DiskPressure|MemoryPressure|PIDPressure|Ready|NodeNotReady|NotReady"))'
+	// cat e2e-events_20240308-085144.json | jq '.items |= map(select(.tempStructuredLocator.keys.node == "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q") | select(.tempStructuredMessage.reason? | match("RegisteredNode|Starting|Cordon|Drain|NodeNotSchedulable|OSUpdateStarted|InClusterUpgrade|OSUpdateStaged|PendingConfig|Reboot|DiskPressure|MemoryPressure|PIDPressure|Ready|NodeNotReady|NotReady")))' > pkg/monitortests/node/nodestateanalyzer/testdata/node.json
 	intervals, err := monitorserialization.EventsFromFile("testdata/node.json")
 	if err != nil {
 		t.Fatal(err)
@@ -22,15 +23,24 @@ func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 	changes := intervalsFromEvents_NodeChanges(intervals, nil, time.Time{}, time.Now())
 	for _, c := range changes {
 		t.Logf("%s - %s", c.From.UTC().Format(time.RFC3339), c.Message)
+		assert.Equal(t, "node-lifecycle-constructor", c.StructuredMessage.Annotations[monitorapi.AnnotationConstructed])
 	}
-	//out, _ := monitorserialization.EventsIntervalsToJSON(changes)
-	require.Equal(t, 3, len(changes))
-	assert.Equal(t, "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
-		changes[0].Message, "unexpected event")
-	assert.Equal(t, "constructed/node-lifecycle-constructor phase/OperatingSystemUpdate reason/NodeUpdate roles/worker updated operating system",
-		changes[1].Message, "unexpected event")
-	assert.Equal(t, "constructed/node-lifecycle-constructor phase/Reboot reason/NodeUpdate roles/worker rebooted and kubelet started",
-		changes[2].Message, "unexpected event")
+
+	require.Equal(t, 4, len(changes))
+	assert.Equal(t, "NodeUpdate", string(changes[0].StructuredMessage.Reason))
+	assert.Equal(t, "Drain", changes[0].StructuredMessage.Annotations[monitorapi.AnnotationPhase])
+	assert.Contains(t, "drained node", changes[0].StructuredMessage.HumanMessage)
+
+	assert.Equal(t, "NodeUpdate", string(changes[1].StructuredMessage.Reason))
+	assert.Equal(t, "OperatingSystemUpdate", changes[1].StructuredMessage.Annotations[monitorapi.AnnotationPhase])
+	assert.Contains(t, "updated operating system", changes[1].StructuredMessage.HumanMessage)
+
+	assert.Equal(t, "NodeUpdate", string(changes[2].StructuredMessage.Reason))
+	assert.Equal(t, "Reboot", changes[2].StructuredMessage.Annotations[monitorapi.AnnotationPhase])
+	assert.Contains(t, "rebooted and kubelet started", changes[2].StructuredMessage.HumanMessage)
+
+	assert.Equal(t, "NotReady", string(changes[3].StructuredMessage.Reason))
+	assert.Contains(t, "node is not ready", changes[3].StructuredMessage.HumanMessage)
 }
 
 func TestNodeUpdateCreation(t *testing.T) {

--- a/pkg/monitortests/node/nodestateanalyzer/node_test.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node_test.go
@@ -9,9 +9,12 @@ import (
 
 	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
+	// regenerate this file if schema changes by getting an updated e2e-events file, finding a worker node, and running:
+	// cat e2e-events_20240308-085144.json | jq '.items [] | select(.tempStructuredLocator.keys.node == "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q") | select(.tempStructuredMessage.reason? | match("RegisteredNode|Starting|Cordon|Drain|NodeNotSchedulable|OSUpdateStarted|InClusterUpgrade|OSUpdateStaged|PendingConfig|Reboot|DiskPressure|MemoryPressure|PIDPressure|Ready|NodeNotReady|NotReady"))'
 	intervals, err := monitorserialization.EventsFromFile("testdata/node.json")
 	if err != nil {
 		t.Fatal(err)
@@ -21,7 +24,7 @@ func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 		t.Logf("%s - %s", c.From.UTC().Format(time.RFC3339), c.Message)
 	}
 	//out, _ := monitorserialization.EventsIntervalsToJSON(changes)
-	assert.Equal(t, 3, len(changes))
+	require.Equal(t, 3, len(changes))
 	assert.Equal(t, "constructed/node-lifecycle-constructor phase/Drain reason/NodeUpdate roles/worker drained node",
 		changes[0].Message, "unexpected event")
 	assert.Equal(t, "constructed/node-lifecycle-constructor phase/OperatingSystemUpdate reason/NodeUpdate roles/worker updated operating system",

--- a/pkg/monitortests/node/nodestateanalyzer/node_test.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node_test.go
@@ -22,7 +22,7 @@ func TestIntervalsFromEvents_NodeChanges(t *testing.T) {
 	}
 	changes := intervalsFromEvents_NodeChanges(intervals, nil, time.Time{}, time.Now())
 	for _, c := range changes {
-		t.Logf("%s - %s", c.From.UTC().Format(time.RFC3339), c.Message)
+		t.Logf("%s - %s", c.From.UTC().Format(time.RFC3339), c.StructuredMessage.OldMessage())
 		assert.Equal(t, "node-lifecycle-constructor", c.StructuredMessage.Annotations[monitorapi.AnnotationConstructed])
 	}
 

--- a/pkg/monitortests/node/nodestateanalyzer/testdata/node.json
+++ b/pkg/monitortests/node/nodestateanalyzer/testdata/node.json
@@ -2,130 +2,13881 @@
   "items": [
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/RegisteredNode roles/worker Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 event: Registered Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 in Controller",
-      "from": "2021-04-12T21:58:08Z",
-      "to": "2021-04-12T21:58:08Z"
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+      "message": "reason/Ready roles/worker node is ready",
+      "tempSource": "NodeMonitor",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "node is ready",
+        "annotations": {
+          "reason": "Ready",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
     },
     {
-
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/RegisteredNode roles/worker Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 event: Registered Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 in Controller",
-      "from": "2021-04-12T21:58:55Z",
-      "to": "2021-04-12T21:58:55Z"
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-9qdk9 uid/ef96b235-8d20-4173-8323-bbf34bdb1395 container/csi-driver",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-driver",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-9qdk9",
+          "uid": "ef96b235-8d20-4173-8323-bbf34bdb1395"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/Starting roles/worker openshift-sdn done initializing node networking.",
-      "from": "2021-04-12T22:17:10Z",
-      "to": "2021-04-12T22:17:10Z"
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-9qdk9 uid/ef96b235-8d20-4173-8323-bbf34bdb1395 container/csi-liveness-probe",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-liveness-probe",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-9qdk9",
+          "uid": "ef96b235-8d20-4173-8323-bbf34bdb1395"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-9qdk9 uid/ef96b235-8d20-4173-8323-bbf34bdb1395 container/csi-node-driver-registrar",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-node-driver-registrar",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-9qdk9",
+          "uid": "ef96b235-8d20-4173-8323-bbf34bdb1395"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-node-tuning-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/tuned-84d8h uid/8d7fae64-c5da-4e4b-a91b-1fa0398deeec container/tuned",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "tuned",
+          "namespace": "openshift-cluster-node-tuning-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "tuned-84d8h",
+          "uid": "8d7fae64-c5da-4e4b-a91b-1fa0398deeec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-7vqbm uid/368e7172-ea39-4158-9dc4-b58081a24293 container/dns",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-7vqbm",
+          "uid": "368e7172-ea39-4158-9dc4-b58081a24293"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-7vqbm uid/368e7172-ea39-4158-9dc4-b58081a24293 container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-7vqbm",
+          "uid": "368e7172-ea39-4158-9dc4-b58081a24293"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-gncpg uid/41f889d4-65c7-4c57-abc4-9b8c95e76dde container/dns-node-resolver",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-gncpg",
+          "uid": "41f889d4-65c7-4c57-abc4-9b8c95e76dde"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/oauth-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "oauth-proxy",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/prod-bearer-token",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prod-bearer-token",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/promtail",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "promtail",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/image-registry-7897b4df56-ncrt2 uid/745c91cd-44de-4a8a-86df-73d5e304a9fb container/registry",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "image-registry-7897b4df56-ncrt2",
+          "uid": "745c91cd-44de-4a8a-86df-73d5e304a9fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-ca-hxmjx uid/0411e297-c414-48c0-8dfa-accdf8d0d609 container/node-ca",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-ca",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-ca-hxmjx",
+          "uid": "0411e297-c414-48c0-8dfa-accdf8d0d609"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-p66s5 uid/34e8549a-1c17-40e7-9a02-adc0512ad004 container/serve-healthcheck-canary",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "serve-healthcheck-canary",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-p66s5",
+          "uid": "34e8549a-1c17-40e7-9a02-adc0512ad004"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:44Z",
+      "to": "2024-03-08T08:51:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-tl9nm uid/461d2e59-e14e-4b40-aa2c-c0f0a7036208 container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-tl9nm",
+          "uid": "461d2e59-e14e-4b40-aa2c-c0f0a7036208"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-tl9nm uid/461d2e59-e14e-4b40-aa2c-c0f0a7036208 container/machine-config-daemon",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "machine-config-daemon",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-tl9nm",
+          "uid": "461d2e59-e14e-4b40-aa2c-c0f0a7036208"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/alertmanager",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "alertmanager",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/kube-rbac-proxy-metric",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metric",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/kube-rbac-proxy-web",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/prom-label-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/init-config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-85dcfd8b56-rc27j uid/3e02af0d-066b-4989-9892-2de7d9ca3222 container/kube-rbac-proxy-main",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-main",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-85dcfd8b56-rc27j",
+          "uid": "3e02af0d-066b-4989-9892-2de7d9ca3222"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-85dcfd8b56-rc27j uid/3e02af0d-066b-4989-9892-2de7d9ca3222 container/kube-rbac-proxy-self",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-self",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-85dcfd8b56-rc27j",
+          "uid": "3e02af0d-066b-4989-9892-2de7d9ca3222"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-85dcfd8b56-rc27j uid/3e02af0d-066b-4989-9892-2de7d9ca3222 container/kube-state-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-state-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-85dcfd8b56-rc27j",
+          "uid": "3e02af0d-066b-4989-9892-2de7d9ca3222"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/monitoring-plugin-89f4b87dd-bt8xt uid/5d0348be-4904-46a6-ad2d-9ee3f9ad0e6c container/monitoring-plugin",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "monitoring-plugin",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "monitoring-plugin-89f4b87dd-bt8xt",
+          "uid": "5d0348be-4904-46a6-ad2d-9ee3f9ad0e6c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-5jptl uid/35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-5jptl",
+          "uid": "35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-5jptl uid/35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c container/node-exporter",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-exporter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-5jptl",
+          "uid": "35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-5jptl uid/35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c container/init-textfile",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-textfile",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-5jptl",
+          "uid": "35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-bd759b667-jx7dj uid/d483ecfd-2814-4aef-a652-b715b19d3a3f container/kube-rbac-proxy-main",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-main",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-bd759b667-jx7dj",
+          "uid": "d483ecfd-2814-4aef-a652-b715b19d3a3f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-bd759b667-jx7dj uid/d483ecfd-2814-4aef-a652-b715b19d3a3f container/kube-rbac-proxy-self",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-self",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-bd759b667-jx7dj",
+          "uid": "d483ecfd-2814-4aef-a652-b715b19d3a3f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-bd759b667-jx7dj uid/d483ecfd-2814-4aef-a652-b715b19d3a3f container/openshift-state-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "openshift-state-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-bd759b667-jx7dj",
+          "uid": "d483ecfd-2814-4aef-a652-b715b19d3a3f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-adapter-6f54d97458-frrqg uid/ac141b43-1139-460b-808f-e724ef0e245f container/prometheus-adapter",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-adapter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-adapter-6f54d97458-frrqg",
+          "uid": "ac141b43-1139-460b-808f-e724ef0e245f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/kube-rbac-proxy-thanos",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-thanos",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/kube-rbac-proxy-web",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/prometheus",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/thanos-sidecar",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-sidecar",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/init-config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/kube-rbac-proxy-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/kube-rbac-proxy-rules",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-rules",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/kube-rbac-proxy-web",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/prom-label-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/thanos-query",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-query",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-5vm4s uid/e0122c9d-fddb-4187-9ddb-9987aa4986fc container/kube-multus-additional-cni-plugins",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-5vm4s",
+          "uid": "e0122c9d-fddb-4187-9ddb-9987aa4986fc"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-5vm4s uid/e0122c9d-fddb-4187-9ddb-9987aa4986fc container/egress-router-binary-copy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "egress-router-binary-copy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-5vm4s",
+          "uid": "e0122c9d-fddb-4187-9ddb-9987aa4986fc"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-5vm4s uid/e0122c9d-fddb-4187-9ddb-9987aa4986fc container/cni-plugins",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-5vm4s",
+          "uid": "e0122c9d-fddb-4187-9ddb-9987aa4986fc"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-5vm4s uid/e0122c9d-fddb-4187-9ddb-9987aa4986fc container/bond-cni-plugin",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "bond-cni-plugin",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-5vm4s",
+          "uid": "e0122c9d-fddb-4187-9ddb-9987aa4986fc"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-5vm4s uid/e0122c9d-fddb-4187-9ddb-9987aa4986fc container/routeoverride-cni",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "routeoverride-cni",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-5vm4s",
+          "uid": "e0122c9d-fddb-4187-9ddb-9987aa4986fc"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-5vm4s uid/e0122c9d-fddb-4187-9ddb-9987aa4986fc container/whereabouts-cni-bincopy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "whereabouts-cni-bincopy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-5vm4s",
+          "uid": "e0122c9d-fddb-4187-9ddb-9987aa4986fc"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-5vm4s uid/e0122c9d-fddb-4187-9ddb-9987aa4986fc container/whereabouts-cni",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "whereabouts-cni",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-5vm4s",
+          "uid": "e0122c9d-fddb-4187-9ddb-9987aa4986fc"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-ll8vt uid/87307845-3e3b-4c63-a879-c22281949124 container/kube-multus",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-ll8vt",
+          "uid": "87307845-3e3b-4c63-a879-c22281949124"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-7lr75 uid/6803b36b-e2d5-4e02-b8e6-92a4d70b981f container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-7lr75",
+          "uid": "6803b36b-e2d5-4e02-b8e6-92a4d70b981f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-7lr75 uid/6803b36b-e2d5-4e02-b8e6-92a4d70b981f container/network-metrics-daemon",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-metrics-daemon",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-7lr75",
+          "uid": "6803b36b-e2d5-4e02-b8e6-92a4d70b981f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xhx48 uid/fb6e9a2d-4e51-48a0-8b78-c19dde90098e container/network-check-target-container",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-check-target-container",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xhx48",
+          "uid": "fb6e9a2d-4e51-48a0-8b78-c19dde90098e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/kube-rbac-proxy-node",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-node",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/kube-rbac-proxy-ovn-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-ovn-metrics",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/nbdb",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/northd",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "northd",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/ovn-acl-logging",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-acl-logging",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/ovn-controller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/ovnkube-controller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/sbdb",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "sbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/kubecfg-setup",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kubecfg-setup",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-pod-network-disruption-poller-69dbf666d-wxlpt uid/6bafbda3-c46f-412c-8ea4-36587746eaa0 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-pod-network-disruption-poller-69dbf666d-wxlpt",
+          "uid": "6bafbda3-c46f-412c-8ea4-36587746eaa0"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-host-network-disruption-poller-6944cc9694-7xjjd uid/39832573-8cc1-4991-bf26-19d933371637 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-host-network-disruption-poller-6944cc9694-7xjjd",
+          "uid": "39832573-8cc1-4991-bf26-19d933371637"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-pod-network-disruption-poller-7b446db555-qvhfh uid/8f3592f6-803d-43f4-a179-0668193cce19 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-pod-network-disruption-poller-7b446db555-qvhfh",
+          "uid": "8f3592f6-803d-43f4-a179-0668193cce19"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-host-network-disruption-poller-6fb456c9-j74vz uid/008031e7-589a-4280-8469-763034f75008 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-host-network-disruption-poller-6fb456c9-j74vz",
+          "uid": "008031e7-589a-4280-8469-763034f75008"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:51:45Z",
+      "to": "2024-03-08T08:51:45Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-disruption-target-fdc46b779-cphct uid/4ef86a65-44f3-4fa2-8399-3210c1b924bb container/pod-disruption-server",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "pod-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-disruption-target-fdc46b779-cphct",
+          "uid": "4ef86a65-44f3-4fa2-8399-3210c1b924bb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:51:46Z",
+      "to": "2024-03-08T08:51:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-disruption-target-69f576bf7f-csdcl uid/6c7aae34-b512-4930-bd73-8c01ac2ab42d container/host-disruption-server",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "host-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-disruption-target-69f576bf7f-csdcl",
+          "uid": "6c7aae34-b512-4930-bd73-8c01ac2ab42d"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:51:46Z",
+      "to": "2024-03-08T08:51:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-service-disruption-poller-5848554867-ptwpf uid/85f81a7e-048b-46f4-bc28-4d07d21c1dd4 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-service-disruption-poller-5848554867-ptwpf",
+          "uid": "85f81a7e-048b-46f4-bc28-4d07d21c1dd4"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:52:03Z",
+      "to": "2024-03-08T08:52:03Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-service-disruption-poller-68c49949d4-zp9jp uid/cff515c9-30f2-48b4-b78c-5a2334b641e7 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-service-disruption-poller-68c49949d4-zp9jp",
+          "uid": "cff515c9-30f2-48b4-b78c-5a2334b641e7"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:52:03Z",
+      "to": "2024-03-08T08:52:03Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-disruption-target-69f576bf7f-csdcl uid/6c7aae34-b512-4930-bd73-8c01ac2ab42d container/host-disruption-server",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "host-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-disruption-target-69f576bf7f-csdcl",
+          "uid": "6c7aae34-b512-4930-bd73-8c01ac2ab42d"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:52:06Z",
+      "to": "2024-03-08T08:52:06Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-disruption-target-fdc46b779-cphct uid/4ef86a65-44f3-4fa2-8399-3210c1b924bb container/pod-disruption-server",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "pod-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-disruption-target-fdc46b779-cphct",
+          "uid": "4ef86a65-44f3-4fa2-8399-3210c1b924bb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:52:06Z",
+      "to": "2024-03-08T08:52:06Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-host-network-disruption-poller-6944cc9694-7xjjd uid/39832573-8cc1-4991-bf26-19d933371637 container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-host-network-disruption-poller-6944cc9694-7xjjd",
+          "uid": "39832573-8cc1-4991-bf26-19d933371637"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:52:07Z",
+      "to": "2024-03-08T08:52:07Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-service-disruption-poller-68c49949d4-zp9jp uid/cff515c9-30f2-48b4-b78c-5a2334b641e7 container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-service-disruption-poller-68c49949d4-zp9jp",
+          "uid": "cff515c9-30f2-48b4-b78c-5a2334b641e7"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:52:07Z",
+      "to": "2024-03-08T08:52:07Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-pod-network-disruption-poller-69dbf666d-wxlpt uid/6bafbda3-c46f-412c-8ea4-36587746eaa0 container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-pod-network-disruption-poller-69dbf666d-wxlpt",
+          "uid": "6bafbda3-c46f-412c-8ea4-36587746eaa0"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:52:07Z",
+      "to": "2024-03-08T08:52:07Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-service-disruption-poller-5848554867-ptwpf uid/85f81a7e-048b-46f4-bc28-4d07d21c1dd4 container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-service-disruption-poller-5848554867-ptwpf",
+          "uid": "85f81a7e-048b-46f4-bc28-4d07d21c1dd4"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:52:07Z",
+      "to": "2024-03-08T08:52:07Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-pod-network-disruption-poller-7b446db555-qvhfh uid/8f3592f6-803d-43f4-a179-0668193cce19 container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-pod-network-disruption-poller-7b446db555-qvhfh",
+          "uid": "8f3592f6-803d-43f4-a179-0668193cce19"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:52:07Z",
+      "to": "2024-03-08T08:52:07Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-host-network-disruption-poller-6fb456c9-j74vz uid/008031e7-589a-4280-8469-763034f75008 container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-host-network-disruption-poller-6fb456c9-j74vz",
+          "uid": "008031e7-589a-4280-8469-763034f75008"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:52:07Z",
+      "to": "2024-03-08T08:52:07Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck uid/5093bbac-e758-45bf-a3de-0a6d3e9b852e container/querier",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "querier",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck",
+          "uid": "5093bbac-e758-45bf-a3de-0a6d3e9b852e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:53:22Z",
+      "to": "2024-03-08T08:53:22Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs uid/d6d27082-f9eb-43ba-9dbe-40bc489586e6 container/app",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "app",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs",
+          "uid": "d6d27082-f9eb-43ba-9dbe-40bc489586e6"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:53:23Z",
+      "to": "2024-03-08T08:53:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-job-upgrade-258 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/foo-j5wbt uid/eeb62b3a-9cb5-4dc6-aefd-44888b87b305 container/c",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "c",
+          "namespace": "e2e-k8s-sig-apps-job-upgrade-258",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "foo-j5wbt",
+          "uid": "eeb62b3a-9cb5-4dc6-aefd-44888b87b305"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:53:23Z",
+      "to": "2024-03-08T08:53:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-replicaset-upgrade-324 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/rs-ht2kp uid/ea1ad029-4897-4c82-864b-2e485a95afd7 container/nginx",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nginx",
+          "namespace": "e2e-k8s-sig-apps-replicaset-upgrade-324",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "rs-ht2kp",
+          "uid": "ea1ad029-4897-4c82-864b-2e485a95afd7"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T08:53:23Z",
+      "to": "2024-03-08T08:53:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs uid/d6d27082-f9eb-43ba-9dbe-40bc489586e6 container/app",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "app",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs",
+          "uid": "d6d27082-f9eb-43ba-9dbe-40bc489586e6"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:53:24Z",
+      "to": "2024-03-08T08:53:24Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-k8s-sig-apps-job-upgrade-258 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/foo-j5wbt uid/eeb62b3a-9cb5-4dc6-aefd-44888b87b305 container/c",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "c",
+          "namespace": "e2e-k8s-sig-apps-job-upgrade-258",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "foo-j5wbt",
+          "uid": "eeb62b3a-9cb5-4dc6-aefd-44888b87b305"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:53:26Z",
+      "to": "2024-03-08T08:53:26Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck uid/5093bbac-e758-45bf-a3de-0a6d3e9b852e container/querier",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "querier",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck",
+          "uid": "5093bbac-e758-45bf-a3de-0a6d3e9b852e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:53:30Z",
+      "to": "2024-03-08T08:53:30Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-k8s-sig-apps-replicaset-upgrade-324 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/rs-ht2kp uid/ea1ad029-4897-4c82-864b-2e485a95afd7 container/nginx",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nginx",
+          "namespace": "e2e-k8s-sig-apps-replicaset-upgrade-324",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "rs-ht2kp",
+          "uid": "ea1ad029-4897-4c82-864b-2e485a95afd7"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T08:53:30Z",
+      "to": "2024-03-08T08:53:30Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/ac7f4b1372",
+      "message": "reason/RegisteredNode roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q event: Registered Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q in Controller",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "ac7f4b1372",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "RegisteredNode",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q event: Registered Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q in Controller",
+        "annotations": {
+          "reason": "RegisteredNode",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:08:10Z",
+      "to": "2024-03-08T09:08:10Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-p66s5 uid/34e8549a-1c17-40e7-9a02-adc0512ad004 container/serve-healthcheck-canary",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "serve-healthcheck-canary",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-p66s5",
+          "uid": "34e8549a-1c17-40e7-9a02-adc0512ad004"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:15:54Z",
+      "to": "2024-03-08T09:15:54Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-operator-admission-webhook-8574d6fd7d-hncht uid/3aaf199b-104a-481d-b655-6683cf3dc941 container/prometheus-operator-admission-webhook",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-operator-admission-webhook",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-operator-admission-webhook-8574d6fd7d-hncht",
+          "uid": "3aaf199b-104a-481d-b655-6683cf3dc941"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:15:54Z",
+      "to": "2024-03-08T09:15:54Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 uid/fd50c0cf-3773-4e6a-ae03-68afc8ea9dd1 container/serve-healthcheck-canary",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "serve-healthcheck-canary",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88",
+          "uid": "fd50c0cf-3773-4e6a-ae03-68afc8ea9dd1"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:15:55Z",
+      "to": "2024-03-08T09:15:55Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-ca-hxmjx uid/0411e297-c414-48c0-8dfa-accdf8d0d609 container/node-ca",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-ca",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-ca-hxmjx",
+          "uid": "0411e297-c414-48c0-8dfa-accdf8d0d609"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:15:57Z",
+      "to": "2024-03-08T09:15:57Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 uid/fd50c0cf-3773-4e6a-ae03-68afc8ea9dd1 container/serve-healthcheck-canary",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "serve-healthcheck-canary",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88",
+          "uid": "fd50c0cf-3773-4e6a-ae03-68afc8ea9dd1"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:15:57Z",
+      "to": "2024-03-08T09:15:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-ca-sglr7 uid/4a6a9488-8182-4a03-a049-432150384cfd container/node-ca",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-ca",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-ca-sglr7",
+          "uid": "4a6a9488-8182-4a03-a049-432150384cfd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:15:57Z",
+      "to": "2024-03-08T09:15:57Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-ca-sglr7 uid/4a6a9488-8182-4a03-a049-432150384cfd container/node-ca",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-ca",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-ca-sglr7",
+          "uid": "4a6a9488-8182-4a03-a049-432150384cfd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:15:59Z",
+      "to": "2024-03-08T09:15:59Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-operator-admission-webhook-8574d6fd7d-hncht uid/3aaf199b-104a-481d-b655-6683cf3dc941 container/prometheus-operator-admission-webhook",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-operator-admission-webhook",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-operator-admission-webhook-8574d6fd7d-hncht",
+          "uid": "3aaf199b-104a-481d-b655-6683cf3dc941"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:15:59Z",
+      "to": "2024-03-08T09:15:59Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-bd759b667-jx7dj uid/d483ecfd-2814-4aef-a652-b715b19d3a3f container/kube-rbac-proxy-main",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-main",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-bd759b667-jx7dj",
+          "uid": "d483ecfd-2814-4aef-a652-b715b19d3a3f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:14Z",
+      "to": "2024-03-08T09:16:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-bd759b667-jx7dj uid/d483ecfd-2814-4aef-a652-b715b19d3a3f container/kube-rbac-proxy-self",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-self",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-bd759b667-jx7dj",
+          "uid": "d483ecfd-2814-4aef-a652-b715b19d3a3f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:14Z",
+      "to": "2024-03-08T09:16:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-bd759b667-jx7dj uid/d483ecfd-2814-4aef-a652-b715b19d3a3f container/openshift-state-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "openshift-state-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-bd759b667-jx7dj",
+          "uid": "d483ecfd-2814-4aef-a652-b715b19d3a3f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:14Z",
+      "to": "2024-03-08T09:16:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-85dcfd8b56-rc27j uid/3e02af0d-066b-4989-9892-2de7d9ca3222 container/kube-rbac-proxy-main",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-main",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-85dcfd8b56-rc27j",
+          "uid": "3e02af0d-066b-4989-9892-2de7d9ca3222"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:14Z",
+      "to": "2024-03-08T09:16:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-85dcfd8b56-rc27j uid/3e02af0d-066b-4989-9892-2de7d9ca3222 container/kube-rbac-proxy-self",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-self",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-85dcfd8b56-rc27j",
+          "uid": "3e02af0d-066b-4989-9892-2de7d9ca3222"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:14Z",
+      "to": "2024-03-08T09:16:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-85dcfd8b56-rc27j uid/3e02af0d-066b-4989-9892-2de7d9ca3222 container/kube-state-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-state-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-85dcfd8b56-rc27j",
+          "uid": "3e02af0d-066b-4989-9892-2de7d9ca3222"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:14Z",
+      "to": "2024-03-08T09:16:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/monitoring-plugin-89f4b87dd-bt8xt uid/5d0348be-4904-46a6-ad2d-9ee3f9ad0e6c container/monitoring-plugin",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "monitoring-plugin",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "monitoring-plugin-89f4b87dd-bt8xt",
+          "uid": "5d0348be-4904-46a6-ad2d-9ee3f9ad0e6c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:16Z",
+      "to": "2024-03-08T09:16:16Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/monitoring-plugin-bc8dc7986-sk4h4 uid/0c1887d1-a526-46ef-9dca-d28b4ac6ff46 container/monitoring-plugin",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "monitoring-plugin",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "monitoring-plugin-bc8dc7986-sk4h4",
+          "uid": "0c1887d1-a526-46ef-9dca-d28b4ac6ff46"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:18Z",
+      "to": "2024-03-08T09:16:18Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-adapter-6f54d97458-frrqg uid/ac141b43-1139-460b-808f-e724ef0e245f container/prometheus-adapter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-adapter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-adapter-6f54d97458-frrqg",
+          "uid": "ac141b43-1139-460b-808f-e724ef0e245f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:21Z",
+      "to": "2024-03-08T09:16:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/monitoring-plugin-bc8dc7986-sk4h4 uid/0c1887d1-a526-46ef-9dca-d28b4ac6ff46 container/monitoring-plugin",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "monitoring-plugin",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "monitoring-plugin-bc8dc7986-sk4h4",
+          "uid": "0c1887d1-a526-46ef-9dca-d28b4ac6ff46"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:21Z",
+      "to": "2024-03-08T09:16:21Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/image-registry-7897b4df56-ncrt2 uid/745c91cd-44de-4a8a-86df-73d5e304a9fb container/registry",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "image-registry-7897b4df56-ncrt2",
+          "uid": "745c91cd-44de-4a8a-86df-73d5e304a9fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:22Z",
+      "to": "2024-03-08T09:16:22Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/image-registry-5fdfc959c8-r8tvh uid/ae83fb91-dbfd-4d9b-b341-dd111f4ec215 container/registry",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "image-registry-5fdfc959c8-r8tvh",
+          "uid": "ae83fb91-dbfd-4d9b-b341-dd111f4ec215"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:22Z",
+      "to": "2024-03-08T09:16:22Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:29Z",
+      "to": "2024-03-08T09:16:29Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/kube-rbac-proxy-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:29Z",
+      "to": "2024-03-08T09:16:29Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/kube-rbac-proxy-rules",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-rules",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:29Z",
+      "to": "2024-03-08T09:16:29Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:29Z",
+      "to": "2024-03-08T09:16:29Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/prom-label-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:29Z",
+      "to": "2024-03-08T09:16:29Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-5f99bfcb5c-prxr4 uid/905ee628-9cae-43fe-a551-2856eb96d9e9 container/thanos-query",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-query",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-5f99bfcb5c-prxr4",
+          "uid": "905ee628-9cae-43fe-a551-2856eb96d9e9"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:29Z",
+      "to": "2024-03-08T09:16:29Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-5jptl uid/35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-5jptl",
+          "uid": "35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:35Z",
+      "to": "2024-03-08T09:16:35Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-5jptl uid/35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c container/node-exporter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-exporter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-5jptl",
+          "uid": "35fd3cb9-50e6-40ca-83a6-fde0eaba0e5c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:35Z",
+      "to": "2024-03-08T09:16:35Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:35Z",
+      "to": "2024-03-08T09:16:35Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/node-exporter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-exporter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:35Z",
+      "to": "2024-03-08T09:16:35Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/init-textfile",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-textfile",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:35Z",
+      "to": "2024-03-08T09:16:35Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-9qdk9 uid/ef96b235-8d20-4173-8323-bbf34bdb1395 container/csi-driver",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-driver",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-9qdk9",
+          "uid": "ef96b235-8d20-4173-8323-bbf34bdb1395"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:37Z",
+      "to": "2024-03-08T09:16:37Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-9qdk9 uid/ef96b235-8d20-4173-8323-bbf34bdb1395 container/csi-liveness-probe",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-liveness-probe",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-9qdk9",
+          "uid": "ef96b235-8d20-4173-8323-bbf34bdb1395"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:37Z",
+      "to": "2024-03-08T09:16:37Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-9qdk9 uid/ef96b235-8d20-4173-8323-bbf34bdb1395 container/csi-node-driver-registrar",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-node-driver-registrar",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-9qdk9",
+          "uid": "ef96b235-8d20-4173-8323-bbf34bdb1395"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:37Z",
+      "to": "2024-03-08T09:16:37Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-driver",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-driver",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:37Z",
+      "to": "2024-03-08T09:16:37Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-liveness-probe",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-liveness-probe",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:37Z",
+      "to": "2024-03-08T09:16:37Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-node-driver-registrar",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-node-driver-registrar",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:37Z",
+      "to": "2024-03-08T09:16:37Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/init-textfile",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-textfile",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:37Z",
+      "to": "2024-03-08T09:16:37Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:39Z",
+      "to": "2024-03-08T09:16:39Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/node-exporter",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-exporter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:39Z",
+      "to": "2024-03-08T09:16:39Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-driver",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-driver",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:41Z",
+      "to": "2024-03-08T09:16:41Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-liveness-probe",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-liveness-probe",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:41Z",
+      "to": "2024-03-08T09:16:41Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-node-driver-registrar",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-node-driver-registrar",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:41Z",
+      "to": "2024-03-08T09:16:41Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/image-registry-5fdfc959c8-r8tvh uid/ae83fb91-dbfd-4d9b-b341-dd111f4ec215 container/registry",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "image-registry-5fdfc959c8-r8tvh",
+          "uid": "ae83fb91-dbfd-4d9b-b341-dd111f4ec215"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:43Z",
+      "to": "2024-03-08T09:16:43Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-node-tuning-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/tuned-84d8h uid/8d7fae64-c5da-4e4b-a91b-1fa0398deeec container/tuned",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "tuned",
+          "namespace": "openshift-cluster-node-tuning-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "tuned-84d8h",
+          "uid": "8d7fae64-c5da-4e4b-a91b-1fa0398deeec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:51Z",
+      "to": "2024-03-08T09:16:51Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-node-tuning-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/tuned-4z6d4 uid/71e6b9a5-f54e-4667-9993-5751f11f4e5d container/tuned",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "tuned",
+          "namespace": "openshift-cluster-node-tuning-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "tuned-4z6d4",
+          "uid": "71e6b9a5-f54e-4667-9993-5751f11f4e5d"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:52Z",
+      "to": "2024-03-08T09:16:52Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/alertmanager",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "alertmanager",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:57Z",
+      "to": "2024-03-08T09:16:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:57Z",
+      "to": "2024-03-08T09:16:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:57Z",
+      "to": "2024-03-08T09:16:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/kube-rbac-proxy-metric",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metric",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:57Z",
+      "to": "2024-03-08T09:16:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:57Z",
+      "to": "2024-03-08T09:16:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/8d5b5bea-9ad9-405a-b07b-d240d251977c container/prom-label-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "8d5b5bea-9ad9-405a-b07b-d240d251977c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:57Z",
+      "to": "2024-03-08T09:16:57Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-node-tuning-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/tuned-4z6d4 uid/71e6b9a5-f54e-4667-9993-5751f11f4e5d container/tuned",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "tuned",
+          "namespace": "openshift-cluster-node-tuning-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "tuned-4z6d4",
+          "uid": "71e6b9a5-f54e-4667-9993-5751f11f4e5d"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:16:57Z",
+      "to": "2024-03-08T09:16:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/alertmanager",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "alertmanager",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:58Z",
+      "to": "2024-03-08T09:16:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:58Z",
+      "to": "2024-03-08T09:16:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:58Z",
+      "to": "2024-03-08T09:16:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy-metric",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metric",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:58Z",
+      "to": "2024-03-08T09:16:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:58Z",
+      "to": "2024-03-08T09:16:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/prom-label-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:58Z",
+      "to": "2024-03-08T09:16:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/init-config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:16:58Z",
+      "to": "2024-03-08T09:16:58Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/init-config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:00Z",
+      "to": "2024-03-08T09:17:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:03Z",
+      "to": "2024-03-08T09:17:03Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:03Z",
+      "to": "2024-03-08T09:17:03Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy-metric",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metric",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:03Z",
+      "to": "2024-03-08T09:17:03Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy-web",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:03Z",
+      "to": "2024-03-08T09:17:03Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/prom-label-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:03Z",
+      "to": "2024-03-08T09:17:03Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/alertmanager",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "alertmanager",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:28Z",
+      "to": "2024-03-08T09:17:28Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:41Z",
+      "to": "2024-03-08T09:17:41Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:41Z",
+      "to": "2024-03-08T09:17:41Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/kube-rbac-proxy-thanos",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-thanos",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:41Z",
+      "to": "2024-03-08T09:17:41Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:41Z",
+      "to": "2024-03-08T09:17:41Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/prometheus",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:41Z",
+      "to": "2024-03-08T09:17:41Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/650c948f-9ca8-47c4-b839-01711d7a499a container/thanos-sidecar",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-sidecar",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "650c948f-9ca8-47c4-b839-01711d7a499a"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:41Z",
+      "to": "2024-03-08T09:17:41Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:42Z",
+      "to": "2024-03-08T09:17:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:42Z",
+      "to": "2024-03-08T09:17:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy-thanos",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-thanos",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:42Z",
+      "to": "2024-03-08T09:17:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:42Z",
+      "to": "2024-03-08T09:17:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/prometheus",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:42Z",
+      "to": "2024-03-08T09:17:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/thanos-sidecar",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-sidecar",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:42Z",
+      "to": "2024-03-08T09:17:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/init-config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:17:42Z",
+      "to": "2024-03-08T09:17:42Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/init-config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:44Z",
+      "to": "2024-03-08T09:17:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:48Z",
+      "to": "2024-03-08T09:17:48Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:48Z",
+      "to": "2024-03-08T09:17:48Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy-thanos",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-thanos",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:48Z",
+      "to": "2024-03-08T09:17:48Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy-web",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:48Z",
+      "to": "2024-03-08T09:17:48Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/thanos-sidecar",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-sidecar",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:17:48Z",
+      "to": "2024-03-08T09:17:48Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/prometheus",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:18:44Z",
+      "to": "2024-03-08T09:18:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/cni-sysctl-allowlist-ds-x89t7 uid/1c44edf3-3240-4dbe-916b-e19ba4621ee0 container/kube-multus-additional-cni-plugins",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "cni-sysctl-allowlist-ds-x89t7",
+          "uid": "1c44edf3-3240-4dbe-916b-e19ba4621ee0"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:02Z",
+      "to": "2024-03-08T09:24:02Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-hhxgq uid/f0fa5227-ac46-4b74-a7b3-369b4ca68905 container/dns",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-hhxgq",
+          "uid": "f0fa5227-ac46-4b74-a7b3-369b4ca68905"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:03Z",
+      "to": "2024-03-08T09:24:03Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-hhxgq uid/f0fa5227-ac46-4b74-a7b3-369b4ca68905 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-hhxgq",
+          "uid": "f0fa5227-ac46-4b74-a7b3-369b4ca68905"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:03Z",
+      "to": "2024-03-08T09:24:03Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-gncpg uid/41f889d4-65c7-4c57-abc4-9b8c95e76dde container/dns-node-resolver",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-gncpg",
+          "uid": "41f889d4-65c7-4c57-abc4-9b8c95e76dde"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:03Z",
+      "to": "2024-03-08T09:24:03Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-lfwkq uid/6cb537df-97a0-4f06-b98e-e7c0a1056739 container/dns-node-resolver",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-lfwkq",
+          "uid": "6cb537df-97a0-4f06-b98e-e7c0a1056739"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:03Z",
+      "to": "2024-03-08T09:24:03Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj uid/9d08b494-b1aa-4606-8480-dceff8a603ec container/dns",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj",
+          "uid": "9d08b494-b1aa-4606-8480-dceff8a603ec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:03Z",
+      "to": "2024-03-08T09:24:03Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj uid/9d08b494-b1aa-4606-8480-dceff8a603ec container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj",
+          "uid": "9d08b494-b1aa-4606-8480-dceff8a603ec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:03Z",
+      "to": "2024-03-08T09:24:03Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-lfwkq uid/6cb537df-97a0-4f06-b98e-e7c0a1056739 container/dns-node-resolver",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-lfwkq",
+          "uid": "6cb537df-97a0-4f06-b98e-e7c0a1056739"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:04Z",
+      "to": "2024-03-08T09:24:04Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/cni-sysctl-allowlist-ds-x89t7 uid/1c44edf3-3240-4dbe-916b-e19ba4621ee0 container/kube-multus-additional-cni-plugins",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "cni-sysctl-allowlist-ds-x89t7",
+          "uid": "1c44edf3-3240-4dbe-916b-e19ba4621ee0"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:04Z",
+      "to": "2024-03-08T09:24:04Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-lfwkq uid/6cb537df-97a0-4f06-b98e-e7c0a1056739 container/dns-node-resolver",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-lfwkq",
+          "uid": "6cb537df-97a0-4f06-b98e-e7c0a1056739"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:04Z",
+      "to": "2024-03-08T09:24:04Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-pjgmv uid/e7f67448-1984-4bc3-a520-a1e9df7df2c3 container/dns-node-resolver",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-pjgmv",
+          "uid": "e7f67448-1984-4bc3-a520-a1e9df7df2c3"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:04Z",
+      "to": "2024-03-08T09:24:04Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-pjgmv uid/e7f67448-1984-4bc3-a520-a1e9df7df2c3 container/dns-node-resolver",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-pjgmv",
+          "uid": "e7f67448-1984-4bc3-a520-a1e9df7df2c3"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:06Z",
+      "to": "2024-03-08T09:24:06Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj uid/9d08b494-b1aa-4606-8480-dceff8a603ec container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj",
+          "uid": "9d08b494-b1aa-4606-8480-dceff8a603ec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:06Z",
+      "to": "2024-03-08T09:24:06Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-ll8vt uid/87307845-3e3b-4c63-a879-c22281949124 container/kube-multus",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-ll8vt",
+          "uid": "87307845-3e3b-4c63-a879-c22281949124"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:14Z",
+      "to": "2024-03-08T09:24:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-r8lb8 uid/b4569411-7f6e-4080-95ef-e37f519eeaef container/kube-multus",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-r8lb8",
+          "uid": "b4569411-7f6e-4080-95ef-e37f519eeaef"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:14Z",
+      "to": "2024-03-08T09:24:14Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-r8lb8 uid/b4569411-7f6e-4080-95ef-e37f519eeaef container/kube-multus",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-r8lb8",
+          "uid": "b4569411-7f6e-4080-95ef-e37f519eeaef"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:15Z",
+      "to": "2024-03-08T09:24:15Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj uid/9d08b494-b1aa-4606-8480-dceff8a603ec container/dns",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj",
+          "uid": "9d08b494-b1aa-4606-8480-dceff8a603ec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:16Z",
+      "to": "2024-03-08T09:24:16Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-7lr75 uid/6803b36b-e2d5-4e02-b8e6-92a4d70b981f container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-7lr75",
+          "uid": "6803b36b-e2d5-4e02-b8e6-92a4d70b981f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:18Z",
+      "to": "2024-03-08T09:24:18Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-7lr75 uid/6803b36b-e2d5-4e02-b8e6-92a4d70b981f container/network-metrics-daemon",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-metrics-daemon",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-7lr75",
+          "uid": "6803b36b-e2d5-4e02-b8e6-92a4d70b981f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:18Z",
+      "to": "2024-03-08T09:24:18Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd uid/b41a9b9c-ba1f-420f-bede-a25179339281 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd",
+          "uid": "b41a9b9c-ba1f-420f-bede-a25179339281"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:18Z",
+      "to": "2024-03-08T09:24:18Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd uid/b41a9b9c-ba1f-420f-bede-a25179339281 container/network-metrics-daemon",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-metrics-daemon",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd",
+          "uid": "b41a9b9c-ba1f-420f-bede-a25179339281"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:18Z",
+      "to": "2024-03-08T09:24:18Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-upgrades-prepuller-ppkwb uid/90cceaad-7bc8-4930-9dc0-ae2c72ad4f0f container/ovnkube-upgrades-prepuller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-upgrades-prepuller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-upgrades-prepuller-ppkwb",
+          "uid": "90cceaad-7bc8-4930-9dc0-ae2c72ad4f0f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:21Z",
+      "to": "2024-03-08T09:24:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd uid/b41a9b9c-ba1f-420f-bede-a25179339281 container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd",
+          "uid": "b41a9b9c-ba1f-420f-bede-a25179339281"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:21Z",
+      "to": "2024-03-08T09:24:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd uid/b41a9b9c-ba1f-420f-bede-a25179339281 container/network-metrics-daemon",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-metrics-daemon",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd",
+          "uid": "b41a9b9c-ba1f-420f-bede-a25179339281"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:21Z",
+      "to": "2024-03-08T09:24:21Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-5vm4s uid/e0122c9d-fddb-4187-9ddb-9987aa4986fc container/kube-multus-additional-cni-plugins",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-5vm4s",
+          "uid": "e0122c9d-fddb-4187-9ddb-9987aa4986fc"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:22Z",
+      "to": "2024-03-08T09:24:22Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/kube-multus-additional-cni-plugins",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:23Z",
+      "to": "2024-03-08T09:24:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/egress-router-binary-copy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "egress-router-binary-copy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:23Z",
+      "to": "2024-03-08T09:24:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/cni-plugins",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:23Z",
+      "to": "2024-03-08T09:24:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/bond-cni-plugin",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "bond-cni-plugin",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:23Z",
+      "to": "2024-03-08T09:24:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/routeoverride-cni",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "routeoverride-cni",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:23Z",
+      "to": "2024-03-08T09:24:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/whereabouts-cni-bincopy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "whereabouts-cni-bincopy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:23Z",
+      "to": "2024-03-08T09:24:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/whereabouts-cni",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "whereabouts-cni",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:23Z",
+      "to": "2024-03-08T09:24:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-upgrades-prepuller-ppkwb uid/90cceaad-7bc8-4930-9dc0-ae2c72ad4f0f container/ovnkube-upgrades-prepuller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-upgrades-prepuller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-upgrades-prepuller-ppkwb",
+          "uid": "90cceaad-7bc8-4930-9dc0-ae2c72ad4f0f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:23Z",
+      "to": "2024-03-08T09:24:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/egress-router-binary-copy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "egress-router-binary-copy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:24Z",
+      "to": "2024-03-08T09:24:24Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/cni-plugins",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:26Z",
+      "to": "2024-03-08T09:24:26Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/bond-cni-plugin",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "bond-cni-plugin",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:28Z",
+      "to": "2024-03-08T09:24:28Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/routeoverride-cni",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "routeoverride-cni",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:30Z",
+      "to": "2024-03-08T09:24:30Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-7vqbm uid/368e7172-ea39-4158-9dc4-b58081a24293 container/dns",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-7vqbm",
+          "uid": "368e7172-ea39-4158-9dc4-b58081a24293"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:32Z",
+      "to": "2024-03-08T09:24:32Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/whereabouts-cni-bincopy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "whereabouts-cni-bincopy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:32Z",
+      "to": "2024-03-08T09:24:32Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/whereabouts-cni",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "whereabouts-cni",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:33Z",
+      "to": "2024-03-08T09:24:33Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/kube-multus-additional-cni-plugins",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:24:34Z",
+      "to": "2024-03-08T09:24:34Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/cni-sysctl-allowlist-ds-x89t7 uid/1c44edf3-3240-4dbe-916b-e19ba4621ee0 container/kube-multus-additional-cni-plugins",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "cni-sysctl-allowlist-ds-x89t7",
+          "uid": "1c44edf3-3240-4dbe-916b-e19ba4621ee0"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:36Z",
+      "to": "2024-03-08T09:24:36Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-7vqbm uid/368e7172-ea39-4158-9dc4-b58081a24293 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-7vqbm",
+          "uid": "368e7172-ea39-4158-9dc4-b58081a24293"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:24:46Z",
+      "to": "2024-03-08T09:24:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xhx48 uid/fb6e9a2d-4e51-48a0-8b78-c19dde90098e container/network-check-target-container",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-check-target-container",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xhx48",
+          "uid": "fb6e9a2d-4e51-48a0-8b78-c19dde90098e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:26:58Z",
+      "to": "2024-03-08T09:26:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v uid/af7a8849-2989-41f4-8144-2a6941c25192 container/network-check-target-container",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-check-target-container",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v",
+          "uid": "af7a8849-2989-41f4-8144-2a6941c25192"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:26:58Z",
+      "to": "2024-03-08T09:26:58Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v uid/af7a8849-2989-41f4-8144-2a6941c25192 container/network-check-target-container",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-check-target-container",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v",
+          "uid": "af7a8849-2989-41f4-8144-2a6941c25192"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:27:38Z",
+      "to": "2024-03-08T09:27:38Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-upgrades-prepuller-ppkwb uid/90cceaad-7bc8-4930-9dc0-ae2c72ad4f0f container/ovnkube-upgrades-prepuller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-upgrades-prepuller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-upgrades-prepuller-ppkwb",
+          "uid": "90cceaad-7bc8-4930-9dc0-ae2c72ad4f0f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:28:08Z",
+      "to": "2024-03-08T09:28:08Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-r8lb8 uid/b4569411-7f6e-4080-95ef-e37f519eeaef container/kube-multus",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-r8lb8",
+          "uid": "b4569411-7f6e-4080-95ef-e37f519eeaef"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/kube-rbac-proxy-node",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-node",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/kube-rbac-proxy-ovn-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-ovn-metrics",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/nbdb",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/northd",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "northd",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/ovn-acl-logging",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-acl-logging",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/ovn-controller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/ovnkube-controller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-cdzrh uid/59a3b1ee-657b-45e3-a27a-a750e3ad3e38 container/sbdb",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "sbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-cdzrh",
+          "uid": "59a3b1ee-657b-45e3-a27a-a750e3ad3e38"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:11Z",
+      "to": "2024-03-08T09:29:11Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kube-rbac-proxy-node",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-node",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kube-rbac-proxy-ovn-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-ovn-metrics",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/nbdb",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/northd",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "northd",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovn-acl-logging",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-acl-logging",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovn-controller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovnkube-controller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/sbdb",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "sbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kubecfg-setup",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kubecfg-setup",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-r8lb8 uid/b4569411-7f6e-4080-95ef-e37f519eeaef container/kube-multus",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-r8lb8",
+          "uid": "b4569411-7f6e-4080-95ef-e37f519eeaef"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kubecfg-setup",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kubecfg-setup",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:12Z",
+      "to": "2024-03-08T09:29:12Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kube-rbac-proxy-node",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-node",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:18Z",
+      "to": "2024-03-08T09:29:18Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kube-rbac-proxy-ovn-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-ovn-metrics",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:18Z",
+      "to": "2024-03-08T09:29:18Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/northd",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "northd",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:18Z",
+      "to": "2024-03-08T09:29:18Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovn-acl-logging",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-acl-logging",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:18Z",
+      "to": "2024-03-08T09:29:18Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovn-controller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:18Z",
+      "to": "2024-03-08T09:29:18Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/nbdb",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:32Z",
+      "to": "2024-03-08T09:29:32Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/sbdb",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "sbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:32Z",
+      "to": "2024-03-08T09:29:32Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovnkube-controller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:29:32Z",
+      "to": "2024-03-08T09:29:32Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-tl9nm uid/461d2e59-e14e-4b40-aa2c-c0f0a7036208 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-tl9nm",
+          "uid": "461d2e59-e14e-4b40-aa2c-c0f0a7036208"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:31:51Z",
+      "to": "2024-03-08T09:31:51Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-tl9nm uid/461d2e59-e14e-4b40-aa2c-c0f0a7036208 container/machine-config-daemon",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "machine-config-daemon",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-tl9nm",
+          "uid": "461d2e59-e14e-4b40-aa2c-c0f0a7036208"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:31:51Z",
+      "to": "2024-03-08T09:31:51Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-25rnz uid/3fb7d10a-4625-4359-9692-b8e1ff126862 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-25rnz",
+          "uid": "3fb7d10a-4625-4359-9692-b8e1ff126862"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:31:51Z",
+      "to": "2024-03-08T09:31:51Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-25rnz uid/3fb7d10a-4625-4359-9692-b8e1ff126862 container/machine-config-daemon",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "machine-config-daemon",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-25rnz",
+          "uid": "3fb7d10a-4625-4359-9692-b8e1ff126862"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:31:51Z",
+      "to": "2024-03-08T09:31:51Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-25rnz uid/3fb7d10a-4625-4359-9692-b8e1ff126862 container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-25rnz",
+          "uid": "3fb7d10a-4625-4359-9692-b8e1ff126862"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:31:53Z",
+      "to": "2024-03-08T09:31:53Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-25rnz uid/3fb7d10a-4625-4359-9692-b8e1ff126862 container/machine-config-daemon",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "machine-config-daemon",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-25rnz",
+          "uid": "3fb7d10a-4625-4359-9692-b8e1ff126862"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:31:53Z",
+      "to": "2024-03-08T09:31:53Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/94b2a62d8a",
       "message": "reason/Cordon roles/worker Cordoned node to apply update",
-      "from": "2021-04-12T22:25:29Z",
-      "to": "2021-04-12T22:25:29Z"
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "94b2a62d8a",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Cordon",
+        "cause": "",
+        "humanMessage": "Cordoned node to apply update",
+        "annotations": {
+          "reason": "Cordon",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:33:15Z",
+      "to": "2024-03-08T09:33:15Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/502676ccb6",
       "message": "reason/Drain roles/worker Draining node to update config.",
-      "from": "2021-04-12T22:25:29Z",
-      "to": "2021-04-12T22:25:29Z"
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "502676ccb6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Drain",
+        "cause": "",
+        "humanMessage": "Draining node to update config.",
+        "annotations": {
+          "reason": "Drain",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:33:15Z",
+      "to": "2024-03-08T09:33:15Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-pod-network-disruption-poller-7b446db555-qvhfh uid/8f3592f6-803d-43f4-a179-0668193cce19 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-pod-network-disruption-poller-7b446db555-qvhfh",
+          "uid": "8f3592f6-803d-43f4-a179-0668193cce19"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:23Z",
+      "to": "2024-03-08T09:33:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-service-disruption-poller-68c49949d4-zp9jp uid/cff515c9-30f2-48b4-b78c-5a2334b641e7 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-service-disruption-poller-68c49949d4-zp9jp",
+          "uid": "cff515c9-30f2-48b4-b78c-5a2334b641e7"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:23Z",
+      "to": "2024-03-08T09:33:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-service-disruption-poller-5848554867-ptwpf uid/85f81a7e-048b-46f4-bc28-4d07d21c1dd4 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-service-disruption-poller-5848554867-ptwpf",
+          "uid": "85f81a7e-048b-46f4-bc28-4d07d21c1dd4"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:23Z",
+      "to": "2024-03-08T09:33:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-host-network-disruption-poller-6fb456c9-j74vz uid/008031e7-589a-4280-8469-763034f75008 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-host-network-disruption-poller-6fb456c9-j74vz",
+          "uid": "008031e7-589a-4280-8469-763034f75008"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-operator-admission-webhook-8574d6fd7d-hncht uid/3aaf199b-104a-481d-b655-6683cf3dc941 container/prometheus-operator-admission-webhook",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-operator-admission-webhook",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-operator-admission-webhook-8574d6fd7d-hncht",
+          "uid": "3aaf199b-104a-481d-b655-6683cf3dc941"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-pod-network-disruption-poller-69dbf666d-wxlpt uid/6bafbda3-c46f-412c-8ea4-36587746eaa0 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-pod-network-disruption-poller-69dbf666d-wxlpt",
+          "uid": "6bafbda3-c46f-412c-8ea4-36587746eaa0"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/monitoring-plugin-bc8dc7986-sk4h4 uid/0c1887d1-a526-46ef-9dca-d28b4ac6ff46 container/monitoring-plugin",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "monitoring-plugin",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "monitoring-plugin-bc8dc7986-sk4h4",
+          "uid": "0c1887d1-a526-46ef-9dca-d28b4ac6ff46"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-host-network-disruption-poller-6944cc9694-7xjjd uid/39832573-8cc1-4991-bf26-19d933371637 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-host-network-disruption-poller-6944cc9694-7xjjd",
+          "uid": "39832573-8cc1-4991-bf26-19d933371637"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-replicaset-upgrade-324 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/rs-ht2kp uid/ea1ad029-4897-4c82-864b-2e485a95afd7 container/nginx",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nginx",
+          "namespace": "e2e-k8s-sig-apps-replicaset-upgrade-324",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "rs-ht2kp",
+          "uid": "ea1ad029-4897-4c82-864b-2e485a95afd7"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/alertmanager",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "alertmanager",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy-metric",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metric",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-0 uid/6b12ca0a-16c5-4608-9c45-9fa191c7ff9f container/prom-label-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-0",
+          "uid": "6b12ca0a-16c5-4608-9c45-9fa191c7ff9f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:24Z",
+      "to": "2024-03-08T09:33:24Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:25Z",
+      "to": "2024-03-08T09:33:25Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:25Z",
+      "to": "2024-03-08T09:33:25Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy-thanos",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-thanos",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:25Z",
+      "to": "2024-03-08T09:33:25Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:25Z",
+      "to": "2024-03-08T09:33:25Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/prometheus",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:25Z",
+      "to": "2024-03-08T09:33:25Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/7582174b-fe8d-48c3-8e32-fd1b7c758e7b container/thanos-sidecar",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-sidecar",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "7582174b-fe8d-48c3-8e32-fd1b7c758e7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:25Z",
+      "to": "2024-03-08T09:33:25Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-disruption-target-69f576bf7f-csdcl uid/6c7aae34-b512-4930-bd73-8c01ac2ab42d container/host-disruption-server",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "host-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-disruption-target-69f576bf7f-csdcl",
+          "uid": "6c7aae34-b512-4930-bd73-8c01ac2ab42d"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:25Z",
+      "to": "2024-03-08T09:33:25Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-job-upgrade-258 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/foo-j5wbt uid/eeb62b3a-9cb5-4dc6-aefd-44888b87b305 container/c",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "c",
+          "namespace": "e2e-k8s-sig-apps-job-upgrade-258",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "foo-j5wbt",
+          "uid": "eeb62b3a-9cb5-4dc6-aefd-44888b87b305"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:25Z",
+      "to": "2024-03-08T09:33:25Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/NodeNotSchedulable roles/worker Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 status is now: NodeNotSchedulable",
-      "from": "2021-04-12T22:25:34Z",
-      "to": "2021-04-12T22:25:34Z"
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/d7eda12db2",
+      "message": "reason/NodeNotSchedulable roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotSchedulable",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "d7eda12db2",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeNotSchedulable",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotSchedulable",
+        "annotations": {
+          "reason": "NodeNotSchedulable",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:33:26Z",
+      "to": "2024-03-08T09:33:26Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-disruption-target-fdc46b779-cphct uid/4ef86a65-44f3-4fa2-8399-3210c1b924bb container/pod-disruption-server",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "pod-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-disruption-target-fdc46b779-cphct",
+          "uid": "4ef86a65-44f3-4fa2-8399-3210c1b924bb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:26Z",
+      "to": "2024-03-08T09:33:26Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-5rgr7 uid/0f4ecf90-2da6-4fdd-b1f0-330bf3121deb container/event-exporter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "event-exporter",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-5rgr7",
+          "uid": "0f4ecf90-2da6-4fdd-b1f0-330bf3121deb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:28Z",
+      "to": "2024-03-08T09:33:28Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-5rgr7 uid/0f4ecf90-2da6-4fdd-b1f0-330bf3121deb container/event-exporter",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "event-exporter",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-5rgr7",
+          "uid": "0f4ecf90-2da6-4fdd-b1f0-330bf3121deb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:33:31Z",
+      "to": "2024-03-08T09:33:31Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/image-registry-5fdfc959c8-r8tvh uid/ae83fb91-dbfd-4d9b-b341-dd111f4ec215 container/registry",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "image-registry-5fdfc959c8-r8tvh",
+          "uid": "ae83fb91-dbfd-4d9b-b341-dd111f4ec215"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:49Z",
+      "to": "2024-03-08T09:33:49Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/0294347a34",
+      "message": "reason/InClusterUpgrade roles/worker Updating from oscontainer registry.ci.openshift.org/ocp/4.16-2024-03-08-080212@sha256:a16edf61fcd9e4896ec143b10fa00182a35c6da2abd3351564464237c0d52ab8",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "0294347a34",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "InClusterUpgrade",
+        "cause": "",
+        "humanMessage": "Updating from oscontainer registry.ci.openshift.org/ocp/4.16-2024-03-08-080212@sha256:a16edf61fcd9e4896ec143b10fa00182a35c6da2abd3351564464237c0d52ab8",
+        "annotations": {
+          "reason": "InClusterUpgrade",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:33:58Z",
+      "to": "2024-03-08T09:33:58Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/873e8ad5d9",
       "message": "reason/OSUpdateStarted roles/worker Upgrading OS",
-      "from": "2021-04-12T22:27:00Z",
-      "to": "2021-04-12T22:27:00Z"
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "873e8ad5d9",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "OSUpdateStarted",
+        "cause": "",
+        "humanMessage": "Upgrading OS",
+        "annotations": {
+          "reason": "OSUpdateStarted",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:33:58Z",
+      "to": "2024-03-08T09:33:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn uid/bb81ca94-deb9-4b9f-bbfd-24a3375a9b52 container/event-exporter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "event-exporter",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn",
+          "uid": "bb81ca94-deb9-4b9f-bbfd-24a3375a9b52"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:58Z",
+      "to": "2024-03-08T09:33:58Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-5rgr7 uid/0f4ecf90-2da6-4fdd-b1f0-330bf3121deb container/event-exporter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "event-exporter",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-5rgr7",
+          "uid": "0f4ecf90-2da6-4fdd-b1f0-330bf3121deb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:33:58Z",
+      "to": "2024-03-08T09:33:58Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/InClusterUpgrade roles/worker Updating from oscontainer registry.build02.ci.openshift.org/ci-op-8sllkmg5/stable@sha256:59298bf4359e51de44b6ca28c211df62ab823566823e8e1b5aaafa090ff481bb",
-      "from": "2021-04-12T22:27:00Z",
-      "to": "2021-04-12T22:27:00Z"
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn uid/bb81ca94-deb9-4b9f-bbfd-24a3375a9b52 container/event-exporter",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "event-exporter",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn",
+          "uid": "bb81ca94-deb9-4b9f-bbfd-24a3375a9b52"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:33:59Z",
+      "to": "2024-03-08T09:33:59Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/3630b39c94",
       "message": "reason/OSUpdateStaged roles/worker Changes to OS staged",
-      "from": "2021-04-12T22:27:21Z",
-      "to": "2021-04-12T22:27:21Z"
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "3630b39c94",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "OSUpdateStaged",
+        "cause": "",
+        "humanMessage": "Changes to OS staged",
+        "annotations": {
+          "reason": "OSUpdateStaged",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:34:17Z",
+      "to": "2024-03-08T09:34:17Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/PendingConfig roles/worker Written pending config rendered-worker-2f04672635ea44b389119d4a0e747bc7",
-      "from": "2021-04-12T22:27:22Z",
-      "to": "2021-04-12T22:27:22Z"
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/bed291d2ac",
+      "message": "reason/Reboot roles/worker Node will reboot into config rendered-worker-f1d2e852441980b2a7b5bcfbf9ab6b6c",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "bed291d2ac",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Reboot",
+        "cause": "",
+        "humanMessage": "Node will reboot into config rendered-worker-f1d2e852441980b2a7b5bcfbf9ab6b6c",
+        "annotations": {
+          "reason": "Reboot",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:34:17Z",
+      "to": "2024-03-08T09:34:17Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/Reboot roles/worker Node will reboot into config rendered-worker-2f04672635ea44b389119d4a0e747bc7",
-      "from": "2021-04-12T22:27:22Z",
-      "to": "2021-04-12T22:27:22Z"
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/de323ecba3",
+      "message": "reason/NodeNotReady roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotReady",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "de323ecba3",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeNotReady",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotReady",
+        "annotations": {
+          "reason": "NodeNotReady",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:34:55Z",
+      "to": "2024-03-08T09:34:55Z"
     },
     {
       "level": "Warning",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "condition/DiskPressure status/Unknown reason/NodeStatusUnknown roles/worker changed",
-      "from": "2021-04-12T22:28:07Z",
-      "to": "2021-04-12T22:28:07Z"
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+      "message": "reason/NotReady roles/worker node is not ready",
+      "tempSource": "NodeMonitor",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "node is not ready",
+        "annotations": {
+          "reason": "NotReady",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:34:55Z",
+      "to": "2024-03-08T09:34:55Z"
     },
     {
       "level": "Warning",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "condition/MemoryPressure status/Unknown reason/NodeStatusUnknown roles/worker changed",
-      "from": "2021-04-12T22:28:07Z",
-      "to": "2021-04-12T22:28:07Z"
-    },
-    {
-      "level": "Warning",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "condition/PIDPressure status/Unknown reason/NodeStatusUnknown roles/worker changed",
-      "from": "2021-04-12T22:28:07Z",
-      "to": "2021-04-12T22:28:07Z"
-    },
-    {
-      "level": "Warning",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "condition/Ready status/Unknown reason/NodeStatusUnknown roles/worker changed",
-      "from": "2021-04-12T22:28:07Z",
-      "to": "2021-04-12T22:28:07Z"
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q row/NodeNotReady",
+      "message": "constructed/node-lifecycle-constructor reason/NotReady roles/worker node is not ready",
+      "tempSource": "NodeState",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "row": "NodeNotReady"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "node is not ready",
+        "annotations": {
+          "constructed": "node-lifecycle-constructor",
+          "reason": "NotReady",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:34:55Z",
+      "to": "2024-03-08T09:35:52Z"
     },
     {
       "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "reason/NodeNotReady roles/worker Node ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2 status is now: NodeNotReady",
-      "from": "2021-04-12T22:28:07Z",
-      "to": "2021-04-12T22:28:07Z"
-    },
-    {
-      "level": "Warning",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
-      "message": "roles/worker node is not ready",
-      "from": "2021-04-12T22:28:08Z",
-      "to": "2021-04-12T22:29:00Z"
-    },
-    {
-      "level": "Info",
-      "locator": "node/ci-op-8sllkmg5-db044-7grbp-worker-b-xvtw2",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/ceb3f574b3",
       "message": "reason/Starting roles/worker Starting kubelet.",
-      "from": "2021-04-12T22:28:50Z",
-      "to": "2021-04-12T22:28:50Z"
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "ceb3f574b3",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Starting",
+        "cause": "",
+        "humanMessage": "Starting kubelet.",
+        "annotations": {
+          "reason": "Starting",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:28Z",
+      "to": "2024-03-08T09:35:28Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/de323ecba3",
+      "message": "reason/NodeNotReady roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotReady",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "de323ecba3",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeNotReady",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotReady",
+        "annotations": {
+          "reason": "NodeNotReady",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:38Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/d7eda12db2",
+      "message": "reason/NodeNotSchedulable roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotSchedulable",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "d7eda12db2",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeNotSchedulable",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotSchedulable",
+        "annotations": {
+          "reason": "NodeNotSchedulable",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:38Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/ece3fbc579",
+      "message": "reason/Rebooted roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q has been rebooted, boot id: 68e0347b-d619-4d8b-aa64-95b5ea65b3cb",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "ece3fbc579",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Rebooted",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q has been rebooted, boot id: 68e0347b-d619-4d8b-aa64-95b5ea65b3cb",
+        "annotations": {
+          "reason": "Rebooted",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:38Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/ceb3f574b3",
+      "message": "reason/Starting roles/worker Starting kubelet.",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "ceb3f574b3",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Starting",
+        "cause": "",
+        "humanMessage": "Starting kubelet.",
+        "annotations": {
+          "reason": "Starting",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:38Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/f4de03a318",
+      "message": "count/2 interesting/true reason/NodeHasNoDiskPressure roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeHasNoDiskPressure",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "f4de03a318",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeHasNoDiskPressure",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeHasNoDiskPressure",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NodeHasNoDiskPressure",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/de323ecba3",
+      "message": "count/2 reason/NodeNotReady roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotReady",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "de323ecba3",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeNotReady",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeNotReady",
+        "annotations": {
+          "count": "2",
+          "reason": "NodeNotReady",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/ece3fbc579",
+      "message": "count/2 reason/Rebooted roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q has been rebooted, boot id: 68e0347b-d619-4d8b-aa64-95b5ea65b3cb",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "ece3fbc579",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Rebooted",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q has been rebooted, boot id: 68e0347b-d619-4d8b-aa64-95b5ea65b3cb",
+        "annotations": {
+          "count": "2",
+          "reason": "Rebooted",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/f4de03a318",
+      "message": "count/3 interesting/true reason/NodeHasNoDiskPressure roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeHasNoDiskPressure",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "f4de03a318",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeHasNoDiskPressure",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeHasNoDiskPressure",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NodeHasNoDiskPressure",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/f4de03a318",
+      "message": "count/4 interesting/true reason/NodeHasNoDiskPressure roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeHasNoDiskPressure",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "f4de03a318",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeHasNoDiskPressure",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeHasNoDiskPressure",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NodeHasNoDiskPressure",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/f4de03a318",
+      "message": "interesting/true reason/NodeHasNoDiskPressure roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeHasNoDiskPressure",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "f4de03a318",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeHasNoDiskPressure",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeHasNoDiskPressure",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NodeHasNoDiskPressure",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+      "message": "reason/KubeletHasNoDiskPressure roles/worker changed",
+      "tempSource": "NodeMonitor",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "KubeletHasNoDiskPressure",
+        "cause": "",
+        "humanMessage": "changed",
+        "annotations": {
+          "reason": "KubeletHasNoDiskPressure",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:38Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+      "message": "reason/KubeletNotReady roles/worker changed",
+      "tempSource": "NodeMonitor",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "KubeletNotReady",
+        "cause": "",
+        "humanMessage": "changed",
+        "annotations": {
+          "reason": "KubeletNotReady",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:38Z",
+      "to": "2024-03-08T09:35:38Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck hmsg/e1f10474a2",
+      "message": "interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs hmsg/e1f10474a2",
+      "message": "interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj hmsg/e1f10474a2",
+      "message": "interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn hmsg/e1f10474a2",
+      "message": "interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf hmsg/e1f10474a2",
+      "message": "interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 hmsg/e1f10474a2",
+      "message": "interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd hmsg/e1f10474a2",
+      "message": "interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v hmsg/e1f10474a2",
+      "message": "interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/oauth-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "oauth-proxy",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/prod-bearer-token",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prod-bearer-token",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/promtail",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "promtail",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-node-tuning-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/tuned-4z6d4 uid/71e6b9a5-f54e-4667-9993-5751f11f4e5d container/tuned",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "tuned",
+          "namespace": "openshift-cluster-node-tuning-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "tuned-4z6d4",
+          "uid": "71e6b9a5-f54e-4667-9993-5751f11f4e5d"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 uid/fd50c0cf-3773-4e6a-ae03-68afc8ea9dd1 container/serve-healthcheck-canary",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "serve-healthcheck-canary",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88",
+          "uid": "fd50c0cf-3773-4e6a-ae03-68afc8ea9dd1"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-ca-sglr7 uid/4a6a9488-8182-4a03-a049-432150384cfd container/node-ca",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-ca",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-ca-sglr7",
+          "uid": "4a6a9488-8182-4a03-a049-432150384cfd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/node-exporter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-exporter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-pjgmv uid/e7f67448-1984-4bc3-a520-a1e9df7df2c3 container/dns-node-resolver",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-pjgmv",
+          "uid": "e7f67448-1984-4bc3-a520-a1e9df7df2c3"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/kube-multus-additional-cni-plugins",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v uid/af7a8849-2989-41f4-8144-2a6941c25192 container/network-check-target-container",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-check-target-container",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v",
+          "uid": "af7a8849-2989-41f4-8144-2a6941c25192"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs uid/d6d27082-f9eb-43ba-9dbe-40bc489586e6 container/app",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "app",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs",
+          "uid": "d6d27082-f9eb-43ba-9dbe-40bc489586e6"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-r8lb8 uid/b4569411-7f6e-4080-95ef-e37f519eeaef container/kube-multus",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-r8lb8",
+          "uid": "b4569411-7f6e-4080-95ef-e37f519eeaef"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck uid/5093bbac-e758-45bf-a3de-0a6d3e9b852e container/querier",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "querier",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck",
+          "uid": "5093bbac-e758-45bf-a3de-0a6d3e9b852e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:39Z",
+      "to": "2024-03-08T09:35:39Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd uid/b41a9b9c-ba1f-420f-bede-a25179339281 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd",
+          "uid": "b41a9b9c-ba1f-420f-bede-a25179339281"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd uid/b41a9b9c-ba1f-420f-bede-a25179339281 container/network-metrics-daemon",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-metrics-daemon",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd",
+          "uid": "b41a9b9c-ba1f-420f-bede-a25179339281"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kube-rbac-proxy-node",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-node",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kube-rbac-proxy-ovn-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-ovn-metrics",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/nbdb",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/northd",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "northd",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovn-acl-logging",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-acl-logging",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovn-controller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovnkube-controller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/sbdb",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "sbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn uid/bb81ca94-deb9-4b9f-bbfd-24a3375a9b52 container/event-exporter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "event-exporter",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn",
+          "uid": "bb81ca94-deb9-4b9f-bbfd-24a3375a9b52"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-driver",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-driver",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-liveness-probe",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-liveness-probe",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-node-driver-registrar",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-node-driver-registrar",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj uid/9d08b494-b1aa-4606-8480-dceff8a603ec container/dns",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj",
+          "uid": "9d08b494-b1aa-4606-8480-dceff8a603ec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj uid/9d08b494-b1aa-4606-8480-dceff8a603ec container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj",
+          "uid": "9d08b494-b1aa-4606-8480-dceff8a603ec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-25rnz uid/3fb7d10a-4625-4359-9692-b8e1ff126862 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-25rnz",
+          "uid": "3fb7d10a-4625-4359-9692-b8e1ff126862"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-25rnz uid/3fb7d10a-4625-4359-9692-b8e1ff126862 container/machine-config-daemon",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "machine-config-daemon",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-25rnz",
+          "uid": "3fb7d10a-4625-4359-9692-b8e1ff126862"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:40Z",
+      "to": "2024-03-08T09:35:40Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/ac7f4b1372",
+      "message": "reason/RegisteredNode roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q event: Registered Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q in Controller",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "ac7f4b1372",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "RegisteredNode",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q event: Registered Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q in Controller",
+        "annotations": {
+          "reason": "RegisteredNode",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:41Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck hmsg/e1f10474a2",
+      "message": "count/2 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs hmsg/e1f10474a2",
+      "message": "count/2 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj hmsg/e1f10474a2",
+      "message": "count/2 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn hmsg/e1f10474a2",
+      "message": "count/2 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf hmsg/e1f10474a2",
+      "message": "count/2 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 hmsg/e1f10474a2",
+      "message": "count/2 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd hmsg/e1f10474a2",
+      "message": "count/2 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v hmsg/e1f10474a2",
+      "message": "count/2 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "2",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-r8lb8 uid/b4569411-7f6e-4080-95ef-e37f519eeaef container/kube-multus",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-r8lb8",
+          "uid": "b4569411-7f6e-4080-95ef-e37f519eeaef"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:41Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-25rnz uid/3fb7d10a-4625-4359-9692-b8e1ff126862 container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-25rnz",
+          "uid": "3fb7d10a-4625-4359-9692-b8e1ff126862"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:41Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-machine-config-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/machine-config-daemon-25rnz uid/3fb7d10a-4625-4359-9692-b8e1ff126862 container/machine-config-daemon",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "machine-config-daemon",
+          "namespace": "openshift-machine-config-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "machine-config-daemon-25rnz",
+          "uid": "3fb7d10a-4625-4359-9692-b8e1ff126862"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:41Z",
+      "to": "2024-03-08T09:35:41Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-node-tuning-operator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/tuned-4z6d4 uid/71e6b9a5-f54e-4667-9993-5751f11f4e5d container/tuned",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "tuned",
+          "namespace": "openshift-cluster-node-tuning-operator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "tuned-4z6d4",
+          "uid": "71e6b9a5-f54e-4667-9993-5751f11f4e5d"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:42Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:42Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-exporter-s4fzh uid/c7db946e-ada7-42d3-9b7b-2c1d2647c2fb container/node-exporter",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-exporter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-exporter-s4fzh",
+          "uid": "c7db946e-ada7-42d3-9b7b-2c1d2647c2fb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:42Z",
+      "to": "2024-03-08T09:35:42Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck hmsg/e1f10474a2",
+      "message": "count/3 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs hmsg/e1f10474a2",
+      "message": "count/3 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj hmsg/e1f10474a2",
+      "message": "count/3 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn hmsg/e1f10474a2",
+      "message": "count/3 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf hmsg/e1f10474a2",
+      "message": "count/3 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 hmsg/e1f10474a2",
+      "message": "count/3 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd hmsg/e1f10474a2",
+      "message": "count/3 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v hmsg/e1f10474a2",
+      "message": "count/3 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "3",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-ca-sglr7 uid/4a6a9488-8182-4a03-a049-432150384cfd container/node-ca",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "node-ca",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-ca-sglr7",
+          "uid": "4a6a9488-8182-4a03-a049-432150384cfd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:43Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/node-resolver-pjgmv uid/e7f67448-1984-4bc3-a520-a1e9df7df2c3 container/dns-node-resolver",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns-node-resolver",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "node-resolver-pjgmv",
+          "uid": "e7f67448-1984-4bc3-a520-a1e9df7df2c3"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:43Z",
+      "to": "2024-03-08T09:35:43Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-driver",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-driver",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:44Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-liveness-probe",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-liveness-probe",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:44Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-cluster-csi-drivers node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/gcp-pd-csi-driver-node-ptmqc uid/26b12706-2034-4a89-9345-66afd31baf78 container/csi-node-driver-registrar",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "csi-node-driver-registrar",
+          "namespace": "openshift-cluster-csi-drivers",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "gcp-pd-csi-driver-node-ptmqc",
+          "uid": "26b12706-2034-4a89-9345-66afd31baf78"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:44Z",
+      "to": "2024-03-08T09:35:44Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck hmsg/e1f10474a2",
+      "message": "count/4 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:45Z",
+      "to": "2024-03-08T09:35:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs hmsg/e1f10474a2",
+      "message": "count/4 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:45Z",
+      "to": "2024-03-08T09:35:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj hmsg/e1f10474a2",
+      "message": "count/4 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:45Z",
+      "to": "2024-03-08T09:35:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn hmsg/e1f10474a2",
+      "message": "count/4 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:45Z",
+      "to": "2024-03-08T09:35:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf hmsg/e1f10474a2",
+      "message": "count/4 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:45Z",
+      "to": "2024-03-08T09:35:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 hmsg/e1f10474a2",
+      "message": "count/4 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:45Z",
+      "to": "2024-03-08T09:35:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd hmsg/e1f10474a2",
+      "message": "count/4 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:45Z",
+      "to": "2024-03-08T09:35:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v hmsg/e1f10474a2",
+      "message": "count/4 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "4",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:45Z",
+      "to": "2024-03-08T09:35:46Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck hmsg/e1f10474a2",
+      "message": "count/5 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "5",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs hmsg/e1f10474a2",
+      "message": "count/5 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "5",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj hmsg/e1f10474a2",
+      "message": "count/5 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "5",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn hmsg/e1f10474a2",
+      "message": "count/5 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "5",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf hmsg/e1f10474a2",
+      "message": "count/5 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "5",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 hmsg/e1f10474a2",
+      "message": "count/5 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "5",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd hmsg/e1f10474a2",
+      "message": "count/5 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "5",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v hmsg/e1f10474a2",
+      "message": "count/5 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "5",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/whereabouts-cni-bincopy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "whereabouts-cni-bincopy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:47Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kube-rbac-proxy-node",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-node",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:47Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/kube-rbac-proxy-ovn-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-ovn-metrics",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:47Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/northd",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "northd",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:47Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovn-controller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:47Z",
+      "to": "2024-03-08T09:35:47Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovn-acl-logging",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovn-acl-logging",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:48Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/whereabouts-cni-bincopy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "whereabouts-cni-bincopy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:48Z",
+      "to": "2024-03-08T09:35:48Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck hmsg/e1f10474a2",
+      "message": "count/6 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "6",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:49Z",
+      "to": "2024-03-08T09:35:50Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs hmsg/e1f10474a2",
+      "message": "count/6 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "6",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:49Z",
+      "to": "2024-03-08T09:35:50Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj hmsg/e1f10474a2",
+      "message": "count/6 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "6",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:49Z",
+      "to": "2024-03-08T09:35:50Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn hmsg/e1f10474a2",
+      "message": "count/6 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "6",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:49Z",
+      "to": "2024-03-08T09:35:50Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 hmsg/e1f10474a2",
+      "message": "count/6 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "6",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:49Z",
+      "to": "2024-03-08T09:35:50Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd hmsg/e1f10474a2",
+      "message": "count/6 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "6",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:49Z",
+      "to": "2024-03-08T09:35:50Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v hmsg/e1f10474a2",
+      "message": "count/6 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "6",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:49Z",
+      "to": "2024-03-08T09:35:50Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/multus-additional-cni-plugins-nc55x uid/536bd91a-2630-4d30-a1ff-ef3c850222ca container/kube-multus-additional-cni-plugins",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "multus-additional-cni-plugins-nc55x",
+          "uid": "536bd91a-2630-4d30-a1ff-ef3c850222ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:50Z",
+      "to": "2024-03-08T09:35:50Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck hmsg/e1f10474a2",
+      "message": "count/7 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "7",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:51Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs hmsg/e1f10474a2",
+      "message": "count/7 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "7",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:51Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj hmsg/e1f10474a2",
+      "message": "count/7 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "7",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:51Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn hmsg/e1f10474a2",
+      "message": "count/7 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "7",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:51Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 hmsg/e1f10474a2",
+      "message": "count/7 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "7",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:51Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd hmsg/e1f10474a2",
+      "message": "count/7 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "7",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:51Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v hmsg/e1f10474a2",
+      "message": "count/7 interesting/true reason/NetworkNotReady network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+      "tempSource": "KubeEvent",
+      "display": true,
+      "tempStructuredLocator": {
+        "type": "Kind",
+        "keys": {
+          "hmsg": "e1f10474a2",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NetworkNotReady",
+        "cause": "",
+        "humanMessage": "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?",
+        "annotations": {
+          "count": "7",
+          "interesting": "true",
+          "reason": "NetworkNotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:51Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/de14aca9ec",
+      "message": "reason/NodeReady roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeReady",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "de14aca9ec",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NodeReady",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q status is now: NodeReady",
+        "annotations": {
+          "reason": "NodeReady",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:52Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+      "message": "reason/Ready roles/worker node is ready",
+      "tempSource": "NodeMonitor",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "node is ready",
+        "annotations": {
+          "reason": "Ready",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:52Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+      "message": "reason/KubeletReady roles/worker changed",
+      "tempSource": "NodeMonitor",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "KubeletReady",
+        "cause": "",
+        "humanMessage": "changed",
+        "annotations": {
+          "reason": "KubeletReady",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:35:52Z",
+      "to": "2024-03-08T09:35:52Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj uid/9d08b494-b1aa-4606-8480-dceff8a603ec container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj",
+          "uid": "9d08b494-b1aa-4606-8480-dceff8a603ec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:56Z",
+      "to": "2024-03-08T09:35:56Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-check-for-dns-availability-4447 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck uid/5093bbac-e758-45bf-a3de-0a6d3e9b852e container/querier",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "querier",
+          "namespace": "e2e-check-for-dns-availability-4447",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-test-5e24b6fb-a6ef-41f0-ab1b-6e0800f33277-9xkck",
+          "uid": "5093bbac-e758-45bf-a3de-0a6d3e9b852e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:56Z",
+      "to": "2024-03-08T09:35:56Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/event-exporter-6fbcd8f646-p6gwn uid/bb81ca94-deb9-4b9f-bbfd-24a3375a9b52 container/event-exporter",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "event-exporter",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "event-exporter-6fbcd8f646-p6gwn",
+          "uid": "bb81ca94-deb9-4b9f-bbfd-24a3375a9b52"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:56Z",
+      "to": "2024-03-08T09:35:56Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ingress-canary node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ingress-canary-95z88 uid/fd50c0cf-3773-4e6a-ae03-68afc8ea9dd1 container/serve-healthcheck-canary",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "serve-healthcheck-canary",
+          "namespace": "openshift-ingress-canary",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ingress-canary-95z88",
+          "uid": "fd50c0cf-3773-4e6a-ae03-68afc8ea9dd1"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:56Z",
+      "to": "2024-03-08T09:35:56Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/kube-rbac-proxy-thanos",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-thanos",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/prometheus",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/thanos-sidecar",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-sidecar",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/init-config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-service-disruption-poller-68c49949d4-rzwht uid/8edbb07b-0010-4fd0-a3e6-f226df272885 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-service-disruption-poller-68c49949d4-rzwht",
+          "uid": "8edbb07b-0010-4fd0-a3e6-f226df272885"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-pod-network-disruption-poller-69dbf666d-55wg4 uid/36bafac5-0e77-4d21-a4f8-9356f713585e container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-pod-network-disruption-poller-69dbf666d-55wg4",
+          "uid": "36bafac5-0e77-4d21-a4f8-9356f713585e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-disruption-target-fdc46b779-8jbj8 uid/65f31f01-1280-4fc6-af9b-0957d8ba9a10 container/pod-disruption-server",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "pod-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-disruption-target-fdc46b779-8jbj8",
+          "uid": "65f31f01-1280-4fc6-af9b-0957d8ba9a10"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-pod-network-disruption-poller-7b446db555-xfwsq uid/5f7e20a1-f1f3-430f-b41f-67158d3f7871 container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-pod-network-disruption-poller-7b446db555-xfwsq",
+          "uid": "5f7e20a1-f1f3-430f-b41f-67158d3f7871"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-disruption-target-69f576bf7f-h9v4n uid/2fdac5c3-e709-421b-8013-61e17902f4c2 container/host-disruption-server",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "host-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-disruption-target-69f576bf7f-h9v4n",
+          "uid": "2fdac5c3-e709-421b-8013-61e17902f4c2"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-service-disruption-poller-5848554867-794jk uid/9e528af2-8177-4cec-9ae1-86e7fdd5af7b container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-service-disruption-poller-5848554867-794jk",
+          "uid": "9e528af2-8177-4cec-9ae1-86e7fdd5af7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-host-network-disruption-poller-6944cc9694-85mz4 uid/d2df9be5-4c3e-4bc5-9975-d2d5355359ca container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-host-network-disruption-poller-6944cc9694-85mz4",
+          "uid": "d2df9be5-4c3e-4bc5-9975-d2d5355359ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-host-network-disruption-poller-6fb456c9-844sp uid/01047004-4114-4506-bbfa-e747c554e43b container/disruption-poller",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-host-network-disruption-poller-6fb456c9-844sp",
+          "uid": "01047004-4114-4506-bbfa-e747c554e43b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-k8s-sig-apps-daemonset-upgrade-20 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ds1-qksqs uid/d6d27082-f9eb-43ba-9dbe-40bc489586e6 container/app",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "app",
+          "namespace": "e2e-k8s-sig-apps-daemonset-upgrade-20",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ds1-qksqs",
+          "uid": "d6d27082-f9eb-43ba-9dbe-40bc489586e6"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd uid/b41a9b9c-ba1f-420f-bede-a25179339281 container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd",
+          "uid": "b41a9b9c-ba1f-420f-bede-a25179339281"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-metrics-daemon-x9pxd uid/b41a9b9c-ba1f-420f-bede-a25179339281 container/network-metrics-daemon",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-metrics-daemon",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-metrics-daemon-x9pxd",
+          "uid": "b41a9b9c-ba1f-420f-bede-a25179339281"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:57Z",
+      "to": "2024-03-08T09:35:57Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/sbdb",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "sbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:58Z",
+      "to": "2024-03-08T09:35:58Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/nbdb",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nbdb",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:58Z",
+      "to": "2024-03-08T09:35:58Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-disruption-target-69f576bf7f-h9v4n uid/2fdac5c3-e709-421b-8013-61e17902f4c2 container/host-disruption-server",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "host-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-disruption-target-69f576bf7f-h9v4n",
+          "uid": "2fdac5c3-e709-421b-8013-61e17902f4c2"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:59Z",
+      "to": "2024-03-08T09:35:59Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-disruption-target-fdc46b779-8jbj8 uid/65f31f01-1280-4fc6-af9b-0957d8ba9a10 container/pod-disruption-server",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "pod-disruption-server",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-disruption-target-fdc46b779-8jbj8",
+          "uid": "65f31f01-1280-4fc6-af9b-0957d8ba9a10"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:35:59Z",
+      "to": "2024-03-08T09:35:59Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-host-network-disruption-poller-6fb456c9-844sp uid/01047004-4114-4506-bbfa-e747c554e43b container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-host-network-disruption-poller-6fb456c9-844sp",
+          "uid": "01047004-4114-4506-bbfa-e747c554e43b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:00Z",
+      "to": "2024-03-08T09:36:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-service-disruption-poller-68c49949d4-rzwht uid/8edbb07b-0010-4fd0-a3e6-f226df272885 container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-service-disruption-poller-68c49949d4-rzwht",
+          "uid": "8edbb07b-0010-4fd0-a3e6-f226df272885"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:00Z",
+      "to": "2024-03-08T09:36:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-pod-network-disruption-poller-69dbf666d-55wg4 uid/36bafac5-0e77-4d21-a4f8-9356f713585e container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-pod-network-disruption-poller-69dbf666d-55wg4",
+          "uid": "36bafac5-0e77-4d21-a4f8-9356f713585e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:00Z",
+      "to": "2024-03-08T09:36:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/host-network-to-pod-network-disruption-poller-7b446db555-xfwsq uid/5f7e20a1-f1f3-430f-b41f-67158d3f7871 container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "host-network-to-pod-network-disruption-poller-7b446db555-xfwsq",
+          "uid": "5f7e20a1-f1f3-430f-b41f-67158d3f7871"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:00Z",
+      "to": "2024-03-08T09:36:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-service-disruption-poller-5848554867-794jk uid/9e528af2-8177-4cec-9ae1-86e7fdd5af7b container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-service-disruption-poller-5848554867-794jk",
+          "uid": "9e528af2-8177-4cec-9ae1-86e7fdd5af7b"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:00Z",
+      "to": "2024-03-08T09:36:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-pod-network-disruption-test-dfmt6 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/pod-network-to-host-network-disruption-poller-6944cc9694-85mz4 uid/d2df9be5-4c3e-4bc5-9975-d2d5355359ca container/disruption-poller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "disruption-poller",
+          "namespace": "e2e-pod-network-disruption-test-dfmt6",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "pod-network-to-host-network-disruption-poller-6944cc9694-85mz4",
+          "uid": "d2df9be5-4c3e-4bc5-9975-d2d5355359ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:00Z",
+      "to": "2024-03-08T09:36:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ovn-kubernetes node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/ovnkube-node-hms6d uid/883f8192-ccd2-4a89-8ff6-3e698f631356 container/ovnkube-controller",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "ovnkube-controller",
+          "namespace": "openshift-ovn-kubernetes",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "ovnkube-node-hms6d",
+          "uid": "883f8192-ccd2-4a89-8ff6-3e698f631356"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:00Z",
+      "to": "2024-03-08T09:36:00Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/oauth-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "oauth-proxy",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:01Z",
+      "to": "2024-03-08T09:36:01Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/prod-bearer-token",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prod-bearer-token",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:01Z",
+      "to": "2024-03-08T09:36:01Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/init-config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:07Z",
+      "to": "2024-03-08T09:36:07Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-dns node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dns-default-vrpwj uid/9d08b494-b1aa-4606-8480-dceff8a603ec container/dns",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "dns",
+          "namespace": "openshift-dns",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dns-default-vrpwj",
+          "uid": "9d08b494-b1aa-4606-8480-dceff8a603ec"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:07Z",
+      "to": "2024-03-08T09:36:07Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:08Z",
+      "to": "2024-03-08T09:36:08Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:08Z",
+      "to": "2024-03-08T09:36:08Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/kube-rbac-proxy-thanos",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-thanos",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:08Z",
+      "to": "2024-03-08T09:36:08Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/kube-rbac-proxy-web",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:08Z",
+      "to": "2024-03-08T09:36:08Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/thanos-sidecar",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-sidecar",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:08Z",
+      "to": "2024-03-08T09:36:08Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-deployment-upgrade-9865 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dp-684c4bfd58-4jz2v uid/cf8d1296-d3af-4c29-b8de-9d82cef64e4f container/updated-name",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "updated-name",
+          "namespace": "e2e-k8s-sig-apps-deployment-upgrade-9865",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dp-684c4bfd58-4jz2v",
+          "uid": "cf8d1296-d3af-4c29-b8de-9d82cef64e4f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-kube-storage-version-migrator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/migrator-79685d988b-mlcmr uid/bf6ae69c-0441-4a9e-96bb-a68fb8f5dfef container/migrator",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "migrator",
+          "namespace": "openshift-kube-storage-version-migrator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "migrator-79685d988b-mlcmr",
+          "uid": "bf6ae69c-0441-4a9e-96bb-a68fb8f5dfef"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/kube-rbac-proxy-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/kube-rbac-proxy-rules",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-rules",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/prom-label-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/thanos-query",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-query",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/monitoring-plugin-bc8dc7986-h6pnn uid/153678e4-58e4-4c7b-ba1c-8f0ff0d3e3cb container/monitoring-plugin",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "monitoring-plugin",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "monitoring-plugin-bc8dc7986-h6pnn",
+          "uid": "153678e4-58e4-4c7b-ba1c-8f0ff0d3e3cb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-console node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/downloads-68b4969c89-7nmq5 uid/60ee4daf-3f71-489b-84f0-7d495412b401 container/download-server",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "download-server",
+          "namespace": "openshift-console",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "downloads-68b4969c89-7nmq5",
+          "uid": "60ee4daf-3f71-489b-84f0-7d495412b401"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:14Z",
+      "to": "2024-03-08T09:36:14Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/image-registry-5fdfc959c8-h6knm uid/41996cac-d5f1-49d3-b5c4-bb8f5e2d00c2 container/registry",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "image-registry-5fdfc959c8-h6knm",
+          "uid": "41996cac-d5f1-49d3-b5c4-bb8f5e2d00c2"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:15Z",
+      "to": "2024-03-08T09:36:15Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-replicaset-upgrade-324 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/rs-6vrfq uid/926e7758-da53-4ad2-99c8-49d7e0db23b2 container/nginx",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nginx",
+          "namespace": "e2e-k8s-sig-apps-replicaset-upgrade-324",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "rs-6vrfq",
+          "uid": "926e7758-da53-4ad2-99c8-49d7e0db23b2"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:15Z",
+      "to": "2024-03-08T09:36:15Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-ingress node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/router-default-58f4c7fcf9-jmk54 uid/0cce9d95-9f5b-430a-990d-05fd3ad2e9b6 container/router",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "router",
+          "namespace": "openshift-ingress",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "router-default-58f4c7fcf9-jmk54",
+          "uid": "0cce9d95-9f5b-430a-990d-05fd3ad2e9b6"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:15Z",
+      "to": "2024-03-08T09:36:15Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-service-lb-test-7nrs5 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/service-test-jgg9x uid/cd81370b-1d8f-4853-916c-cc48fdb06a0c container/netexec",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "netexec",
+          "namespace": "e2e-service-lb-test-7nrs5",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "service-test-jgg9x",
+          "uid": "cd81370b-1d8f-4853-916c-cc48fdb06a0c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:15Z",
+      "to": "2024-03-08T09:36:15Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-e2e-loki node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/loki-promtail-tqvsf uid/0f75f010-78a6-4681-a248-6c72eda27355 container/promtail",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "promtail",
+          "namespace": "openshift-e2e-loki",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "loki-promtail-tqvsf",
+          "uid": "0f75f010-78a6-4681-a248-6c72eda27355"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:15Z",
+      "to": "2024-03-08T09:36:15Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-87d9ffd9-4b5dd uid/0b043047-d4ab-41ec-a7a3-686140a39b05 container/kube-rbac-proxy-main",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-main",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-87d9ffd9-4b5dd",
+          "uid": "0b043047-d4ab-41ec-a7a3-686140a39b05"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:16Z",
+      "to": "2024-03-08T09:36:16Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-87d9ffd9-4b5dd uid/0b043047-d4ab-41ec-a7a3-686140a39b05 container/kube-rbac-proxy-self",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-self",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-87d9ffd9-4b5dd",
+          "uid": "0b043047-d4ab-41ec-a7a3-686140a39b05"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:16Z",
+      "to": "2024-03-08T09:36:16Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-87d9ffd9-4b5dd uid/0b043047-d4ab-41ec-a7a3-686140a39b05 container/openshift-state-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "openshift-state-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-87d9ffd9-4b5dd",
+          "uid": "0b043047-d4ab-41ec-a7a3-686140a39b05"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:16Z",
+      "to": "2024-03-08T09:36:16Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-554c4fcc66-pz62n uid/11fd551e-fc27-4f50-9d4a-401637f7c685 container/kube-rbac-proxy-main",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-main",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-554c4fcc66-pz62n",
+          "uid": "11fd551e-fc27-4f50-9d4a-401637f7c685"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:16Z",
+      "to": "2024-03-08T09:36:16Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-554c4fcc66-pz62n uid/11fd551e-fc27-4f50-9d4a-401637f7c685 container/kube-rbac-proxy-self",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-self",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-554c4fcc66-pz62n",
+          "uid": "11fd551e-fc27-4f50-9d4a-401637f7c685"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:16Z",
+      "to": "2024-03-08T09:36:16Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-554c4fcc66-pz62n uid/11fd551e-fc27-4f50-9d4a-401637f7c685 container/kube-state-metrics",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-state-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-554c4fcc66-pz62n",
+          "uid": "11fd551e-fc27-4f50-9d4a-401637f7c685"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:16Z",
+      "to": "2024-03-08T09:36:16Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-operator-admission-webhook-8574d6fd7d-kvtz7 uid/8c0e80bf-3e1d-4d0c-847a-10da5d274709 container/prometheus-operator-admission-webhook",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-operator-admission-webhook",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-operator-admission-webhook-8574d6fd7d-kvtz7",
+          "uid": "8c0e80bf-3e1d-4d0c-847a-10da5d274709"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:17Z",
+      "to": "2024-03-08T09:36:17Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-adapter-5878fd4b5b-k8szl uid/37226158-8968-4ef1-832d-358bca354263 container/prometheus-adapter",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-adapter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-adapter-5878fd4b5b-k8szl",
+          "uid": "37226158-8968-4ef1-832d-358bca354263"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:17Z",
+      "to": "2024-03-08T09:36:17Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-k8s-sig-apps-deployment-upgrade-9865 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/dp-684c4bfd58-4jz2v uid/cf8d1296-d3af-4c29-b8de-9d82cef64e4f container/updated-name",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "updated-name",
+          "namespace": "e2e-k8s-sig-apps-deployment-upgrade-9865",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "dp-684c4bfd58-4jz2v",
+          "uid": "cf8d1296-d3af-4c29-b8de-9d82cef64e4f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:17Z",
+      "to": "2024-03-08T09:36:17Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/monitoring-plugin-bc8dc7986-h6pnn uid/153678e4-58e4-4c7b-ba1c-8f0ff0d3e3cb container/monitoring-plugin",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "monitoring-plugin",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "monitoring-plugin-bc8dc7986-h6pnn",
+          "uid": "153678e4-58e4-4c7b-ba1c-8f0ff0d3e3cb"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:17Z",
+      "to": "2024-03-08T09:36:17Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-service-lb-test-7nrs5 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/service-test-jgg9x uid/cd81370b-1d8f-4853-916c-cc48fdb06a0c container/netexec",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "netexec",
+          "namespace": "e2e-service-lb-test-7nrs5",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "service-test-jgg9x",
+          "uid": "cd81370b-1d8f-4853-916c-cc48fdb06a0c"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:18Z",
+      "to": "2024-03-08T09:36:18Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-k8s-sig-apps-replicaset-upgrade-324 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/rs-6vrfq uid/926e7758-da53-4ad2-99c8-49d7e0db23b2 container/nginx",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "nginx",
+          "namespace": "e2e-k8s-sig-apps-replicaset-upgrade-324",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "rs-6vrfq",
+          "uid": "926e7758-da53-4ad2-99c8-49d7e0db23b2"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:18Z",
+      "to": "2024-03-08T09:36:18Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/alertmanager",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "alertmanager",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:19Z",
+      "to": "2024-03-08T09:36:19Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:19Z",
+      "to": "2024-03-08T09:36:19Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/kube-rbac-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:19Z",
+      "to": "2024-03-08T09:36:19Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/kube-rbac-proxy-metric",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metric",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:19Z",
+      "to": "2024-03-08T09:36:19Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/kube-rbac-proxy-web",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:19Z",
+      "to": "2024-03-08T09:36:19Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/prom-label-proxy",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:19Z",
+      "to": "2024-03-08T09:36:19Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/init-config-reloader",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:19Z",
+      "to": "2024-03-08T09:36:19Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-operator-admission-webhook-8574d6fd7d-kvtz7 uid/8c0e80bf-3e1d-4d0c-847a-10da5d274709 container/prometheus-operator-admission-webhook",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-operator-admission-webhook",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-operator-admission-webhook-8574d6fd7d-kvtz7",
+          "uid": "8c0e80bf-3e1d-4d0c-847a-10da5d274709"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:20Z",
+      "to": "2024-03-08T09:36:20Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/kube-rbac-proxy-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/kube-rbac-proxy-rules",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-rules",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/prom-label-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/thanos-query",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "thanos-query",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-87d9ffd9-4b5dd uid/0b043047-d4ab-41ec-a7a3-686140a39b05 container/kube-rbac-proxy-main",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-main",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-87d9ffd9-4b5dd",
+          "uid": "0b043047-d4ab-41ec-a7a3-686140a39b05"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-87d9ffd9-4b5dd uid/0b043047-d4ab-41ec-a7a3-686140a39b05 container/kube-rbac-proxy-self",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-self",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-87d9ffd9-4b5dd",
+          "uid": "0b043047-d4ab-41ec-a7a3-686140a39b05"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/openshift-state-metrics-87d9ffd9-4b5dd uid/0b043047-d4ab-41ec-a7a3-686140a39b05 container/openshift-state-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "openshift-state-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "openshift-state-metrics-87d9ffd9-4b5dd",
+          "uid": "0b043047-d4ab-41ec-a7a3-686140a39b05"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-kube-storage-version-migrator node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/migrator-79685d988b-mlcmr uid/bf6ae69c-0441-4a9e-96bb-a68fb8f5dfef container/migrator",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "migrator",
+          "namespace": "openshift-kube-storage-version-migrator",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "migrator-79685d988b-mlcmr",
+          "uid": "bf6ae69c-0441-4a9e-96bb-a68fb8f5dfef"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:21Z",
+      "to": "2024-03-08T09:36:21Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/init-config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "init-config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:22Z",
+      "to": "2024-03-08T09:36:22Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/thanos-querier-7d89cc89b5-xrp7j uid/ff0802a8-309b-4c47-b732-ad625caf90ca container/kube-rbac-proxy-web",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "thanos-querier-7d89cc89b5-xrp7j",
+          "uid": "ff0802a8-309b-4c47-b732-ad625caf90ca"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:22Z",
+      "to": "2024-03-08T09:36:22Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-ingress node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/router-default-58f4c7fcf9-jmk54 uid/0cce9d95-9f5b-430a-990d-05fd3ad2e9b6 container/router",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "router",
+          "namespace": "openshift-ingress",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "router-default-58f4c7fcf9-jmk54",
+          "uid": "0cce9d95-9f5b-430a-990d-05fd3ad2e9b6"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:22Z",
+      "to": "2024-03-08T09:36:22Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-554c4fcc66-pz62n uid/11fd551e-fc27-4f50-9d4a-401637f7c685 container/kube-rbac-proxy-main",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-main",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-554c4fcc66-pz62n",
+          "uid": "11fd551e-fc27-4f50-9d4a-401637f7c685"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:23Z",
+      "to": "2024-03-08T09:36:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-554c4fcc66-pz62n uid/11fd551e-fc27-4f50-9d4a-401637f7c685 container/kube-rbac-proxy-self",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-self",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-554c4fcc66-pz62n",
+          "uid": "11fd551e-fc27-4f50-9d4a-401637f7c685"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:23Z",
+      "to": "2024-03-08T09:36:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/kube-state-metrics-554c4fcc66-pz62n uid/11fd551e-fc27-4f50-9d4a-401637f7c685 container/kube-state-metrics",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-state-metrics",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "kube-state-metrics-554c4fcc66-pz62n",
+          "uid": "11fd551e-fc27-4f50-9d4a-401637f7c685"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:23Z",
+      "to": "2024-03-08T09:36:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/config-reloader",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "config-reloader",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:23Z",
+      "to": "2024-03-08T09:36:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/kube-rbac-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:23Z",
+      "to": "2024-03-08T09:36:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/kube-rbac-proxy-metric",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-metric",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:23Z",
+      "to": "2024-03-08T09:36:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/kube-rbac-proxy-web",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-rbac-proxy-web",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:23Z",
+      "to": "2024-03-08T09:36:23Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/prom-label-proxy",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prom-label-proxy",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:23Z",
+      "to": "2024-03-08T09:36:23Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/e2e-k8s-sig-apps-job-upgrade-258 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/foo-zjhzn uid/3c328fc3-ff7d-4aad-8310-df766682cd4f container/c",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "c",
+          "namespace": "e2e-k8s-sig-apps-job-upgrade-258",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "foo-zjhzn",
+          "uid": "3c328fc3-ff7d-4aad-8310-df766682cd4f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:36:24Z",
+      "to": "2024-03-08T09:36:24Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/e2e-k8s-sig-apps-job-upgrade-258 node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/foo-zjhzn uid/3c328fc3-ff7d-4aad-8310-df766682cd4f container/c",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "c",
+          "namespace": "e2e-k8s-sig-apps-job-upgrade-258",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "foo-zjhzn",
+          "uid": "3c328fc3-ff7d-4aad-8310-df766682cd4f"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:25Z",
+      "to": "2024-03-08T09:36:25Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-adapter-5878fd4b5b-k8szl uid/37226158-8968-4ef1-832d-358bca354263 container/prometheus-adapter",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus-adapter",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-adapter-5878fd4b5b-k8szl",
+          "uid": "37226158-8968-4ef1-832d-358bca354263"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:27Z",
+      "to": "2024-03-08T09:36:27Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-image-registry node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/image-registry-5fdfc959c8-h6knm uid/41996cac-d5f1-49d3-b5c4-bb8f5e2d00c2 container/registry",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "registry",
+          "namespace": "openshift-image-registry",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "image-registry-5fdfc959c8-h6knm",
+          "uid": "41996cac-d5f1-49d3-b5c4-bb8f5e2d00c2"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:35Z",
+      "to": "2024-03-08T09:36:35Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-network-diagnostics node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/network-check-target-xz25v uid/af7a8849-2989-41f4-8144-2a6941c25192 container/network-check-target-container",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "network-check-target-container",
+          "namespace": "openshift-network-diagnostics",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "network-check-target-xz25v",
+          "uid": "af7a8849-2989-41f4-8144-2a6941c25192"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:35Z",
+      "to": "2024-03-08T09:36:35Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-console node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/downloads-68b4969c89-7nmq5 uid/60ee4daf-3f71-489b-84f0-7d495412b401 container/download-server",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "download-server",
+          "namespace": "openshift-console",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "downloads-68b4969c89-7nmq5",
+          "uid": "60ee4daf-3f71-489b-84f0-7d495412b401"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:45Z",
+      "to": "2024-03-08T09:36:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/prometheus-k8s-0 uid/8721ebf7-5e82-4d2f-87f6-1ac1eb89f776 container/prometheus",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "prometheus",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "prometheus-k8s-0",
+          "uid": "8721ebf7-5e82-4d2f-87f6-1ac1eb89f776"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:45Z",
+      "to": "2024-03-08T09:36:45Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-monitoring node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/alertmanager-main-1 uid/ac44ef3f-090d-463e-85df-ad47deb77e9e container/alertmanager",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "alertmanager",
+          "namespace": "openshift-monitoring",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "alertmanager-main-1",
+          "uid": "ac44ef3f-090d-463e-85df-ad47deb77e9e"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:36:49Z",
+      "to": "2024-03-08T09:36:49Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/cni-sysctl-allowlist-ds-86cww uid/b2831e05-6757-42d3-adf4-f2281a632d47 container/kube-multus-additional-cni-plugins",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "cni-sysctl-allowlist-ds-86cww",
+          "uid": "b2831e05-6757-42d3-adf4-f2281a632d47"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:38:31Z",
+      "to": "2024-03-08T09:38:31Z"
+    },
+    {
+      "level": "Info",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/cni-sysctl-allowlist-ds-86cww uid/b2831e05-6757-42d3-adf4-f2281a632d47 container/kube-multus-additional-cni-plugins",
+      "message": "reason/Ready",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "cni-sysctl-allowlist-ds-86cww",
+          "uid": "b2831e05-6757-42d3-adf4-f2281a632d47"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "Ready",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "Ready"
+        }
+      },
+      "from": "2024-03-08T09:38:32Z",
+      "to": "2024-03-08T09:38:32Z"
+    },
+    {
+      "level": "Warning",
+      "locator": "namespace/openshift-multus node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q pod/cni-sysctl-allowlist-ds-86cww uid/b2831e05-6757-42d3-adf4-f2281a632d47 container/kube-multus-additional-cni-plugins",
+      "message": "reason/NotReady",
+      "tempSource": "PodMonitor",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "container": "kube-multus-additional-cni-plugins",
+          "namespace": "openshift-multus",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q",
+          "pod": "cni-sysctl-allowlist-ds-86cww",
+          "uid": "b2831e05-6757-42d3-adf4-f2281a632d47"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "NotReady",
+        "cause": "",
+        "humanMessage": "",
+        "annotations": {
+          "reason": "NotReady"
+        }
+      },
+      "from": "2024-03-08T09:40:01Z",
+      "to": "2024-03-08T09:40:01Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/ac7f4b1372",
+      "message": "reason/RegisteredNode roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q event: Registered Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q in Controller",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "ac7f4b1372",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "RegisteredNode",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q event: Registered Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q in Controller",
+        "annotations": {
+          "reason": "RegisteredNode",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:40:35Z",
+      "to": "2024-03-08T09:40:35Z"
+    },
+    {
+      "level": "Info",
+      "locator": "node/ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q hmsg/ac7f4b1372",
+      "message": "reason/RegisteredNode roles/worker Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q event: Registered Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q in Controller",
+      "tempSource": "KubeEvent",
+      "tempStructuredLocator": {
+        "type": "Node",
+        "keys": {
+          "hmsg": "ac7f4b1372",
+          "node": "ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q"
+        }
+      },
+      "tempStructuredMessage": {
+        "reason": "RegisteredNode",
+        "cause": "",
+        "humanMessage": "Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q event: Registered Node ci-op-0774jw7y-f9945-k9278-worker-a-c2l9q in Controller",
+        "annotations": {
+          "reason": "RegisteredNode",
+          "roles": "worker"
+        }
+      },
+      "from": "2024-03-08T09:45:42Z",
+      "to": "2024-03-08T09:45:42Z"
     }
   ]
 }

--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -556,7 +556,7 @@ func buildTransitionsForCategory(locatorToIntervals map[string][]monitorapi.Inte
 				// .Build() was private before I found this.
 				msg := monitorapi.NewMessage().Constructed(monitorapi.ConstructionOwnerPodLifecycle).Reason(startReason).HumanMessagef("missed real %q", startReason)
 				nextInterval.StructuredMessage = msg.Build()
-				nextInterval.Message = msg.BuildString()
+				nextInterval.Message = msg.BuildString() // TODO: Remove
 			}
 
 			// if the current reason is a logical ending point, reset to an empty previous

--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -68,7 +68,7 @@ func createPodIntervalsFromInstants(input monitorapi.Intervals, recordedResource
 		}
 
 		// We have to strip out container, this needs to be just pod locator here
-		podLocator := monitorapi.PodFromLocator(event.StructuredLocator).ToLocator()
+		podLocator := monitorapi.PodFrom(event.StructuredLocator).ToLocator()
 		pls := podLocator.OldLocator()
 		locatorKeyToLocator[pls] = podLocator
 		reason := event.StructuredMessage.Reason
@@ -198,7 +198,7 @@ func (t podLifecycleTimeBounder) getStartTime(inLocator monitorapi.Locator) time
 	podCreationTime := t.getPodCreationTime(inLocator)
 
 	// We could have been given a container locator if we were delegated to, create a purely pod locator:
-	podLocator := monitorapi.PodFromLocator(inLocator).ToLocator()
+	podLocator := monitorapi.PodFrom(inLocator).ToLocator()
 	podLocatorStr := podLocator.OldLocator()
 
 	// use the earliest known event as a creation time, since it clearly existed at that point in time.
@@ -233,7 +233,7 @@ func (t podLifecycleTimeBounder) getStartTime(inLocator monitorapi.Locator) time
 func (t podLifecycleTimeBounder) getEndTime(inLocator monitorapi.Locator) time.Time {
 
 	// We could have been given a container locator if we were delegated to, create a purely pod locator:
-	podLocator := monitorapi.PodFromLocator(inLocator).ToLocator()
+	podLocator := monitorapi.PodFrom(inLocator).ToLocator()
 	podLocatorStr := podLocator.OldLocator()
 
 	// if this is a RunOnce pod that has finished running all of its containers, then the intervals chart will show that
@@ -265,7 +265,7 @@ func (t podLifecycleTimeBounder) getEndTime(inLocator monitorapi.Locator) time.T
 }
 
 func (t podLifecycleTimeBounder) getPodCreationTime(inLocator monitorapi.Locator) *time.Time {
-	podCoordinates := monitorapi.PodFromLocator(inLocator)
+	podCoordinates := monitorapi.PodFrom(inLocator)
 	instanceKey := monitorapi.InstanceKey{
 		Namespace: podCoordinates.Namespace,
 		Name:      podCoordinates.Name,

--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -21,7 +21,7 @@ func intervalsFromEvents_PodChanges(events monitorapi.Intervals, beginning, end 
 		if _, ok := event.StructuredLocator.Keys[monitorapi.LocatorPodKey]; !ok {
 			continue
 		}
-		podLocator := monitorapi.PodFrom(event.Locator).ToLocator()
+		podLocator := monitorapi.PodFrom(event.StructuredLocator).ToLocator()
 		reason := event.StructuredMessage.Reason
 		switch reason {
 		case monitorapi.PodPendingReason, monitorapi.PodNotPendingReason, monitorapi.PodReasonDeleted:
@@ -302,7 +302,7 @@ func (t podLifecycleTimeBounder) getPodCreationTime(inLocator monitorapi.Locator
 }
 
 func (t podLifecycleTimeBounder) getPodDeletionPlusGraceTime(inLocator monitorapi.Locator) *time.Time {
-	podCoordinates := monitorapi.PodFrom(inLocator.OldLocator())
+	podCoordinates := monitorapi.PodFrom(inLocator)
 	instanceKey := monitorapi.InstanceKey{
 		Namespace: podCoordinates.Namespace,
 		Name:      podCoordinates.Name,
@@ -331,7 +331,7 @@ func (t podLifecycleTimeBounder) getPodDeletionPlusGraceTime(inLocator monitorap
 }
 
 func (t podLifecycleTimeBounder) getRunOnceContainerEnd(inLocator monitorapi.Locator) *time.Time {
-	podCoordinates := monitorapi.PodFrom(inLocator.OldLocator())
+	podCoordinates := monitorapi.PodFrom(inLocator)
 	instanceKey := monitorapi.InstanceKey{
 		Namespace: podCoordinates.Namespace,
 		Name:      podCoordinates.Name,

--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -149,7 +149,7 @@ func createPodIntervalsFromInstants(input monitorapi.Intervals, recordedResource
 					// Re-use the structured message, but make sure to set our constructed annotation:
 					WithAnnotations(instantEvent.StructuredMessage.Annotations).
 					Constructed(monitorapi.ConstructionOwnerPodLifecycle).
-					HumanMessage(instantEvent.Message)).
+					HumanMessage(instantEvent.StructuredMessage.HumanMessage)).
 				Build(instantEvent.From, instantEvent.From.Add(1*time.Second)))
 		}
 	}
@@ -251,7 +251,7 @@ func (t podLifecycleTimeBounder) getEndTime(inLocator monitorapi.Locator) time.T
 		return t.delegate.getEndTime(podLocator)
 	}
 	for _, event := range podEvents {
-		if monitorapi.ReasonFrom(event.Message) == monitorapi.PodReasonDeleted {
+		if event.StructuredMessage.Reason == monitorapi.PodReasonDeleted {
 			// if the last possible pod delete is before the delete from teh watch stream, it just means our watch was delayed.
 			// use the pod time instead.
 			if lastPossiblePodDelete != nil && lastPossiblePodDelete.Before(event.From) {
@@ -383,7 +383,7 @@ func (t containerLifecycleTimeBounder) getStartTime(inLocator monitorapi.Locator
 		return t.delegate.getStartTime(locator)
 	}
 	for _, event := range containerEvents {
-		if monitorapi.ReasonFrom(event.Message) == monitorapi.ContainerReasonContainerWait {
+		if event.StructuredMessage.Reason == monitorapi.ContainerReasonContainerWait {
 			return event.From
 		}
 	}
@@ -406,7 +406,7 @@ func (t containerLifecycleTimeBounder) getEndTime(inLocator monitorapi.Locator) 
 	// if the last event is a containerExit, then that's as long as the container lasted.
 	// if the last event isn't a containerExit, then the last time we're aware of for the container is parent.
 	lastEvent := containerEvents[len(containerEvents)-1]
-	if monitorapi.ReasonFrom(lastEvent.Message) == monitorapi.ContainerReasonContainerExit {
+	if lastEvent.StructuredMessage.Reason == monitorapi.ContainerReasonContainerExit {
 		return lastEvent.From
 	}
 
@@ -491,7 +491,7 @@ func (t containerReadinessTimeBounder) getStartTime(inLocator monitorapi.Locator
 	}
 	for _, event := range containerEvents {
 		// you can only be ready from the time your container is started.
-		if monitorapi.ReasonFrom(event.Message) == monitorapi.ContainerReasonContainerStart {
+		if event.StructuredMessage.Reason == monitorapi.ContainerReasonContainerStart {
 			return event.From
 		}
 	}
@@ -527,11 +527,11 @@ func buildTransitionsForCategory(locatorToIntervals map[string][]monitorapi.Inte
 		endTime := timeBounder.getEndTime(locator)
 		prevEvent := emptyEvent(timeBounder.getStartTime(locator))
 		for i := range instantEvents {
-			hasPrev := len(prevEvent.Message) > 0
+			hasPrev := len(prevEvent.StructuredMessage.HumanMessage) > 0 || len(prevEvent.StructuredMessage.Reason) > 0 || len(prevEvent.StructuredMessage.Annotations) > 0
 			currEvent := instantEvents[i]
-			currReason := monitorapi.ReasonFrom(currEvent.Message)
-			prevAnnotations := monitorapi.AnnotationsFromMessage(prevEvent.Message)
-			prevBareMessage := monitorapi.NonAnnotationMessage(prevEvent.Message)
+			currReason := currEvent.StructuredMessage.Reason
+			prevAnnotations := prevEvent.StructuredMessage.Annotations
+			prevBareMessage := prevEvent.StructuredMessage.HumanMessage
 
 			nextInterval := monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Info).
 				Locator(locatorKeys[locatorStr]).
@@ -545,6 +545,7 @@ func buildTransitionsForCategory(locatorToIntervals map[string][]monitorapi.Inte
 				// we need to be sure we get the times from nextInterval because they are not all event times,
 				// but we need the message from the currEvent
 				prevEvent = nextInterval
+				prevEvent.StructuredMessage = currEvent.StructuredMessage
 				prevEvent.Message = currEvent.Message
 				continue
 
@@ -566,10 +567,10 @@ func buildTransitionsForCategory(locatorToIntervals map[string][]monitorapi.Inte
 			}
 			ret = append(ret, nextInterval)
 		}
-		if len(prevEvent.Message) > 0 {
+		if len(prevEvent.StructuredMessage.HumanMessage) > 0 || len(prevEvent.StructuredMessage.Reason) > 0 || len(prevEvent.StructuredMessage.Annotations) > 0 {
 			nextInterval := monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Info).
 				Locator(locatorKeys[locatorStr]).
-				Message(monitorapi.ExpandMessage(prevEvent.Message).Constructed(monitorapi.ConstructionOwnerPodLifecycle)).
+				Message(monitorapi.ExpandMessage(prevEvent.StructuredMessage).Constructed(monitorapi.ConstructionOwnerPodLifecycle)).
 				Build(prevEvent.From, timeBounder.getEndTime(locator))
 			nextInterval = sanitizeTime(nextInterval, startTime, endTime)
 			ret = append(ret, nextInterval)
@@ -634,5 +635,5 @@ func (n ByPodLifecycle) Less(i, j int) bool {
 	case d > 0:
 		return false
 	}
-	return n[i].Message < n[j].Message
+	return n[i].StructuredMessage.OldMessage() < n[j].StructuredMessage.OldMessage()
 }

--- a/pkg/monitortests/node/watchpods/podTest/container-life/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/container-life/expected.json
@@ -106,7 +106,7 @@
         {
             "level": "Info",
             "locator": "namespace/e2e-kubectl-3271 pod/without-label uid/e185b70c-ea3e-4600-850a-b2370a729a73 container/without-label",
-            "message": "cause/ constructed/pod-lifecycle-constructor duration/6.00s reason/ContainerStart",
+            "message": "constructed/pod-lifecycle-constructor duration/6.00s reason/ContainerStart",
             "tempSource": "PodState",
             "tempStructuredLocator": {
                 "type": "Container",
@@ -122,7 +122,6 @@
                 "cause": "",
                 "humanMessage": "",
                 "annotations": {
-                    "cause": "",
                     "constructed": "pod-lifecycle-constructor",
                     "duration": "6.00s",
                     "reason": "ContainerStart"

--- a/pkg/monitortests/node/watchpods/podTest/container-life/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/container-life/startingEvents.json
@@ -17,7 +17,9 @@
         "reason": "Created",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Created"
+        }
       },
       "from": "2022-03-07T18:41:46Z",
       "to": "2022-03-07T18:41:46Z"
@@ -40,7 +42,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "node": "ip-10-0-141-9.us-west-2.compute.internal"
+          "node": "ip-10-0-141-9.us-west-2.compute.internal",
+          "reason": "Scheduled"
         }
       },
       "from": "2022-03-07T18:41:46Z",
@@ -65,7 +68,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "duration": "6.00s"
+          "duration": "6.00s",
+          "reason": "ContainerStart"
         }
       },
       "from": "2022-03-07T18:41:52Z",
@@ -89,7 +93,9 @@
         "reason": "Ready",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Ready"
+        }
       },
       "from": "2022-03-07T18:41:52Z",
       "to": "2022-03-07T18:41:52Z"
@@ -112,7 +118,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "mirrored": "false"
+          "mirrored": "false",
+          "reason": "ForceDelete"
         }
       },
       "from": "2022-03-07T18:41:54Z",
@@ -135,7 +142,9 @@
         "reason": "Deleted",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Deleted"
+        }
       },
       "from": "2022-03-07T18:41:54Z",
       "to": "2022-03-07T18:41:54Z"

--- a/pkg/monitortests/node/watchpods/podTest/end-before-begin/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/end-before-begin/startingEvents.json
@@ -17,7 +17,9 @@
         "reason": "Created",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Created"
+        }
       },
       "from": "2022-03-21T16:43:39Z",
       "to": "2022-03-21T16:43:39Z"
@@ -36,11 +38,12 @@
         }
       },
       "tempStructuredMessage": {
-        "reason": "Created",
+        "reason": "Scheduled",
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "node": "ip-10-0-214-214.us-west-1.compute.internal"
+          "node": "ip-10-0-214-214.us-west-1.compute.internal",
+          "reason": "Scheduled"
         }
       },
       "from": "2022-03-21T16:43:39Z",
@@ -64,7 +67,9 @@
         "reason": "NotReady",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "NotReady"
+        }
       },
       "from": "2022-03-21T16:43:39Z",
       "to": "2022-03-21T16:43:39Z"

--- a/pkg/monitortests/node/watchpods/podTest/installer-pod/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/installer-pod/startingEvents.json
@@ -17,7 +17,9 @@
         "reason": "Created",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Created"
+        }
       },
       "from": "2022-03-21T21:37:20Z",
       "to": "2022-03-21T21:37:20Z"
@@ -40,7 +42,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "node": "ci-op-97t906zm-db044-bwrrn-master-0"
+          "node": "ci-op-97t906zm-db044-bwrrn-master-0",
+          "reason": "Scheduled"
         }
       },
       "from": "2022-03-21T21:37:20Z",
@@ -64,7 +67,9 @@
         "reason": "NotReady",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "NotReady"
+        }
       },
       "from": "2022-03-21T21:37:20Z",
       "to": "2022-03-21T21:37:20Z"
@@ -87,7 +92,9 @@
         "reason": "Ready",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Ready"
+        }
       },
       "from": "2022-03-21T21:37:23Z",
       "to": "2022-03-21T21:37:23Z"
@@ -112,7 +119,8 @@
         "humanMessage": "",
         "annotations": {
           "cause": "",
-          "duration": "3.00s"
+          "duration": "3.00s",
+          "reason": "ContainerStart"
         }
       },
       "from": "2022-03-21T21:37:23Z",
@@ -136,7 +144,9 @@
         "reason": "NotReady",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "NotReady"
+        }
       },
       "from": "2022-03-21T21:37:56Z",
       "to": "2022-03-21T21:37:56Z"
@@ -161,7 +171,8 @@
         "humanMessage": "",
         "annotations": {
           "cause": "Completed",
-          "code": "0"
+          "code": "0",
+          "reason": "ContainerExit"
         }
       },
       "from": "2022-03-21T21:37:56Z",
@@ -185,7 +196,9 @@
         "reason": "DeletedAfterCompletion",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "DeletedAfterCompletion"
+        }
       },
       "from": "2022-03-21T22:22:32Z",
       "to": "2022-03-21T22:22:32Z"
@@ -207,7 +220,9 @@
         "reason": "Deleted",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Deleted"
+        }
       },
       "from": "2022-03-21T22:22:32Z",
       "to": "2022-03-21T22:22:32Z"

--- a/pkg/monitortests/node/watchpods/podTest/long-not-ready/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/long-not-ready/startingEvents.json
@@ -17,7 +17,9 @@
         "reason": "Created",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Created"
+        }
       },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"
@@ -40,7 +42,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "node": "ip-10-0-142-23.us-east-2.compute.internal"
+          "node": "ip-10-0-142-23.us-east-2.compute.internal",
+          "reason": "Scheduled"
         }
       },
       "from": "2022-03-22T19:00:26Z",
@@ -64,7 +67,9 @@
         "reason": "Ready",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Ready"
+        }
       },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"
@@ -87,7 +92,9 @@
         "reason": "Ready",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Ready"
+        }
       },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"
@@ -110,7 +117,9 @@
         "reason": "Ready",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Ready"
+        }
       },
       "from": "2022-03-22T19:00:26Z",
       "to": "2022-03-22T19:00:26Z"

--- a/pkg/monitortests/node/watchpods/podTest/run-once-done/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/run-once-done/startingEvents.json
@@ -17,7 +17,9 @@
         "reason": "Created",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Created"
+        }
       },
       "from": "2022-03-10T22:46:20Z",
       "to": "2022-03-10T22:46:20Z"
@@ -40,7 +42,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "node": "ip-10-0-136-132.us-west-2.compute.internal"
+          "node": "ip-10-0-136-132.us-west-2.compute.internal",
+          "reason": "Scheduled"
         }
       },
       "from": "2022-03-10T22:46:20Z",
@@ -64,7 +67,9 @@
         "reason": "NotReady",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "NotReady"
+        }
       },
       "from": "2022-03-10T22:46:20Z",
       "to": "2022-03-10T22:46:20Z"

--- a/pkg/monitortests/node/watchpods/podTest/simple/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/simple/startingEvents.json
@@ -17,7 +17,9 @@
         "reason": "Created",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Created"
+        }
       },
       "from": "2022-03-22T22:02:53Z",
       "to": "2022-03-22T22:02:53Z"
@@ -40,7 +42,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "node": "ci-op-ckiwry67-db044-lzjpd-master-0"
+          "node": "ci-op-ckiwry67-db044-lzjpd-master-0",
+          "reason": "Scheduled"
         }
       },
       "from": "2022-03-22T22:02:53Z",
@@ -64,7 +67,9 @@
         "reason": "Ready",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Ready"
+        }
       },
       "from": "2022-03-22T22:02:53Z",
       "to": "2022-03-22T22:02:53Z"
@@ -87,7 +92,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "duration": "30s"
+          "duration": "30s",
+          "reason": "GracefulDelete"
         }
       },
       "from": "2022-03-22T22:29:35Z",
@@ -111,7 +117,9 @@
         "reason": "NotReady",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "NotReady"
+        }
       },
       "from": "2022-03-22T22:29:36Z",
       "to": "2022-03-22T22:29:36Z"
@@ -134,7 +142,9 @@
         "reason": "TerminationStateCleared",
         "cause": "",
         "humanMessage": "lastState.terminated was cleared on a pod (bug https://bugzilla.redhat.com/show_bug.cgi?id=1933760 or similar)",
-        "annotations": null
+        "annotations": {
+          "reason": "TerminationStateCleared"
+        }
       },
       "from": "2022-03-22T22:29:36Z",
       "to": "2022-03-22T22:29:36Z"
@@ -158,7 +168,8 @@
         "cause": "Completed",
         "humanMessage": "",
         "annotations": {
-          "code": "0"
+          "code": "0",
+          "reason": "ContainerExit"
         }
       },
       "from": "2022-03-22T22:29:36Z",
@@ -181,7 +192,9 @@
         "reason": "Deleted",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Deleted"
+        }
       },
       "from": "2022-03-22T22:29:36Z",
       "to": "2022-03-22T22:29:36Z"

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready-2/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready-2/startingEvents.json
@@ -17,7 +17,9 @@
         "reason": "Created",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Created"
+        }
       },
       "from": "2022-03-08T23:17:18Z",
       "to": "2022-03-08T23:17:18Z"
@@ -40,7 +42,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "node": "ip-10-0-231-18.us-east-2.compute.internal"
+          "node": "ip-10-0-231-18.us-east-2.compute.internal",
+          "reason": "Scheduled"
         }
       },
       "from": "2022-03-08T23:17:18Z",
@@ -64,7 +67,9 @@
         "reason": "Ready",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Ready"
+        }
       },
       "from": "2022-03-08T23:17:18Z",
       "to": "2022-03-08T23:17:18Z"

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready/expected.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready/expected.json
@@ -106,7 +106,7 @@
         {
             "level": "Info",
             "locator": "namespace/openshift-marketplace pod/community-operators-sp6lm uid/efb1885a-1fe1-4f5b-ad41-044e55f806a9 container/registry-server",
-            "message": "cause/ constructed/pod-lifecycle-constructor duration/3.00s reason/ContainerStart",
+            "message": "constructed/pod-lifecycle-constructor duration/3.00s reason/ContainerStart",
             "tempSource": "PodState",
             "tempStructuredLocator": {
                 "type": "Container",
@@ -122,7 +122,6 @@
                 "cause": "",
                 "humanMessage": "",
                 "annotations": {
-                    "cause": "",
                     "constructed": "pod-lifecycle-constructor",
                     "duration": "3.00s",
                     "reason": "ContainerStart"

--- a/pkg/monitortests/node/watchpods/podTest/trailing-ready/startingEvents.json
+++ b/pkg/monitortests/node/watchpods/podTest/trailing-ready/startingEvents.json
@@ -17,7 +17,9 @@
         "reason": "Created",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Created"
+        }
       },
       "from": "2022-03-07T22:47:04Z",
       "to": "2022-03-07T22:47:04Z"
@@ -40,7 +42,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "node": "ip-10-0-154-151.ec2.internal"
+          "node": "ip-10-0-154-151.ec2.internal",
+          "reason": "Scheduled"
         }
       },
       "from": "2022-03-07T22:47:04Z",
@@ -65,7 +68,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "duration": "3.00s"
+          "duration": "3.00s",
+          "reason": "ContainerStart"
         }
       },
       "from": "2022-03-07T22:47:07Z",
@@ -89,7 +93,9 @@
         "reason": "Ready",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Ready"
+        }
       },
       "from": "2022-03-07T22:47:14Z",
       "to": "2022-03-07T22:47:14Z"
@@ -112,7 +118,8 @@
         "cause": "",
         "humanMessage": "",
         "annotations": {
-          "duration": "1s"
+          "duration": "1s",
+          "reason": "GracefulDelete"
         }
       },
       "from": "2022-03-07T22:47:14Z",
@@ -138,7 +145,8 @@
         "humanMessage": "",
         "annotations": {
           "code": "0",
-          "cause": "Completed"
+          "cause": "Completed",
+          "reason": "ContainerExit"
         }
       },
       "from": "2022-03-07T22:47:15Z",
@@ -162,7 +170,9 @@
         "reason": "NotReady",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "NotReady"
+        }
       },
       "from": "2022-03-07T22:47:15Z",
       "to": "2022-03-07T22:47:15Z"
@@ -184,7 +194,9 @@
         "reason": "Deleted",
         "cause": "",
         "humanMessage": "",
-        "annotations": null
+        "annotations": {
+          "reason": "Deleted"
+        }
       },
       "from": "2022-03-07T22:47:15Z",
       "to": "2022-03-07T22:47:15Z"

--- a/pkg/monitortests/node/watchpods/pod_ip_controller.go
+++ b/pkg/monitortests/node/watchpods/pod_ip_controller.go
@@ -171,7 +171,7 @@ func (c *SimultaneousPodIPController) sync(ctx context.Context, key string) erro
 				otherPodIP := otherIP.IP
 				if currPodIP == otherPodIP {
 					otherPodLocator := monitorapi.LocatePod(otherPod)
-					podNames.Insert(otherPodLocator)
+					podNames.Insert(otherPodLocator.OldLocator())
 				}
 			}
 		}
@@ -179,10 +179,10 @@ func (c *SimultaneousPodIPController) sync(ctx context.Context, key string) erro
 		if len(podNames) > 1 {
 			// the .Record function adds a timestamp of now to the condition so we track time.
 			c.recorder.Record(monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: podLocator,
-				Message: monitorapi.NewMessage().Reason(monitorapi.PodIPReused).
-					HumanMessagef("podIP %v is currently assigned to multiple pods: %v", currPodIP, strings.Join(podNames.List(), ";")).BuildString(),
+				Level:             monitorapi.Error,
+				StructuredLocator: podLocator,
+				StructuredMessage: monitorapi.NewMessage().Reason(monitorapi.PodIPReused).
+					HumanMessagef("podIP %v is currently assigned to multiple pods: %v", currPodIP, strings.Join(podNames.List(), ";")).Build(),
 			})
 		}
 	}

--- a/pkg/monitortests/storage/legacystoragemonitortests/storage.go
+++ b/pkg/monitortests/storage/legacystoragemonitortests/storage.go
@@ -28,8 +28,8 @@ func testAPIQuotaEvents(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	for i := range events {
 		event := events[i]
 		for _, msg := range throttlingMessages {
-			if msg.MatchString(event.Message) {
-				matches = append(matches, event.Message)
+			if msg.MatchString(event.StructuredMessage.HumanMessage) {
+				matches = append(matches, event.StructuredMessage.HumanMessage)
 			}
 		}
 	}

--- a/pkg/monitortests/testframework/alertanalyzer/alerts.go
+++ b/pkg/monitortests/testframework/alertanalyzer/alerts.go
@@ -119,7 +119,7 @@ func blackoutEvents(startingEvents, blackoutWindows []monitorapi.Interval) []mon
 	blackoutsByLocator := indexByLocator(blackoutWindows)
 	for i := range startingEvents {
 		startingEvent := startingEvents[i]
-		blackouts := blackoutsByLocator[startingEvent.Locator]
+		blackouts := blackoutsByLocator[startingEvent.StructuredLocator.OldLocator()]
 		if len(blackouts) == 0 {
 			ret = append(ret, startingEvent)
 			continue
@@ -285,7 +285,7 @@ func indexByLocator(events []monitorapi.Interval) map[string][]monitorapi.Interv
 	ret := map[string][]monitorapi.Interval{}
 	for i := range events {
 		event := events[i]
-		ret[event.Locator] = append(ret[event.Locator], event)
+		ret[event.StructuredLocator.OldLocator()] = append(ret[event.StructuredLocator.OldLocator()], event)
 	}
 	return ret
 }

--- a/pkg/monitortests/testframework/alertanalyzer/job_run_data.go
+++ b/pkg/monitortests/testframework/alertanalyzer/job_run_data.go
@@ -129,8 +129,7 @@ func getAlertLevelFromEvent(event monitorapi.Interval) AlertLevel {
 func computeAlertData(events monitorapi.Intervals) *AlertList {
 	alertEvents := events.Filter(
 		func(eventInterval monitorapi.Interval) bool {
-			locator := monitorapi.LocatorParts(eventInterval.Locator)
-			alertName := monitorapi.AlertFrom(locator)
+			alertName := eventInterval.StructuredLocator.Keys[monitorapi.LocatorAlertKey]
 			if len(alertName) == 0 {
 				return false
 			}
@@ -147,10 +146,9 @@ func computeAlertData(events monitorapi.Intervals) *AlertList {
 
 	alertMap := map[AlertKey]*Alert{}
 	for _, alertInterval := range alertEvents {
-		alertLocator := monitorapi.LocatorParts(alertInterval.Locator)
 		alertKey := AlertKey{
-			Name:      monitorapi.AlertFrom(alertLocator),
-			Namespace: monitorapi.NamespaceFrom(alertLocator),
+			Name:      alertInterval.StructuredLocator.Keys[monitorapi.LocatorAlertKey],
+			Namespace: alertInterval.StructuredLocator.Keys[monitorapi.LocatorNamespaceKey],
 			Level:     getAlertLevelFromEvent(alertInterval),
 		}
 		alert, ok := alertMap[alertKey]

--- a/pkg/monitortests/testframework/disruptionserializer/monitortest.go
+++ b/pkg/monitortests/testframework/disruptionserializer/monitortest.go
@@ -99,10 +99,10 @@ func computeDisruptionData(eventIntervals monitorapi.Intervals) *BackendDisrupti
 		),
 	)
 	for _, eventInterval := range allDisruptionEventsIntervals {
-		locatorParts := monitorapi.LocatorParts(eventInterval.Locator)
-		backendDisruptionName := monitorapi.BackendDisruptionNameFrom(locatorParts)
-		connectionType := monitorapi.DisruptionConnectionTypeFrom(locatorParts)
-		backendDisruptionNamesToConnectionType[backendDisruptionName] = connectionType
+		backendDisruptionName := monitorapi.BackendDisruptionNameFromLocator(eventInterval.StructuredLocator)
+		connectionType := eventInterval.StructuredLocator.Keys[monitorapi.LocatorConnectionKey]
+
+		backendDisruptionNamesToConnectionType[backendDisruptionName] = monitorapi.BackendConnectionType(connectionType)
 	}
 
 	for backendDisruptionName, connectionType := range backendDisruptionNamesToConnectionType {

--- a/pkg/monitortests/testframework/disruptionserializer/write_job_run_data_test.go
+++ b/pkg/monitortests/testframework/disruptionserializer/write_job_run_data_test.go
@@ -22,12 +22,27 @@ func TestComputeDisruptionData(t *testing.T) {
 			intervals: []monitorapi.Interval{
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "disruption/kube-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-60 * time.Minute),
-					To:   time.Now().Add(-1 * time.Minute),
+					From:   time.Now().Add(-60 * time.Minute),
+					To:     time.Now().Add(-1 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 			},
 			expected: map[string]BackendDisruption{
@@ -45,30 +60,75 @@ func TestComputeDisruptionData(t *testing.T) {
 			intervals: []monitorapi.Interval{
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "disruption/kube-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-60 * time.Minute),
-					To:   time.Now().Add(-30 * time.Minute),
+					From:   time.Now().Add(-60 * time.Minute),
+					To:     time.Now().Add(-30 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Error,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "reason/DisruptionBegan ns/openshift-image-registry route/test-disruption-new disruption/image-registry connection/new stopped responding to GET requests over new connections: Get \"https://test-disruption-new-openshift-image-registry.apps.ci-op-4mb5069g-03fd1.XXXXXXXXXXXXXXXXXXXXXX/healthz\": dial tcp 104.154.53.8:443: connect: connection refused",
+						Level: monitorapi.Error,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionBeganEventReason,
+							Cause:        "",
+							HumanMessage: "foo",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionBeganEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-30 * time.Minute),
-					To:   time.Now().Add(-20 * time.Minute),
+					From:   time.Now().Add(-30 * time.Minute),
+					To:     time.Now().Add(-20 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "disruption/kube-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-20 * time.Minute),
-					To:   time.Now().Add(-10 * time.Minute),
+					From:   time.Now().Add(-20 * time.Minute),
+					To:     time.Now().Add(-10 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 			},
 			expected: map[string]BackendDisruption{
@@ -85,48 +145,123 @@ func TestComputeDisruptionData(t *testing.T) {
 			intervals: []monitorapi.Interval{
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "disruption/kube-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-60 * time.Minute),
-					To:   time.Now().Add(-50 * time.Minute),
+					From:   time.Now().Add(-60 * time.Minute),
+					To:     time.Now().Add(-50 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Error,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "reason/DisruptionBegan ns/openshift-image-registry route/test-disruption-new disruption/image-registry connection/new stopped responding to GET requests over new connections: Get \"https://test-disruption-new-openshift-image-registry.apps.ci-op-4mb5069g-03fd1.XXXXXXXXXXXXXXXXXXXXXX/healthz\": dial tcp 104.154.53.8:443: connect: connection refused",
+						Level: monitorapi.Error,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionBeganEventReason,
+							Cause:        "",
+							HumanMessage: "foo",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionBeganEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-50 * time.Minute),
-					To:   time.Now().Add(-40 * time.Minute),
+					From:   time.Now().Add(-50 * time.Minute),
+					To:     time.Now().Add(-40 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "disruption/kube-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-40 * time.Minute),
-					To:   time.Now().Add(-30 * time.Minute),
+					From:   time.Now().Add(-40 * time.Minute),
+					To:     time.Now().Add(-30 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Error,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "reason/DisruptionBegan ns/openshift-image-registry route/test-disruption-new disruption/image-registry connection/new stopped responding to GET requests over new connections: Get \"https://test-disruption-new-openshift-image-registry.apps.ci-op-4mb5069g-03fd1.XXXXXXXXXXXXXXXXXXXXXX/healthz\": dial tcp 104.154.53.8:443: connect: connection refused",
+						Level: monitorapi.Error,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionBeganEventReason,
+							Cause:        "",
+							HumanMessage: "foo",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionBeganEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-30 * time.Minute),
-					To:   time.Now().Add(-20 * time.Minute),
+					From:   time.Now().Add(-30 * time.Minute),
+					To:     time.Now().Add(-20 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "disruption/kube-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-20 * time.Minute),
-					To:   time.Now().Add(-10 * time.Minute),
+					From:   time.Now().Add(-20 * time.Minute),
+					To:     time.Now().Add(-10 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 			},
 			expected: map[string]BackendDisruption{
@@ -143,57 +278,147 @@ func TestComputeDisruptionData(t *testing.T) {
 			intervals: []monitorapi.Interval{
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "disruption/kube-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-60 * time.Minute),
-					To:   time.Now().Add(-30 * time.Minute),
+					From:   time.Now().Add(-60 * time.Minute),
+					To:     time.Now().Add(-30 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Error,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "reason/DisruptionBegan ns/openshift-image-registry route/test-disruption-new disruption/image-registry connection/new stopped responding to GET requests over new connections: Get \"https://test-disruption-new-openshift-image-registry.apps.ci-op-4mb5069g-03fd1.XXXXXXXXXXXXXXXXXXXXXX/healthz\": dial tcp 104.154.53.8:443: connect: connection refused",
+						Level: monitorapi.Error,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionBeganEventReason,
+							Cause:        "",
+							HumanMessage: "foo",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionBeganEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-30 * time.Minute),
-					To:   time.Now().Add(-20 * time.Minute),
+					From:   time.Now().Add(-30 * time.Minute),
+					To:     time.Now().Add(-20 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/kube-api-new-connections disruption/kube-api connection/new",
-						Message: "disruption/kube-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "kube-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "kube-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-20 * time.Minute),
-					To:   time.Now().Add(-10 * time.Minute),
+					From:   time.Now().Add(-20 * time.Minute),
+					To:     time.Now().Add(-10 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/openshift-api-new-connections disruption/openshift-api connection/new",
-						Message: "disruption/openshift-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "openshift-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "openshift-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/openshift-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-60 * time.Minute),
-					To:   time.Now().Add(-30 * time.Minute),
+					From:   time.Now().Add(-60 * time.Minute),
+					To:     time.Now().Add(-30 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Error,
-						Locator: "backend-disruption-name/openshift-api-new-connections disruption/openshift-api connection/new",
-						Message: "reason/DisruptionBegan ns/openshift-image-registry route/test-disruption-new disruption/image-registry connection/new stopped responding to GET requests over new connections: Get \"https://test-disruption-new-openshift-image-registry.apps.ci-op-4mb5069g-03fd1.XXXXXXXXXXXXXXXXXXXXXX/healthz\": dial tcp 104.154.53.8:443: connect: connection refused",
+						Level: monitorapi.Error,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "openshift-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "openshift-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionBeganEventReason,
+							Cause:        "",
+							HumanMessage: "foo",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionBeganEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-30 * time.Minute),
-					To:   time.Now().Add(-25 * time.Minute),
+					From:   time.Now().Add(-30 * time.Minute),
+					To:     time.Now().Add(-25 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 				{
 					Condition: monitorapi.Condition{
-						Level:   monitorapi.Info,
-						Locator: "backend-disruption-name/openshift-api-new-connections disruption/openshift-api connection/new",
-						Message: "disruption/openshift-api connection/new started responding to GET requests over new connections",
+						Level: monitorapi.Info,
+						StructuredLocator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeDisruption,
+							Keys: map[monitorapi.LocatorKey]string{
+								monitorapi.LocatorBackendDisruptionNameKey: "openshift-api-new-connections",
+								monitorapi.LocatorDisruptionKey:            "openshift-api",
+								monitorapi.LocatorConnectionKey:            "new",
+							},
+						},
+						StructuredMessage: monitorapi.Message{
+							Reason:       monitorapi.DisruptionEndedEventReason,
+							Cause:        "",
+							HumanMessage: "disruption/kube-api connection/new started responding to GET requests over new connections",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: string(monitorapi.DisruptionEndedEventReason),
+							},
+						},
 					},
-					From: time.Now().Add(-25 * time.Minute),
-					To:   time.Now().Add(-10 * time.Minute),
+					From:   time.Now().Add(-25 * time.Minute),
+					To:     time.Now().Add(-10 * time.Minute),
+					Source: monitorapi.SourceDisruption,
 				},
 			},
 			expected: map[string]BackendDisruption{

--- a/pkg/monitortests/testframework/knownimagechecker/monitortest.go
+++ b/pkg/monitortests/testframework/knownimagechecker/monitortest.go
@@ -136,7 +136,7 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 			continue
 		}
 		// only look at pull events from an e2e-* namespace
-		if !strings.Contains(event.StructuredLocator.Keys[monitorapi.LocatorNamespaceKey], "e2e-") {
+		if !strings.HasPrefix(event.StructuredLocator.Keys[monitorapi.LocatorNamespaceKey], "e2e-") {
 			continue
 		}
 

--- a/pkg/monitortests/testframework/knownimagechecker/monitortest.go
+++ b/pkg/monitortests/testframework/knownimagechecker/monitortest.go
@@ -132,11 +132,11 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 
 	for _, event := range finalIntervals {
 		// only messages that include a Pulled reason
-		if !strings.Contains(" "+event.Message, " reason/Pulled ") {
+		if event.StructuredMessage.Reason != "Pulled" {
 			continue
 		}
 		// only look at pull events from an e2e-* namespace
-		if !strings.Contains(" "+event.Locator, " ns/e2e-") {
+		if !strings.Contains(event.StructuredLocator.Keys[monitorapi.LocatorNamespaceKey], "e2e-") {
 			continue
 		}
 
@@ -146,36 +146,36 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 		if len(images) < 3 {
 			continue
 		}
-		image := ""
+		img := ""
 		for i := 1; i < len(images); i++ {
-			image = images[i]
+			img = images[i]
 			// the match will be either 2nd or 3rd element in the list
-			if image != "" {
+			if img != "" {
 				break
 			}
 		}
-		if hasAnyStringPrefix(image, allowedPrefixesSlice) || allowedImages.Has(image) {
+		if hasAnyStringPrefix(img, allowedPrefixesSlice) || allowedImages.Has(img) {
 			continue
 		}
-		byImage, ok := pulls[image]
+		byImage, ok := pulls[img]
 		if !ok {
 			byImage = sets.NewString()
-			pulls[image] = byImage
-			fmt.Printf("[sig-arch] unknown image: %s (%v)\n", image, event.Message)
+			pulls[img] = byImage
+			fmt.Printf("[sig-arch] unknown image: %s (%v)\n", img, event.Message)
 		}
-		byImage.Insert(event.Locator)
+		byImage.Insert(event.StructuredLocator.OldLocator())
 	}
 
 	if len(pulls) > 0 {
 		images := make([]string, 0, len(pulls))
-		for image := range pulls {
-			images = append(images, image)
+		for img := range pulls {
+			images = append(images, img)
 		}
 		sort.Strings(images)
 		buf := &bytes.Buffer{}
-		for _, image := range images {
-			fmt.Fprintf(buf, "%s from pods:\n", image)
-			for _, locator := range pulls[image].List() {
+		for _, img := range images {
+			fmt.Fprintf(buf, "%s from pods:\n", img)
+			for _, locator := range pulls[img].List() {
 				fmt.Fprintf(buf, "  %s\n", locator)
 			}
 		}

--- a/pkg/monitortests/testframework/knownimagechecker/monitortest.go
+++ b/pkg/monitortests/testframework/knownimagechecker/monitortest.go
@@ -140,7 +140,7 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 			continue
 		}
 
-		images := imageRe.FindStringSubmatch(event.Message)
+		images := imageRe.FindStringSubmatch(event.StructuredMessage.HumanMessage)
 		// the images will contain full match and two group matches, see above
 		// for the regexp definition, so we skip the first in the below for-loop
 		if len(images) < 3 {
@@ -161,7 +161,7 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 		if !ok {
 			byImage = sets.NewString()
 			pulls[img] = byImage
-			fmt.Printf("[sig-arch] unknown image: %s (%v)\n", img, event.Message)
+			fmt.Printf("[sig-arch] unknown image: %s (%v)\n", img, event.StructuredMessage.OldMessage())
 		}
 		byImage.Insert(event.StructuredLocator.OldLocator())
 	}

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
@@ -172,7 +172,7 @@ func runBackstopTest(
 
 	// New version for alert testing against intervals instead of directly from prometheus:
 	for _, firing := range firingIntervals {
-		fan := monitorapi.AlertFromLocator(firing.Locator)
+		fan := firing.StructuredLocator.Keys[monitorapi.LocatorAlertKey]
 		if isSkippedAlert(fan) {
 			continue
 		}
@@ -191,7 +191,7 @@ func runBackstopTest(
 	}
 	// New version for alert testing against intervals instead of directly from prometheus:
 	for _, pending := range pendingIntervals {
-		fan := monitorapi.AlertFromLocator(pending.Locator)
+		fan := pending.StructuredLocator.Keys[monitorapi.LocatorAlertKey]
 		if isSkippedAlert(fan) {
 			continue
 		}

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
@@ -177,7 +177,7 @@ func runBackstopTest(
 			continue
 		}
 		seconds := firing.To.Sub(firing.From)
-		violation := fmt.Sprintf("V2 alert %s fired for %s seconds with labels: %s", fan, seconds, firing.Message)
+		violation := fmt.Sprintf("V2 alert %s fired for %s seconds with labels: %s", fan, seconds, firing.StructuredMessage.OldMessage())
 		if cause := allowedFiringAlerts.MatchesInterval(firing); cause != nil {
 			// TODO: this seems to never be happening? no search.ci results show allowed
 			debug.Insert(fmt.Sprintf("%s result=allow (%s)", violation, cause.Text))
@@ -196,7 +196,7 @@ func runBackstopTest(
 			continue
 		}
 		seconds := pending.To.Sub(pending.From)
-		violation := fmt.Sprintf("V2 alert %s pending for %s seconds with labels: %s", fan, seconds, pending.Message)
+		violation := fmt.Sprintf("V2 alert %s pending for %s seconds with labels: %s", fan, seconds, pending.StructuredMessage.OldMessage())
 		if cause := allowedPendingAlerts.MatchesInterval(pending); cause != nil {
 			// TODO: this seems to never be happening? no search.ci results show allowed
 			debug.Insert(fmt.Sprintf("%s result=allow (%s)", violation, cause.Text))

--- a/pkg/monitortests/testframework/timelineserializer/render_test_01_skip_e2e.json
+++ b/pkg/monitortests/testframework/timelineserializer/render_test_01_skip_e2e.json
@@ -3,14 +3,44 @@
     {
       "level": "Info",
       "locator": "ns/e2e-daemonsets-2620 pod/daemon-set-cx5wt uid/7f73a02a-584e-4b86-a4e4-efb786051ac6",
+      "tempStructuredLocator": {
+        "type": "Pod",
+        "keys": {
+          "namespace": "e2e-daemonsets-2620",
+          "pod": "daemon-set-cx5wt",
+          "uid": "7f73a02a-584e-4b86-a4e4-efb786051ac6"
+        }
+      },
       "message": "constructed/pod-lifecycle-constructor reason/Created ",
+      "tempStructuredMessage": {
+        "reason": "Created",
+        "annotations": {
+          "constructed": "pod-lifecycle-constructor"
+        }
+      },
       "from": "2022-03-07T22:46:16Z",
       "to": "2022-03-07T22:46:16Z"
     },
     {
       "level": "Info",
       "locator": "ns/e2e-daemonsets-2620 pod/daemon-set-cx5wt uid/7f73a02a-584e-4b86-a4e4-efb786051ac6 container/app",
+      "tempStructuredLocator": {
+        "type": "Container",
+        "keys": {
+          "namespace": "e2e-daemonsets-2620",
+          "pod": "daemon-set-cx5wt",
+          "uid": "7f73a02a-584e-4b86-a4e4-efb786051ac6",
+          "container": "app"
+        }
+      },
       "message": "constructed/pod-lifecycle-constructor reason/ContainerWait missed real \"ContainerWait\"",
+      "tempStructuredMessage": {
+        "reason": "ContainerWait",
+        "humanMessage": "missed real \"ContainerWait\"",
+        "annotations": {
+          "constructed": "pod-lifecycle-constructor"
+        }
+      },
       "from": "2022-03-07T22:46:16Z",
       "to": "2022-03-07T22:46:22Z"
     }

--- a/pkg/monitortests/testframework/timelineserializer/rendering.go
+++ b/pkg/monitortests/testframework/timelineserializer/rendering.go
@@ -139,7 +139,7 @@ func BelongsInKubeAPIServer(eventInterval monitorapi.Interval) bool {
 }
 
 func IsPodLifecycle(eventInterval monitorapi.Interval) bool {
-	return monitorapi.ConstructionOwnerFrom(eventInterval.Message) == monitorapi.ConstructionOwnerPodLifecycle
+	return eventInterval.StructuredMessage.Annotations[monitorapi.AnnotationConstructed] == monitorapi.ConstructionOwnerPodLifecycle
 }
 
 func IsOriginalPodEvent(eventInterval monitorapi.Interval) bool {

--- a/pkg/monitortests/testframework/timelineserializer/rendering.go
+++ b/pkg/monitortests/testframework/timelineserializer/rendering.go
@@ -96,7 +96,7 @@ func BelongsInSpyglass(eventInterval monitorapi.Interval) bool {
 		if eventInterval.StructuredMessage.Annotations[monitorapi.AnnotationPathological] != "true" {
 			return false
 		}
-		ns := monitorapi.NamespaceFromLocator(eventInterval.Locator)
+		ns := monitorapi.NamespaceFromLocator(eventInterval.StructuredLocator)
 		if strings.Contains(ns, "e2e") {
 			return false
 		}
@@ -155,7 +155,7 @@ func isPlatformPodEvent(eventInterval monitorapi.Interval) bool {
 	if !IsPodLifecycle(eventInterval) {
 		return false
 	}
-	pod := monitorapi.PodFrom(eventInterval.Locator)
+	pod := monitorapi.PodFrom(eventInterval.StructuredLocator)
 	if len(pod.UID) == 0 {
 		return false
 	}

--- a/pkg/monitortests/testframework/timelineserializer/rendering_per_namespace.go
+++ b/pkg/monitortests/testframework/timelineserializer/rendering_per_namespace.go
@@ -175,9 +175,9 @@ func (r ingressServicePodRendering) WriteRunData(artifactDir string, _ monitorap
 			switch {
 			case isInterestingNamespace(eventInterval, relevantNamespaces):
 				return true
-			case monitorapi.IsNode(eventInterval.Locator):
+			case monitorapi.IsNode(eventInterval.StructuredLocator):
 				return true
-			case disruptionReasons.Has(monitorapi.ReasonFrom(eventInterval.Message)):
+			case disruptionReasons.Has(eventInterval.StructuredMessage.Reason):
 				return true
 			}
 			return false

--- a/pkg/monitortests/testframework/timelineserializer/rendering_per_namespace.go
+++ b/pkg/monitortests/testframework/timelineserializer/rendering_per_namespace.go
@@ -100,7 +100,7 @@ func NewPodEventIntervalRenderer() podRendering {
 func (r podRendering) WriteRunData(artifactDir string, _ monitorapi.ResourcesMap, events monitorapi.Intervals, timeSuffix string) error {
 	allNamespaces := sets.NewString()
 	for _, interval := range events {
-		allNamespaces.Insert(monitorapi.NamespaceFromLocator(interval.Locator))
+		allNamespaces.Insert(monitorapi.NamespaceFromLocator(interval.StructuredLocator))
 	}
 
 	namespaceGroups := wellKnownNamespaceGroups()

--- a/pkg/monitortests/testframework/watchclusteroperators/watcher.go
+++ b/pkg/monitortests/testframework/watchclusteroperators/watcher.go
@@ -1,7 +1,6 @@
 package watchclusteroperators
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -45,9 +44,9 @@ func (w *errorRecordingListWatcher) handle(err error) {
 	if err != nil {
 		if !w.receivedError {
 			w.recorder.Record(monitorapi.Condition{
-				Level:   monitorapi.Error,
-				Locator: "kube-apiserver",
-				Message: fmt.Sprintf("failed contacting the API: %v", err),
+				Level:             monitorapi.Error,
+				StructuredLocator: monitorapi.NewLocator().KubeAPIServer(),
+				StructuredMessage: monitorapi.NewMessage().HumanMessagef("failed contacting the API: %v", err).Build(),
 			})
 		}
 		w.receivedError = true

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52634,68 +52634,59 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     });
 
     function isOperatorAvailable(eventInterval) {
-        if (eventInterval.locator.includes("clusteroperator/") && eventInterval.message.includes("condition/Available") && eventInterval.message.includes("status/False")) {
-            return true
-        }
-        return false
+        return eventInterval.tempStructuredLocator.type === "ClusterOperator" &&
+            eventInterval.tempStructuredMessage.annotations["condition"] === "Available" &&
+            eventInterval.tempStructuredMessage.annotations["status"] === "False";
     }
 
     function isOperatorDegraded(eventInterval) {
-        if (eventInterval.locator.includes("clusteroperator/") && eventInterval.message.includes("condition/Degraded") && eventInterval.message.includes("status/True")) {
-            return true
-        }
-        return false
+        return eventInterval.tempStructuredLocator.type === "ClusterOperator" &&
+            eventInterval.tempStructuredMessage.annotations["condition"] === "Degraded" &&
+            eventInterval.tempStructuredMessage.annotations["status"] === "True";
     }
 
     function isOperatorProgressing(eventInterval) {
-        if (eventInterval.locator.includes("clusteroperator/") && eventInterval.message.includes("condition/Progressing") && eventInterval.message.includes("status/True")) {
-            return true
-        }
-        return false
+        return eventInterval.tempStructuredLocator.type === "ClusterOperator" &&
+            eventInterval.tempStructuredMessage.annotations["condition"] === "Progressing" &&
+            eventInterval.tempStructuredMessage.annotations["status"] === "True";
     }
 
     // When an interval in the openshift-etcd namespace had a reason of LeaderFound, LeaderLost,
     // LeaderElected, or LeaderMissing, tempSource was set to 'EtcdLeadership'.
     function isEtcdLeadership(eventInterval) {
-        if (eventInterval.tempSource == 'EtcdLeadership') {
-            return true
-        }
-        return false
+        return eventInterval.tempSource === 'EtcdLeadership';
+
     }
 
     function isPodLog(eventInterval) {
-        if (eventInterval.tempSource == 'PodLog') {
+        if (eventInterval.tempSource === 'PodLog') {
             return true
         }
-        if (eventInterval.tempSource == 'EtcdLog') {
-            return true
-        }
-        return false
+        return eventInterval.tempSource === 'EtcdLog';
+
     }
 
     function isInterestingOrPathological(eventInterval) {
-        if (eventInterval.tempSource == 'KubeEvent' && eventInterval.message.includes("pathological/true")) {
-            return true
-        }
-        return false
+        return !!(eventInterval.tempSource === 'KubeEvent' && eventInterval.tempStructuredMessage.annotations["pathological"] === "true");
+
     }
 
     function isE2EFailed(eventInterval) {
-        if (eventInterval.locator.includes("e2e-test/") && eventInterval.message.includes("finished As \"Failed")) {
+        if (eventInterval.tempSource === "E2ETest" && eventInterval.tempStructuredMessage.annotations["status"] === "Failed") {
             return true
         }
         return false
     }
 
     function isE2EFlaked(eventInterval) {
-        if (eventInterval.locator.includes("e2e-test/") && eventInterval.message.includes("finished As \"Flaked")) {
+        if (eventInterval.tempSource === "E2ETest" && eventInterval.tempStructuredMessage.annotations["status"] === "Flaked") {
             return true
         }
         return false
     }
 
     function isE2EPassed(eventInterval) {
-        if (eventInterval.locator.includes("e2e-test/") && eventInterval.message.includes("finished As \"Passed")) {
+        if (eventInterval.tempSource === "E2ETest" && eventInterval.tempStructuredMessage.annotations["status"] === "Passed") {
             return true
         }
         return false
@@ -52706,16 +52697,16 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function isEndpointConnectivity(eventInterval) {
-        if (!eventInterval.message.includes("reason/DisruptionBegan") && !eventInterval.message.includes("reason/DisruptionSamplerOutageBegan")){
+        if (eventInterval.tempStructuredMessage.reason !== "DisruptionBegan" && eventInterval.tempStructuredMessage.reason !== "DisruptionSamplerOutageBegan") {
             return false
         }
-        if (eventInterval.locator.includes("disruption/")) {
+        if (eventInterval.tempSource === "Disruption") {
             return true
         }
-        if (eventInterval.locator.includes("ns/e2e-k8s-service-lb-available")) {
+        if (eventInterval.tempStructuredLocator.keys["namespace"] === "e2e-k8s-service-lb-available") {
             return true
         }
-        if (eventInterval.locator.includes(" route/")) {
+        if (eventInterval.tempStructuredLocator.keys.has("route")) {
             return true
         }
 
@@ -52723,9 +52714,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function isNodeState(eventInterval) {
-        return eventInterval.tempStructuredLocator.type === "Node" &&
-            (eventInterval.tempStructuredMessage.reason === "NodeUpdate" ||
-                eventInterval.tempStructuredMessage.reason === "NotReady");
+        return eventInterval.tempSource === "NodeState"
     }
 
     function isCloudMetrics(eventInterval) {
@@ -52733,34 +52722,32 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function isAlert(eventInterval) {
-        if (eventInterval.locator.includes("alert/")) {
-            return true
-        }
-        return false
+        return eventInterval.tempSource === "Alert"
     }
 
     function pathologicalEvents(item) {
-        if (item.message.includes("pathological/true")) {
-            if (item.message.includes("interesting/true")) {
-                return [item.locator, ` + "`" + ` (pathological known)` + "`" + `, "PathologicalKnown"];
+        if (item.tempStructuredMessage.annotations["pathological"] === "true") {
+            if (item.tempStructuredMessage.annotations["interesting"] === "true") {
+                return [buildLocatorDisplayString(item.tempStructuredLocator), ` + "`" + ` (pathological known)` + "`" + `, "PathologicalKnown"];
             } else {
-                return [item.locator, ` + "`" + ` (pathological new)` + "`" + `, "PathologicalNew"];
+                return [buildLocatorDisplayString(item.tempStructuredLocator), ` + "`" + ` (pathological new)` + "`" + `, "PathologicalNew"];
             }
         }
         // TODO: hack that can likely be removed when we get to structured intervals for these
-        if (item.message.includes("interesting/true") && item.message.includes("pod sandbox")) {
-            return [item.locator, ` + "`" + ` (pod sandbox)` + "`" + `, "PodSandbox"];
+        // Always show pod sandbox events even if they didn't make it to pathological
+        if (item.tempStructuredMessage.annotations["interesting"] === "true" && item.tempStructuredMessage.humanMessage.includes("pod sandbox")) {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), ` + "`" + ` (pod sandbox)` + "`" + `, "PodSandbox"];
         }
 	}
 
     function podLogs(item) {
         if (item.level == "Warning") {
-            return [item.locator, ` + "`" + ` (pod log)` + "`" + `, "PodLogWarning"];
+            return [buildLocatorDisplayString(item.tempStructuredLocator), ` + "`" + ` (pod log)` + "`" + `, "PodLogWarning"];
         }
         if (item.level == "Error") {
-            return [item.locator, ` + "`" + ` (pod log)` + "`" + `, "PodLogError"];
+            return [buildLocatorDisplayString(item.tempStructuredLocator), ` + "`" + ` (pod log)` + "`" + `, "PodLogError"];
         }
-        return [item.locator, ` + "`" + ` (pod log)` + "`" + `, "PodLogInfo"];
+        return [buildLocatorDisplayString(item.tempStructuredLocator), ` + "`" + ` (pod log)` + "`" + `, "PodLogInfo"];
     }
 
 
@@ -52772,10 +52759,10 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         }
 
         if (item.tempStructuredMessage.reason === 'NotReady') {
-            return [item.locator, ` + "`" + ` (${roles})` + "`" + `, "NodeNotReady"]
+            return [buildLocatorDisplayString(item.tempStructuredLocator), ` + "`" + ` (${roles})` + "`" + `, "NodeNotReady"]
         }
         let m = item.tempStructuredMessage.annotations.phase;
-        return [item.locator, ` + "`" + ` (${roles})` + "`" + `, m];
+        return [buildLocatorDisplayString(item.tempStructuredLocator), ` + "`" + ` (${roles})` + "`" + `, m];
     }
 
     function etcdLeadershipLogsValue(item) {
@@ -52802,57 +52789,52 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function cloudMetricsValue(item) {
-        return [item.locator, "", "CloudMetric"];
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "CloudMetric"];
     }
 
     function alertSeverity(item) {
         // the other types can be pending, so check pending first
-        let pendingIndex = item.message.indexOf("pending")
-        if (pendingIndex != -1) {
-            return [item.locator, "", "AlertPending"]
+        if (item.tempStructuredMessage.annotations["alertstate"] === "pending") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertPending"]
         }
 
-        let infoIndex = item.message.indexOf("info")
-        if (infoIndex != -1) {
-            return [item.locator, "", "AlertInfo"]
+        if (item.tempStructuredMessage.annotations["severity"] === "info") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertInfo"]
         }
-        let warningIndex = item.message.indexOf("warning")
-        if (warningIndex != -1) {
-            return [item.locator, "", "AlertWarning"]
+        if (item.tempStructuredMessage.annotations["severity"] === "warning") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertWarning"]
         }
-        let criticalIndex = item.message.indexOf("critical")
-        if (criticalIndex != -1) {
-            return [item.locator, "", "AlertCritical"]
+        if (item.tempStructuredMessage.annotations["severity"] === "critical") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertCritical"]
         }
 
         // color as critical if nothing matches so that we notice that something has gone wrong
-        return [item.locator, "", "AlertCritical"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "AlertCritical"]
     }
 
     function apiserverDisruptionValue(item) {
         // TODO: isolate DNS error into CIClusterDisruption
-        return [item.locator, "", "Disruption"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "Disruption"]
     }
 
     function apiserverShutdownValue(item) {
         // TODO: isolate DNS error into CIClusterDisruption
-        return [item.locator, "", "GracefulShutdownInterval"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "GracefulShutdownInterval"]
     }
 
     function disruptionValue(item) {
         // We classify these disruption samples with this message if it thinks
         // it looks like a problem in the CI cluster running the tests, not the cluster under test.
         // (typically DNS lookup problems)
-        let ciClusterDisruption = item.message.indexOf("likely a problem in cluster running tests")
-        if (ciClusterDisruption != -1) {
-            return [item.locator, "", "CIClusterDisruption"]
+        if (item.tempStructuredMessage.reason === "DisruptionSamplerOutageBegan") {
+            return [buildLocatorDisplayString(item.tempStructuredLocator), "", "CIClusterDisruption"]
         }
-        return [item.locator, "", "Disruption"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "Disruption"]
     }
 
     function apiserverShutdownEventsValue(item) {
         // TODO: isolate DNS error into CIClusterDisruption
-        return [item.locator, "", "GracefulShutdownWindow"]
+        return [buildLocatorDisplayString(item.tempStructuredLocator), "", "GracefulShutdownWindow"]
     }
 
     function getDurationString(durationSeconds) {
@@ -52867,15 +52849,84 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function defaultToolTip(item) {
-        let tt = item.message
-        if ('tempSource' in item) {
-            tt = tt + " source/" + item.tempSource
+        if (!item.tempStructuredMessage || !item.tempStructuredMessage.annotations) {
+            return '';
         }
+
+        const structuredMessage = item.tempStructuredMessage;
+        const annotations = structuredMessage.annotations;
+
+        const keyValuePairs = Object.entries(annotations).map(([key, value]) => {
+            return ` + "`" + `${key}/${value}` + "`" + `;
+        });
+
+        let tt = keyValuePairs.join(' ') + ' ' + structuredMessage.humanMessage;
+
+        // TODO: can probably remove this once we're confident all displayed intervals have it set
         if ('display' in item) {
-            tt = tt + " display/" + item.display
+            tt = "display/" + item.display + " " + tt
+        }
+        if ('tempSource' in item) {
+            tt = "source/" + item.tempSource + " " + tt
         }
         tt = tt + " " + getDurationString(((new Date(item.to)).getTime() - (new Date(item.from).getTime()))/1000);
         return tt
+    }
+
+
+    // Used for the actual locators displayed on the right hand side of the chart. Based on the origin go code that does
+    // similar for whenever we serialize a locator to display.
+    function buildLocatorDisplayString(i) {
+        let keys = Object.keys(i.keys);
+        keys = sortKeys(keys);
+
+        let annotations = [];
+        for (let k of keys) {
+            let v = i.keys[k];
+            if (k === 'LocatorE2ETestKey') {
+                annotations.push(` + "`" + `${k}/${JSON.stringify(v)}` + "`" + `);
+            } else {
+                annotations.push(` + "`" + `${k}/${v}` + "`" + `);
+            }
+        }
+
+        return annotations.join(' ');
+    }
+
+    function sortKeys(keys) {
+        // Ensure these keys appear in this order. Other keys can be mixed in and will appear at the end in alphabetical order.
+        const orderedKeys = ["namespace", "node", "pod", "uid", "server", "container", "shutdown", "row"];
+
+        // Create a map to store the indices of keys in the orderedKeys array.
+        // This will allow us to efficiently check if a key is in orderedKeys and find its position.
+        const orderedKeyIndices = {};
+        orderedKeys.forEach((key, index) => {
+            orderedKeyIndices[key] = index;
+        });
+
+        // Define a custom sorting function that orders the keys based on the orderedKeys array.
+        keys.sort((a, b) => {
+            // Get the indices of keys a and b in orderedKeys.
+            const indexA = orderedKeyIndices[a];
+            const indexB = orderedKeyIndices[b];
+
+            // If both keys exist in orderedKeys, sort them based on their order.
+            if (indexA !== undefined && indexB !== undefined) {
+                return indexA - indexB;
+            }
+
+            // If only one of the keys exists in orderedKeys, move it to the front.
+            if (indexA !== undefined) {
+                return -1;
+            } else if (indexB !== undefined) {
+                return 1;
+            }
+
+            // If neither key is in orderedKeys, sort alphabetically so we have predictable ordering.
+            return a.localeCompare(b);
+        });
+
+        return keys;
     }
 
     function createTimelineData(timelineVal, timelineData, rawEventIntervals, preconditionFunc, regex) {
@@ -52901,7 +52952,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
             if (!item.to) {
                 endDate = latest
             }
-            let label = item.locator
+            let label = buildLocatorDisplayString(item.tempStructuredLocator)
             let sub = ""
             let val = timelineVal
             if (typeof val === "function") {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -52667,8 +52667,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
     }
 
     function isInterestingOrPathological(eventInterval) {
-        return !!(eventInterval.tempSource === 'KubeEvent' && eventInterval.tempStructuredMessage.annotations["pathological"] === "true");
-
+        return eventInterval.tempSource === 'KubeEvent' && eventInterval.tempStructuredMessage.annotations["pathological"] === "true";
     }
 
     function isE2EFailed(eventInterval) {


### PR DESCRIPTION
Builds on #28597 by removing remaining locator and message read/writes not related to serialization. 

- **Remove several uses of legacy string locators**
- **Fix unit tests**
- **Port more locator use**
- **Update node state test json with real world data and adjust test**
- **Fix json in nodestateanalyzer tests**
- **Remove more use of unstructured locators**
- **Clean out locator (and some message) use in network invariant tests**
- **Various fixes to broken functionality in the pathological event matching**
- **Fix remaining Locator reads**
- **Fix disrupton/dns overlap test inputs**
- **Remove more locator/message use in tests**
- **Remove last locator writes**
- **Significant improvements to apiserver shutdown intervals**
- **Remove a direct instantiation of Locator**
- **Lots more legacy Message removal**
- **Port message use in very tricky pod watch interval computation**
- **Simplify inputs for very simple tests**
- **Omit new keys if strings provided are empty for pod locator**
- **Port remaining message reads and writes**
- **Fix another test**
- **Port spyglass e2e to use structured intervals**

If successful, next step will be to remove the flat string legacy locator/message, reclaim those fields for the structured fields, collapse Condition into Interval.
