### PR TITLE
OCPBUGS-35535: add Proxy config

### DIFF
--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -59,6 +59,7 @@ func makeHTTPClient(useHTTP2Transport bool, timeout time.Duration) *http.Client 
 
 	transport := &http.Transport{
 		TLSClientConfig: &tlsConfig,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	c := &http.Client{


### PR DESCRIPTION
For hypershift agent CI, the cluster is private. We configured the proxy but didn't apply it, so we submitted a PR.