### PR TITLE
#28776 FIX [release-4.15] OCPBUGS-33368: monitor test fix to wait before connecting to a non-existent dns on PowerVS and IBMCloud platforms

### DIFF
--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
@@ -201,6 +202,15 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 		return fmt.Errorf("error creating PDB: %w", err)
 	}
 
+	// On certain platforms hitting the hostname before it is ready leads to a blackhole, this code checks
+	// the host from the cluster's context
+	if infra.Spec.PlatformSpec.Type == configv1.PowerVSPlatformType || infra.Spec.PlatformSpec.Type == configv1.IBMCloudPlatformType {
+		nodeTgt := "node/" + nodeList.Items[0].ObjectMeta.Name
+		if err := checkHostnameReady(tcpService, nodeTgt); err != nil {
+			return err
+		}
+	}
+
 	// Hit it once before considering ourselves ready
 	fmt.Fprintf(os.Stderr, "hitting pods through the service's LoadBalancer\n")
 	timeout := 10 * time.Minute
@@ -314,4 +324,35 @@ func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Re
 	}
 
 	return client.Get(url)
+}
+
+// Uses the first node in the cluster to verify the LoadBalancer host is active before returning
+func checkHostnameReady(tcpService *corev1.Service, nodeTgt string) error {
+	oc := exutil.NewCLIForMonitorTest(tcpService.GetObjectMeta().GetNamespace())
+
+	var (
+		stdOut string
+		err    error
+	)
+
+	for i := 0; i < 60; i++ {
+		fmt.Printf("Checking load balancer host is active \n")
+		wait.Poll(3*time.Second, 60*time.Second, func() (bool, error) {
+			stdOut, _, err = oc.AsAdmin().WithoutNamespace().RunInMonitorTest("debug").Args(nodeTgt, "--", "dig", "+short", tcpService.Status.LoadBalancer.Ingress[0].Hostname).Outputs()
+			if err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+
+		output := strings.TrimSpace(stdOut)
+		if output == "" {
+			fmt.Println("waiting for the LB to come active")
+			time.Sleep(1 * time.Minute)
+			continue
+		} else {
+			break
+		}
+	}
+	return nil
 }

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -179,6 +179,32 @@ func NewCLIWithoutNamespace(project string) *CLI {
 	return cli
 }
 
+// NewCLIForMonitorTest initializes the CLI and Kube framework helpers
+// without a namespace. Should be called outside of a Ginkgo .It()
+// function.
+func NewCLIForMonitorTest(project string) *CLI {
+	cli := &CLI{
+		kubeFramework: &framework.Framework{
+			SkipNamespaceCreation: true,
+			BaseName:              project,
+			Options: framework.Options{
+				ClientQPS:   20,
+				ClientBurst: 50,
+			},
+			Timeouts: framework.NewTimeoutContext(),
+		},
+		username:                "admin",
+		execPath:                "oc",
+		adminConfigPath:         KubeConfigPath(),
+		staticConfigManifestDir: StaticConfigManifestDir(),
+		withoutNamespace:        true,
+	}
+
+	// Called only once (assumed the objects will never get modified)
+	cli.setupStaticConfigsFromManifests()
+	return cli
+}
+
 // NewHypershiftManagementCLI returns a CLI that interacts with the Hypershift management cluster.
 // Contrary to a normal CLI it does not perform any cleanup, and it must not be used for any mutating
 // operations. Also, contrary to a normal CLI it must be constructed inside an `It` block. This is
@@ -808,6 +834,22 @@ func (c *CLI) Run(commands ...string) *CLI {
 	}
 	if !c.withoutNamespace {
 		nc.globalArgs = append([]string{fmt.Sprintf("--namespace=%s", c.Namespace())}, nc.globalArgs...)
+	}
+	nc.stdin, nc.stdout, nc.stderr = in, out, errout
+	return nc.setOutput(c.stdout)
+}
+
+// Executes with the kubeconfig specified from the environment
+func (c *CLI) RunInMonitorTest(commands ...string) *CLI {
+	in, out, errout := &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
+	nc := &CLI{
+		execPath:        c.execPath,
+		verb:            commands[0],
+		kubeFramework:   c.KubeFramework(),
+		adminConfigPath: c.adminConfigPath,
+		configPath:      c.configPath,
+		username:        c.username,
+		globalArgs:      commands,
 	}
 	nc.stdin, nc.stdout, nc.stderr = in, out, errout
 	return nc.setOutput(c.stdout)


### PR DESCRIPTION
Added logrus to fix #28776 of cherry pic #28739 for release-4.15 branch