### PR TITLE
STOR-1839: run vsphere driver config test on non techpreview clusters

### DIFF
--- a/test/extended/storage/driver_configuration.go
+++ b/test/extended/storage/driver_configuration.go
@@ -40,11 +40,6 @@ var _ = g.Describe("[sig-storage][Feature:VSphereDriverConfiguration][Serial][ap
 	o.SetDefaultEventuallyPollingInterval(5 * time.Second)
 
 	g.BeforeEach(func() {
-		//TODO: remove when GA
-		if !exutil.IsTechPreviewNoUpgrade(oc) {
-			g.Skip("this test is only expected to work with TechPreviewNoUpgrade clusters")
-		}
-
 		if !framework.ProviderIs("vsphere") {
 			g.Skip("this test is only expected to work with vSphere clusters")
 		}


### PR DESCRIPTION
VSphereDriverConfiguration is GA in 4.16: https://github.com/openshift/api/pull/1902 + https://github.com/openshift/api/pull/1904

This skip should be removed to enable test on non tech preview clusters.

/cc @openshift/storage 