### PR TITLE
NO-JIRA: drop ocp-storage exceptions for termination policy

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -122,17 +122,9 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 			"pods/catalogd-controller-manager",
 		),
 		"openshift-cluster-csi-drivers": sets.NewString(
-			"containers[openstack-cinder-csi-driver-operator]",
-			"containers[azure-file-csi-driver-operator]",
-			"containers[shared-resource-csi-driver-operator]",
-			"containers[vmware-vsphere-csi-driver-operator]",
-			"containers[vsphere-webhook]",
 			"pods/kubevirt-csi-node",
 			"pods/nutanix-csi-controller",
 			"pods/nutanix-csi-node",
-			"pods/ibm-vpc-block-csi-controller",
-			"pods/ibm-vpc-block-csi-node",
-			"pods/powervs-block-csi-driver-operator",
 		),
 		"openshift-multus": sets.NewString(
 			"containers[multus-networkpolicy]",


### PR DESCRIPTION
Follow up to https://github.com/openshift/origin/pull/28777

This drops the exceptions that should be fixed by:

https://github.com/openshift/cluster-storage-operator/pull/470
https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/231
https://github.com/openshift/ibm-vpc-block-csi-driver-operator/pull/114

I'm hoping the presubmit jobs will tell us that they really are fixed.

/cc @deads2k @jsafrane
/test all
