### PR TITLE
OCPEDGE-1101: skip etcd test for hardware speed on sno

### DIFF
--- a/test/extended/etcd/hardware_speed.go
+++ b/test/extended/etcd/hardware_speed.go
@@ -21,6 +21,11 @@ var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", func
 	oc := exutil.NewCLIWithoutNamespace("etcd-hardware-speed").AsAdmin()
 
 	g.BeforeEach(func() {
+		isSingleNode, err := exutil.IsSingleNode(context.Background(), oc.AdminConfigClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isSingleNode {
+			g.Skip("the test is for etcd peer communication which is not valid for single node")
+		}
 		//TODO remove this check once https://github.com/openshift/api/pull/1844 has merged
 		if !exutil.IsTechPreviewNoUpgrade(oc) {
 			g.Skip("the test is not expected to work within Tech Preview disabled clusters")


### PR DESCRIPTION
the following test is for peer communication for etcd, this is not valid for single node and can cause disruption increases.

/assign @dusk125 