### PR TITLE
OCPBUGS-32923: Fix allowed firing alerts not triggering

### DIFF
--- a/pkg/alerts/allowed_conformance.go
+++ b/pkg/alerts/allowed_conformance.go
@@ -2,47 +2,49 @@ package alerts
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
-	helper "github.com/openshift/origin/test/extended/util/prometheus"
 )
 
 // AllowedAlertsDuringConformance lists all alerts that are allowed to be pending or firing during
 // conformance testing.
 // WARNING: there is a parallel list for allowed alerts during upgrade in allowed_upgrade.go,
 // ensure that alerts we want to allow in both are added to both.
-func AllowedAlertsDuringConformance(featureSet configv1.FeatureSet) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending helper.MetricConditions) {
+func AllowedAlertsDuringConformance(featureSet configv1.FeatureSet) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending MetricConditions) {
 
-	firingAlertsWithBugs := helper.MetricConditions{}
-	allowedFiringAlerts := helper.MetricConditions{
+	firingAlertsWithBugs := MetricConditions{}
+	allowedFiringAlerts := MetricConditions{
 		{
-			Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
+			AlertName:      "TargetDown",
+			AlertNamespace: "openshift-e2e-loki",
+			Text:           "Loki is nice to have, but we can allow it to be down",
 		},
 		{
-			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
+			AlertName:      "KubePodNotReady",
+			AlertNamespace: "openshift-e2e-loki",
+			Text:           "Loki is nice to have, but we can allow it to be down",
 		},
 		{
-			Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
+			AlertName:      "KubeDeploymentReplicasMismatch",
+			AlertNamespace: "openshift-e2e-loki",
+			Text:           "Loki is nice to have, but we can allow it to be down",
 		},
 		{
-			Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
-			Text:     "high CPU utilization during e2e runs is normal",
+			AlertName: "HighOverallControlPlaneCPU",
+			Text:      "high CPU utilization during e2e runs is normal",
 		},
 		{
-			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
-			Text:     "high CPU utilization during e2e runs is normal",
+			AlertName: "ExtremelyHighIndividualControlPlaneCPU",
+			Text:      "high CPU utilization during e2e runs is normal",
 		},
 	}
-	pendingAlertsWithBugs := helper.MetricConditions{}
-	allowedPendingAlerts := helper.MetricConditions{
+	pendingAlertsWithBugs := MetricConditions{}
+	allowedPendingAlerts := MetricConditions{
 		{
-			Selector: map[string]string{"alertname": "HighOverallControlPlaneCPU"},
-			Text:     "high CPU utilization during e2e runs is normal",
+			AlertName: "HighOverallControlPlaneCPU",
+			Text:      "high CPU utilization during e2e runs is normal",
 		},
 		{
-			Selector: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU"},
-			Text:     "high CPU utilization during e2e runs is normal",
+			AlertName: "ExtremelyHighIndividualControlPlaneCPU",
+			Text:      "high CPU utilization during e2e runs is normal",
 		},
 	}
 
@@ -50,13 +52,13 @@ func AllowedAlertsDuringConformance(featureSet configv1.FeatureSet) (allowedFiri
 	case configv1.TechPreviewNoUpgrade:
 		allowedFiringAlerts = append(
 			allowedFiringAlerts,
-			helper.MetricCondition{
-				Selector: map[string]string{"alertname": "TechPreviewNoUpgrade"},
-				Text:     "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been enabled",
+			MetricCondition{
+				AlertName: "TechPreviewNoUpgrade",
+				Text:      "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been enabled",
 			},
-			helper.MetricCondition{
-				Selector: map[string]string{"alertname": "ClusterNotUpgradeable"},
-				Text:     "Allow testing of ClusterNotUpgradeable clusters, this will only fire when a FeatureGate has been enabled",
+			MetricCondition{
+				AlertName: "ClusterNotUpgradeable",
+				Text:      "Allow testing of ClusterNotUpgradeable clusters, this will only fire when a FeatureGate has been enabled",
 			})
 	}
 

--- a/pkg/alerts/allowed_upgrade.go
+++ b/pkg/alerts/allowed_upgrade.go
@@ -2,36 +2,38 @@ package alerts
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
-	helper "github.com/openshift/origin/test/extended/util/prometheus"
 )
 
 // AllowedAlertsDuringUpgrade lists all alerts that are allowed to be pending or firing during
 // upgrade.
 // WARNING: there is a parallel list for allowed alerts during conformance in allowed_conformance.go,
 // ensure that alerts we want to allow in both are added to both.
-func AllowedAlertsDuringUpgrade(featureSet configv1.FeatureSet) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending helper.MetricConditions) {
+func AllowedAlertsDuringUpgrade(featureSet configv1.FeatureSet) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending MetricConditions) {
 
-	firingAlertsWithBugs := helper.MetricConditions{}
+	firingAlertsWithBugs := MetricConditions{}
 
-	allowedFiringAlerts := helper.MetricConditions{
+	allowedFiringAlerts := MetricConditions{
 		{
-			Selector: map[string]string{"alertname": "TargetDown", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
+			AlertName:      "TargetDown",
+			AlertNamespace: "openshift-e2e-loki",
+			Text:           "Loki is nice to have, but we can allow it to be down",
 		},
 		{
-			Selector: map[string]string{"alertname": "KubePodNotReady", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
+			AlertName:      "KubePodNotReady",
+			AlertNamespace: "openshift-e2e-loki",
+			Text:           "Loki is nice to have, but we can allow it to be down",
 		},
 		{
-			Selector: map[string]string{"alertname": "KubeDeploymentReplicasMismatch", "namespace": "openshift-e2e-loki"},
-			Text:     "Loki is nice to have, but we can allow it to be down",
+			AlertName:      "KubeDeploymentReplicasMismatch",
+			AlertNamespace: "openshift-e2e-loki",
+			Text:           "Loki is nice to have, but we can allow it to be down",
 		},
 	}
-	pendingAlertsWithBugs := helper.MetricConditions{}
-	allowedPendingAlerts := helper.MetricConditions{
+	pendingAlertsWithBugs := MetricConditions{}
+	allowedPendingAlerts := MetricConditions{
 		{
-			Selector: map[string]string{"alertname": "etcdMemberCommunicationSlow"},
-			Text:     "Excluded because it triggers during upgrade (detects ~5m of high latency immediately preceeding the end of the test), and we don't want to change the alert because it is correct",
+			AlertName: "etcdMemberCommunicationSlow",
+			Text:      "Excluded because it triggers during upgrade (detects ~5m of high latency immediately preceeding the end of the test), and we don't want to change the alert because it is correct",
 		},
 	}
 
@@ -39,13 +41,13 @@ func AllowedAlertsDuringUpgrade(featureSet configv1.FeatureSet) (allowedFiringWi
 	case configv1.TechPreviewNoUpgrade:
 		allowedFiringAlerts = append(
 			allowedFiringAlerts,
-			helper.MetricCondition{
-				Selector: map[string]string{"alertname": "TechPreviewNoUpgrade"},
-				Text:     "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been enabled",
+			MetricCondition{
+				AlertName: "TechPreviewNoUpgrade",
+				Text:      "Allow testing of TechPreviewNoUpgrade clusters, this will only fire when a FeatureGate has been enabled",
 			},
-			helper.MetricCondition{
-				Selector: map[string]string{"alertname": "ClusterNotUpgradeable"},
-				Text:     "Allow testing of ClusterNotUpgradeable clusters, this will only fire when a FeatureGate has been enabled",
+			MetricCondition{
+				AlertName: "ClusterNotUpgradeable",
+				Text:      "Allow testing of ClusterNotUpgradeable clusters, this will only fire when a FeatureGate has been enabled",
 			})
 	}
 

--- a/pkg/alerts/types.go
+++ b/pkg/alerts/types.go
@@ -1,0 +1,45 @@
+package alerts
+
+import (
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/prometheus/common/model"
+)
+
+type MetricCondition struct {
+	AlertName      string
+	AlertNamespace string
+	AlertLevel     string
+
+	// Text is the description of why this alert condition matched.
+	Text string
+
+	Matches func(sample *model.Sample) bool
+}
+
+type MetricConditions []MetricCondition
+
+func (c MetricConditions) MatchesInterval(alertInterval monitorapi.Interval) *MetricCondition {
+
+	if alertInterval.Source != monitorapi.SourceAlert {
+		return nil
+	}
+
+	checkAlertName := alertInterval.StructuredLocator.Keys[monitorapi.LocatorAlertKey]
+	checkAlertNamespace := alertInterval.StructuredLocator.Keys[monitorapi.LocatorNamespaceKey]
+
+	for _, condition := range c {
+		matches := true
+		// We can assume AlertName is set:
+		if condition.AlertName != checkAlertName {
+			matches = false
+			// But Namespace may not be:
+		} else if condition.AlertNamespace != "" && condition.AlertNamespace != checkAlertNamespace {
+			matches = false
+		}
+
+		if matches {
+			return &condition
+		}
+	}
+	return nil
+}

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/alerts"
 	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/monitortestlibrary/allowedalerts"
 	"github.com/openshift/origin/pkg/monitortestlibrary/historicaldata"
@@ -14,11 +15,9 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/sirupsen/logrus"
 
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
-	helper "github.com/openshift/origin/test/extended/util/prometheus"
-
-	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -27,7 +26,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-type AllowedAlertsFunc func(featureSet configv1.FeatureSet) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending helper.MetricConditions)
+type AllowedAlertsFunc func(featureSet configv1.FeatureSet) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending alerts.MetricConditions)
 
 func testAlerts(events monitorapi.Intervals,
 	allowancesFunc AllowedAlertsFunc,
@@ -143,23 +142,23 @@ func runBackstopTest(
 		case allowedalerts.AlertPending:
 			// a pending test covers pending and everything above (firing)
 			allowedPendingAlerts = append(allowedPendingAlerts,
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": alertTest.AlertName()},
-					Text:     "has a separate e2e test",
+				alerts.MetricCondition{
+					AlertName: alertTest.AlertName(),
+					Text:      "has a separate e2e test",
 				},
 			)
 			allowedFiringAlerts = append(allowedFiringAlerts,
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": alertTest.AlertName()},
-					Text:     "has a separate e2e test",
+				alerts.MetricCondition{
+					AlertName: alertTest.AlertName(),
+					Text:      "has a separate e2e test",
 				},
 			)
 		case allowedalerts.AlertInfo:
 			// an info test covers all firing
 			allowedFiringAlerts = append(allowedFiringAlerts,
-				helper.MetricCondition{
-					Selector: map[string]string{"alertname": alertTest.AlertName()},
-					Text:     "has a separate e2e test",
+				alerts.MetricCondition{
+					AlertName: alertTest.AlertName(),
+					Text:      "has a separate e2e test",
 				},
 			)
 		}

--- a/test/extended/util/prometheus/helpers_test.go
+++ b/test/extended/util/prometheus/helpers_test.go
@@ -1,0 +1,93 @@
+package prometheus
+
+import (
+	"testing"
+
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/pkg/alerts"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricConditions_MatchesInterval(t *testing.T) {
+
+	_, allowedFiring, _, _ := alerts.AllowedAlertsDuringConformance(v1.FeatureSet(""))
+
+	type args struct {
+		alertInterval monitorapi.Interval
+	}
+	type want struct {
+		alert     string
+		namespace string
+	}
+	tests := []struct {
+		name string
+		c    alerts.MetricConditions
+		args args
+		want *want
+	}{
+		{
+			name: "KubePodNotReady openshift-e2e-loki",
+			c:    allowedFiring,
+			args: args{
+				alertInterval: monitorapi.NewInterval(monitorapi.SourceAlert, monitorapi.Warning).
+					Locator(monitorapi.NewLocator().AlertFromPromSampleStream(&model.SampleStream{
+						Metric: map[model.LabelName]model.LabelValue{
+							"alertname":  "KubePodNotReady",
+							"alertstate": "firing",
+							"namespace":  "openshift-e2e-loki",
+							"severity":   "warning",
+						},
+					})).BuildNow(),
+			},
+			want: &want{
+				alert:     "KubePodNotReady",
+				namespace: "openshift-e2e-loki",
+			},
+		},
+		{
+			name: "HighOverallControlPlaneCPU",
+			c:    allowedFiring,
+			args: args{
+				alertInterval: monitorapi.NewInterval(monitorapi.SourceAlert, monitorapi.Warning).
+					Locator(monitorapi.NewLocator().AlertFromPromSampleStream(&model.SampleStream{
+						Metric: map[model.LabelName]model.LabelValue{
+							"alertname":  "HighOverallControlPlaneCPU",
+							"alertstate": "firing",
+							"severity":   "warning",
+						},
+					})).BuildNow(),
+			},
+			want: &want{
+				alert: "HighOverallControlPlaneCPU",
+			},
+		},
+		{
+			name: "FakeAlertWithNoAllowance",
+			c:    allowedFiring,
+			args: args{
+				alertInterval: monitorapi.NewInterval(monitorapi.SourceAlert, monitorapi.Warning).
+					Locator(monitorapi.NewLocator().AlertFromPromSampleStream(&model.SampleStream{
+						Metric: map[model.LabelName]model.LabelValue{
+							"alertname":  "FakeAlert",
+							"alertstate": "firing",
+							"severity":   "warning",
+						},
+					})).BuildNow(),
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.c.MatchesInterval(tt.args.alertInterval)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.Equal(t, tt.want.alert, got.AlertName)
+				assert.Equal(t, tt.want.namespace, got.AlertNamespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This looks to have been partially implemented some time ago and thus has been broken ever since.
