### PR TITLE
OCPBUGS-31210: add support for multi-arch codeready-builder-for-rhel-9

### DIFF
--- a/test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel9.yaml
+++ b/test/extended/testdata/builds/subscription-content/buildconfig-subscription-content-rhel9.yaml
@@ -32,7 +32,7 @@ spec:
     dockerfile: |
       FROM registry.access.redhat.com/ubi9/ubi:latest
       RUN rm -rf /etc/rhsm-host
-      RUN yum --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms install \
+      RUN yum --enablerepo=codeready-builder-for-rhel-9-$(arch)-rpms install \
           nss_wrapper \
           uid_wrapper -y && \
           yum clean all -y


### PR DESCRIPTION
OCPBUGS-31210: add support for multi-arch codeready-builder-for-rhel-9

1. verified that the arches do have supporting codeready-builder's
2. arch reports aarch64, s390x, ppc64le and x86_64 properly
3. arch matches to the proper repo
