### PR TITLE
WIP: Add OpenShift specific CSI certification test

### DIFF
--- a/pkg/clioptions/clusterdiscovery/csi.go
+++ b/pkg/clioptions/clusterdiscovery/csi.go
@@ -6,23 +6,51 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openshift/origin/test/extended/storage/csi"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/storage/external"
+	"sigs.k8s.io/yaml"
 )
 
 const (
 	CSIManifestEnvVar = "TEST_CSI_DRIVER_FILES"
+	OCPManifestEnvVar = "TEST_OCP_DRIVER_FILES"
 )
 
 // Initialize openshift/csi suite, i.e. define CSI tests from TEST_CSI_DRIVER_FILES.
 func initCSITests(dryRun bool) error {
-	manifestList := os.Getenv(CSIManifestEnvVar)
-	if manifestList != "" {
-		manifests := strings.Split(manifestList, ",")
+	ocpDrivers := sets.New[string]()
+	upstreamDrivers := sets.New[string]()
+
+	// Load OCP specific tests first, because AddOpenShiftCSITests() modifies global list of
+	// testsuites.CSISuites used by AddDriverDefinition() below.
+	ocpManifestList := os.Getenv(OCPManifestEnvVar)
+	if ocpManifestList != "" {
+		manifests := strings.Split(ocpManifestList, ",")
+		for _, manifest := range manifests {
+			fmt.Printf("Loading OCP test manifest from %q\n", manifest)
+			csiDriver, err := csi.AddOpenShiftCSITests(manifest)
+			if err != nil {
+				return fmt.Errorf("failed to load OCP manifest from %q: %s", manifest, err)
+			}
+			ocpDrivers.Insert(csiDriver)
+		}
+	}
+
+	upstreamManifestList := os.Getenv(CSIManifestEnvVar)
+	if upstreamManifestList != "" {
+		manifests := strings.Split(upstreamManifestList, ",")
 		for _, manifest := range manifests {
 			if err := external.AddDriverDefinition(manifest); err != nil {
 				return fmt.Errorf("failed to load manifest from %q: %s", manifest, err)
 			}
+			csiDriver, err := parseDriverName(manifest)
+			if err != nil {
+				return fmt.Errorf("failed to parse CSI driver name from manifest %q: %s", manifest, err)
+			}
+			upstreamDrivers.Insert(csiDriver)
+
 			// Register the base dir of the manifest file as a file source.
 			// With this we can reference the CSI driver's storageClass
 			// in the manifest file (FromFile field).
@@ -32,5 +60,34 @@ func initCSITests(dryRun bool) error {
 		}
 	}
 
+	// We allow missing OCP specific manifest for CI jobs that do not have it defined yet,
+	// but all OCP specific manifest must have a corresponding upstream manifest.
+	if ocpDrivers.Difference(upstreamDrivers).Len() > 0 {
+		return fmt.Errorf("env. var %s must describe the same CSI drivers as %s: %v vs. %v", OCPManifestEnvVar, CSIManifestEnvVar, ocpDrivers.UnsortedList(), upstreamDrivers.UnsortedList())
+	}
+
 	return nil
+}
+
+func parseDriverName(filename string) (string, error) {
+	bytes, err := os.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+
+	// Minimal chunk of the upstream CSI driver manifest to extract the driver name.
+	// See vendor/k8s.io/kubernetes/test/e2e/storage/external/external.go for the full definition.
+	// It's private in that file, so we can't import it here.
+	type upstreamManifest struct {
+		DriverInfo struct {
+			Name string
+		}
+	}
+	manifest := &upstreamManifest{}
+	err = yaml.Unmarshal(bytes, manifest)
+	if err != nil {
+		return "", err
+	}
+	return manifest.DriverInfo.Name, nil
+
 }

--- a/test/extended/storage/csi/csi.go
+++ b/test/extended/storage/csi/csi.go
@@ -1,0 +1,71 @@
+package csi
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
+)
+
+// OpenShiftCSIDriverConfig holds definition test parameters of OpenShift specific CSI test
+type OpenShiftCSIDriverConfig struct {
+	// Name of the CSI driver.
+	Driver string
+	// Configuration of the LUN stress test. If nil, the test is skipped.
+	LUNStressTest *LUNStressTestConfig
+}
+
+// Definition of the LUN stress test parameters.
+// The test runs PodsTotal Pods with a single volume each, targeting the same node.
+// All Pods are created at once. We expect that the CSI driver reports correct
+// attach capacity and that the scheduler respects it*.
+// Each pod does something very simple, like `ls /the/volume` and exits quickly.
+// *) We know the scheduler does not respect the attach limit, see
+// https://github.com/kubernetes/kubernetes/issues/126502
+type LUNStressTestConfig struct {
+	// How many Pods with one volume each to run in total. Set to 0 to disable the test.
+	PodsTotal int
+	// How long to wait for all Pods to start. 40 minutes by default.
+	Timeout time.Duration
+}
+
+// runtime.DecodeInto needs a runtime.Object but doesn't do any
+// deserialization of it and therefore none of the methods below need
+// an implementation.
+var _ runtime.Object = &OpenShiftCSIDriverConfig{}
+
+const DefaultLUNStressTestTimeout = 40 * time.Minute
+
+func (d *OpenShiftCSIDriverConfig) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (d *OpenShiftCSIDriverConfig) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+// Register all OCP specific CSI tests into upstream testsuites.CSISuites.
+func AddOpenShiftCSITests(filename string) (string, error) {
+	bytes, err := os.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+
+	// Select sane defaults
+	cfg := &OpenShiftCSIDriverConfig{
+		LUNStressTest: &LUNStressTestConfig{
+			PodsTotal: 260,
+			Timeout:   DefaultLUNStressTestTimeout,
+		},
+	}
+	if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), bytes, cfg); err != nil {
+		return "", fmt.Errorf("%s: %w", filename, err)
+	}
+
+	testsuites.CSISuites = append(testsuites.CSISuites, initSCSILUNOverflowCSISuite(cfg.LUNStressTest))
+	return cfg.Driver, nil
+}

--- a/test/extended/storage/csi/csi.go
+++ b/test/extended/storage/csi/csi.go
@@ -3,7 +3,6 @@ package csi
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,8 +28,10 @@ type OpenShiftCSIDriverConfig struct {
 type LUNStressTestConfig struct {
 	// How many Pods with one volume each to run in total. Set to 0 to disable the test.
 	PodsTotal int
-	// How long to wait for all Pods to start. 40 minutes by default.
-	Timeout time.Duration
+	// How long to wait for all Pods to start. Accepts the same suffixes as go
+	// time.Duration, e.g. "40m15s" for 40 minutes and 15 seconds. 40 minutes
+	// by default.
+	Timeout string
 }
 
 // runtime.DecodeInto needs a runtime.Object but doesn't do any
@@ -38,7 +39,7 @@ type LUNStressTestConfig struct {
 // an implementation.
 var _ runtime.Object = &OpenShiftCSIDriverConfig{}
 
-const DefaultLUNStressTestTimeout = 40 * time.Minute
+const DefaultLUNStressTestTimeout = "40m"
 
 func (d *OpenShiftCSIDriverConfig) DeepCopyObject() runtime.Object {
 	return nil

--- a/test/extended/storage/csi/scsi_overflow.go
+++ b/test/extended/storage/csi/scsi_overflow.go
@@ -1,0 +1,207 @@
+package csi
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	resource2 "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	node2 "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+func initSCSILUNOverflowCSISuite(cfg *LUNStressTestConfig) func() storageframework.TestSuite {
+	return func() storageframework.TestSuite {
+		return &scsiLUNOverflowCSISuite{
+			tsInfo: storageframework.TestSuiteInfo{
+				Name: "OpenShift CSI extended - SCSI LUN Overflow",
+				TestPatterns: []storageframework.TestPattern{
+					storageframework.FsVolModeDynamicPV,
+				},
+			},
+			lunStressTestConfig: cfg,
+		}
+	}
+}
+
+// scsiLUNOverflowCSISuite is a test suite for the LUN stress test.
+type scsiLUNOverflowCSISuite struct {
+	tsInfo              storageframework.TestSuiteInfo
+	lunStressTestConfig *LUNStressTestConfig
+}
+
+var _ storageframework.TestSuite = &scsiLUNOverflowCSISuite{}
+
+func (csiSuite *scsiLUNOverflowCSISuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return csiSuite.tsInfo
+}
+
+func (csiSuite *scsiLUNOverflowCSISuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	return
+}
+
+func (csiSuite *scsiLUNOverflowCSISuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	f := e2e.NewFrameworkWithCustomTimeouts("storage-lun-overflow", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	// propagate the timeoutString from the test config to ginkgo.It("[Timeout:xyz]") to set test suite timeoutString
+	timeoutString := DefaultLUNStressTestTimeout
+	if csiSuite.lunStressTestConfig != nil && csiSuite.lunStressTestConfig.Timeout != "" {
+		timeoutString = csiSuite.lunStressTestConfig.Timeout
+	}
+	timeout, err := time.ParseDuration(timeoutString)
+	if err != nil {
+		panic(fmt.Sprintf("Cannot parse %s as time.Duration: %s", timeoutString, err))
+	}
+	testName := fmt.Sprintf("should use many PVs on a single node [Serial][Timeout:%s]", timeoutString)
+
+	g.It(testName, func(ctx context.Context) {
+		if csiSuite.lunStressTestConfig == nil {
+			g.Skip("lunStressTestConfig is empty")
+		}
+		if csiSuite.lunStressTestConfig.PodsTotal == 0 {
+			g.Skip("lunStressTestConfig is explicitly disabled")
+		}
+		e2e.Logf("Starting LUN stress test with config: %+v", csiSuite.lunStressTestConfig)
+		until := time.Now().Add(timeout)
+
+		g.By("Selecting a schedulable node")
+		node, err := node2.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+		e2e.ExpectNoError(err, "getting a schedulable node")
+
+		g.By("Creating a StorageClass")
+		config := driver.PrepareTest(ctx, f)
+		sc, err := createSC(ctx, f, driver, config)
+		e2e.ExpectNoError(err, "creating StorageClass")
+		g.DeferCleanup(func(ctx context.Context) {
+			e2e.Logf("Cleaning up StorageClass %s", sc.Name)
+			err := f.ClientSet.StorageV1().StorageClasses().Delete(ctx, sc.Name, metav1.DeleteOptions{})
+			e2e.ExpectNoError(err, "deleting StorageClass", sc.Name)
+		})
+
+		podCount := csiSuite.lunStressTestConfig.PodsTotal
+		e2e.Logf("Starting %d pods", podCount)
+		for i := 0; i < podCount; i++ {
+			startTestPod(ctx, f, node.Name, config, sc.Name, i)
+		}
+		e2e.Logf("All pods created, waiting for them to start until %s", until.String())
+
+		// Some time was already spent when creating pods.
+		waitTimeout := until.Sub(time.Now())
+		err = waitForPodsComplete(ctx, f, podCount, waitTimeout)
+		e2e.ExpectNoError(err, "waiting for pods to complete")
+		e2e.Logf("All pods completed, cleaning up")
+	})
+}
+
+// Create one PVC + Pod. Do not wait for the pod to start!
+func startTestPod(ctx context.Context, f *e2e.Framework, nodeName string, config *storageframework.PerTestConfig, scName string, podNumber int) {
+	pvcName := fmt.Sprintf("pvc-%d", podNumber)
+
+	claimSize := config.Driver.GetDriverInfo().SupportedSizeRange.Min
+	if claimSize == "" {
+		claimSize = "1Gi"
+	}
+	claimQuantity, err := resource2.ParseQuantity(claimSize)
+	e2e.ExpectNoError(err, "parsing claim size %s", claimSize)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: f.Namespace.Name,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: claimQuantity,
+				},
+			},
+		},
+	}
+	pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
+	e2e.ExpectNoError(err, "creating PVC %s", pvcName)
+
+	g.DeferCleanup(func(ctx context.Context) {
+		err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
+		e2e.ExpectNoError(err, "deleting PVC %s", pvc.Name)
+	})
+
+	podConfig := &e2epod.Config{
+		NS:            f.Namespace.Name,
+		PVCs:          []*corev1.PersistentVolumeClaim{pvc},
+		NodeSelection: e2epod.NodeSelection{Name: nodeName},
+		Command:       "ls -la " + e2epod.VolumeMountPath1,
+	}
+	pod, err := e2epod.MakeSecPod(podConfig)
+	e2e.ExpectNoError(err, "preparing pod %d", podNumber)
+	// Make the pod name nicer to users, it has a random uuid otherwise
+	pod.Name = fmt.Sprintf("pod-%d", podNumber)
+
+	pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	e2e.ExpectNoError(err, "creating pod %d", podNumber)
+	e2e.Logf("Pod %s + PVC %s created", pod.Name, pvc.Name)
+	g.DeferCleanup(func(ctx context.Context) {
+		err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		e2e.ExpectNoError(err, "deleting pod %s", pod.Name)
+	})
+}
+
+func createSC(ctx context.Context, f *e2e.Framework, driver storageframework.TestDriver, config *storageframework.PerTestConfig) (*storagev1.StorageClass, error) {
+	pvTester, ok := driver.(storageframework.DynamicPVTestDriver)
+	if !ok {
+		return nil, fmt.Errorf("driver %s does not support dynamic provisioning", driver.GetDriverInfo().Name)
+	}
+
+	sc := pvTester.GetDynamicProvisionStorageClass(ctx, config, "")
+	_, err := f.ClientSet.StorageV1().StorageClasses().Create(ctx, sc, metav1.CreateOptions{})
+	return sc, err
+}
+
+func waitForPodsComplete(ctx context.Context, f *e2e.Framework, podCount int, timeout time.Duration) error {
+	var incomplete, complete []*corev1.Pod
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, false, func(ctx context.Context) (done bool, err error) {
+		pods, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Errorf("error listing pods: %w", err)
+		}
+		complete = nil
+		incomplete = nil
+
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodSucceeded {
+				complete = append(complete, &pod)
+			} else {
+				incomplete = append(incomplete, &pod)
+			}
+		}
+
+		if len(complete) == podCount {
+			return true, nil
+		}
+		if len(complete)+len(incomplete) != podCount {
+			return false, fmt.Errorf("unexpected pod count: expected %d, got %d", len(complete)+len(incomplete), podCount)
+		}
+		e2e.Logf("Waiting for %d pods to complete, %d done", podCount, len(complete))
+		return false, nil
+	})
+
+	if err != nil {
+		e2e.Logf("Wait failed")
+		for i := range incomplete {
+			e2e.Logf("Incomplete pod %s: %s", incomplete[i].Name, incomplete[i].Status.Phase)
+		}
+	}
+	return err
+}


### PR DESCRIPTION
This is a hacked version of https://github.com/openshift/origin/pull/28967 that runs the new test by default, without any configuration, so we can run it in CI before merge.

---

Add a new OpenShift-specific test to `openshift/csi` suite that test a larger number of volumes used in a pod in sequence (or in manageable chunks). There was a 3rd party CSI driver that overflew a kernel counter after 256th attached volume.

This PR introduces OpenShift specific configuration manifest that configures OCP specific tests. There is just one test today, more can come in the future.

Usage:

```
cat <<EOF >ocp-specific-manifest.yaml
Driver: disk.csi.azure.com
LUNStressTest:
  Timeout: "40m"
  PodsTotal: 260
EOF

export TEST_OCP_DRIVER_FILES=ocp-specific-manifest.yaml
export TEST_CSI_DRIVER_FILES=upstream-test-manifest.yaml
openshift-tests run openshift/csi 
```

The test itself selects a random schedulable node, and creates configured nr. of Pods in parallel (260 by default). The test expects that the CSI driver reports correct attachment limit and the Kubernetes scheduler respects it.
We know [the scheduler can put more volumes to a node than the CSI driver can handle](https://github.com/kubernetes/kubernetes/issues/126502), however, we expect CSI drivers to handle it (and e.g. return errors).
