### PR TITLE
STOR-1839: Remove the featuregate check condition for VSphereDriverConfiguration tests

### DIFF
--- a/test/extended/storage/driver_configuration.go
+++ b/test/extended/storage/driver_configuration.go
@@ -29,7 +29,7 @@ const (
 )
 
 // This is [Serial] because it modifies ClusterCSIDriver.
-var _ = g.Describe("[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration", func() {
+var _ = g.Describe("[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration", func() {
 	defer g.GinkgoRecover()
 	var (
 		ctx                      = context.Background()
@@ -41,10 +41,6 @@ var _ = g.Describe("[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial
 	o.SetDefaultEventuallyPollingInterval(5 * time.Second)
 
 	g.BeforeEach(func() {
-		//TODO: remove when GA
-		if !exutil.IsTechPreviewNoUpgrade(oc) {
-			g.Skip("this test is only expected to work with TechPreviewNoUpgrade clusters")
-		}
 
 		if !framework.ProviderIs("vsphere") {
 			g.Skip("this test is only expected to work with vSphere clusters")

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1603,15 +1603,15 @@ var Annotations = map[string]string{
 
 	"[sig-storage][Feature:DisableStorageClass][Serial][apigroup:operator.openshift.io] should remove the StorageClass when StorageClassState is Removed": " [Suite:openshift/conformance/serial]",
 
-	"[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow all limits to be set at once": " [Suite:openshift/conformance/serial]",
+	"[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow all limits to be set at once": " [Suite:openshift/conformance/serial]",
 
-	"[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting VSAN limit": " [Suite:openshift/conformance/serial]",
+	"[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting VSAN limit": " [Suite:openshift/conformance/serial]",
 
-	"[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting VVOL limit": " [Suite:openshift/conformance/serial]",
+	"[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting VVOL limit": " [Suite:openshift/conformance/serial]",
 
-	"[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting global snapshot limit": " [Suite:openshift/conformance/serial]",
+	"[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting global snapshot limit": " [Suite:openshift/conformance/serial]",
 
-	"[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should use default when unset": " [Suite:openshift/conformance/serial]",
+	"[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should use default when unset": " [Suite:openshift/conformance/serial]",
 
 	"[sig-storage][Late] Metrics should report short attach times": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -162,21 +162,4 @@ spec:
         [LinuxOnly] [Feature:SELinux] [Serial] warning is not bumped on two Pods with
         the same context on RWO volume [FeatureGate:SELinuxMountReadWriteOncePod]
         [Beta] [Feature:SELinuxMountReadWriteOncePodOnly]'
-  - featureGate: VSphereDriverConfiguration
-    tests:
-    - testName: '[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io]
-        vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should
-        allow all limits to be set at once'
-    - testName: '[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io]
-        vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should
-        allow setting VSAN limit'
-    - testName: '[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io]
-        vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should
-        allow setting VVOL limit'
-    - testName: '[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io]
-        vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should
-        allow setting global snapshot limit'
-    - testName: '[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io]
-        vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should
-        use default when unset'
 status: {}


### PR DESCRIPTION
### Remove the featuregate check condition for VSphereDriverConfiguration tests
- Since we have already promote `VSphereDriverConfiguration` feature from Tech Preview to GA (Accessible-by-default), the featuregate check condition is not needed any more.
<details>
  <summary><mark>Local Test Record</mark></summary>
  <pre><code>
$ ./openshift-tests run all --dry-run | grep "Feature:VSphereDriverConfiguration"|./openshift-tests run --monitor="audit-log-analyzer" -f -
INFO[0000] Decoding provider                             clusterState="<nil>" discover=true dryRun=true func=DecodeProvider providerType=
INFO[0000] Decoding provider                             clusterState="<nil>" discover=true dryRun=false func=DecodeProvider providerType=
  Jun 14 15:47:48.062: INFO: microshift-version configmap not found
openshift-tests version: v4.1.0-8166-g4f8059c
found 8079 tests for suite
Attempting to pull tests from external binary...
Falling back to built-in suite, failed reading external test suites: unable to extract k8s-tests binary: failed extracting image-references: exit status 1
found 8079 tests (incl externals)
found 5 filtered tests
INFO[0013]   Starting audit-log-analyzer for kube-apiserver 
All monitor tests started.
started: 0/1/5 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should use default when unset [Suite:openshift/conformance/serial]"

passed: (1m29s) 2024-06-14T07:49:26 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should use default when unset [Suite:openshift/conformance/serial]"

started: 0/2/5 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting global snapshot limit [Suite:openshift/conformance/serial]"

passed: (1m43s) 2024-06-14T07:51:09 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting global snapshot limit [Suite:openshift/conformance/serial]"

started: 0/3/5 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting VSAN limit [Suite:openshift/conformance/serial]"

passed: (32.7s) 2024-06-14T07:51:42 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting VSAN limit [Suite:openshift/conformance/serial]"

started: 0/4/5 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting VVOL limit [Suite:openshift/conformance/serial]"

passed: (40.8s) 2024-06-14T07:52:22 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow setting VVOL limit [Suite:openshift/conformance/serial]"

started: 0/5/5 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow all limits to be set at once [Suite:openshift/conformance/serial]"

passed: (24.9s) 2024-06-14T07:52:47 "[sig-storage][Feature:VSphereDriverConfiguration][Serial][apigroup:operator.openshift.io] vSphere CSI Driver Configuration snapshot options in clusterCSIDriver should allow all limits to be set at once [Suite:openshift/conformance/serial]"

found errors fetching in-cluster data: [failed to list files in disruption event folder on node zhsun-vs14-hbvwg-master-0: the server could not find the requested resource failed to list files in disruption event folder on node zhsun-vs14-hbvwg-master-1: the server could not find the requested resource failed to list files in disruption event folder on node zhsun-vs14-hbvwg-master-2: the server could not find the requested resource failed to list files in disruption event folder on node zhsun-vs14-hbvwg-worker-0-9h42q: the server could not find the requested resource failed to list files in disruption event folder on node zhsun-vs14-hbvwg-worker-0-x59bd: the server could not find the requested resource]
Failed to write events from in-cluster monitors, err: open /var/folders/l3/mm6pcq3j1mdg12y9n7573smw0000gn/T/artifacts/junit/AdditionalEvents__in_cluster_disruption.json: no such file or directory
Shutting down the monitor
Collecting data.
INFO[0306] Starting CollectData for all monitor tests   
INFO[0306]   Starting CollectData for [Jira:"kube-apiserver"] monitor test audit-log-analyzer collection 
INFO[1030]   Finished CollectData for [Jira:"kube-apiserver"] monitor test audit-log-analyzer collection 
INFO[1030] Finished CollectData for all monitor tests   
Computing intervals.
Evaluating tests.
Cleaning up.
INFO[1030] beginning cleanup                             monitorTest=audit-log-analyzer
Serializing results.
Writing to storage.
  m.startTime = 2024-06-14 15:47:57.365746 +0800 CST m=+13.827315096
  m.stopTime  = 2024-06-14 16:04:54.467078 +0800 CST m=+1030.879680524
Processing monitorTest: audit-log-analyzer
  finalIntervals size = 10
  first interval time: From = 2024-06-14 15:47:57.369024 +0800 CST m=+13.830592906; To = 2024-06-14 15:47:57.369024 +0800 CST m=+13.830592906
  last interval time: From = 2024-06-14 15:52:47.849559 +0800 CST m=+304.283961661; To = 2024-06-14 15:52:47.849559 +0800 CST m=+304.283961661
Writing junits.
Writing JUnit report to e2e-monitor-tests__20240614-074757.xml
5 pass, 0 skip (4m51s)
  </code></pre>
</details>