### PR TITLE
OCPBUGS-30267: Clarify a misleading message in patho event failures

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
@@ -222,7 +222,7 @@ func (d *duplicateEventsEvaluator) testDuplicatedEvents(testName string, flakeOn
 	nsResults := map[string]*eventResult{}
 	for intervalDisplayMsg, interval := range displayToCount {
 		namespace := interval.StructuredLocator.Keys[monitorapi.LocatorNamespaceKey]
-		intervalMsgWithTime := intervalDisplayMsg + " From: " + interval.From.Format("15:04:05Z") + " To: " + interval.To.Format("15:04:05Z")
+		intervalMsgWithTime := intervalDisplayMsg + " (" + interval.From.Format("15:04:05Z") + ")"
 		msg := fmt.Sprintf("event happened %d times, something is wrong: %v",
 			GetTimesAnEventHappened(interval.StructuredMessage), intervalMsgWithTime)
 

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -233,7 +233,7 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			namespace:       "openshift",
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong: namespace/openshift - reason/SomeEvent1 foo From: 04:00:00Z To: 04:00:00Z result=reject ",
+			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong: namespace/openshift - reason/SomeEvent1 foo (04:00:00Z) result=reject ",
 		},
 		{
 			name: "matches 22 with namespace e2e",
@@ -249,7 +249,7 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			namespace:       "",
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong: namespace/random - reason/SomeEvent1 foo From: 04:00:00Z To: 04:00:00Z result=reject ",
+			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong: namespace/random - reason/SomeEvent1 foo (04:00:00Z) result=reject ",
 		},
 		{
 			name: "matches 22 with no namespace",
@@ -263,7 +263,7 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			namespace:       "",
 			platform:        v1.AWSPlatformType,
 			topology:        v1.SingleReplicaTopologyMode,
-			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong:  - reason/SomeEvent1 foo From: 04:00:00Z To: 04:00:00Z result=reject ",
+			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong:  - reason/SomeEvent1 foo (04:00:00Z) result=reject ",
 		},
 		{
 			name: "matches 12 with namespace openshift",
@@ -337,7 +337,7 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			namespace:       "openshift-controller-manager",
 			platform:        v1.AWSPlatformType,
 			topology:        v1.HighlyAvailableTopologyMode,
-			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong: namespace/openshift-controller-manager - reason/FailedScheduling 0/6 nodes are available: 2 node(s) were unschedulable, 4 node(s) didn't match pod anti-affinity rules. preemption: 0/6 nodes are available: 2 Preemption is not helpful for scheduling, 4 No preemption victims found for incoming pod.. From: 04:00:00Z To: 04:00:00Z result=reject ",
+			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong: namespace/openshift-controller-manager - reason/FailedScheduling 0/6 nodes are available: 2 node(s) were unschedulable, 4 node(s) didn't match pod anti-affinity rules. preemption: 0/6 nodes are available: 2 Preemption is not helpful for scheduling, 4 No preemption victims found for incoming pod.. (04:00:00Z) result=reject ",
 		},
 		{
 			// This still matches despite the masters updating because it's not in an openshift namespace
@@ -376,7 +376,7 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			namespace:       "mynamespace",
 			platform:        v1.AWSPlatformType,
 			topology:        v1.HighlyAvailableTopologyMode,
-			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong:  - ns/mynamespace reason/FailedScheduling 0/6 nodes are available: 2 node(s) were unschedulable, 4 node(s) didn't match pod anti-affinity rules. preemption: 0/6 nodes are available: 2 Preemption is not helpful for scheduling, 4 No preemption victims found for incoming pod.. From: 04:00:00Z To: 04:00:00Z result=reject ",
+			expectedMessage: "1 events happened too frequently\n\nevent happened 22 times, something is wrong:  - ns/mynamespace reason/FailedScheduling 0/6 nodes are available: 2 node(s) were unschedulable, 4 node(s) didn't match pod anti-affinity rules. preemption: 0/6 nodes are available: 2 Preemption is not helpful for scheduling, 4 No preemption victims found for incoming pod.. (04:00:00Z) result=reject ",
 		},
 	}
 


### PR DESCRIPTION
We were outputting From: To: timestamps, which was always 1s implying
the event happened 20+ times in a second, which was entirely untrue. We
don't really know the start time for the event, and even the observed
time is a little sketchy. Switch to just showing the time we received
the event with the count being displayed for now.
