### PR TITLE
SDN-4168: Increase IPsec timeout parameters

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -251,7 +251,7 @@ var staticSuites = []ginkgo.TestSuite{
 			return strings.Contains(name, "[Suite:openshift/network/ipsec")
 		},
 		Parallelism: 1,
-		TestTimeout: 60 * time.Minute,
+		TestTimeout: 120 * time.Minute,
 	},
 	{
 		Name: "openshift/network/stress",

--- a/test/extended/networking/ipsec.go
+++ b/test/extended/networking/ipsec.go
@@ -31,7 +31,7 @@ const (
 	tcpdumpICMPFilter            = "icmp and src %s and dst %s"
 	masterIPsecMachineConfigName = "80-ipsec-master-extensions"
 	workerIPSecMachineConfigName = "80-ipsec-worker-extensions"
-	ipsecRolloutWaitDuration     = 20 * time.Minute
+	ipsecRolloutWaitDuration     = 40 * time.Minute
 	ipsecRolloutWaitInterval     = 1 * time.Minute
 	nmstateConfigureManifestFile = "nmstate.yaml"
 	nsCertMachineConfigFile      = "ipsec-nsconfig-machine-config.yaml"


### PR DESCRIPTION
It is found that the IPsec tests need extra time to rollout different IPsec modes and finish executing each test in CI cluster. Hence this PR increases those timeout values accordingly.

Sample runs:

- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50687/rehearse-50687-pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-ipsec-serial/1788123460904423424
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50687/rehearse-50687-pull-ci-openshift-cluster-network-operator-release-4.16-e2e-aws-ovn-ipsec-serial/1788123460988309504
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50687/rehearse-50687-pull-ci-openshift-origin-master-e2e-aws-ovn-ipsec-serial/1788123460661153792
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50687/rehearse-50687-pull-ci-openshift-origin-release-4.16-e2e-aws-ovn-ipsec-serial/1788123460749234176
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50687/rehearse-50687-pull-ci-openshift-origin-release-4.17-e2e-aws-ovn-ipsec-serial/1788123460828925952