### PR TITLE
OCPBUGS-34403: Only look for thanos connections to platform monitoring stack

### DIFF
--- a/pkg/monitortests/testframework/alertanalyzer/alerts.go
+++ b/pkg/monitortests/testframework/alertanalyzer/alerts.go
@@ -46,7 +46,7 @@ func fetchEventIntervalsForAllAlerts(ctx context.Context, restConfig *rest.Confi
 	// (possibly with gaps) when after an upgrade, one of the Prometheus
 	// sidecars hasn't been reconnected yet to the Thanos queriers.
 	if err = wait.PollImmediateWithContext(ctx, 5*time.Second, 5*time.Minute, func(context.Context) (bool, error) {
-		v, warningsForQuery, err := prometheusClient.Query(ctx, `min(count by(pod) (thanos_store_nodes_grpc_connections{store_type="sidecar"})) == min(kube_statefulset_replicas{statefulset="prometheus-k8s"})`, time.Time{})
+		v, warningsForQuery, err := prometheusClient.Query(ctx, `min(count by(pod) (thanos_store_nodes_grpc_connections{store_type="sidecar",external_labels=~".*prometheus=\"openshift-monitoring/k8s\".*"})) == min(kube_statefulset_replicas{statefulset="prometheus-k8s"})`, time.Time{})
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
When observing the number of thanos connections and comparing to the number of platform monitoring stack replicas, the thanos connections to the user-workload-monitoring stack are not accounted for. This will cause metric collection to fail if user-workload-monitoring is enabled.

This fixes the query to only focus on the connections specifically to the platform monitoring stack, as the type of data collection the monitoring tests are doing focuses on platform metrics as opposed to ones from the UWM stack.