### PR TITLE
USHIFT-3142: Automatically exclude FeatureGate tagged tests

### DIFF
--- a/pkg/clioptions/suiteselection/feature_filter.go
+++ b/pkg/clioptions/suiteselection/feature_filter.go
@@ -3,10 +3,11 @@ package suiteselection
 import (
 	"context"
 	"fmt"
+	"regexp"
+
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"regexp"
 )
 
 type featureGateFilter struct {
@@ -70,6 +71,10 @@ func (f *featureGateFilter) includeTest(name string) bool {
 	}
 
 	return f.enabled.HasAll(featureGates...)
+}
+
+func includeNonFeatureGateTest(name string) bool {
+	return featureGateRegex.FindAllStringSubmatch(name, -1) == nil
 }
 
 var (

--- a/pkg/clioptions/suiteselection/suite_flags.go
+++ b/pkg/clioptions/suiteselection/suite_flags.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned"
 	"io/ioutil"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/client-go/discovery"
 
@@ -148,7 +149,9 @@ func (f *TestSuiteSelectionFlags) SelectSuite(
 		featureGateFilter, err := newFeatureGateFilter(context.TODO(), configClient)
 		switch {
 		case apierrors.IsNotFound(err):
-		// do nothing and we'll select all featuregated tests. this is the safest for something like microshift
+			// In case we are unable to determine if there is support for feature gates, exclude all featuregated tests
+			// as the test target doesnt comply with preconditions.
+			suite.AddRequiredMatchFunc(includeNonFeatureGateTest)
 		case err != nil:
 			return nil, fmt.Errorf("unable to build FeatureGate filter: %w", err)
 		default:


### PR DESCRIPTION
MicroShift does not have support for FeatureGate API. Exclude all tagged tests in case the cluster does not have explicit support for FeatureGate API.