### PR TITLE
TRT-1218: Add the display flag for interval Sources that should have them

### DIFF
--- a/pkg/monitortests/etcd/etcdloganalyzer/monitortest.go
+++ b/pkg/monitortests/etcd/etcdloganalyzer/monitortest.go
@@ -194,6 +194,7 @@ func (g etcdRecorder) HandleLogLine(logLine podaccess.LogLineContent) {
 					monitorapi.NewMessage().
 						HumanMessage(parsedLine.Msg),
 				).
+				Display().
 				Build(parsedLine.Timestamp, parsedLine.Timestamp.Add(1*time.Second)))
 	}
 
@@ -268,6 +269,7 @@ func (g etcdRecorder) HandleLogLine(logLine podaccess.LogLineContent) {
 			monitorapi.NewInterval(etcdSource, monitorapi.Warning).
 				Locator(logLine.Locator).
 				Message(message).
+				Display().
 				Build(logLine.Instant, logLine.Instant.Add(time.Second)),
 		)
 	}

--- a/pkg/monitortests/node/kubeletlogcollector/node.go
+++ b/pkg/monitortests/node/kubeletlogcollector/node.go
@@ -221,6 +221,7 @@ func readinessFailure(nodeName, logLine string) monitorapi.Intervals {
 		monitorapi.NewInterval(monitorapi.SourceKubeletLog, monitorapi.Info).
 			Locator(containerRef).
 			Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonReadinessFailed).Node(nodeName).HumanMessage(message)).
+			Display().
 			Build(failureTime, failureTime),
 	}
 }
@@ -252,6 +253,7 @@ func readinessError(nodeName, logLine string) monitorapi.Intervals {
 					Node(nodeName).
 					HumanMessage(message),
 			).
+			Display().
 			Build(failureTime, failureTime),
 	}
 }
@@ -278,6 +280,7 @@ func errParsingSignature(nodeName, logLine string) monitorapi.Intervals {
 					Cause(monitorapi.ContainerUnrecognizedSignatureFormat).
 					Node(nodeName),
 			).
+			Display().
 			Build(failureTime, failureTime),
 	}
 }
@@ -323,6 +326,7 @@ func startupProbeError(nodeName, logLine string) monitorapi.Intervals {
 					Node(nodeName).
 					HumanMessage(message),
 			).
+			Display().
 			Build(failureTime, failureTime),
 	}
 }
@@ -423,6 +427,7 @@ func failedToDeleteCGroupsPath(nodeLocator monitorapi.Locator, logLine string) m
 		monitorapi.NewInterval(monitorapi.SourceKubeletLog, monitorapi.Error).
 			Locator(nodeLocator).
 			Message(monitorapi.NewMessage().Reason(monitorapi.FailedToDeleteCGroupsPath).HumanMessage(logLine)).
+			Display().
 			Build(failureTime, failureTime.Add(1*time.Second)),
 	}
 }
@@ -439,6 +444,7 @@ func anonymousCertConnectionError(nodeLocator monitorapi.Locator, logLine string
 			Locator(nodeLocator).
 			Message(monitorapi.NewMessage().Reason(monitorapi.FailedToAuthenticateWithOpenShiftUser).
 				HumanMessage(logLine)).
+			Display().
 			Build(failureTime, failureTime.Add(1*time.Second)),
 	}
 }
@@ -491,6 +497,7 @@ func leaseUpdateError(nodeLocator monitorapi.Locator, logLine string) monitorapi
 			Message(
 				monitorapi.NewMessage().Reason(monitorapi.NodeFailedLease).HumanMessage(fmt.Sprintf("%s - %s", url, msg)),
 			).
+			Display().
 			Build(failureTime, failureTime.Add(1*time.Second)),
 	}
 }
@@ -533,6 +540,7 @@ func commonErrorInterval(nodeName, logLine string, messageExp *regexp.Regexp, re
 			Message(
 				monitorapi.NewMessage().Reason(reason).Node(nodeName).HumanMessage(message),
 			).
+			Display().
 			Build(failureTime, failureTime),
 	}
 }

--- a/pkg/monitortests/testframework/e2etestanalyzer/e2etest.go
+++ b/pkg/monitortests/testframework/e2etestanalyzer/e2etest.go
@@ -49,6 +49,7 @@ func intervalsFromEvents_E2ETests(events monitorapi.Intervals, _ monitorapi.Reso
 			Message(monitorapi.NewMessage().
 				HumanMessagef("e2e test finished As %q", testStatus).
 				WithAnnotation(monitorapi.AnnotationStatus, testStatus)).
+			Display().
 			Build(from, event.From))
 	}
 
@@ -58,6 +59,7 @@ func intervalsFromEvents_E2ETests(events monitorapi.Intervals, _ monitorapi.Reso
 			Message(monitorapi.NewMessage().
 				HumanMessagef("e2e test did not finish %q", "DidNotFinish").
 				WithAnnotation(monitorapi.AnnotationStatus, "DidNotFinish")).
+			Display().
 			Build(testStart, end))
 	}
 


### PR DESCRIPTION
KubeletLog, EtcdLog, EtcdLeadership, and E2ETest intervals all should
have had this flag true.

This flag will hopefully soon be used to determine what gets shown in a
more dynamic UI.
