### PR TITLE
NO-JIRA: add to the operator list

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -20,6 +20,7 @@ RUN PACKAGES="git gzip util-linux" && \
     git config --system user.email test@test.com && \
     chmod g+w /etc/passwd
 LABEL io.k8s.display-name="OpenShift End-to-End Tests" \
+      io.openshift.release.operator=true \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.build.versions="kubernetes-tests=1.29.0" \
       io.openshift.tags="openshift,tests,e2e"


### PR DESCRIPTION
Adding this label so that `/manifests` dir is pulled into the ReleaseInfo.  This is necessary to include the number of tests per feature.

/assign @wking 

Trevor: does this have any other side-effects? 