### PR TITLE
Revert "TRT-1691: Revert #28735 "TRT-1576: Fail if operator has Available=False unless in upgrade window""

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -200,6 +200,12 @@ const (
 	FailedToDeleteCGroupsPath             IntervalReason = "FailedToDeleteCGroupsPath"
 	FailedToAuthenticateWithOpenShiftUser IntervalReason = "FailedToAuthenticateWithOpenShiftUser"
 	FailedContactingAPIReason             IntervalReason = "FailedContactingAPI"
+
+	UpgradeStartedReason  IntervalReason = "UpgradeStarted"
+	UpgradeVersionReason  IntervalReason = "UpgradeVersion"
+	UpgradeRollbackReason IntervalReason = "UpgradeRollback"
+	UpgradeFailedReason   IntervalReason = "UpgradeFailed"
+	UpgradeCompleteReason IntervalReason = "UpgradeComplete"
 )
 
 type AnnotationKey string
@@ -300,6 +306,10 @@ type Interval struct {
 
 	From time.Time
 	To   time.Time
+}
+
+func (r IntervalReason) String() string {
+	return string(r)
 }
 
 func (i Interval) String() string {

--- a/pkg/monitortestlibrary/platformidentification/upgrade.go
+++ b/pkg/monitortestlibrary/platformidentification/upgrade.go
@@ -13,8 +13,8 @@ func DidUpgradeHappenDuringCollection(intervals monitorapi.Intervals, beginning,
 		if event.Source != monitorapi.SourceKubeEvent || event.Locator.Keys[monitorapi.LocatorClusterVersionKey] != "cluster" {
 			continue
 		}
-		reason := string(event.Message.Reason)
-		if reason == "UpgradeStarted" || reason == "UpgradeRollback" {
+		reason := event.Message.Reason
+		if reason == monitorapi.UpgradeStartedReason || reason == monitorapi.UpgradeRollbackReason {
 			return true
 		}
 	}

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/monitortest.go
@@ -42,7 +42,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	if isUpgrade {
 		junits = append(junits, testUpgradeOperatorStateTransitions(finalIntervals, w.adminRESTConfig)...)
 	} else {
-		junits = append(junits, testStableSystemOperatorStateTransitions(finalIntervals)...)
+		junits = append(junits, testStableSystemOperatorStateTransitions(finalIntervals, w.adminRESTConfig)...)
 	}
 
 	return junits, nil

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -61,6 +61,9 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 					return "https://issues.redhat.com/browse/OCPBUGS-20056", nil
 				}
 			}
+			if operator == "image-registry" {
+				return "Image-registry operator is allowed to have Available=False on a non-upgrade scenario for now", nil
+			}
 			return "", nil
 		}
 		return "We are not worried about Degraded=True blips for stable-system tests yet.", nil
@@ -197,6 +200,10 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				// We'll honor exceptions for authentication operator because it is affected by etcd performance issues.
 				logrus.Info("Operator authentication is in Available=False state, but we give an exception")
 
+			} else if operator == "image-registry" {
+				// For now, we'll honor exceptions for image-registry operator as it's affected by tests that
+				// cause replicas to go down (e.g., tests that taint two nodes).
+				logrus.Info("Operator image-registry is in Available=False state, but we give an exception")
 			} else {
 				return "", nil
 			}

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -10,21 +10,24 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/origin/pkg/monitortests/clusterversionoperator/operatorstateanalyzer"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
+	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 	platformidentification2 "github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	exutil "github.com/openshift/origin/test/extended/util"
 	"k8s.io/client-go/rest"
 )
 
 // exceptionCallback consumes a suspicious condition and returns an
 // exception string if does not think the condition should be fatal.
-type exceptionCallback func(operator string, condition *configv1.ClusterOperatorStatusCondition, clientConfig *rest.Config) (string, error)
+type exceptionCallback func(operator string, condition *configv1.ClusterOperatorStatusCondition, eventInterval monitorapi.Interval, clientConfig *rest.Config) (string, error)
 
-func testStableSystemOperatorStateTransitions(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
-	except := func(_ string, condition *configv1.ClusterOperatorStatusCondition, _ *rest.Config) (string, error) {
+func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clientConfig *rest.Config) []*junitapi.JUnitTestCase {
+	except := func(_ string, condition *configv1.ClusterOperatorStatusCondition, _ monitorapi.Interval, clientConfig *rest.Config) (string, error) {
 		if condition.Status == configv1.ConditionTrue {
 			if condition.Type == configv1.OperatorAvailable {
 				return fmt.Sprintf("%s=%s is the happy case", condition.Type, condition.Status), nil
@@ -35,14 +38,117 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals) []*ju
 			}
 		}
 
-		return "We are not worried about Available=False or Degraded=True blips for stable-system tests yet.", nil
+		isSingleNode, err := isSingleNodeCheck(clientConfig)
+		if err != nil {
+			logrus.Warnf("Error checking for Single Node configuration on stable system (unable to make exception): %v", err)
+			isSingleNode = false
+		}
+
+		// For the non-upgrade case, if any operator has Available=False, fail the test.
+		if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
+			if isSingleNode {
+				return "Operators are allowed to go degraded on single-node for now", nil
+			}
+			return "", nil
+		}
+		return "We are not worried about Degraded=True blips for stable-system tests yet.", nil
 	}
 
-	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded}, except)
+	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded}, except, clientConfig)
+}
+
+func isSingleNodeCheck(clientConfig *rest.Config) (bool, error) {
+	configClient, err := clientconfigv1.NewForConfig(clientConfig)
+	if err != nil {
+		logrus.WithError(err).Error("Error creating config client to check for Single Node configuration")
+		return false, err
+	}
+	return exutil.IsSingleNode(context.Background(), configClient)
+}
+
+// isInUpgradeWindow determines if the given eventInterval falls within an upgrade window.
+// UpgradeStart and UpgradeRollback events start upgrade windows and can end and already started upgrade window.
+// UpgradeComplete and UpgradeFailed events end upgrade windows; if there was not an already started upgrade window,
+// we ignore the event.
+// If we don't find any upgrade ending point, we assume the ending point is at the end of the test.
+func isInUpgradeWindow(eventList monitorapi.Intervals, eventInterval monitorapi.Interval) bool {
+	type upgradeWindowHolder struct {
+		startInterval *monitorapi.Interval
+		endInterval   *monitorapi.Interval
+	}
+
+	var upgradeWindows []*upgradeWindowHolder
+	var currentWindow *upgradeWindowHolder
+
+	for _, event := range eventList {
+		if event.Source != monitorapi.SourceKubeEvent || event.Locator.Keys[monitorapi.LocatorClusterVersionKey] != "cluster" {
+			continue
+		}
+
+		switch event.Message.Reason {
+		case monitorapi.UpgradeStartedReason, monitorapi.UpgradeRollbackReason:
+			if currentWindow != nil {
+				// Close current window since there's already an upgrade window started
+				currentWindow.endInterval = &monitorapi.Interval{
+					Condition: monitorapi.Condition{
+						Message: monitorapi.Message{
+							Reason: event.Message.Reason,
+						},
+					},
+					From: event.From,
+					To:   event.To,
+				}
+			}
+
+			// Start new window
+			currentWindow = &upgradeWindowHolder{
+				startInterval: &monitorapi.Interval{
+					Condition: monitorapi.Condition{
+						Message: monitorapi.Message{
+							Reason: event.Message.Reason,
+						},
+					},
+					From: event.From,
+					To:   event.To,
+				},
+			}
+			upgradeWindows = append(upgradeWindows, currentWindow)
+		case monitorapi.UpgradeCompleteReason, monitorapi.UpgradeFailedReason:
+			if currentWindow != nil {
+				if currentWindow.endInterval == nil {
+					// End current window
+					currentWindow.endInterval = &monitorapi.Interval{
+						Condition: monitorapi.Condition{
+							Message: monitorapi.Message{
+								Reason: event.Message.Reason,
+							},
+						},
+						From: event.From,
+						To:   event.To,
+					}
+				}
+			} else {
+				// We have no current window which means that the events indicate we completed
+				// or failed an upgrade without starting one.  This is stange situation that
+				// we should not see; in this case, there is no upgrade window to check against.
+				logrus.Warnf("Found upgrade completion or failed event without a start or rollback event: %v", event)
+			}
+		}
+	}
+
+	for _, upgradeWindow := range upgradeWindows {
+		if eventInterval.From.After(upgradeWindow.startInterval.From) {
+			if upgradeWindow.endInterval == nil || eventInterval.To.Before(upgradeWindow.endInterval.To) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConfig *rest.Config) []*junitapi.JUnitTestCase {
-	except := func(operator string, condition *configv1.ClusterOperatorStatusCondition, clientConfig *rest.Config) (string, error) {
+	except := func(operator string, condition *configv1.ClusterOperatorStatusCondition, eventInterval monitorapi.Interval, clientConfig *rest.Config) (string, error) {
 		if condition.Status == configv1.ConditionTrue {
 			if condition.Type == configv1.OperatorAvailable {
 				return fmt.Sprintf("%s=%s is the happy case", condition.Type, condition.Status), nil
@@ -55,6 +161,22 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 
 		if condition.Type == configv1.OperatorDegraded {
 			return "We are not worried about Degraded=True blips for update tests yet.", nil
+		}
+
+		var availableEqualsFalseAllowed bool
+		if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
+			availableEqualsFalseAllowed = isInUpgradeWindow(events, eventInterval) && eventInterval.To.Sub(eventInterval.From) < 10*time.Minute
+		}
+
+		isSingleNode, err := isSingleNodeCheck(clientConfig)
+		if err != nil {
+			logrus.Warnf("Error checking for Single Node configuration on upgrade (unable to make exception): %v", err)
+			isSingleNode = false
+		}
+
+		// We'll add an exception for single node for now.
+		if !availableEqualsFalseAllowed && !isSingleNode {
+			return "", nil
 		}
 
 		switch operator {
@@ -99,7 +221,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			}
 		case "image-registry":
 			if replicaCount, _ := checkReplicas("openshift-image-registry", operator, clientConfig); replicaCount == 1 {
-				return "image-registry has only single replica", nil
+				return "https://issues.redhat.com/browse/OCPBUGS-22382", nil
 			}
 		}
 
@@ -128,7 +250,7 @@ func checkReplicas(namespace string, operator string, clientConfig *rest.Config)
 	return 0, fmt.Errorf("Error fetching replicas")
 }
 
-func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []configv1.ClusterStatusConditionType, except exceptionCallback, clientConfig ...*rest.Config) []*junitapi.JUnitTestCase {
+func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []configv1.ClusterStatusConditionType, except exceptionCallback, clientConfig *rest.Config) []*junitapi.JUnitTestCase {
 	ret := []*junitapi.JUnitTestCase{}
 
 	var start, stop time.Time
@@ -195,11 +317,7 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 				if len(concurrentE2E) > 0 {
 					failure = fmt.Sprintf("%s\n%d tests failed during this blip (%v to %v): %v", failure, len(concurrentE2E), eventInterval.From, eventInterval.From, strings.Join(concurrentE2E, "\n"))
 				}
-				var Config *rest.Config
-				if len(clientConfig) > 0 {
-					Config = clientConfig[0]
-				}
-				exception, err := except(operatorName, condition, Config)
+				exception, err := except(operatorName, condition, eventInterval, clientConfig)
 				if err != nil || exception == "" {
 					fatal = append(fatal, failure)
 				} else {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
@@ -1,0 +1,193 @@
+package legacycvomonitortests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/stretchr/testify/assert"
+)
+
+// buildUpgradeInterval creates a standard upgrade interval using the given reason and eventTime.
+// These are the fields used by the isInUpgradeWindow function.
+func buildUpgradeInterval(reason monitorapi.IntervalReason, eventTime time.Time) monitorapi.Interval {
+	interval := monitorapi.Interval{
+		Condition: monitorapi.Condition{
+			Locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorClusterVersionKey: "cluster",
+				},
+			},
+			Message: monitorapi.Message{
+				Reason: reason,
+			},
+		},
+		Source: monitorapi.SourceKubeEvent,
+		From:   eventTime,
+		To:     eventTime,
+	}
+	return interval
+}
+
+type upgradeEvent struct {
+	eventTime time.Time
+	reason    monitorapi.IntervalReason
+}
+
+// intervalWithSingleTime creates a monitorapi.Interval with the same start and end time.
+func intervalWithSingleTime(eventTime time.Time) monitorapi.Interval {
+	return monitorapi.Interval{
+		From: eventTime,
+		To:   eventTime,
+	}
+}
+
+// makeUpgradeEventList creates a list of standard upgrade events using
+// output from parsing the e2e-events.file
+//
+//	cat e2e-events_20240502-205107.json | jq '.items[] | \
+//	   select(.source == "KubeEvent" and .locator.keys.clusterversion? == "cluster")| \
+//	   "\(.from) \(.to) \(.message.reason)"'
+func makeUpgradeEventList(events []upgradeEvent) monitorapi.Intervals {
+	var intervals monitorapi.Intervals
+	for _, event := range events {
+		interval := buildUpgradeInterval(event.reason, event.eventTime)
+		intervals = append(intervals, interval)
+	}
+	return intervals
+}
+
+func Test_isInUpgradeWindow(t *testing.T) {
+	type args struct {
+		eventList     monitorapi.Intervals
+		eventInterval monitorapi.Interval
+	}
+
+	standardEventList := makeUpgradeEventList([]upgradeEvent{
+		{eventTime: time.Date(2024, 5, 1, 12, 51, 9, 0, time.UTC), reason: monitorapi.UpgradeStartedReason},
+		{eventTime: time.Date(2024, 5, 1, 13, 46, 44, 0, time.UTC), reason: monitorapi.UpgradeVersionReason},
+		{eventTime: time.Date(2024, 5, 1, 13, 46, 44, 0, time.UTC), reason: monitorapi.UpgradeCompleteReason},
+	})
+
+	eventListWithRollback := makeUpgradeEventList([]upgradeEvent{
+		{eventTime: time.Date(2024, 5, 1, 22, 21, 42, 0, time.UTC), reason: monitorapi.UpgradeStartedReason},
+		{eventTime: time.Date(2024, 5, 1, 23, 15, 8, 0, time.UTC), reason: monitorapi.UpgradeRollbackReason},
+		{eventTime: time.Date(2024, 5, 2, 0, 11, 18, 0, time.UTC), reason: monitorapi.UpgradeVersionReason},
+		{eventTime: time.Date(2024, 5, 2, 0, 11, 18, 0, time.UTC), reason: monitorapi.UpgradeCompleteReason},
+	})
+
+	rollbackHappenedBeforeStartList := makeUpgradeEventList([]upgradeEvent{
+		{eventTime: time.Date(2024, 5, 1, 13, 46, 44, 0, time.UTC), reason: monitorapi.UpgradeCompleteReason},
+	})
+
+	rollbackAfterErroneousCompletionList := makeUpgradeEventList([]upgradeEvent{
+		{eventTime: time.Date(2024, 5, 2, 11, 0, 0, 0, time.UTC), reason: monitorapi.UpgradeCompleteReason},
+		{eventTime: time.Date(2024, 5, 2, 11, 45, 0, 0, time.UTC), reason: monitorapi.UpgradeRollbackReason},
+	})
+
+	rollbackAfterCompletionList := makeUpgradeEventList([]upgradeEvent{
+		{eventTime: time.Date(2024, 5, 2, 11, 0, 0, 0, time.UTC), reason: monitorapi.UpgradeStartedReason},
+		{eventTime: time.Date(2024, 5, 2, 11, 30, 0, 0, time.UTC), reason: monitorapi.UpgradeCompleteReason},
+		{eventTime: time.Date(2024, 5, 2, 11, 45, 0, 0, time.UTC), reason: monitorapi.UpgradeRollbackReason},
+	})
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "A rollback followed an upgrade completion",
+			args: args{
+				eventList:     rollbackAfterCompletionList,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 2, 11, 35, 0, 0, time.UTC)),
+			},
+			want: true,
+		},
+		{
+			name: "A rollback followed an erroneous upgrade completion (error condition)",
+			args: args{
+				eventList:     rollbackAfterErroneousCompletionList,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 2, 11, 30, 0, 0, time.UTC)),
+			},
+			want: false,
+		},
+		{
+			name: "An upgrade completion happened before an upgrade start or rollback (error condition)",
+			args: args{
+				eventList:     rollbackHappenedBeforeStartList,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 2, 11, 20, 0, 0, time.UTC)),
+			},
+			want: false,
+		},
+		{
+			name: "single upgrade window, interval not within",
+			args: args{
+				eventList:     standardEventList,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 1, 12, 49, 28, 0, time.UTC)),
+			},
+			want: false,
+		},
+		{
+			name: "single upgrade window, interval within",
+			args: args{
+				eventList:     standardEventList,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 1, 13, 44, 28, 0, time.UTC)),
+			},
+			want: true,
+		},
+		{
+			name: "single upgrade window, with no end",
+			args: args{
+				eventList:     standardEventList[0:2],
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 1, 14, 0, 0, 0, time.UTC)),
+			},
+			want: true,
+		},
+		{
+			name: "upgrade with rollback, interval before first upgrade",
+			args: args{
+				eventList:     eventListWithRollback,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 1, 22, 10, 0, 0, time.UTC)),
+			},
+			want: false,
+		},
+		{
+			name: "upgrade with rollback, interval inside first upgrade",
+			args: args{
+				eventList:     eventListWithRollback,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 1, 22, 25, 0, 0, time.UTC)),
+			},
+			want: true,
+		},
+		{
+			name: "upgrade with rollback, interval inside rollback",
+			args: args{
+				eventList:     eventListWithRollback,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 1, 23, 18, 0, 0, time.UTC)),
+			},
+			want: true,
+		},
+		{
+			name: "upgrade with rollback, interval past end of rollback",
+			args: args{
+				eventList:     eventListWithRollback,
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 2, 11, 20, 0, 0, time.UTC)),
+			},
+			want: false,
+		},
+		{
+			name: "upgrade with rollback, interval past end of rollback with no end",
+			args: args{
+				eventList:     eventListWithRollback[0:3],
+				eventInterval: intervalWithSingleTime(time.Date(2024, 5, 2, 11, 20, 0, 0, time.UTC)),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isInUpgradeWindow(tt.args.eventList, tt.args.eventInterval)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/monitortests/node/legacynodemonitortests/kubelet.go
+++ b/pkg/monitortests/node/legacynodemonitortests/kubelet.go
@@ -391,8 +391,8 @@ func testNodeUpgradeTransitions(events monitorapi.Intervals) []*junitapi.JUnitTe
 		for i, event := range events {
 			// treat multiple sequential upgrades as distinct test failures
 			if event.Locator.Keys[monitorapi.LocatorClusterVersionKey] == "cluster" &&
-				(string(event.Message.Reason) == "UpgradeStarted" ||
-					string(event.Message.Reason) == "UpgradeRollback") {
+				(event.Message.Reason == monitorapi.UpgradeStartedReason ||
+					event.Message.Reason == monitorapi.UpgradeRollbackReason) {
 
 				text = event.Message.HumanMessage
 				events = events[i+1:]


### PR DESCRIPTION
Reverts openshift/origin#28847

For this test: [bz-%v] clusteroperator/%v should not change condition/Available]:

* For non-upgrade jobs, fail when operator goes to Available=False
* For upgrade-jobs, fail when operator goes to Available=False unless it's during an upgrade window and the condition lasts for less than 10 minutes.

Exceptions:

* authentication operator is affected by etcd performance issues
* image-registry is affected by other tests that cause all image-registry replicas to go down

For the above exceptions, their tests still run but they will flake as they did before this PR.

Testing tasks:

- [ ] Test with azure since this is where the authentication operator has problems due to etcd performance issues; the clusteroperator/authentication flakes 8, pass 2
  * see [/payload for azure](https://pr-payload-tests.ci.openshift.org/runs/ci/d8511d30-281a-11ef-9083-d014afac8f40-0)
- [ ] Test with gcp techpreview serial to ensure image-registry operator test flakes as it did before (now that we give it an exception)
  * see [/payload for techpreview jobs](https://pr-payload-tests.ci.openshift.org/runs/ci/0d6e9310-27e1-11ef-8f24-4a8b14294335-0); 5 of 10 jobs finished, those 5 passed on clusteroperator/image-registry test.
- [ ] Run /payload 4.17 nightly blocking
  * see [/payload for 4.17 blocking](https://pr-payload-tests.ci.openshift.org/runs/ci/6c1e6040-2866-11ef-9091-677516e6db09-0)
  * still trying to run the [metal job](https://pr-payload-tests.ci.openshift.org/runs/ci/189a17a0-28b8-11ef-8adf-49cc0ed6dd05-0) that failed twice earlier due to `Could not acquire CI resource: No available resource found`
  * the metal job finally [ran](https://pr-payload-tests.ci.openshift.org/runs/ci/3d5e7420-291f-11ef-9445-888b9e3f685e-0)