### PR TITLE
WIP: Webhook test refactor

### DIFF
--- a/test/extended/builds/webhook.go
+++ b/test/extended/builds/webhook.go
@@ -43,6 +43,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][webhook]", func() {
 		g.BeforeEach(func() {
 			clusterAdminBuildClient = oc.AdminBuildClient().BuildV1()
 			adminHTTPClient = clusterAdminBuildClient.RESTClient().(*rest.RESTClient).Client
+			o.Expect(adminHTTPClient).NotTo(o.BeNil(), "check authenticated HTTP client")
 
 			// create buildconfig
 			buildConfig := mockBuildConfigImageParms("originalimage", "imagestream", "validtag")

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -183,6 +183,7 @@
 // test/extended/testdata/builds/webhook/github/testdata/pushevent.json
 // test/extended/testdata/builds/webhook/gitlab/testdata/pushevent-not-master-branch.json
 // test/extended/testdata/builds/webhook/gitlab/testdata/pushevent.json
+// test/extended/testdata/builds/webhook/webhooks-unauth.yaml
 // test/extended/testdata/cli/test-release-image-references.json
 // test/extended/testdata/cluster/master-vert.yaml
 // test/extended/testdata/cluster/quickstarts/cakephp-mysql.json
@@ -24475,6 +24476,40 @@ func testExtendedTestdataBuildsWebhookGitlabTestdataPusheventJson() (*asset, err
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/builds/webhook/gitlab/testdata/pushevent.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsWebhookWebhooksUnauthYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: webhooks-unauth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:webhook
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated
+`)
+
+func testExtendedTestdataBuildsWebhookWebhooksUnauthYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsWebhookWebhooksUnauthYaml, nil
+}
+
+func testExtendedTestdataBuildsWebhookWebhooksUnauthYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsWebhookWebhooksUnauthYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/webhook/webhooks-unauth.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -54970,6 +55005,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/builds/webhook/github/testdata/pushevent.json":                                   testExtendedTestdataBuildsWebhookGithubTestdataPusheventJson,
 	"test/extended/testdata/builds/webhook/gitlab/testdata/pushevent-not-master-branch.json":                 testExtendedTestdataBuildsWebhookGitlabTestdataPusheventNotMasterBranchJson,
 	"test/extended/testdata/builds/webhook/gitlab/testdata/pushevent.json":                                   testExtendedTestdataBuildsWebhookGitlabTestdataPusheventJson,
+	"test/extended/testdata/builds/webhook/webhooks-unauth.yaml":                                             testExtendedTestdataBuildsWebhookWebhooksUnauthYaml,
 	"test/extended/testdata/cli/test-release-image-references.json":                                          testExtendedTestdataCliTestReleaseImageReferencesJson,
 	"test/extended/testdata/cluster/master-vert.yaml":                                                        testExtendedTestdataClusterMasterVertYaml,
 	"test/extended/testdata/cluster/quickstarts/cakephp-mysql.json":                                          testExtendedTestdataClusterQuickstartsCakephpMysqlJson,
@@ -55602,6 +55638,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 								"pushevent.json":                   {testExtendedTestdataBuildsWebhookGitlabTestdataPusheventJson, map[string]*bintree{}},
 							}},
 						}},
+						"webhooks-unauth.yaml": {testExtendedTestdataBuildsWebhookWebhooksUnauthYaml, map[string]*bintree{}},
 					}},
 				}},
 				"cli": {nil, map[string]*bintree{

--- a/test/extended/testdata/builds/webhook/webhooks-unauth.yaml
+++ b/test/extended/testdata/builds/webhook/webhooks-unauth.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: webhooks-unauth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:webhook
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -641,6 +641,16 @@ var Annotations = map[string]string{
 
 	"[sig-builds][Feature:Builds][volumes] csi build volumes within Tech Preview enabled cluster [apigroup:config.openshift.io] should mount given csi shared resource secret without resource refresh into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-builds][Feature:Builds][webhook] TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io] bitbucket": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-builds][Feature:Builds][webhook] TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io] generic": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-builds][Feature:Builds][webhook] TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io] github": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-builds][Feature:Builds][webhook] TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io] gitlab": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-builds][Feature:Builds][webhook] TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io] unauthenticated forbidden": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-builds][Feature:Builds][webhook] TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-builds][Feature:Builds][webhook] TestWebhookGitHubPing [apigroup:image.openshift.io][apigroup:build.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Starting in OCP 4.16, the `system:webhook` ClusterRole will not be
granted to anonymous users by default. This will break most systems
that use BuildConfig webhooks to trigger builds, since many can't be
add an OpenShift auth token to their HTTP headers (ex: GitHub). Only
new installations will be impacted; upgrades to 4.16 will continue to
support unauthenticated BuildConfig webhooks.

This test update verifies that BuildConfig webhooks can be triggered
using a namespace-scoped RoleBinding for the `system:unauthenticated`
group. RoleBindings are preferable to ClusterRoleBindings as they limit
unauthenticated API calls to specific namespaces, reducing the
potential attack surface. The core webhook tests were also updated to
verify that unauthenticated webhooks fail if this rolebinding is
missing.

Use of BuildConfig webhooks should be discouraged in favor of Pipelines
as Code, which has more robust mechanisms for securing webhook calls
from external systems. It also does not rely on an aggregated apiserver
and associated RBAC.

This PR also includes a refactor of the core BuildConfig webhook test suite, to take advantage of Ginkgo v2's table driven test functions. This makes the test more readable and provides missing context on error.