### PR TITLE
SDN-4168: Optimize timing for IPsec tests 

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -260,7 +260,7 @@ var staticSuites = []ginkgo.TestSuite{
 			return strings.Contains(name, "[Suite:openshift/network/ipsec")
 		},
 		Parallelism: 1,
-		TestTimeout: 120 * time.Minute,
+		TestTimeout: 60 * time.Minute,
 	},
 	{
 		Name: "openshift/network/stress",

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1477,15 +1477,9 @@ var Annotations = map[string]string{
 
 	"[sig-network][Feature:EgressRouterCNI] when using openshift ovn-kubernetes should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][Feature:IPsec] when using openshift ovn-kubernetes check traffic for east west IPsec [apigroup:config.openshift.io] [Suite:openshift/network/ipsec] with IPsec in disabled mode": "",
+	"[sig-network][Feature:IPsec] when using openshift ovn-kubernetes check traffic [apigroup:config.openshift.io] [Suite:openshift/network/ipsec] with IPsec in external mode": "",
 
-	"[sig-network][Feature:IPsec] when using openshift ovn-kubernetes check traffic for east west IPsec [apigroup:config.openshift.io] [Suite:openshift/network/ipsec] with IPsec in external mode": "",
-
-	"[sig-network][Feature:IPsec] when using openshift ovn-kubernetes check traffic for east west IPsec [apigroup:config.openshift.io] [Suite:openshift/network/ipsec] with IPsec in full mode": "",
-
-	"[sig-network][Feature:IPsec] when using openshift ovn-kubernetes check traffic for north south IPsec [apigroup:config.openshift.io] [Suite:openshift/network/ipsec] with IPsec in external mode": "",
-
-	"[sig-network][Feature:IPsec] when using openshift ovn-kubernetes check traffic for north south IPsec [apigroup:config.openshift.io] [Suite:openshift/network/ipsec] with IPsec in full mode": "",
+	"[sig-network][Feature:IPsec] when using openshift ovn-kubernetes check traffic [apigroup:config.openshift.io] [Suite:openshift/network/ipsec] with IPsec in full mode": "",
 
 	"[sig-network][Feature:MultiNetworkPolicy][Serial][apigroup:operator.openshift.io] should enforce a network policies on secondary network IPv4": " [Suite:openshift/conformance/serial]",
 

--- a/test/extended/util/clusterversion.go
+++ b/test/extended/util/clusterversion.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -68,9 +69,10 @@ func DetermineImageFromRelease(ctx context.Context, oc *CLI, imageTagName string
 	if len(releaseImage) == 0 {
 		return "", fmt.Errorf("cannot determine release image from ClusterVersion resource")
 	}
+	podName := "extract-release-imagerefs"
 	podClient := e2epod.PodClientNS(oc.KubeFramework(), oc.Namespace())
 	podClient.CreateSync(ctx, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "extract-release-imagerefs"},
+		ObjectMeta: metav1.ObjectMeta{Name: podName},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
@@ -81,8 +83,15 @@ func DetermineImageFromRelease(ctx context.Context, oc *CLI, imageTagName string
 			},
 		},
 	})
-	defer podClient.Delete(ctx, "extract-release-imagerefs", metav1.DeleteOptions{})
-	imageRefsString := e2epod.ExecShellInContainer(oc.KubeFramework(), "extract-release-imagerefs", "imagerefs", "cat /release-manifests/image-references")
+	defer func() {
+		podClient.Delete(ctx, podName, metav1.DeleteOptions{})
+		err = e2epod.WaitForPodNotFoundInNamespace(ctx, oc.kubeFramework.ClientSet,
+			podName, oc.Namespace(), e2epod.PodDeleteTimeout)
+		if err != nil {
+			framework.Logf("pod %q is still found in namespace %q", podName, oc.Namespace())
+		}
+	}()
+	imageRefsString := e2epod.ExecShellInContainer(oc.KubeFramework(), podName, "imagerefs", "cat /release-manifests/image-references")
 	imageRefs := struct {
 		Spec struct {
 			Tags []struct {


### PR DESCRIPTION
The ipsec test suite takes about 5-6 hours to finish running the tests,  This PR optimizes ipsec tests such that it reboots only worker nodes for cert installation and tests execution time can be greatly reduced to 2-3 hrs.
