### PR TITLE
OCPBUGS-31860: ppc64le without python-cinder

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -8,7 +8,7 @@ RUN make; \
 FROM registry.ci.openshift.org/ocp/4.16:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
 RUN PACKAGES="git gzip util-linux" && \
-    if [ $HOSTTYPE = x86_64 ] || [ $HOSTTYPE = ppc64le ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
+    if [ $HOSTTYPE = x86_64 ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
     if [ $HOSTTYPE = x86_64 ]; then PACKAGES="$PACKAGES rt-tests rteval"; fi && \
     yum install --setopt=tsflags=nodocs -y $PACKAGES && \
     yum update -y python3-six && \


### PR DESCRIPTION
This is a preparation to the move to rhel9. For rhel8, there was an openstack-16.1 repo available for ppc64le. For rhel9 openstack 17.1, this seems to be not the case.