### PR TITLE
OCPBUGS-34448: monitortestframework: unsupported monitors should warn, not error

### DIFF
--- a/pkg/monitortestframework/impl.go
+++ b/pkg/monitortestframework/impl.go
@@ -178,7 +178,7 @@ func (r *monitorTestRegistry) CollectData(ctx context.Context, storageDir string
 							},
 						},
 					}
-					logrus.WithError(nsErr).Errorf("  Finished CollectData for %s with not-supported error", testName)
+					logrus.WithFields(logrus.Fields{"reason": nsErr.Reason}).Warningf("  Finished CollectData for %s with not supported warning", testName)
 					return
 				}
 				junitCh <- []*junitapi.JUnitTestCase{


### PR DESCRIPTION
Logging this as an error can confuse users grepping logs to understand why a job failed, and leading them to investigate something that's not a problem. If a particular monitor isn't supported, then we should just log it as a warning.

```
ERRO[0352]   Finished CollectData for [Jira:"kube-apiserver"] monitor
test apiserver-availability collection with not-supported error
error="not supported: namespace openshift-oauth-apiserver not present"
```