### PR TITLE
OCPBUGS-31589: e2e: use bound API token for prometheus-k8s SA

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -25,14 +25,14 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		earlyTimeStamp = time.Now()
 	})
 
-	g.It("leader changes are not excessive [Late]", func() {
+	g.It("leader changes are not excessive [Late]", func(ctx g.SpecContext) {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
 			oc = exutil.NewHypershiftManagementCLI("default").AsAdmin().WithoutNamespace()
 		}
 
-		prometheus, err := client.NewE2EPrometheusRouterClient(oc)
+		prometheus, err := client.NewE2EPrometheusRouterClient(ctx, oc)
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		// we only consider series sent since the beginning of the test

--- a/test/extended/prometheus/client/via_route.go
+++ b/test/extended/prometheus/client/via_route.go
@@ -22,7 +22,7 @@ import (
 
 // NewE2EPrometheusRouterClient returns a Prometheus HTTP API client configured to
 // use the Prometheus route host, a bearer token, and no certificate verification.
-func NewE2EPrometheusRouterClient(oc *util.CLI) (prometheusv1.API, error) {
+func NewE2EPrometheusRouterClient(ctx context.Context, oc *util.CLI) (prometheusv1.API, error) {
 	kubeClient := oc.AdminKubeClient()
 	routeClient := oc.AdminRouteClient()
 
@@ -45,7 +45,10 @@ func NewE2EPrometheusRouterClient(oc *util.CLI) (prometheusv1.API, error) {
 		return nil, err
 	}
 
-	token := promHelpers.GetPrometheusSABearerToken(oc)
+	token, err := promHelpers.RequestPrometheusServiceAccountAPIToken(ctx, oc)
+	if err != nil {
+		return nil, err
+	}
 
 	// prometheus API client, configured for route host and bearer token auth, and no cert verification
 	client, err := api.NewClient(api.Config{

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -9,31 +9,26 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
-
-	authenticationv1 "k8s.io/api/authentication/v1"
-	corev1 "k8s.io/api/core/v1"
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
-	clientset "k8s.io/client-go/kubernetes"
-	watchtools "k8s.io/client-go/tools/watch"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
-	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
-	admissionapi "k8s.io/pod-security-admission/api"
-
-	exutil "github.com/openshift/origin/test/extended/util"
-
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	admissionapi "k8s.io/pod-security-admission/api"
 )
 
 var _ = g.Describe("[sig-network][Feature:Router]", func() {
@@ -255,19 +250,21 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			o.Expect(results).To(o.ContainSubstring("# runtime.MemStats"))
 		})
 
-		g.It("should enable openshift-monitoring to pull metrics", func() {
-			prometheusURL, token, exists := locatePrometheus(oc)
-			if !exists {
+		g.It("should enable openshift-monitoring to pull metrics", func(ctx g.SpecContext) {
+			url, err := prometheus.PrometheusServiceURL(ctx, oc)
+			if errors.IsNotFound(err) {
 				g.Skip("prometheus not found on this cluster")
 			}
-
+			o.Expect(err).NotTo(o.HaveOccurred(), "Get url of prometheus service")
+			token, err := prometheus.RequestPrometheusServiceAccountAPIToken(ctx, oc)
+			o.Expect(err).NotTo(o.HaveOccurred(), "Request prometheus service account API token")
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
 			defer func() {
-				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
+				_ = oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()
 
 			o.Expect(wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
-				contents, err := getBearerTokenURLViaPod(ns, execPod.Name, fmt.Sprintf("%s/api/v1/targets?state=active", prometheusURL), token)
+				contents, err := getBearerTokenURLViaPod(ns, execPod.Name, fmt.Sprintf("%s/api/v1/targets?state=active", url), token)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				targets := &promTargets{}
@@ -329,48 +326,6 @@ func (t *promTargets) Expect(l promLabels, health, scrapeURLPattern string) erro
 		return nil
 	}
 	return fmt.Errorf("no match for %v with health %s and scrape URL %s", l, health, scrapeURLPattern)
-}
-
-func waitForServiceAccountInNamespace(c clientset.Interface, ns, serviceAccountName string, timeout time.Duration) error {
-	w, err := c.CoreV1().ServiceAccounts(ns).Watch(context.Background(), metav1.SingleObject(metav1.ObjectMeta{Name: serviceAccountName}))
-	if err != nil {
-		return err
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	_, err = watchtools.UntilWithoutRetry(ctx, w, exutil.ServiceAccountHasSecrets)
-	return err
-}
-
-func locatePrometheus(oc *exutil.CLI) (url, bearerToken string, ok bool) {
-	_, err := oc.AdminKubeClient().CoreV1().Services("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
-	if kapierrs.IsNotFound(err) {
-		return "", "", false
-	}
-
-	waitForServiceAccountInNamespace(oc.AdminKubeClient(), "openshift-monitoring", "prometheus-k8s", 2*time.Minute)
-	for i := 0; i < 30; i++ {
-		secrets, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-monitoring").List(context.Background(), metav1.ListOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		for _, secret := range secrets.Items {
-			if secret.Type != corev1.SecretTypeServiceAccountToken {
-				continue
-			}
-			if !strings.HasPrefix(secret.Name, "prometheus-") {
-				continue
-			}
-			bearerToken = string(secret.Data[corev1.ServiceAccountTokenKey])
-			break
-		}
-		if len(bearerToken) == 0 {
-			e2e.Logf("Waiting for prometheus service account secret to show up")
-			time.Sleep(time.Second)
-			continue
-		}
-	}
-	o.Expect(bearerToken).ToNot(o.BeEmpty())
-
-	return "https://prometheus-k8s.openshift-monitoring.svc:9091", bearerToken, true
 }
 
 func findMetricsWithLabels(f *dto.MetricFamily, promLabels map[string]string) []*dto.Metric {

--- a/test/extended/util/conditions.go
+++ b/test/extended/util/conditions.go
@@ -4,11 +4,6 @@ import (
 	"os"
 	"strconv"
 	"time"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
 // LimitTestsToStartTime returns a time.Time which should be the earliest
@@ -83,20 +78,4 @@ func unixTimeFromEnv(name string) time.Time {
 		return time.Time{}
 	}
 	return time.Unix(seconds, 0)
-}
-
-// ServiceAccountHasSecrets returns true if the service account has at least one secret,
-// false if it does not, or an error.
-// This is originally from k8s.io/kubernetes/pkg/client/conditions/conditions.go, but it
-// got removed in https://github.com/kubernetes/kubernetes/pull/115110.
-func ServiceAccountHasSecrets(event watch.Event) (bool, error) {
-	switch event.Type {
-	case watch.Deleted:
-		return false, errors.NewNotFound(schema.GroupResource{Resource: "serviceaccounts"}, "")
-	}
-	switch t := event.Object.(type) {
-	case *v1.ServiceAccount:
-		return len(t.Secrets) > 0, nil
-	}
-	return false, nil
 }

--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -17,16 +18,13 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	exutil "github.com/openshift/origin/test/extended/util"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	v1 "k8s.io/api/core/v1"
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	clientset "k8s.io/client-go/kubernetes"
-	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 )
@@ -95,77 +93,62 @@ func GetURLWithToken(url, bearerToken string) (string, error) {
 	return string(body), nil
 }
 
-func waitForServiceAccountInNamespace(c clientset.Interface, ns, serviceAccountName string, timeout time.Duration) error {
-	w, err := c.CoreV1().ServiceAccounts(ns).Watch(context.Background(), metav1.SingleObject(metav1.ObjectMeta{Name: serviceAccountName}))
+const (
+	namespace      = "openshift-monitoring"
+	prometheusName = "prometheus-k8s"
+	thanosName     = "thanos-querier"
+	serviceAccount = prometheusName
+)
+
+// PrometheusServiceURL returns the url of the cluster prometheus service or an error if the service is not found.
+func PrometheusServiceURL(ctx context.Context, oc *exutil.CLI) (string, error) {
+	svc, err := oc.AdminKubeClient().CoreV1().Services(namespace).Get(ctx, prometheusName, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return "", fmt.Errorf("unable to get the %s service in the %s namespace: %w", prometheusName, namespace, err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	_, err = watchtools.UntilWithoutRetry(ctx, w, exutil.ServiceAccountHasSecrets)
-	return err
+	i := slices.IndexFunc(svc.Spec.Ports, func(port corev1.ServicePort) bool { return port.Name == "web" })
+	return fmt.Sprintf("https://%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[i].Port), nil
 }
 
-// LocatePrometheus uses an existing CLI to return information used to make http requests to Prometheus.
-func LocatePrometheus(oc *exutil.CLI) (queryURL, prometheusURL, bearerToken string, ok bool) {
-	_, err := oc.AdminKubeClient().CoreV1().Services("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
-	if kapierrs.IsNotFound(err) {
-		return "", "", "", false
+// ThanosQuerierServiceURL returns the url of the thanos querier service or an error if the service is not found.
+func ThanosQuerierServiceURL(ctx context.Context, oc *exutil.CLI) (string, error) {
+	svc, err := oc.AdminKubeClient().CoreV1().Services(namespace).Get(ctx, thanosName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to get the %s service in the %s namespace: %w", thanosName, namespace, err)
 	}
-
-	bearerToken = GetPrometheusSABearerToken(oc)
-
-	return "https://thanos-querier.openshift-monitoring.svc:9091", "https://prometheus-k8s.openshift-monitoring.svc:9091", bearerToken, true
+	i := slices.IndexFunc(svc.Spec.Ports, func(port corev1.ServicePort) bool { return port.Name == "web" })
+	return fmt.Sprintf("https://%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[i].Port), nil
 }
 
-// LocatePrometheusUsingRoutes uses an existing CLI to return routes used to make http requests to Prometheus.
-func LocatePrometheusUsingRoutes(oc *exutil.CLI) (queryURL, prometheusURL, bearerToken string, ok bool) {
-	_, err := oc.AdminKubeClient().CoreV1().Services("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
-	if kapierrs.IsNotFound(err) {
-		return "", "", "", false
-	}
-
-	bearerToken = GetPrometheusSABearerToken(oc)
-
-	thanosRoute, err := oc.AsAdmin().RouteClient().RouteV1().Routes("openshift-monitoring").Get(context.Background(), "thanos-querier", metav1.GetOptions{})
+// PrometheusRouteURL returns the public url of the cluster prometheus service or an error if the route is not found.
+func PrometheusRouteURL(ctx context.Context, oc *exutil.CLI) (string, error) {
+	rte, err := oc.AsAdmin().RouteClient().RouteV1().Routes(namespace).Get(ctx, prometheusName, metav1.GetOptions{})
 	if err != nil {
-		return "", "", "", false
+		return "", fmt.Errorf("unable to get the %s route in the %s namespace: %w", prometheusName, namespace, err)
 	}
-	queryURL = "https://" + thanosRoute.Status.Ingress[0].Host
-
-	prometheusRoute, err := oc.AsAdmin().RouteClient().RouteV1().Routes("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
-	if err != nil {
-		return "", "", "", false
-	}
-	prometheusURL = "https://" + prometheusRoute.Status.Ingress[0].Host
-
-	return queryURL, prometheusURL, bearerToken, true
+	return "https://" + rte.Status.Ingress[0].Host, nil
 }
 
-func GetPrometheusSABearerToken(oc *exutil.CLI) string {
-	var bearerToken string
-	waitForServiceAccountInNamespace(oc.AdminKubeClient(), "openshift-monitoring", "prometheus-k8s", 2*time.Minute)
-	for i := 0; i < 30; i++ {
-		secrets, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-monitoring").List(context.Background(), metav1.ListOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		for _, secret := range secrets.Items {
-			if secret.Type != v1.SecretTypeServiceAccountToken {
-				continue
-			}
-			if !strings.HasPrefix(secret.Name, "prometheus-k8s-token") {
-				continue
-			}
-			bearerToken = string(secret.Data[v1.ServiceAccountTokenKey])
-			break
-		}
-		if len(bearerToken) == 0 {
-			framework.Logf("Waiting for prometheus service account secret to show up")
-			time.Sleep(time.Second)
-			continue
-		}
+// ThanosQuerierRouteURL returns the public url of the thanos querier service or an error if the route is not found.
+func ThanosQuerierRouteURL(ctx context.Context, oc *exutil.CLI) (string, error) {
+	rte, err := oc.AsAdmin().RouteClient().RouteV1().Routes(namespace).Get(ctx, thanosName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to get the %s route in the %s namespace: %w", thanosName, namespace, err)
 	}
-	o.Expect(bearerToken).ToNot(o.BeEmpty())
-	return bearerToken
+	return "https://" + rte.Status.Ingress[0].Host, nil
+}
+
+// RequestPrometheusServiceAccountAPIToken returns a time-bound (24hr) API token for the prometheus service account.
+func RequestPrometheusServiceAccountAPIToken(ctx context.Context, oc *exutil.CLI) (string, error) {
+	expirationSeconds := int64(24 * time.Hour / time.Second)
+	req, err := oc.AdminKubeClient().CoreV1().ServiceAccounts(namespace).CreateToken(ctx, serviceAccount,
+		&authenticationv1.TokenRequest{
+			Spec: authenticationv1.TokenRequestSpec{ExpirationSeconds: &expirationSeconds},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to get an API token for the %s service account in the %s namespace: %w", serviceAccount, namespace, err)
+	}
+	return req.Status.Token, nil
 }
 
 type MetricCondition struct {
@@ -381,7 +364,7 @@ func ExpectPrometheusEndpoint(url string) {
 // FetchAlertingRules fetchs all alerting rules from the Prometheus at
 // the given URL using the given bearer token.  The results are returned
 // as a map of group names to lists of alerting rules.
-func FetchAlertingRules(promURL, bearerToken string) (map[string][]promv1.AlertingRule, error) {
+func FetchAlertingRules(promURL, bearerToken string) (map[string][]prometheusv1.AlertingRule, error) {
 	url := fmt.Sprintf("%s/api/v1/rules", promURL)
 	contents, err := GetURLWithToken(url, bearerToken)
 	if err != nil {
@@ -389,21 +372,21 @@ func FetchAlertingRules(promURL, bearerToken string) (map[string][]promv1.Alerti
 	}
 
 	var result struct {
-		Status string             `json:"status"`
-		Data   promv1.RulesResult `json:"data"`
+		Status string                   `json:"status"`
+		Data   prometheusv1.RulesResult `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(contents), &result); err != nil {
 		return nil, fmt.Errorf("unable to parse response %q from %s: %v", contents, url, err)
 	}
 
-	alertingRules := make(map[string][]promv1.AlertingRule)
+	alertingRules := make(map[string][]prometheusv1.AlertingRule)
 
 	for _, rg := range result.Data.Groups {
 		for _, r := range rg.Rules {
 			switch v := r.(type) {
-			case promv1.RecordingRule:
+			case prometheusv1.RecordingRule:
 				continue
-			case promv1.AlertingRule:
+			case prometheusv1.AlertingRule:
 				alertingRules[rg.Name] = append(alertingRules[rg.Name], v)
 			default:
 				return nil, fmt.Errorf("unexpected rule of type %T", r)
@@ -463,7 +446,7 @@ func QueryURL(rawURL string, timeout time.Duration) error {
 // function.  The function takes the alerting rule, and returns a set of
 // violations, which maye be empty or nil.  If after all rules are
 // checked, there are any violations, an error is returned.
-func ForEachAlertingRule(rules map[string][]promv1.AlertingRule, f func(a promv1.AlertingRule) sets.String) error {
+func ForEachAlertingRule(rules map[string][]prometheusv1.AlertingRule, f func(a prometheusv1.AlertingRule) sets.String) error {
 	allViolations := sets.NewString()
 
 	for group, alerts := range rules {


### PR DESCRIPTION
Clean up tests that rely on the existence of a legacy service account API token secret for the `prometheus-k8s` service account.