### PR TITLE
OCPBUGS-20097: Switch to use must-gather image in build multi-stage

### DIFF
--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -31,8 +31,8 @@ USER 1001
 FROM %[1]s as other
 COPY --from=test /usr/bin/curl /test/
 COPY --from=%[2]s /bin/echo /test/
-COPY --from=%[2]s /bin/ping /test/
-`, image.LimitedShellImage(), image.ShellImage())
+COPY --from=%[2]s /bin/wget /test/
+`, image.LimitedShellImage(), image.MustGatherImage())
 	)
 
 	g.AfterEach(func() {
@@ -124,7 +124,7 @@ COPY --from=%[2]s /bin/ping /test/
 		m, err := oc.Run("logs").Args("-f", "test", "-c", "check").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(m).To(o.ContainSubstring("echo"))
-		o.Expect(m).To(o.ContainSubstring("ping"))
+		o.Expect(m).To(o.ContainSubstring("wget"))
 		e2e.Logf("Pod logs:\n%s\n%s", string(data), string(m))
 	})
 })

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -24,7 +24,9 @@ var (
 	releasePullSpecInitializationLock sync.RWMutex
 	releasePullSpecInitialized        bool
 	availablePullSpecs                = map[string]string{
-		"cli":   "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest",
+		"cli":         "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest",
+		"must-gather": "image-registry.openshift-image-registry.svc:5000/openshift/must-gather:latest",
+		// tools during transition period, can be on a different rhel level
 		"tools": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest",
 	}
 	imageRegistryPullSpecRegex = regexp.MustCompile(`image-registry\.openshift-image-registry\.svc:5000\/openshift\/([A-Za-z0-9._-]+)[@:A-Za-z0-9._-]*`)
@@ -178,6 +180,13 @@ the test/extended/util/image/README.md file.`, image))
 // extending an existing image.
 func ShellImage() string {
 	return GetPullSpecForOrPanic("tools")
+}
+
+// MustGatherImage returns a docker pull spec that any pod on the cluster
+// has access to that contains bash and standard commandline tools.
+// This image has oc and must-gather scripts.
+func MustGatherImage() string {
+	return GetPullSpecForOrPanic("must-gather")
 }
 
 // LimitedShellImage returns a docker pull spec that any pod on the cluster


### PR DESCRIPTION
During transition period, when we're updating RHEL versions for oc, it's possible that tools and cli images will be on different levels of RHEL. Whereas cli and must-gather will match. To prevent problems in tests use cli & must-gather in multi-stage build tests.

/assign @ardaguclu 