### PR TITLE
OCPEDGE-800: feat: add SNO upgrade consideration during pathological errors

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -210,6 +210,8 @@ const (
 	UpgradeRollbackReason IntervalReason = "UpgradeRollback"
 	UpgradeFailedReason   IntervalReason = "UpgradeFailed"
 	UpgradeCompleteReason IntervalReason = "UpgradeComplete"
+
+	NodeInstallerReason IntervalReason = "NodeInstaller"
 )
 
 type AnnotationKey string


### PR DESCRIPTION
during single node upgrades we run into errors when the kube-apiserver is progressing that are expected updating the pathological matcher to account for expected errors during kube-apiserver installer progressing