### PR TITLE
OCPBUGS-29373: test/extended/router/http2: Use unique certs

### DIFF
--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -234,14 +234,23 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			notBefore := time.Now().Add(-24 * time.Hour)
 			notAfter := time.Now().Add(24 * time.Hour)
 
-			// Generate crt/key for routes that need them.
-			_, tlsCrtData, tlsPrivateKey, err := certgen.GenerateKeyPair(notBefore, notAfter)
+			// Generate crts/keys for routes that need them.
+			_, tlsCrt1Data, tlsPrivateKey1, err := certgen.GenerateKeyPair(notBefore, notAfter)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			derKey, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey)
+			_, tlsCrt2Data, tlsPrivateKey2, err := certgen.GenerateKeyPair(notBefore, notAfter)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			pemCrt, err := certgen.MarshalCertToPEMString(tlsCrtData)
+			derKey1, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey1)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			derKey2, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey2)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			pemCrt1, err := certgen.MarshalCertToPEMString(tlsCrt1Data)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			pemCrt2, err := certgen.MarshalCertToPEMString(tlsCrt2Data)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			shardFQDN := oc.Namespace() + "." + defaultDomain
@@ -319,8 +328,8 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationEdge,
 							InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-							Key:                           derKey,
-							Certificate:                   pemCrt,
+							Key:                           derKey1,
+							Certificate:                   pemCrt1,
 						},
 						To: routev1.RouteTargetReference{
 							Kind:   "Service",
@@ -345,8 +354,8 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationReencrypt,
 							InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-							Key:                           derKey,
-							Certificate:                   pemCrt,
+							Key:                           derKey2,
+							Certificate:                   pemCrt2,
 						},
 						To: routev1.RouteTargetReference{
 							Kind:   "Service",


### PR DESCRIPTION
Use a unique certificate for each route in the "The HAProxy router should pass the http2 tests" extended test.

To fix OCPBUGS-29373, OpenShift router will be changed to configure HAProxy not to negotiate HTTP/2 with TLS ALPN for routes that share certificates. This change in the router causes the aforesaid extended test to fail because it uses the same certificate for two test routes that are used to verify HTTP/2 compliance.

After this PR, the extended tests should pass with the router change.