### PR TITLE
STOR-1892: Add option to disable all monitors

### DIFF
--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -88,7 +88,7 @@ func (f *RunMonitorFlags) BindFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&f.DisplayFromNow, "display-from-now", f.DisplayFromNow, "Only display intervals from at or after this comand was started.")
 	flags.StringSliceVar(&f.ExactMonitorTests, "monitor", f.ExactMonitorTests,
 		fmt.Sprintf("list of exactly which monitors to enable. All others will be disabled.  Current monitors are: [%s]", strings.Join(monitorNames, ", ")))
-	flags.StringSliceVar(&f.DisableMonitorTests, "disable-monitor", f.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored.")
+	flags.StringSliceVar(&f.DisableMonitorTests, "disable-monitor", f.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored. Special value 'all' disables all monitors.")
 	flags.StringVar(&f.FromRepository, "from-repository", f.FromRepository, "A container image repository to retrieve test images from.")
 }
 

--- a/pkg/cmd/openshift-tests/run-test/command.go
+++ b/pkg/cmd/openshift-tests/run-test/command.go
@@ -2,13 +2,13 @@ package run_test
 
 import (
 	"fmt"
-	"github.com/openshift/origin/pkg/defaultmonitortests"
 	"os"
 	"strings"
 
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/clioptions/imagesetup"
 	"github.com/openshift/origin/pkg/clioptions/upgradeoptions"
+	"github.com/openshift/origin/pkg/defaultmonitortests"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
@@ -77,6 +77,6 @@ func NewRunTestCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVar(&testOpt.DryRun, "dry-run", testOpt.DryRun, "Print the test to run without executing them.")
 	cmd.Flags().StringSliceVar(&testOpt.ExactMonitorTests, "monitor", testOpt.ExactMonitorTests,
 		fmt.Sprintf("list of exactly which monitors to enable. All others will be disabled.  Current monitors are: [%s]", strings.Join(monitorNames, ", ")))
-	cmd.Flags().StringSliceVar(&testOpt.DisableMonitorTests, "disable-monitor", testOpt.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored.")
+	cmd.Flags().StringSliceVar(&testOpt.DisableMonitorTests, "disable-monitor", testOpt.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored. Special value 'all' disables all monitors.")
 	return cmd
 }

--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -49,6 +49,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/testframework/watchevents"
 	"github.com/openshift/origin/pkg/monitortests/testframework/watchrequestcountscollector"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // ListAllMonitorTests is a helper that returns a simple list of
@@ -90,6 +91,11 @@ func NewMonitorTestsFor(info monitortestframework.MonitorTestInitializationInfo)
 	case len(info.DisableMonitorTests) > 0:
 		testsToInclude := startingRegistry.ListMonitorTests()
 		testsToInclude.Delete(info.DisableMonitorTests...)
+		for _, monitor := range info.DisableMonitorTests {
+			if monitor == "all" {
+				testsToInclude = sets.NewString()
+			}
+		}
 		return startingRegistry.GetRegistryFor(testsToInclude.List()...)
 	}
 

--- a/pkg/disruption/backend/sampler/remote.go
+++ b/pkg/disruption/backend/sampler/remote.go
@@ -57,6 +57,11 @@ var (
 )
 
 func TearDownInClusterMonitors(config *rest.Config) error {
+	if namespace == "" {
+		fmt.Fprintf(os.Stdout, "No in-cluster monitor daemonsets started, skipping teardown\n")
+		return nil
+	}
+
 	ctx := context.Background()
 
 	client, err := kubernetes.NewForConfig(config)

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -94,7 +94,7 @@ func (o *GinkgoRunSuiteOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&o.Parallelism, "max-parallel-tests", o.Parallelism, "Maximum number of tests running in parallel. 0 defaults to test suite recommended value, which is different in each suite.")
 	flags.StringSliceVar(&o.ExactMonitorTests, "monitor", o.ExactMonitorTests,
 		fmt.Sprintf("list of exactly which monitors to enable. All others will be disabled.  Current monitors are: [%s]", strings.Join(monitorNames, ", ")))
-	flags.StringSliceVar(&o.DisableMonitorTests, "disable-monitor", o.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored.")
+	flags.StringSliceVar(&o.DisableMonitorTests, "disable-monitor", o.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored. Special value 'all' disables all monitors.")
 }
 
 func (o *GinkgoRunSuiteOptions) Validate() error {


### PR DESCRIPTION
`openshift-tests run --disable-monitor all` disables all monitors, so the output and artifacts are not polluted by monitors, and contain the ginkgo test results only.

This is useful when running the tests by a human and not in CI - the monitors are _very_ talkative on stdout. We use openshift-tests as a certification suite for CSI drivers and  3rd party CSI driver vendors are not interested in megabytes of logs of OCP health, they're interested in the CSI driver test results.

In addition, when all monitors are disabled, do not collect `AdditionalEvents__in_cluster_disruption.json` from nodes - no monitoring means no monitoring DaemonSets running and thus there is nothing to collect from them. 