### PR TITLE
#28746 FIX [release-4.15] OCPBUGS-33023: update egressFWTestE2E image which contains ping binary

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -23,7 +23,7 @@ const (
 	egressFWTestPod      = "egressfirewall"
 	egressFWE2E          = "egress-firewall-e2e"
 	noEgressFWE2E        = "no-egress-firewall-e2e"
-	egressFWTestImage    = "registry.k8s.io/e2e-test-images/agnhost:2.45"
+	egressFWTestImage    = "registry.k8s.io/e2e-test-images/agnhost:2.47"
 	oVNKManifest         = "ovnk-egressfirewall-test.yaml"
 	openShiftSDNManifest = "sdn-egressnetworkpolicy-test.yaml"
 )

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -23,7 +23,7 @@ const (
 	egressFWTestPod      = "egressfirewall"
 	egressFWE2E          = "egress-firewall-e2e"
 	noEgressFWE2E        = "no-egress-firewall-e2e"
-	egressFWTestImage    = "quay.io/redhat-developer/nfs-server:1.1"
+	egressFWTestImage    = "registry.k8s.io/e2e-test-images/agnhost:2.45"
 	oVNKManifest         = "ovnk-egressfirewall-test.yaml"
 	openShiftSDNManifest = "sdn-egressnetworkpolicy-test.yaml"
 )


### PR DESCRIPTION
Updated agnhost image tag to fix #28746 of cherry pic #28408 for release-4.15 branch