### PR TITLE
USHIFT-2985: Fix MicroShift crash and router tests skipping

### DIFF
--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -70,9 +70,17 @@ func InitializeTestFramework(context *e2e.TestContextType, config *ClusterConfig
 	// IPFamily constants are taken from kube e2e and used by tests
 	context.IPFamily = config.IPFamily
 
+	coreClient, err := e2e.LoadClientset(true)
+	if err != nil {
+		return err
+	}
+	isMicroShift, err := exutil.IsMicroShiftCluster(coreClient)
+	if err != nil {
+		return err
+	}
 	// As an extra precaution for now, we do not run this check on all tests since some might fail to pull
 	// release payload information
-	if config.HasNoOptionalCapabilities {
+	if config.HasNoOptionalCapabilities && !isMicroShift {
 		imageStreamString, _, err := exutil.NewCLIWithoutNamespace("").AsAdmin().Run("adm", "release", "info", `-ojsonpath={.references}`).Outputs()
 		if err != nil {
 			return err

--- a/pkg/monitortests/cloud/azure/metrics/monitortest.go
+++ b/pkg/monitortests/cloud/azure/metrics/monitortest.go
@@ -15,6 +15,7 @@ import (
 	azureutil "github.com/openshift/origin/test/extended/util/azure"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/objx"
+	"k8s.io/client-go/kubernetes"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,8 +32,9 @@ const (
 )
 
 type azureMetricsCollector struct {
-	adminRESTConfig *rest.Config
-	flakeErr        error
+	adminRESTConfig    *rest.Config
+	flakeErr           error
+	notSupportedReason error
 }
 
 // metricTest is used to group test data such as azure metrics query params and threshold
@@ -47,7 +49,20 @@ func NewAzureMetricsCollector() monitortestframework.MonitorTest {
 
 func (w *azureMetricsCollector) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
 	w.adminRESTConfig = adminRESTConfig
-	return nil
+	kubeClient, err := kubernetes.NewForConfig(w.adminRESTConfig)
+	if err != nil {
+		return err
+	}
+	isMicroShift, err := exutil.IsMicroShiftCluster(kubeClient)
+	if err != nil {
+		return fmt.Errorf("unable to determine if cluster is MicroShift: %v", err)
+	}
+	if isMicroShift {
+		w.notSupportedReason = &monitortestframework.NotSupportedError{
+			Reason: "platform MicroShift not supported",
+		}
+	}
+	return w.notSupportedReason
 }
 
 func objects(from *objx.Value) []objx.Map {
@@ -139,6 +154,9 @@ func fetchExtrenuousMetrics(ctx context.Context, allVMs []string, client *armmon
 // CollectData collects azure metrics. Since azure metrics are collected to facilitate debugging, some errors (like cloud throttling) are not considered fatal.
 // We will simply log the error and return nil to the caller.
 func (w *azureMetricsCollector) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
+	}
 	// Only collect if we are on azure
 	oc := exutil.NewCLI("cloudmetrics").AsAdmin()
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})

--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -47,6 +47,14 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 			g.Skip("default router is not exposed by a load balancer service")
 		}
+
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		if err != nil {
+			o.Expect(err).NotTo(o.HaveOccurred(), "error determining if running on MicroShift: %v", err)
+		}
+		if isMicroShift {
+			g.Skip("MicroShift does not support ingress-canary or monitoring")
+		}
 	})
 
 	g.It("should expose cluster services outside the cluster [apigroup:route.openshift.io]", func() {

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -49,6 +49,12 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	)
 
 	g.BeforeEach(func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("MicroShift does not have Prometheus")
+		}
+
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		platformType := infra.Status.Platform


### PR DESCRIPTION
According to what was discussed last month, fix:
- openshift-tests crashing when executing over MicroShift.
- Port router tests skip patches from MicroShift.
- Port monitor tests skip patches from MicroShift.

/cc @dgoodwin
/cc @stbenjam 