### PR TITLE
OCPBUGS-31030, OCPBUGS-31032: Reduce deploymentconfig test 3GBi memory size to reasonable

### DIFF
--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -371,7 +371,7 @@ func deploymentInfo(oc *exutil.CLI, name string) (*appsv1.DeploymentConfig, []*c
 type deploymentConditionFunc func(dc *appsv1.DeploymentConfig, rcs []*corev1.ReplicationController, pods []corev1.Pod) (bool, error)
 
 func waitForLatestCondition(oc *exutil.CLI, name string, timeout time.Duration, fn deploymentConditionFunc) error {
-	return wait.PollImmediate(200*time.Millisecond, timeout, func() (bool, error) {
+	return wait.PollImmediate(500*time.Millisecond, timeout, func() (bool, error) {
 		dc, rcs, pods, err := deploymentInfo(oc, name)
 		if err != nil {
 			return false, err

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -42764,7 +42764,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 3Gi
+            memory: 1.4Gi
 `)
 
 func testExtendedTestdataDeploymentsTagImagesDeploymentYamlBytes() ([]byte, error) {

--- a/test/extended/testdata/deployments/tag-images-deployment.yaml
+++ b/test/extended/testdata/deployments/tag-images-deployment.yaml
@@ -35,4 +35,4 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 3Gi
+            memory: 1.4Gi


### PR DESCRIPTION
`tools:latest` image takes 922792256 bytes (i.e. ~1GBi). So that there is no reason to allocate memory size to 3Gi, besides this test fails on the cluster having limited resources. This PR reduces the allocated memory size to 1.4Gi. This value has been chosen to have a safety gap in the cases where tools image's size is increased. 

Moreover, there are numerous deploymentconfig deprecated warnings stemming from deploymentconfig status check function that is executed per 200ms, this PR increases period to 500ms in order to reduce the count of warning messages. 