### PR TITLE
OCPEDGE-812: feat: add tests for cpu limits on workload partitioning

### DIFF
--- a/test/extended/cpu_partitioning/crio.go
+++ b/test/extended/cpu_partitioning/crio.go
@@ -15,6 +15,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -26,7 +27,7 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
-// This collection script queries CRIO for all it's containers, that data is then filtered down to only a subset
+// This collection script queries CRI-O for all it's containers, that data is then filtered down to only a subset
 // of information needed for validating workload partitioning and the PIDs are mapped to their corresponding host
 // CPUSet via the taskset command.
 const collectionScript = `
@@ -40,7 +41,9 @@ workload_containers=$(echo $container_data | jq -rs '[
 	.[] | select(.info.runtimeSpec.annotations["target.workload.openshift.io/management"]) | 
 	{
 		cpuSet: (.info.runtimeSpec.linux.resources.cpu.cpus // ""),
-        cpuShare: .info.runtimeSpec.linux.resources.cpu.shares,
+        cpuShares: .info.runtimeSpec.linux.resources.cpu.shares,
+        cpuQuota: .info.runtimeSpec.linux.resources.cpu.quota,
+        cpuPeriod: .info.runtimeSpec.linux.resources.cpu.period,
 		annotations: .info.runtimeSpec.annotations,
         podNamespace: .info.runtimeSpec.annotations["io.kubernetes.pod.namespace"],
         podName: .info.runtimeSpec.annotations["io.kubernetes.pod.name"],
@@ -62,19 +65,27 @@ final_results=$(echo "$workload_containers $workload_host_cpu_set" | jq -rs '.[0
 echo "$final_results" | jq -rc '[.[] | select(.hostCPUSet != "-1")]'
 `
 
-const jsonKeyCPUShare = "cpushares"
-
 // Collection data for each container in a node
 type crioContainerData struct {
 	PodNamespace string            `json:"podNamespace"`
 	PodName      string            `json:"podName"`
 	Name         string            `json:"name"`
 	CPUSet       string            `json:"cpuSet"`
-	CPUShare     int               `json:"cpuShare"`
+	CPUShares    int64             `json:"cpuShares"`
+	CPUQuota     int64             `json:"cpuQuota"`
+	CPUPeriod    int64             `json:"cpuPeriod"`
 	Annotations  map[string]string `json:"annotations"`
 	HostCPUSet   string            `json:"hostCPUSet"`
 	Hostname     string            `json:"hostname"`
 	Pid          int               `json:"pid"`
+}
+
+// Parse the workload cpu resource annotation
+type crioCPUResource struct {
+	// Specifies the number of CPU shares this Pod has access to.
+	CPUShares int64 `json:"cpushares,omitempty"`
+	// Specifies the CPU limit in millicores. This will be used to calculate the CPU quota.
+	CPULimit int64 `json:"cpulimit,omitempty"`
 }
 
 // Container struct for master and worker node CPUSets
@@ -84,40 +95,40 @@ type nodeCPUSets struct {
 }
 
 // getAnnotationCPUShare Looks through the annotations to find the workload partitioning annotation and
-// returns the cpushares or error if no such annotation exists.
-func (c *crioContainerData) getAnnotationCPUShare() (int, error) {
-	anno := fmt.Sprintf("%s/%s", WorkloadAnnotationPrefix, c.Name)
-	cpuShare, ok := c.Annotations[anno]
+// returns the crio cpu resources or error if no such annotation exists.
+func (c *crioContainerData) getAnnotationCPUResources() (crioCPUResource, error) {
+	annotationCPUResource := crioCPUResource{}
+	anno := fmt.Sprintf("%s/%s", workloadAnnotationPrefix, c.Name)
+	cpuResources, ok := c.Annotations[anno]
 	if !ok {
-		return 0, fmt.Errorf("workload annotation of [%s] was expected but not found", anno)
+		return annotationCPUResource, fmt.Errorf("workload annotation of [%s] was expected but not found", anno)
 	}
 
-	// workload cpushare annotations have a json string that will contain `{ "cpushares": <share int> }`
-	// we parse and return that value here.
-	temp := map[string]int{}
-	err := json.Unmarshal([]byte(cpuShare), &temp)
+	// workload annotations have a json string that will contain the cpushares and cpulimit
+	// these values are passed down from kubernetes, we parse and return that value here to validate.
+	err := json.Unmarshal([]byte(cpuResources), &annotationCPUResource)
 	if err != nil {
-		return 0, fmt.Errorf("err parsing cpushare json annotation: %w", err)
+		return annotationCPUResource, fmt.Errorf("err parsing cpushare json annotation: %w", err)
 	}
 
-	value, ok := temp[jsonKeyCPUShare]
-	if !ok {
-		return 0, fmt.Errorf("err cpushare annotation was incorrect expected format {\"cpushares\": <int> }")
-	}
-
-	return value, nil
+	return annotationCPUResource, nil
 }
 
 var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning node validation", func() {
 
 	var (
 		oc                      = exutil.NewCLIWithoutNamespace("cpu-partitioning").AsAdmin()
+		managedNamespace        = exutil.NewCLI("managed-namespace").SetManagedNamespace().AsAdmin()
 		ctx                     = context.Background()
 		isClusterCPUPartitioned = false
 	)
 
 	g.BeforeEach(func() {
 		isClusterCPUPartitioned = getCpuPartitionedStatus(oc) == ocpv1.CPUPartitioningAllNodes
+	})
+
+	g.AfterEach(func() {
+		o.Expect(cleanup(managedNamespace, managedNamespace.Namespace())).To(o.Succeed())
 	})
 
 	g.It("should have correct cpuset and cpushare set in crio containers", func() {
@@ -130,6 +141,18 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning no
 		if *controlPlaneTopology == ocpv1.ExternalTopologyMode {
 			g.Skip("Clusters with external control plane topology do not run PerformanceProfile Controller")
 		}
+
+		// Create deployment with limits to validate cpu limits are respected
+		requests := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("20m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		}
+		limits := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("30m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		}
+		_, err = createManagedDeployment(managedNamespace, requests, limits)
+		o.Expect(err).ToNot(o.HaveOccurred(), "error creating deployment with cpu limits")
 
 		nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred(), "error listing cluster nodes")
@@ -186,9 +209,12 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning no
 				// If we are in a CPU Partitioned cluster, containers MUST be annotated with the correct CPU Share at the CRIO level
 				// and the desired annotation cpu shares must equal the crio config cpu shares
 				if isClusterCPUPartitioned {
-					share, err := containerInfo.getAnnotationCPUShare()
-					o.Expect(err).ToNot(o.HaveOccurred(), "failed to get cpushares annotation json", err)
-					o.Expect(share).To(o.Equal(containerInfo.CPUShare), "cpushares do not match between crio config and desired")
+					resource, err := containerInfo.getAnnotationCPUResources()
+					o.Expect(err).ToNot(o.HaveOccurred(), "failed to get container resource annotation json", err)
+					o.Expect(resource.CPUShares).To(o.Equal(containerInfo.CPUShares), "cpushares do not match between crio config and desired")
+
+					desiredCPUQuota := milliCPUToQuota(resource.CPULimit, containerInfo.CPUPeriod)
+					o.Expect(desiredCPUQuota).To(o.Equal(containerInfo.CPUQuota), "cpuquota do not match between crio config and desired")
 				}
 			}
 		}

--- a/test/extended/cpu_partitioning/utils.go
+++ b/test/extended/cpu_partitioning/utils.go
@@ -2,6 +2,8 @@ package cpu_partitioning
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 
 	o "github.com/onsi/gomega"
 	t "github.com/onsi/gomega/types"
@@ -10,14 +12,19 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/origin/test/extended/util/image"
 )
 
 const (
 	resourceLabel            = "management.workload.openshift.io/cores"
 	namespaceAnnotationKey   = "workload.openshift.io/allowed"
 	workloadAnnotations      = "target.workload.openshift.io/management"
-	WorkloadAnnotationPrefix = "resources.workload.openshift.io"
-	workloadAnnotationsRegex = WorkloadAnnotationPrefix + "/.*"
+	workloadAnnotationPrefix = "resources.workload.openshift.io"
+	workloadAnnotationsRegex = workloadAnnotationPrefix + "/.*"
 
 	expectedMessage    = "expected to"
 	notExpectedMessage = "expected not to"
@@ -25,6 +32,14 @@ const (
 	namespaceMachineConfigOperator = "openshift-machine-config-operator"
 	nodeWorkerLabel                = "node-role.kubernetes.io/worker"
 	nodeMasterLabel                = "node-role.kubernetes.io/master"
+
+	milliCPUToCPU = 1000
+	// 100000 microseconds is equivalent to 100ms
+	defaultQuotaPeriod = 100000
+	// 1000 microseconds is equivalent to 1ms
+	// defined here:
+	// https://github.com/torvalds/linux/blob/cac03ac368fabff0122853de2422d4e17a32de08/kernel/sched/core.c#L10546
+	minQuotaPeriod = 1000
 )
 
 var (
@@ -46,4 +61,90 @@ func adjustMatcherAndMessageForCluster(isClusterCPUPartitioned bool, matcher t.G
 		return o.Not(matcher), notExpectedMessage
 	}
 	return matcher, expectedMessage
+}
+
+// milliCPUToQuota converts milliCPU to CFS quota and period values.
+// Input parameters and resulting value is number of microseconds.
+func milliCPUToQuota(milliCPU, period int64) (quota int64) {
+	if milliCPU == 0 {
+		return quota
+	}
+
+	if period == 0 {
+		period = defaultQuotaPeriod
+	}
+
+	// We then convert the milliCPU to a value normalized over a period.
+	quota = (milliCPU * period) / milliCPUToCPU
+
+	// quota needs to be a minimum of 1ms.
+	if quota < minQuotaPeriod {
+		quota = minQuotaPeriod
+	}
+	return quota
+}
+
+func createManagedDeployment(oc *exutil.CLI, requests, limits corev1.ResourceList) (*appv1.Deployment, error) {
+	zero := int64(0)
+	depLabels := map[string]string{"app": "workload"}
+	name := "busy-box-deployment"
+
+	container := corev1.Container{
+		Name:  "busy-work",
+		Image: image.ShellImage(),
+		Command: []string{
+			"/bin/bash",
+			"-c",
+			`while true; do echo "Busy working, cycling through the ones and zeros"; sleep 5; done`,
+		},
+	}
+
+	if requests != nil {
+		container.Resources.Requests = requests
+	}
+	if limits != nil {
+		container.Resources.Limits = limits
+	}
+
+	deployment := &appv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: depLabels,
+		},
+		Spec: appv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: depLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      depLabels,
+					Annotations: deploymentPodAnnotation,
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &zero,
+					Containers: []corev1.Container{
+						container,
+					},
+				},
+			},
+		},
+	}
+
+	return oc.KubeClient().AppsV1().
+		Deployments(oc.Namespace()).
+		Create(context.Background(), deployment, metav1.CreateOptions{})
+}
+
+func getWorkloadAnnotationResource(annotations map[string]string) (map[string]crioCPUResource, error) {
+	resources := map[string]crioCPUResource{}
+	for k, v := range annotations {
+		if strings.Contains(k, workloadAnnotationPrefix) {
+			r := crioCPUResource{}
+			if err := json.Unmarshal([]byte(v), &r); err != nil {
+				return resources, err
+			}
+			resources[strings.TrimPrefix(k, workloadAnnotationPrefix+"/")] = r
+		}
+	}
+	return resources, nil
 }

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1471,6 +1471,8 @@ var Annotations = map[string]string{
 
 	"[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster workloads in non-annotated namespaces should be allowed if CPUPartitioningMode = AllNodes with a warning annotation": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster workloads with limits should have resources modified if CPUPartitioningMode = AllNodes": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node][apigroup:config.openshift.io] CPU Partitioning node validation should have correct cpuset and cpushare set in crio containers": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
workload partitioning now supports cpu limits in resources added a new test and updated existing ones to validate it.

added test to check annotations and resources have been altered updated existing crio check to also validate cpu limits via quota settings