### PR TITLE
API-1783: Conditionally skip tests to help with k8s 1.30

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -611,7 +611,11 @@ func (o *GinkgoRunSuiteOptions) filterOutRebaseTests(restConfig *rest.Config, te
 
 	// Below list should only be filled in when we're trying to land k8s rebase.
 	// Don't pile them up!
-	exclusions := []string{}
+	exclusions := []string{
+		// compare https://github.com/kubernetes/kubernetes/pull/123405
+		// which changed the healthz handler name
+		`[sig-api-machinery] health handlers should contain necessary checks`,
+	}
 
 	matches := make([]*testCase, 0, len(tests))
 outerLoop:


### PR DESCRIPTION
This will help with metal failures like https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-kubernetes-1953-nightly-4.17-e2e-metal-ipi-ovn-bm/1791720908369432576 because the healthz handler changed its name.

/assign @dinhxuanvu 