### PR TITLE
OCPBUGS-33378: Verify Build Webhooks on Upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10
 	go.etcd.io/etcd/client/v3 v3.5.10
 	golang.org/x/crypto v0.21.0
+	golang.org/x/mod v0.14.0
 	golang.org/x/net v0.23.0
 	golang.org/x/oauth2 v0.10.0
 	golang.org/x/sync v0.5.0
@@ -251,7 +252,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
-	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/pkg/clusterversion/doc.go
+++ b/pkg/clusterversion/doc.go
@@ -1,0 +1,2 @@
+// Package clusterversion contains utitlities to access version information for the cluster.
+package clusterversion

--- a/pkg/clusterversion/upgrade.go
+++ b/pkg/clusterversion/upgrade.go
@@ -1,0 +1,45 @@
+package clusterversion
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// IsUpgradedFromMinorVersion returns true if the cluster has been upgraded from or through the given version.
+// This will only check for X.Y version upgrades - it will ignore patch/z-stream versions.
+// Returns false if the input version is not a semver.
+func IsUpgradedFromMinorVersion(version string, cv *configv1.ClusterVersion) bool {
+	fromMajorMinor := majorMinorVersion(version)
+	if !semver.IsValid(fromMajorMinor) {
+		return false
+	}
+
+	beforeOrAtVersionFound := false
+	atOrLaterVersionFound := false
+
+	// History is always ordered from most recent to oldest.
+	for _, history := range cv.Status.History {
+		historyMajorMinor := majorMinorVersion(history.Version)
+		// Version in history can be empty or not a semver. Skip in this case.
+		if !semver.IsValid(historyMajorMinor) {
+			continue
+		}
+		if semver.Compare(historyMajorMinor, fromMajorMinor) >= 0 {
+			atOrLaterVersionFound = true
+		}
+		if semver.Compare(historyMajorMinor, fromMajorMinor) <= 0 {
+			beforeOrAtVersionFound = true
+		}
+	}
+	return beforeOrAtVersionFound && atOrLaterVersionFound
+}
+
+func majorMinorVersion(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return semver.MajorMinor(version)
+}

--- a/pkg/clusterversion/upgrade_test.go
+++ b/pkg/clusterversion/upgrade_test.go
@@ -1,0 +1,71 @@
+package clusterversion
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestIsUpgradedFromMinorVersion(t *testing.T) {
+	cases := []struct {
+		Name               string
+		UpgradeFromVersion string
+		VersionHistory     []string
+		Expected           bool
+	}{
+		{
+			Name:               "no history",
+			UpgradeFromVersion: "4.15",
+			Expected:           false,
+		},
+		{
+			Name:               "upgraded to 4.16 from 4.15",
+			UpgradeFromVersion: "4.15",
+			VersionHistory:     []string{"4.16.0", "4.15.9", "4.15.7", "4.15.2"},
+			Expected:           true,
+		},
+		{
+			Name:               "upgraded to 4.16 from 4.14",
+			UpgradeFromVersion: "4.15",
+			VersionHistory:     []string{"4.16.0", "4.15.9", "4.15.7", "4.15.2", "4.14.9"},
+			Expected:           true,
+		},
+		{
+			Name:               "skip odd minor version",
+			UpgradeFromVersion: "4.15",
+			VersionHistory:     []string{"4.16.0", "4.14.9", "4.14.2", "4.12.14", "4.12.8"},
+			Expected:           true,
+		},
+		{
+			Name:               "not reached upgrade",
+			UpgradeFromVersion: "4.15",
+			VersionHistory:     []string{"4.14.0", "4.13.9", "4.13.2", "4.12.14", "4.12.8"},
+			Expected:           false,
+		},
+		{
+			Name:               "invalid version",
+			UpgradeFromVersion: "bad-data",
+			VersionHistory:     []string{"4.16.0", "4.15.9", "4.15.7"},
+			Expected:           false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			history := []configv1.UpdateHistory{}
+			for _, version := range tc.VersionHistory {
+				history = append(history, configv1.UpdateHistory{
+					Version: version,
+				})
+			}
+			cv := &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					History: history,
+				},
+			}
+			upgraded := IsUpgradedFromMinorVersion(tc.UpgradeFromVersion, cv)
+			if upgraded != tc.Expected {
+				t.Errorf("expected %v, got %v", tc.Expected, upgraded)
+			}
+		})
+	}
+}

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -14,6 +14,8 @@ import (
 	o "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -409,6 +411,43 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("start a build via a webhook", func() {
+
+				// AUTH-509: Webhooks do not allow unauthenticated requests by default.
+				// Create a role binding which allows unauthenticated webhooks.
+				g.BeforeEach(func() {
+					ctx := context.Background()
+					adminRoleBindingsClient := oc.AdminKubeClient().RbacV1().RoleBindings(oc.Namespace())
+					_, err := adminRoleBindingsClient.Get(ctx, "webooks-unauth", metav1.GetOptions{})
+					if apierrors.IsNotFound(err) {
+						unauthWebhooksRB := &rbacv1.RoleBinding{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "webooks-unauth",
+							},
+							RoleRef: rbacv1.RoleRef{
+								APIGroup: "rbac.authorization.k8s.io",
+								Kind:     "ClusterRole",
+								Name:     "system:webhook",
+							},
+							Subjects: []rbacv1.Subject{
+								{
+									APIGroup: "rbac.authorization.k8s.io",
+									Kind:     "Group",
+									Name:     "system:authenticated",
+								},
+								{
+									APIGroup: "rbac.authorization.k8s.io",
+									Kind:     "Group",
+									Name:     "system:unauthenticated",
+								},
+							},
+						}
+						_, err = adminRoleBindingsClient.Create(ctx, unauthWebhooksRB, metav1.CreateOptions{})
+						o.Expect(err).NotTo(o.HaveOccurred(), "creating webhook role binding")
+						return
+					}
+					o.Expect(err).NotTo(o.HaveOccurred(), "checking if webhook role binding exists")
+				})
+
 				g.It("should be able to start builds via the webhook with valid secrets and fail with invalid secrets [apigroup:build.openshift.io]", func() {
 					g.By("clearing existing builds")
 					_, err := oc.Run("delete").Args("builds", "--all").Output()

--- a/test/extended/builds/webhook.go
+++ b/test/extended/builds/webhook.go
@@ -3,10 +3,12 @@ package builds
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -25,7 +27,10 @@ import (
 
 var _ = g.Describe("[sig-builds][Feature:Builds][webhook]", func() {
 	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithPodSecurityLevel("build-webhooks", admissionapi.LevelBaseline)
+
+	var (
+		oc = exutil.NewCLIWithPodSecurityLevel("build-webhooks", admissionapi.LevelBaseline)
+	)
 
 	g.It("TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
 		TestWebhook(g.GinkgoT(), oc)
@@ -43,6 +48,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][webhook]", func() {
 
 func TestWebhook(t g.GinkgoTInterface, oc *exutil.CLI) {
 	clusterAdminBuildClient := oc.AdminBuildClient().BuildV1()
+	adminHTTPClient := clusterAdminBuildClient.RESTClient().(*rest.RESTClient).Client
 
 	// create buildconfig
 	buildConfig := mockBuildConfigImageParms("originalimage", "imagestream", "validtag")
@@ -53,10 +59,12 @@ func TestWebhook(t g.GinkgoTInterface, oc *exutil.CLI) {
 	// Bug #1752581: reduce number of URLs per test case
 	// OCP 4.2 tests on GCP had high flake levels because namespaces took too long to tear down
 	tests := []struct {
-		Name       string
-		Payload    string
-		HeaderFunc func(*http.Header)
-		URLs       []string
+		Name           string
+		Payload        string
+		HeaderFunc     func(*http.Header)
+		URLs           []string
+		client         *http.Client
+		expectedStatus int
 	}{
 		{
 			Name:       "generic",
@@ -65,6 +73,8 @@ func TestWebhook(t g.GinkgoTInterface, oc *exutil.CLI) {
 			URLs: []string{
 				"/apis/build.openshift.io/v1/namespaces/" + oc.Namespace() + "/buildconfigs/pushbuild/webhooks/secret200/generic",
 			},
+			client:         adminHTTPClient,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			Name:       "github",
@@ -73,6 +83,8 @@ func TestWebhook(t g.GinkgoTInterface, oc *exutil.CLI) {
 			URLs: []string{
 				"/apis/build.openshift.io/v1/namespaces/" + oc.Namespace() + "/buildconfigs/pushbuild/webhooks/secret100/github",
 			},
+			client:         adminHTTPClient,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			Name:       "gitlab",
@@ -81,6 +93,8 @@ func TestWebhook(t g.GinkgoTInterface, oc *exutil.CLI) {
 			URLs: []string{
 				"/apis/build.openshift.io/v1/namespaces/" + oc.Namespace() + "/buildconfigs/pushbuild/webhooks/secret300/gitlab",
 			},
+			client:         adminHTTPClient,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			Name:       "bitbucket",
@@ -89,6 +103,29 @@ func TestWebhook(t g.GinkgoTInterface, oc *exutil.CLI) {
 			URLs: []string{
 				"/apis/build.openshift.io/v1/namespaces/" + oc.Namespace() + "/buildconfigs/pushbuild/webhooks/secret400/bitbucket",
 			},
+			client:         adminHTTPClient,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			// AUTH-509: Webhooks do not allow unauthenticated requests by default.
+			// Test will verify that an unauthenticated request fails with 403 Forbidden.
+			Name:       "unauthenticated forbidden",
+			Payload:    "generic/testdata/push-generic.json",
+			HeaderFunc: genericHeaderFunc,
+			URLs: []string{
+				"/apis/build.openshift.io/v1/namespaces/" + oc.Namespace() + "/buildconfigs/pushbuild/webhooks/secret200/generic",
+			},
+			// Need client to skip TLS verification - CI clusters have self-signed certificates.
+			// Transport also needs to accept proxy information from *_PROXY environment variables.
+			client: &http.Client{
+				Transport: &http.Transport{
+					Proxy: http.ProxyFromEnvironment,
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				},
+			},
+			expectedStatus: http.StatusForbidden,
 		},
 	}
 
@@ -99,8 +136,12 @@ func TestWebhook(t g.GinkgoTInterface, oc *exutil.CLI) {
 			clusterAdminClientConfig := oc.AdminConfig()
 
 			g.By("executing the webhook to get the build object")
-			body := postFile(clusterAdminBuildClient.RESTClient(), test.HeaderFunc, test.Payload, clusterAdminClientConfig.Host+s, http.StatusOK, t, oc)
+			body := postFile(test.client, test.HeaderFunc, test.Payload, clusterAdminClientConfig.Host+s, test.expectedStatus, t, oc)
 			o.Expect(body).NotTo(o.BeEmpty())
+			// If expected HTTP status is not 200 OK, continue as we will not receive a Build object in the response body.
+			if test.expectedStatus != http.StatusOK {
+				continue
+			}
 
 			g.By("Unmarshalling the build object")
 			returnedBuild := &buildv1.Build{}
@@ -124,6 +165,7 @@ func TestWebhookGitHubPushWithImage(t g.GinkgoTInterface, oc *exutil.CLI) {
 	clusterAdminClientConfig := oc.AdminConfig()
 	clusterAdminImageClient := oc.AdminImageClient().ImageV1()
 	clusterAdminBuildClient := oc.AdminBuildClient().BuildV1()
+	adminHTTPClient := clusterAdminBuildClient.RESTClient().(*rest.RESTClient).Client
 
 	// create imagerepo
 	imageStream := &imagev1.ImageStream{
@@ -173,7 +215,7 @@ func TestWebhookGitHubPushWithImage(t g.GinkgoTInterface, oc *exutil.CLI) {
 	} {
 
 		// trigger build event sending push notification
-		body := postFile(clusterAdminBuildClient.RESTClient(), githubHeaderFunc, "github/testdata/pushevent.json", clusterAdminClientConfig.Host+s, http.StatusOK, t, oc)
+		body := postFile(adminHTTPClient, githubHeaderFunc, "github/testdata/pushevent.json", clusterAdminClientConfig.Host+s, http.StatusOK, t, oc)
 		if len(body) == 0 {
 			t.Errorf("Webhook did not return Build in body")
 		}
@@ -201,7 +243,6 @@ func TestWebhookGitHubPushWithImage(t g.GinkgoTInterface, oc *exutil.CLI) {
 		if actual.Spec.Strategy.DockerStrategy.From.Name != "originalimage" {
 			t.Errorf("Expected %s, got %s", "originalimage", actual.Spec.Strategy.DockerStrategy.From.Name)
 		}
-
 		if actual.Name != returnedBuild.Name {
 			t.Errorf("Build returned in response body does not match created Build. Expected %s, got %s", actual.Name, returnedBuild.Name)
 		}
@@ -214,6 +255,7 @@ func TestWebhookGitHubPushWithImageStream(t g.GinkgoTInterface, oc *exutil.CLI) 
 	clusterAdminClientConfig := oc.AdminConfig()
 	clusterAdminImageClient := oc.AdminImageClient().ImageV1()
 	clusterAdminBuildClient := oc.AdminBuildClient().BuildV1()
+	adminHTTPClient := clusterAdminBuildClient.RESTClient().(*rest.RESTClient).Client
 
 	// create imagerepo
 	imageStream := &imagev1.ImageStream{
@@ -265,7 +307,7 @@ func TestWebhookGitHubPushWithImageStream(t g.GinkgoTInterface, oc *exutil.CLI) 
 	s := "/apis/build.openshift.io/v1/namespaces/" + oc.Namespace() + "/buildconfigs/pushbuild/webhooks/secret101/github"
 
 	// trigger build event sending push notification
-	postFile(clusterAdminBuildClient.RESTClient(), githubHeaderFunc, "github/testdata/pushevent.json", clusterAdminClientConfig.Host+s, http.StatusOK, t, oc)
+	postFile(adminHTTPClient, githubHeaderFunc, "github/testdata/pushevent.json", clusterAdminClientConfig.Host+s, http.StatusOK, t, oc)
 
 	var build *buildv1.Build
 
@@ -291,6 +333,7 @@ Loop:
 
 func TestWebhookGitHubPing(t g.GinkgoTInterface, oc *exutil.CLI) {
 	clusterAdminBuildClient := oc.AdminBuildClient().BuildV1()
+	adminHTTPClient := clusterAdminBuildClient.RESTClient().(*rest.RESTClient).Client
 
 	// create buildconfig
 	buildConfig := mockBuildConfigImageParms("originalimage", "imagestream", "validtag")
@@ -312,7 +355,7 @@ func TestWebhookGitHubPing(t g.GinkgoTInterface, oc *exutil.CLI) {
 		// trigger build event sending push notification
 		clusterAdminClientConfig := oc.AdminConfig()
 
-		postFile(clusterAdminBuildClient.RESTClient(), githubHeaderFuncPing, "github/testdata/pingevent.json", clusterAdminClientConfig.Host+s, http.StatusOK, t, oc)
+		postFile(adminHTTPClient, githubHeaderFuncPing, "github/testdata/pingevent.json", clusterAdminClientConfig.Host+s, http.StatusOK, t, oc)
 
 		// TODO: improve negative testing
 		timer := time.NewTimer(time.Second * 5)
@@ -326,9 +369,9 @@ func TestWebhookGitHubPing(t g.GinkgoTInterface, oc *exutil.CLI) {
 	}
 }
 
-func postFile(client rest.Interface, headerFunc func(*http.Header), filename, url string, expStatusCode int, t g.GinkgoTInterface, oc *exutil.CLI) []byte {
+func postFile(client *http.Client, headerFunc func(*http.Header), filename, url string, expStatusCode int, t g.GinkgoTInterface, oc *exutil.CLI) []byte {
 	path := exutil.FixturePath("testdata", "builds", "webhook", filename)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("Failed to open %s: %v", filename, err)
 	}
@@ -337,11 +380,11 @@ func postFile(client rest.Interface, headerFunc func(*http.Header), filename, ur
 		t.Fatalf("Error creating POST request: %v", err)
 	}
 	headerFunc(&req.Header)
-	resp, err := client.(*rest.RESTClient).Client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("Failed posting webhook: %v", err)
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != expStatusCode {
 		t.Errorf("Wrong response code, expecting %d, got %d: %s!", expStatusCode, resp.StatusCode, string(body))
 	}


### PR DESCRIPTION
Updating the build suite test to verify the unautenticated build webhook behavior on upgrade. For clusters upgrading from v4.15 or earlier to v4.16, unauthenticated webhooks should continue to be allowed. For clusters that upgrade from v4.16 to a later version, unauthenticated webhooks should be denied by default.