### PR TITLE
WIP: Use ephemeral cluster docker config.json for test binary extraction

### DIFF
--- a/pkg/test/ginkgo/external.go
+++ b/pkg/test/ginkgo/external.go
@@ -83,7 +83,7 @@ func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
 		return "", fmt.Errorf("cannot determine release image from ClusterVersion resource")
 	}
 
-	if err := runImageExtract(releaseImage, "/release-manifests/image-references", tmpDir); err != nil {
+	if err := runImageExtract(releaseImage, "/release-manifests/image-references", tmpDir, ""); err != nil {
 		return "", fmt.Errorf("failed extracting image-references: %w", err)
 	}
 	jsonFile, err := os.Open(filepath.Join(tmpDir, "image-references"))
@@ -110,10 +110,26 @@ func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
 			break
 		}
 	}
+
+	// The preceding runImageExtract was against a release payload that was created in the local
+	// ci-operator namespace. Our process was free to access it. The release payload, however,
+	// may be referencing images in other registries that we don't have access to (e.g. quay.io,
+	// registry.ci.openshift.org). One location that does have access is in the cluster under test.
+	// It cluster-wide pull-secret must have pull access to these images in order for it to have
+	// installed. Read it's dockerconfigjson value and use it when extract external test binaries
+	// from images referenced by the release payload.
+	clusterPullSecret, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
+	clusterDockerConfig := clusterPullSecret.Data[".dockerconfigjson"]
+	dockerConfigJsonPath := filepath.Join(tmpDir, ".dockerconfigjson")
+	err = os.WriteFile(dockerConfigJsonPath, clusterDockerConfig, 0644)
+	if err != nil {
+		return "", fmt.Errorf("unable to serialize ephemeral cluster pull secret locally: %v", err)
+	}
+
 	if len(image) == 0 {
 		return "", fmt.Errorf("%s not found", tag)
 	}
-	if err := runImageExtract(image, binary, tmpDir); err != nil {
+	if err := runImageExtract(image, binary, tmpDir, dockerConfigJsonPath); err != nil {
 		return "", fmt.Errorf("failed extracting %q from %q: %w", binary, image, err)
 	}
 
@@ -125,7 +141,15 @@ func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
 }
 
 // runImageExtract extracts src from specified image to dst
-func runImageExtract(image, src, dst string) error {
-	cmd := exec.Command("oc", "--kubeconfig="+util.KubeConfigPath(), "image", "extract", image, fmt.Sprintf("--path=%s:%s", src, dst), "--confirm")
-	return cmd.Run()
+func runImageExtract(image, src, dst string, dockerConfigJsonPath string) error {
+	args := []string{"--kubeconfig=" + util.KubeConfigPath(), "image", "extract", image, fmt.Sprintf("--path=%s:%s", src, dst), "--confirm"}
+	if len(dockerConfigJsonPath) > 0 {
+		args = append(args, fmt.Sprintf("--registry-config=%s", dockerConfigJsonPath))
+	}
+	cmd := exec.Command("oc", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error during image extract: %w (%v)", err, string(out))
+	}
+	return nil
 }


### PR DESCRIPTION
The service account running the e2e tests does not necessarily have pull access to the component images in the release payload. The cluster under test, however, must have a valid pull secret. Utilize the ephemeral cluster's pull secret to extract binaries from the payload under test.