### PR TITLE
OCPBUGS-33944: Fix regex parser for censoring private key

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -557,7 +557,7 @@ func DumpPodLogs(pods []corev1.Pod, oc *CLI) {
 		if err == nil {
 			if strings.Contains(descOutput, "BEGIN PRIVATE KEY") {
 				// replace private key with XXXXX string
-				re := regexp.MustCompile(`BEGIN\s+PRIVATE\s+KEY.*END\s+PRIVATE\s+KEY`)
+				re := regexp.MustCompile(`BEGIN\s+PRIVATE\s+KEY[\s\S]*END\s+PRIVATE\s+KEY`)
 				descOutput = re.ReplaceAllString(descOutput, "XXXXXXXXXXXXXX")
 			}
 			e2e.Logf("Describing pod %q\n%s\n\n", pod.Name, descOutput)


### PR DESCRIPTION
The current regex parser fails to match when there is a new line. Have fixed it to match any whitespace/non whitespace character. Mocked a negative test run locally and verified that it works fine and pasted the results below. The private key is now censored as XXXX as shown below

BEFORE:
```
`Environment:
        POD_NAMESPACE:        e2e-test-unprivileged-router-7qzms (v1:metadata.namespace)
        DEFAULT_CERTIFICATE:
                              -----BEGIN CERTIFICATE-----
                              **<Certificate is displayed here, its not censored in the logs, I have just not copied it here for security reasons>**
                              -----END CERTIFICATE-----
                              -----BEGIN PRIVATE KEY-----
                              **<Private key is displayed here, I have just not copied it here for security reasons>**
                              -----END PRIVATE KEY-----

 Mounts:
        /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-rgtsw (ro)`
```

AFTER:
```
`Environment:
        POD_NAMESPACE:        e2e-test-unprivileged-router-x8c78 (v1:metadata.namespace)
        DEFAULT_CERTIFICATE:
                              -----BEGIN CERTIFICATE-----
                              **<Certificate is displayed here, its not censored in the logs, I have just not copied it here for security reasons>**
                              -----END CERTIFICATE-----
                              -----XXXXXXXXXXXXXX-----          ====> private key censored here

 Mounts:
        /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-sxhq4 (ro)`
```