### PR TITLE
OCPBUGS-31492: Add a test that will fail on over 10k etcd took too long messages

### DIFF
--- a/pkg/monitortests/etcd/legacyetcdmonitortests/monitortest.go
+++ b/pkg/monitortests/etcd/legacyetcdmonitortests/monitortest.go
@@ -38,6 +38,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	junits = append(junits, testEtcdShouldNotLogSlowFdataSyncs(finalIntervals)...)
 	junits = append(junits, testEtcdShouldNotLogDroppedRaftMessages(finalIntervals)...)
 	junits = append(junits, testOperatorStatusChanged(finalIntervals)...)
+	junits = append(junits, testEtcdDoesNotLogExcessiveTookTooLongMessages(finalIntervals)...)
 
 	return junits, nil
 }


### PR DESCRIPTION
We've found a subset of jobs in a specific environment showing extremely
unhealthy etcd pod logs throughout the run, indicating disk IO issues
for etcd.

Add a test to help identify these runs, and clearly communicate with
engineers looking at the failures to help them notice that etcd is
unhealthy and this can cause a multitude of other failures.
