### PR TITLE
ETCD-611: update cert rotation tests

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -354,8 +354,24 @@ var staticSuites = []ginkgo.TestSuite{
 			return strings.Contains(name, "[Suite:openshift/etcd/recovery") || strings.Contains(name, "[Feature:EtcdRecovery]") || isStandardEarlyOrLateTest(name)
 		},
 		// etcd's restore test can take a while for apiserver rollouts to stabilize
+		Parallelism:                1,
 		TestTimeout:                120 * time.Minute,
 		ClusterStabilityDuringTest: ginkgo.Disruptive,
+	},
+	{
+		Name: "openshift/etcd/certrotation",
+		Description: templates.LongDesc(`
+		This test suite runs etcd cert rotation tests to exercise the the automatic and manual certificate rotation.
+		`),
+		Matches: func(name string) bool {
+			if isDisabled(name) {
+				return false
+			}
+			return strings.Contains(name, "[Suite:openshift/etcd/certrotation") || strings.Contains(name, "[Feature:CertRotation]") || isStandardEarlyOrLateTest(name)
+		},
+		TestTimeout:                60 * time.Minute,
+		Parallelism:                1,
+		ClusterStabilityDuringTest: ginkgo.Stable,
 	},
 	{
 		Name: "openshift/nodes/realtime",

--- a/test/extended/dr/cert_rotation.go
+++ b/test/extended/dr/cert_rotation.go
@@ -2,19 +2,21 @@ package dr
 
 import (
 	"context"
+	"fmt"
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	"github.com/openshift/origin/test/extended/prometheus/client"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"math/rand"
 	"strings"
 	"time"
 )
 
-var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recovery] etcd", func() {
+var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certrotation] etcd", func() {
 	defer g.GinkgoRecover()
 
 	ctx := context.TODO()
@@ -36,22 +38,15 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recove
 	g.It("can manually rotate signer certificates [Timeout:30m]", func() {
 		kasSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-kube-apiserver")
 		etcdSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-etcd")
-		configSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-config")
 
 		currentKasClientCert, err := kasSecretsClient.Get(ctx, "etcd-client", v1.GetOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
 		currentEtcdLeafCerts, err := etcdSecretsClient.Get(ctx, "etcd-all-certs", v1.GetOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
 
-		// as of 4.16, the manual signer rotation is effectively a secret copy, similar to below OC command:
-		// $ oc get secret etcd-signer -n openshift-etcd -ojson | \
-		// jq 'del(.metadata["namespace","creationTimestamp","resourceVersion","selfLink","uid"])' | \
-		// oc apply -n openshift-config -f -
-		newSigner, err := etcdSecretsClient.Get(ctx, "etcd-signer", v1.GetOptions{})
-		o.Expect(err).ToNot(o.HaveOccurred())
-
-		newSigner.ObjectMeta = v1.ObjectMeta{Name: "etcd-signer", Namespace: "openshift-config"}
-		_, err = configSecretsClient.Update(ctx, newSigner, v1.UpdateOptions{})
+		// as of 4.17, the manual signer rotation is effectively a secret deletion
+		// the operator will automatically recreate, rollout and regenerate all leaf certificates
+		err = etcdSecretsClient.Delete(ctx, "etcd-signer", v1.DeleteOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		g.GinkgoT().Log("waiting for etcd/apiserver to stabilize on the same revision")
@@ -73,26 +68,21 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recove
 		o.Expect(rotatedEtcdLeafCerts.Data).ToNot(o.Equal(currentEtcdLeafCerts.Data))
 	})
 
-	g.It("can manually rotate metrics signer certificates [Timeout:30m]", func() {
+	g.It("can manually rotate metrics signer certificates [Timeout:45m]", func() {
 		etcdSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-etcd")
-		configSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-config")
+		prometheus, err := client.NewE2EPrometheusRouterClient(ctx, oc)
+		o.Expect(err).ToNot(o.HaveOccurred())
 
 		currentEtcdMetricCert, err := etcdSecretsClient.Get(ctx, "etcd-metric-client", v1.GetOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
 
-		// as of 4.16, the manual signer rotation is effectively a secret copy, similar to below OC command:
-		// $ oc get secret etcd-metrics-signer -n openshift-etcd -ojson | \
-		// jq 'del(.metadata["namespace","creationTimestamp","resourceVersion","selfLink","uid"])' | \
-		// oc apply -n openshift-config -f -
-		newSigner, err := etcdSecretsClient.Get(ctx, "etcd-metric-signer", v1.GetOptions{})
-		o.Expect(err).ToNot(o.HaveOccurred())
-
-		newSigner.ObjectMeta = v1.ObjectMeta{Name: "etcd-metric-signer", Namespace: "openshift-config"}
-		_, err = configSecretsClient.Update(ctx, newSigner, v1.UpdateOptions{})
+		// as of 4.17, the manual signer rotation is effectively a secret deletion
+		// the operator will automatically recreate, rollout and regenerate all leaf certificates
+		err = etcdSecretsClient.Delete(ctx, "etcd-metric-signer", v1.DeleteOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		g.GinkgoT().Log("waiting for etcd to stabilize on the same revision")
-		// await all rollouts, then assert the leaf certs all successfully changed
+		// await all rollouts, then assert the leaf client cert has successfully changed
 		err = waitForEtcdToStabilizeOnTheSameRevisionLonger(g.GinkgoT(), oc)
 
 		err = errors.Wrap(err, "timed out waiting for etcd pods to stabilize on the same revision")
@@ -101,48 +91,62 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recove
 		rotatedEtcdMetricsCert, err := etcdSecretsClient.Get(ctx, "etcd-metric-client", v1.GetOptions{})
 		o.Expect(err).ToNot(o.HaveOccurred())
 		o.Expect(rotatedEtcdMetricsCert.Data).ToNot(o.Equal(currentEtcdMetricCert.Data))
-		// TODO check whether we still have prometheus metrics
+
+		err = wait.Poll(30*time.Second, 40*time.Minute, func() (bool, error) {
+			// ensure that prometheus has etcd metrics again
+			result, _, err := prometheus.Query(context.Background(), "sum(up{job=\"etcd\"})", time.Now())
+			if err != nil {
+				return false, err
+			}
+
+			vec, ok := result.(model.Vector)
+			if !ok {
+				o.Expect(fmt.Errorf("expecting Prometheus query to return a vector, got %s instead", vec.Type())).ToNot(o.HaveOccurred())
+			}
+
+			if len(vec) == 0 {
+				o.Expect(fmt.Errorf("expecting Prometheus query to return at least one item, got 0 instead")).ToNot(o.HaveOccurred())
+			}
+
+			numUpEtcds := int(vec[0].Value)
+			g.GinkgoT().Logf("Found [%d] etcds that are up as reported by prometheus...", numUpEtcds)
+			return numUpEtcds > 0, nil
+		})
+		err = errors.Wrap(err, "timed out waiting for metrics to appear again")
+		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 
-	g.It("can recreate dynamic certificates [Timeout:15m]", func() {
+	g.It("can recreate dynamic certificates [Timeout:30m]", func() {
+		nodes := masterNodes(oc)
 		etcdSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-etcd")
-
-		allEtcdSecrets, err := etcdSecretsClient.List(ctx, v1.ListOptions{})
-		o.Expect(err).ToNot(o.HaveOccurred())
-
-		// we pick any peer cert at random and delete it
-		rand.Shuffle(len(allEtcdSecrets.Items), func(i, j int) {
-			allEtcdSecrets.Items[i], allEtcdSecrets.Items[j] = allEtcdSecrets.Items[j], allEtcdSecrets.Items[i]
-		})
 
 		var currentSecretName string
 		var currentSecretData map[string][]byte
-		for _, item := range allEtcdSecrets.Items {
-			if strings.Contains(item.Name, "etcd-peer") {
-				currentSecretName = item.Name
-				currentSecretData = item.Data
-				g.GinkgoT().Logf("Deleting secret %s...", currentSecretName)
-				err = etcdSecretsClient.Delete(ctx, item.Name, v1.DeleteOptions{})
-				o.Expect(err).ToNot(o.HaveOccurred())
-				break
-			}
+		for _, node := range nodes {
+			s, err := etcdSecretsClient.Get(context.Background(), fmt.Sprintf("etcd-peer-%s", node.Name), v1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+			currentSecretName = s.Name
+			currentSecretData = s.Data
+			break
 		}
 
 		o.Expect(currentSecretData).ToNot(o.BeNil())
+		g.GinkgoT().Logf("Deleting secret [%s]...", currentSecretName)
+		err := etcdSecretsClient.Delete(ctx, currentSecretName, v1.DeleteOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
 
 		g.GinkgoT().Log("waiting for the secret to be recreated...")
-		err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
+		err = wait.Poll(30*time.Second, 25*time.Minute, func() (bool, error) {
 			_, err := etcdSecretsClient.Get(ctx, currentSecretName, v1.GetOptions{})
 			if err != nil {
 				return !apierrors.IsNotFound(err), err
 			}
 			return true, nil
 		})
-		err = errors.Wrap(err, "timed out waiting for secret to be recreated by CEO")
+		err = errors.Wrap(err, fmt.Sprintf("timed out waiting for secret [%s] to be recreated by CEO", currentSecretName))
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		g.GinkgoT().Log("waiting for etcd to stabilize on the same revision")
-		// await all rollouts, then assert the leaf certs all successfully changed
 		err = waitForEtcdToStabilizeOnTheSameRevisionLonger(g.GinkgoT(), oc)
 		err = errors.Wrap(err, "timed out waiting for etcd pods to stabilize on the same revision")
 		o.Expect(err).ToNot(o.HaveOccurred())
@@ -152,7 +156,17 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recove
 		etcdConfigMapClient := oc.AdminKubeClient().CoreV1().ConfigMaps("openshift-etcd")
 		bundleName := "etcd-ca-bundle"
 
-		err := etcdConfigMapClient.Delete(ctx, bundleName, v1.DeleteOptions{})
+		get, err := etcdConfigMapClient.Get(ctx, bundleName, v1.GetOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// it makes little sense to recreate a bundle that only has a single CA in it, so we skip this test when the
+		// randomization will run this before any signer rotation.
+		// TODO(thomas): we should serialize this with the signer rotation somehow
+		if strings.Count(get.Data["ca-bundle.crt"], "BEGIN CERTIFICATE") <= 1 {
+			g.Skip("only one CA in the bundle detected, skipping test")
+		}
+
+		err = etcdConfigMapClient.Delete(ctx, bundleName, v1.DeleteOptions{})
 		err = errors.Wrap(err, "error while deleting etcd CA bundle")
 		o.Expect(err).ToNot(o.HaveOccurred())
 
@@ -168,7 +182,6 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recove
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		g.GinkgoT().Log("waiting for etcd to stabilize on the same revision")
-		// await all rollouts, then assert the leaf certs all successfully changed
 		err = waitForEtcdToStabilizeOnTheSameRevisionLonger(g.GinkgoT(), oc)
 		err = errors.Wrap(err, "timed out waiting for etcd pods to stabilize on the same revision")
 		o.Expect(err).ToNot(o.HaveOccurred())

--- a/test/extended/dr/common.go
+++ b/test/extended/dr/common.go
@@ -796,7 +796,7 @@ func waitForEtcdToStabilizeOnTheSameRevision(t library.LoggingT, oc *exutil.CLI)
 
 func waitForEtcdToStabilizeOnTheSameRevisionLonger(t library.LoggingT, oc *exutil.CLI) error {
 	podClient := oc.AdminKubeClient().CoreV1().Pods(openshiftEtcdNamespace)
-	return library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "app=etcd", 5, 1*time.Minute, 5*time.Second, 30*time.Minute)
+	return library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "app=etcd", 3, 1*time.Minute, 10*time.Second, 30*time.Minute)
 }
 
 func waitForApiServerToStabilizeOnTheSameRevision(t library.LoggingT, oc *exutil.CLI) error {
@@ -806,5 +806,5 @@ func waitForApiServerToStabilizeOnTheSameRevision(t library.LoggingT, oc *exutil
 
 func waitForApiServerToStabilizeOnTheSameRevisionLonger(t library.LoggingT, oc *exutil.CLI) error {
 	podClient := oc.AdminKubeClient().CoreV1().Pods("openshift-kube-apiserver")
-	return library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "apiserver=true", 5, 1*time.Minute, 5*time.Second, 30*time.Minute)
+	return library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "apiserver=true", 3, 1*time.Minute, 10*time.Second, 30*time.Minute)
 }

--- a/test/extended/dr/recovery.go
+++ b/test/extended/dr/recovery.go
@@ -3,7 +3,6 @@ package dr
 import (
 	"context"
 	"fmt"
-
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1069,13 +1069,13 @@ var Annotations = map[string]string{
 
 	"[sig-etcd] etcd record the start revision of the etcd-operator [Early]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recovery] etcd can manually rotate metrics signer certificates [Timeout:30m]": "",
+	"[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certrotation] etcd can manually rotate metrics signer certificates [Timeout:45m]": "",
 
-	"[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recovery] etcd can manually rotate signer certificates [Timeout:30m]": "",
+	"[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certrotation] etcd can manually rotate signer certificates [Timeout:30m]": "",
 
-	"[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recovery] etcd can recreate dynamic certificates [Timeout:15m]": "",
+	"[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certrotation] etcd can recreate dynamic certificates [Timeout:30m]": "",
 
-	"[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/recovery] etcd can recreate trust bundle [Timeout:15m]": "",
+	"[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certrotation] etcd can recreate trust bundle [Timeout:15m]": "",
 
 	"[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/recovery][Timeout:2h] [Feature:EtcdRecovery][Disruptive] Recover with snapshot with two unhealthy nodes and lost quorum": " [Serial]",
 


### PR DESCRIPTION
This adds the following fixes:
* manual CA rotation does not need openshift-config signers anymore
* fixing the dynamic cert rotation by selecting a node that's actually alive
* recreating the trust bundle
* move to a dedicated test suite to not impact recovery tests