### PR TITLE
WIP: feat: add leases to resource watch

### DIFF
--- a/pkg/resourcewatch/operator/starter.go
+++ b/pkg/resourcewatch/operator/starter.go
@@ -108,6 +108,7 @@ func RunResourceWatch() error {
 		appResource("replicasets"),
 		resource("events.k8s.io", "v1", "events"),
 		resource("policy", "v1", "poddisruptionbudgets"),
+		resource("coordination.k8s.io", "v1", "leases"),
 		coreResource("pods"),
 		coreResource("nodes"),
 		coreResource("replicationcontrollers"),


### PR DESCRIPTION
adding leases to resource watch help determine if we are releasing leader election lock, this is very useful for SNO deployments where we want to make sure pods are releasing their lock when they are terminating
