### PR TITLE
ETCD-578: remove Tech Preview check from etcd profiles e2e test

### DIFF
--- a/test/extended/etcd/hardware_speed.go
+++ b/test/extended/etcd/hardware_speed.go
@@ -26,10 +26,6 @@ var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", func
 		if isSingleNode {
 			g.Skip("the test is for etcd peer communication which is not valid for single node")
 		}
-		//TODO remove this check once https://github.com/openshift/api/pull/1844 has merged
-		if !exutil.IsTechPreviewNoUpgrade(oc) {
-			g.Skip("the test is not expected to work within Tech Preview disabled clusters")
-		}
 	})
 
 	g.AfterEach(func() {


### PR DESCRIPTION
The GA of this feature has merged [1] so this check is no longer needed.

[1] https://github.com/openshift/api/pull/1844