### PR TITLE
OCPBUGS-18534: monitor test fix to wait before connecting to a non-existent dns on PowerVS and IBMCloud platforms

### DIFF
--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -208,7 +208,7 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 	// the host from the cluster's context
 	if infra.Spec.PlatformSpec.Type == configv1.PowerVSPlatformType || infra.Spec.PlatformSpec.Type == configv1.IBMCloudPlatformType {
 		nodeTgt := "node/" + nodeList.Items[0].ObjectMeta.Name
-		if err := checkHostnameReady(tcpService, nodeTgt); err != nil {
+		if err := checkHostnameReady(ctx, tcpService, nodeTgt); err != nil {
 			return err
 		}
 	}
@@ -356,7 +356,7 @@ func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Re
 }
 
 // Uses the first node in the cluster to verify the LoadBalancer host is active before returning
-func checkHostnameReady(tcpService *corev1.Service, nodeTgt string) error {
+func checkHostnameReady(ctx context.Context, tcpService *corev1.Service, nodeTgt string) error {
 	oc := exutil.NewCLIForMonitorTest(tcpService.GetObjectMeta().GetNamespace())
 
 	var (
@@ -364,24 +364,19 @@ func checkHostnameReady(tcpService *corev1.Service, nodeTgt string) error {
 		err    error
 	)
 
-	for i := 0; i < 60; i++ {
-		fmt.Printf("Checking load balancer host is active \n")
-		wait.Poll(3*time.Second, 60*time.Second, func() (bool, error) {
-			stdOut, _, err = oc.AsAdmin().WithoutNamespace().RunInMonitorTest("debug").Args(nodeTgt, "--", "dig", "+short", tcpService.Status.LoadBalancer.Ingress[0].Hostname).Outputs()
-			if err != nil {
-				return false, nil
-			}
-			return true, nil
-		})
-
+	wait.PollUntilContextTimeout(ctx, 15*time.Second, 60*time.Minute, true, func(ctx context.Context) (bool, error) {
+		logrus.Debug("Checking load balancer host is active \n")
+		stdOut, _, err = oc.AsAdmin().WithoutNamespace().RunInMonitorTest("debug").Args(nodeTgt, "--", "dig", "+short", "+notcp", tcpService.Status.LoadBalancer.Ingress[0].Hostname).Outputs()
+		if err != nil {
+			return false, nil
+		}
 		output := strings.TrimSpace(stdOut)
 		if output == "" {
-			fmt.Println("waiting for the LB to come active")
-			time.Sleep(1 * time.Minute)
-			continue
-		} else {
-			break
+			logrus.Debug("Waiting for the load balancer to become active")
+			return false, nil
 		}
-	}
-	return nil
+		logrus.Debug("Load balancer active")
+		return true, nil
+	})
+	return err
 }

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -179,6 +179,32 @@ func NewCLIWithoutNamespace(project string) *CLI {
 	return cli
 }
 
+// NewCLIForMonitorTest initializes the CLI and Kube framework helpers
+// without a namespace. Should be called outside of a Ginkgo .It()
+// function.
+func NewCLIForMonitorTest(project string) *CLI {
+	cli := &CLI{
+		kubeFramework: &framework.Framework{
+			SkipNamespaceCreation: true,
+			BaseName:              project,
+			Options: framework.Options{
+				ClientQPS:   20,
+				ClientBurst: 50,
+			},
+			Timeouts: framework.NewTimeoutContext(),
+		},
+		username:                "admin",
+		execPath:                "oc",
+		adminConfigPath:         KubeConfigPath(),
+		staticConfigManifestDir: StaticConfigManifestDir(),
+		withoutNamespace:        true,
+	}
+
+	// Called only once (assumed the objects will never get modified)
+	cli.setupStaticConfigsFromManifests()
+	return cli
+}
+
 // NewHypershiftManagementCLI returns a CLI that interacts with the Hypershift management cluster.
 // Contrary to a normal CLI it does not perform any cleanup, and it must not be used for any mutating
 // operations. Also, contrary to a normal CLI it must be constructed inside an `It` block. This is
@@ -808,6 +834,22 @@ func (c *CLI) Run(commands ...string) *CLI {
 	}
 	if !c.withoutNamespace {
 		nc.globalArgs = append([]string{fmt.Sprintf("--namespace=%s", c.Namespace())}, nc.globalArgs...)
+	}
+	nc.stdin, nc.stdout, nc.stderr = in, out, errout
+	return nc.setOutput(c.stdout)
+}
+
+// Executes with the kubeconfig specified from the environment
+func (c *CLI) RunInMonitorTest(commands ...string) *CLI {
+	in, out, errout := &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
+	nc := &CLI{
+		execPath:        c.execPath,
+		verb:            commands[0],
+		kubeFramework:   c.KubeFramework(),
+		adminConfigPath: c.adminConfigPath,
+		configPath:      c.configPath,
+		username:        c.username,
+		globalArgs:      commands,
 	}
 	nc.stdin, nc.stdout, nc.stderr = in, out, errout
 	return nc.setOutput(c.stdout)


### PR DESCRIPTION
[OCPBUGS-18534](https://issues.redhat.com/browse/OCPBUGS-18534)  
Monitor test changes to fix loadbalancer issue in PowerVS platforms.

Test checks if platform is either a PowerVS or IBMCloud cluster and then runs function `checkHostnameReady` where it debugs the master node of the cluster and verifies the hostname is active before hitting through the load balancer