### PR TITLE
OCPBUGS-31484: Use centos7 tag instead of latest for cmd images tests

### DIFF
--- a/examples/image-streams/image-streams-centos7.json
+++ b/examples/image-streams/image-streams-centos7.json
@@ -208,7 +208,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/httpd-24-centos7:latest"
+              "name": "quay.io/centos7/httpd-24-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -230,7 +230,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/httpd-24-centos7:latest"
+              "name": "quay.io/centos7/httpd-24-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -411,7 +411,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-105-centos7:latest"
+              "name": "quay.io/centos7/mariadb-105-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -431,7 +431,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-103-centos7:latest"
+              "name": "quay.io/centos7/mariadb-103-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -451,7 +451,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-103-centos7:latest"
+              "name": "quay.io/centos7/mariadb-103-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -511,7 +511,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mysql-80-centos7:latest"
+              "name": "quay.io/centos7/mysql-80-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -531,7 +531,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mysql-80-centos7:latest"
+              "name": "quay.io/centos7/mysql-80-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1002,7 +1002,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/perl-530-centos7:latest"
+              "name": "quay.io/centos7/perl-530-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1024,7 +1024,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/perl-530-centos7:latest"
+              "name": "quay.io/centos7/perl-530-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1198,7 +1198,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/php-73-centos7:latest"
+              "name": "quay.io/centos7/php-73-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1258,7 +1258,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-13-centos7:latest"
+              "name": "quay.io/centos7/postgresql-13-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1278,7 +1278,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-13-centos7:latest"
+              "name": "quay.io/centos7/postgresql-13-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1298,7 +1298,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-12-centos7:latest"
+              "name": "quay.io/centos7/postgresql-12-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1318,7 +1318,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-12-centos7:latest"
+              "name": "quay.io/centos7/postgresql-12-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1338,7 +1338,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-10-centos7:latest"
+              "name": "quay.io/centos7/postgresql-10-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1358,7 +1358,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-10-centos7:latest"
+              "name": "quay.io/centos7/postgresql-10-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1592,7 +1592,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/redis-5-centos7:latest"
+              "name": "quay.io/centos7/redis-5-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1612,7 +1612,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/redis-5-centos7:latest"
+              "name": "quay.io/centos7/redis-5-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -1785,7 +1785,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/ruby-27-centos7:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -3008,7 +3008,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/httpd-24-centos7:latest"
+              "name": "quay.io/centos7/httpd-24-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3030,7 +3030,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/httpd-24-centos7:latest"
+              "name": "quay.io/centos7/httpd-24-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3211,7 +3211,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-105-centos7:latest"
+              "name": "quay.io/centos7/mariadb-105-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3231,7 +3231,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-103-centos7:latest"
+              "name": "quay.io/centos7/mariadb-103-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3251,7 +3251,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-103-centos7:latest"
+              "name": "quay.io/centos7/mariadb-103-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3311,7 +3311,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mysql-80-centos7:latest"
+              "name": "quay.io/centos7/mysql-80-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3331,7 +3331,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mysql-80-centos7:latest"
+              "name": "quay.io/centos7/mysql-80-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3802,7 +3802,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/perl-530-centos7:latest"
+              "name": "quay.io/centos7/perl-530-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3824,7 +3824,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/perl-530-centos7:latest"
+              "name": "quay.io/centos7/perl-530-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -3998,7 +3998,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/php-73-centos7:latest"
+              "name": "quay.io/centos7/php-73-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4058,7 +4058,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-13-centos7:latest"
+              "name": "quay.io/centos7/postgresql-13-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4078,7 +4078,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-13-centos7:latest"
+              "name": "quay.io/centos7/postgresql-13-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4098,7 +4098,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-12-centos7:latest"
+              "name": "quay.io/centos7/postgresql-12-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4118,7 +4118,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-12-centos7:latest"
+              "name": "quay.io/centos7/postgresql-12-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4138,7 +4138,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-10-centos7:latest"
+              "name": "quay.io/centos7/postgresql-10-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4158,7 +4158,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-10-centos7:latest"
+              "name": "quay.io/centos7/postgresql-10-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4392,7 +4392,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/redis-5-centos7:latest"
+              "name": "quay.io/centos7/redis-5-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4412,7 +4412,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/redis-5-centos7:latest"
+              "name": "quay.io/centos7/redis-5-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -4585,7 +4585,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/ruby-27-centos7:latest"
+              "name": "quay.io/centos7/ruby-27-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -36171,7 +36171,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/httpd-24-centos7:latest"
+              "name": "quay.io/centos7/httpd-24-centos7:centos7"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -36269,7 +36269,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-103-centos7:latest"
+              "name": "quay.io/centos7/mariadb-103-centos7:centos7"
             },
             "name": "10.3",
             "referencePolicy": {
@@ -36287,7 +36287,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-105-centos7:latest"
+              "name": "quay.io/centos7/mariadb-105-centos7:centos7"
             },
             "name": "10.5",
             "referencePolicy": {
@@ -36336,7 +36336,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mongodb-26-centos7:latest"
+              "name": "quay.io/centos7/mongodb-26-centos7:centos7"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -36354,7 +36354,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mongodb-32-centos7:latest"
+              "name": "quay.io/centos7/mongodb-32-centos7:centos7"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -36372,7 +36372,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mongodb-34-centos7:latest"
+              "name": "quay.io/centos7/mongodb-34-centos7:centos7"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -36421,7 +36421,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mysql-80-centos7:latest"
+              "name": "quay.io/centos7/mysql-80-centos7:centos7"
             },
             "name": "8",
             "referencePolicy": {
@@ -36455,7 +36455,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/nginx-114-centos7:latest"
+              "name": "quay.io/centos7/nginx-114-centos7:centos7"
             },
             "name": "1.14",
             "referencePolicy": {
@@ -36475,7 +36475,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/nginx-116-centos7:latest"
+              "name": "quay.io/centos7/nginx-116-centos7:centos7"
             },
             "name": "1.16",
             "referencePolicy": {
@@ -36546,7 +36546,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/nodejs-10-centos7:latest"
+              "name": "quay.io/centos7/nodejs-10-centos7:centos7"
             },
             "name": "10",
             "referencePolicy": {
@@ -36565,7 +36565,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/nodejs-12-centos7:latest"
+              "name": "quay.io/centos7/nodejs-12-centos7:centos7"
             },
             "name": "12",
             "referencePolicy": {
@@ -36641,7 +36641,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/perl-530-centos7:latest"
+              "name": "quay.io/centos7/perl-530-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -36695,7 +36695,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/php-70-centos7:latest"
+              "name": "quay.io/centos7/php-70-centos7:centos7"
             },
             "name": "7.0",
             "referencePolicy": {
@@ -36715,7 +36715,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/php-71-centos7:latest"
+              "name": "quay.io/centos7/php-71-centos7:centos7"
             },
             "name": "7.1",
             "referencePolicy": {
@@ -36764,7 +36764,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-95-centos7:latest"
+              "name": "quay.io/centos7/postgresql-95-centos7:centos7"
             },
             "name": "9.5",
             "referencePolicy": {
@@ -36782,7 +36782,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-96-centos7:latest"
+              "name": "quay.io/centos7/postgresql-96-centos7:centos7"
             },
             "name": "9.6",
             "referencePolicy": {
@@ -36835,7 +36835,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/python-27-centos7:latest"
+              "name": "quay.io/centos7/python-27-centos7:centos7"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -36855,7 +36855,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/python-36-centos7:latest"
+              "name": "quay.io/centos7/python-36-centos7:centos7"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -36904,7 +36904,7 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/redis-5-centos7:latest"
+              "name": "quay.io/centos7/redis-5-centos7:centos7"
             },
             "name": "5",
             "referencePolicy": {

--- a/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
@@ -45,7 +45,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/httpd-24-centos7:latest"
+              "name": "quay.io/centos7/httpd-24-centos7:centos7"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -143,7 +143,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-103-centos7:latest"
+              "name": "quay.io/centos7/mariadb-103-centos7:centos7"
             },
             "name": "10.3",
             "referencePolicy": {
@@ -161,7 +161,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mariadb-105-centos7:latest"
+              "name": "quay.io/centos7/mariadb-105-centos7:centos7"
             },
             "name": "10.5",
             "referencePolicy": {
@@ -210,7 +210,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mongodb-26-centos7:latest"
+              "name": "quay.io/centos7/mongodb-26-centos7:centos7"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -228,7 +228,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mongodb-32-centos7:latest"
+              "name": "quay.io/centos7/mongodb-32-centos7:centos7"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -246,7 +246,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mongodb-34-centos7:latest"
+              "name": "quay.io/centos7/mongodb-34-centos7:centos7"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -295,7 +295,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/mysql-80-centos7:latest"
+              "name": "quay.io/centos7/mysql-80-centos7:centos7"
             },
             "name": "8",
             "referencePolicy": {
@@ -329,7 +329,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/nginx-114-centos7:latest"
+              "name": "quay.io/centos7/nginx-114-centos7:centos7"
             },
             "name": "1.14",
             "referencePolicy": {
@@ -349,7 +349,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/nginx-116-centos7:latest"
+              "name": "quay.io/centos7/nginx-116-centos7:centos7"
             },
             "name": "1.16",
             "referencePolicy": {
@@ -420,7 +420,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/nodejs-10-centos7:latest"
+              "name": "quay.io/centos7/nodejs-10-centos7:centos7"
             },
             "name": "10",
             "referencePolicy": {
@@ -439,7 +439,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/nodejs-12-centos7:latest"
+              "name": "quay.io/centos7/nodejs-12-centos7:centos7"
             },
             "name": "12",
             "referencePolicy": {
@@ -515,7 +515,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/perl-530-centos7:latest"
+              "name": "quay.io/centos7/perl-530-centos7:centos7"
             },
             "generation": null,
             "importPolicy": {},
@@ -569,7 +569,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/php-70-centos7:latest"
+              "name": "quay.io/centos7/php-70-centos7:centos7"
             },
             "name": "7.0",
             "referencePolicy": {
@@ -589,7 +589,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/php-71-centos7:latest"
+              "name": "quay.io/centos7/php-71-centos7:centos7"
             },
             "name": "7.1",
             "referencePolicy": {
@@ -638,7 +638,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-95-centos7:latest"
+              "name": "quay.io/centos7/postgresql-95-centos7:centos7"
             },
             "name": "9.5",
             "referencePolicy": {
@@ -656,7 +656,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/postgresql-96-centos7:latest"
+              "name": "quay.io/centos7/postgresql-96-centos7:centos7"
             },
             "name": "9.6",
             "referencePolicy": {
@@ -709,7 +709,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/python-27-centos7:latest"
+              "name": "quay.io/centos7/python-27-centos7:centos7"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -729,7 +729,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/python-36-centos7:latest"
+              "name": "quay.io/centos7/python-36-centos7:centos7"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -778,7 +778,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "quay.io/centos7/redis-5-centos7:latest"
+              "name": "quay.io/centos7/redis-5-centos7:centos7"
             },
             "name": "5",
             "referencePolicy": {


### PR DESCRIPTION
Images' `latest` tag and auto built mechanisms have been permanently disabled in `quay.io/centos7` repository. 
This PR modifies these images to use `centos7` tag instead of latest. So that cmd/images.sh tests will continue passing. 

But there is no indication whether, at some point in the future, these images or this tag will be removed also or not. I try to remove unit tests entirely to overcome this issue https://github.com/openshift/oc/pull/1717 but maybe for e2e tests, we can give one more try to continue with `centos7` tag, until it is removed.