### PR TITLE
#28775 FIX [release-4.14] OCPBUGS-33367: monitor test fix to wait before connecting to a non-existent dns on PowerVS and IBMCloud platforms 

### DIFF
--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -200,7 +200,7 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 	// the host from the cluster's context
 	if infra.Spec.PlatformSpec.Type == configv1.PowerVSPlatformType || infra.Spec.PlatformSpec.Type == configv1.IBMCloudPlatformType {
 		nodeTgt := "node/" + nodeList.Items[0].ObjectMeta.Name
-		if err := checkHostnameReady(ctx, tcpService, nodeTgt); err != nil {
+		if err := checkHostnameReady(ctx, tcpService, nodeTgt, w.namespaceName); err != nil {
 			return err
 		}
 	}
@@ -321,7 +321,7 @@ func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Re
 }
 
 // Uses the first node in the cluster to verify the LoadBalancer host is active before returning
-func checkHostnameReady(ctx context.Context, tcpService *corev1.Service, nodeTgt string) error {
+func checkHostnameReady(ctx context.Context, tcpService *corev1.Service, nodeTgt string, namespace string) error {
 	oc := exutil.NewCLIForMonitorTest(tcpService.GetObjectMeta().GetNamespace())
 
 	var (
@@ -331,7 +331,7 @@ func checkHostnameReady(ctx context.Context, tcpService *corev1.Service, nodeTgt
 
 	wait.PollUntilContextTimeout(ctx, 15*time.Second, 60*time.Minute, true, func(ctx context.Context) (bool, error) {
 		logrus.Debug("Checking load balancer host is active \n")
-		stdOut, _, err = oc.AsAdmin().WithoutNamespace().RunInMonitorTest("debug").Args(nodeTgt, "--", "dig", "+short", "+notcp", tcpService.Status.LoadBalancer.Ingress[0].Hostname).Outputs()
+		stdOut, _, err = oc.AsAdmin().WithoutNamespace().RunInMonitorTest("debug").Args(nodeTgt, "--to-namespace="+namespace, "--", "dig", "+short", "+notcp", tcpService.Status.LoadBalancer.Ingress[0].Hostname).Outputs()
 		if err != nil {
 			return false, nil
 		}

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
@@ -194,6 +195,15 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 		return fmt.Errorf("error creating PDB: %w", err)
 	}
 
+	// On certain platforms hitting the hostname before it is ready leads to a blackhole, this code checks
+	// the host from the cluster's context
+	if infra.Spec.PlatformSpec.Type == configv1.PowerVSPlatformType || infra.Spec.PlatformSpec.Type == configv1.IBMCloudPlatformType {
+		nodeTgt := "node/" + nodeList.Items[0].ObjectMeta.Name
+		if err := checkHostnameReady(tcpService, nodeTgt); err != nil {
+			return err
+		}
+	}
+
 	// Hit it once before considering ourselves ready
 	fmt.Fprintf(os.Stderr, "hitting pods through the service's LoadBalancer\n")
 	timeout := 10 * time.Minute
@@ -307,4 +317,35 @@ func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Re
 	}
 
 	return client.Get(url)
+}
+
+// Uses the first node in the cluster to verify the LoadBalancer host is active before returning
+func checkHostnameReady(tcpService *corev1.Service, nodeTgt string) error {
+	oc := exutil.NewCLIForMonitorTest(tcpService.GetObjectMeta().GetNamespace())
+
+	var (
+		stdOut string
+		err    error
+	)
+
+	for i := 0; i < 60; i++ {
+		fmt.Printf("Checking load balancer host is active \n")
+		wait.Poll(3*time.Second, 60*time.Second, func() (bool, error) {
+			stdOut, _, err = oc.AsAdmin().WithoutNamespace().RunInMonitorTest("debug").Args(nodeTgt, "--", "dig", "+short", tcpService.Status.LoadBalancer.Ingress[0].Hostname).Outputs()
+			if err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+
+		output := strings.TrimSpace(stdOut)
+		if output == "" {
+			fmt.Println("waiting for the LB to come active")
+			time.Sleep(1 * time.Minute)
+			continue
+		} else {
+			break
+		}
+	}
+	return nil
 }

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -199,7 +199,7 @@ func (w *availability) StartCollection(ctx context.Context, adminRESTConfig *res
 	// the host from the cluster's context
 	if infra.Spec.PlatformSpec.Type == configv1.PowerVSPlatformType || infra.Spec.PlatformSpec.Type == configv1.IBMCloudPlatformType {
 		nodeTgt := "node/" + nodeList.Items[0].ObjectMeta.Name
-		if err := checkHostnameReady(tcpService, nodeTgt); err != nil {
+		if err := checkHostnameReady(ctx, tcpService, nodeTgt); err != nil {
 			return err
 		}
 	}
@@ -320,7 +320,7 @@ func httpGetNoConnectionPoolTimeout(url string, timeout time.Duration) (*http.Re
 }
 
 // Uses the first node in the cluster to verify the LoadBalancer host is active before returning
-func checkHostnameReady(tcpService *corev1.Service, nodeTgt string) error {
+func checkHostnameReady(ctx context.Context, tcpService *corev1.Service, nodeTgt string) error {
 	oc := exutil.NewCLIForMonitorTest(tcpService.GetObjectMeta().GetNamespace())
 
 	var (
@@ -328,24 +328,19 @@ func checkHostnameReady(tcpService *corev1.Service, nodeTgt string) error {
 		err    error
 	)
 
-	for i := 0; i < 60; i++ {
-		fmt.Printf("Checking load balancer host is active \n")
-		wait.Poll(3*time.Second, 60*time.Second, func() (bool, error) {
-			stdOut, _, err = oc.AsAdmin().WithoutNamespace().RunInMonitorTest("debug").Args(nodeTgt, "--", "dig", "+short", tcpService.Status.LoadBalancer.Ingress[0].Hostname).Outputs()
-			if err != nil {
-				return false, nil
-			}
-			return true, nil
-		})
-
+	wait.PollUntilContextTimeout(ctx, 15*time.Second, 60*time.Minute, true, func(ctx context.Context) (bool, error) {
+		logrus.Debug("Checking load balancer host is active \n")
+		stdOut, _, err = oc.AsAdmin().WithoutNamespace().RunInMonitorTest("debug").Args(nodeTgt, "--", "dig", "+short", "+notcp", tcpService.Status.LoadBalancer.Ingress[0].Hostname).Outputs()
+		if err != nil {
+			return false, nil
+		}
 		output := strings.TrimSpace(stdOut)
 		if output == "" {
-			fmt.Println("waiting for the LB to come active")
-			time.Sleep(1 * time.Minute)
-			continue
-		} else {
-			break
+			logrus.Debug("Waiting for the load balancer to become active")
+			return false, nil
 		}
-	}
-	return nil
+		logrus.Debug("Load balancer active")
+		return true, nil
+	})
+	return err
 }

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -179,6 +179,32 @@ func NewCLIWithoutNamespace(project string) *CLI {
 	return cli
 }
 
+// NewCLIForMonitorTest initializes the CLI and Kube framework helpers
+// without a namespace. Should be called outside of a Ginkgo .It()
+// function.
+func NewCLIForMonitorTest(project string) *CLI {
+	cli := &CLI{
+		kubeFramework: &framework.Framework{
+			SkipNamespaceCreation: true,
+			BaseName:              project,
+			Options: framework.Options{
+				ClientQPS:   20,
+				ClientBurst: 50,
+			},
+			Timeouts: framework.NewTimeoutContext(),
+		},
+		username:                "admin",
+		execPath:                "oc",
+		adminConfigPath:         KubeConfigPath(),
+		staticConfigManifestDir: StaticConfigManifestDir(),
+		withoutNamespace:        true,
+	}
+
+	// Called only once (assumed the objects will never get modified)
+	cli.setupStaticConfigsFromManifests()
+	return cli
+}
+
 // NewHypershiftManagementCLI returns a CLI that interacts with the Hypershift management cluster.
 // Contrary to a normal CLI it does not perform any cleanup, and it must not be used for any mutating
 // operations. Also, contrary to a normal CLI it must be constructed inside an `It` block. This is
@@ -790,6 +816,22 @@ func (c *CLI) Run(commands ...string) *CLI {
 	}
 	if !c.withoutNamespace {
 		nc.globalArgs = append([]string{fmt.Sprintf("--namespace=%s", c.Namespace())}, nc.globalArgs...)
+	}
+	nc.stdin, nc.stdout, nc.stderr = in, out, errout
+	return nc.setOutput(c.stdout)
+}
+
+// Executes with the kubeconfig specified from the environment
+func (c *CLI) RunInMonitorTest(commands ...string) *CLI {
+	in, out, errout := &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
+	nc := &CLI{
+		execPath:        c.execPath,
+		verb:            commands[0],
+		kubeFramework:   c.KubeFramework(),
+		adminConfigPath: c.adminConfigPath,
+		configPath:      c.configPath,
+		username:        c.username,
+		globalArgs:      commands,
 	}
 	nc.stdin, nc.stdout, nc.stderr = in, out, errout
 	return nc.setOutput(c.stdout)


### PR DESCRIPTION
Added logrus to fix #28775 of Cherry pick [#28739](https://github.com/openshift/origin/pull/28739) for release 4.14 branch