### PR TITLE
ETCD-606: Open up the RequiredInstallerResourcesMissing test to more resources.

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -575,7 +575,6 @@ var AllowBackOffRestartingFailedContainer = &SimplePathologicalEventMatcher{
 var EtcdRequiredResourcesMissing = &SimplePathologicalEventMatcher{
 	name:               "EtcdRequiredResourcesMissing",
 	messageReasonRegex: regexp.MustCompile(`^RequiredInstallerResourcesMissing$`),
-	messageHumanRegex:  regexp.MustCompile(`secrets: etcd-all-certs-[0-9]+`),
 }
 
 // reason/OperatorStatusChanged Status for clusteroperator/etcd changed: Degraded message changed from "NodeControllerDegraded: All master nodes are ready\nEtcdMembersDegraded: 2 of 3 members are available, ip-10-0-217-93.us-west-1.compute.internal is unhealthy" to "NodeControllerDegraded: All master nodes are ready\nEtcdMembersDegraded: No unhealthy members found"


### PR DESCRIPTION
This was limited to secrets, there are others including a new bundle in
https://github.com/openshift/cluster-etcd-operator/pull/1271. Open the
regex up to match more, and this has it's own test which only adds a
flake threshold, but keeps the 20 fail threshold.
