### PR TITLE
OCPBUGS-31738: Bump timeout for the pod-network-service endpoints check

### DIFF
--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -181,7 +181,7 @@ func (pna *podNetworkAvalibility) StartCollection(ctx context.Context, adminREST
 	}
 
 	// we need to have the service network pollers wait until we have at least one healthy endpoint before starting.
-	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 120*time.Second, true, pna.serviceHasEndpoints)
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 300*time.Second, true, pna.serviceHasEndpoints)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In certain environments, it can take 3 minutes to download the agnhost image from quay.io. Bump the timeout to 5 minutes to accommodate such slow environments.