### PR TITLE
OCPBUGS-36187: Revert #28515 Re-enable test/extended/router/http2 tests on AWS"

### DIFF
--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -3,7 +3,6 @@ package router
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"sort"
 	"strconv"
@@ -471,7 +470,7 @@ BFNBRELPe53ZdLKWpf2Sr96vRPRNw
 				return
 			}
 
-			testSuites, err := runConformanceTests(oc, host, "h2spec", 10*time.Minute)
+			testSuites, err := runConformanceTests(oc, host, "h2spec", 5*time.Minute)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(testSuites).ShouldNot(o.BeEmpty())
 
@@ -547,14 +546,7 @@ func failingTests(testSuites []*h2spec.JUnitTestSuite) []h2specFailingTest {
 func runConformanceTests(oc *exutil.CLI, host, podName string, timeout time.Duration) ([]*h2spec.JUnitTestSuite, error) {
 	var testSuites []*h2spec.JUnitTestSuite
 
-	if err := wait.Poll(2*time.Second, timeout, func() (bool, error) {
-		// Error message will read as:
-		//   <date>: INFO: lookup <host>: no such host, retrying...
-		if _, err := net.LookupHost(host); err != nil {
-			e2e.Logf("%v, retrying...", err)
-			return false, nil
-		}
-
+	if err := wait.Poll(time.Second, timeout, func() (bool, error) {
 		g.By("Running the h2spec CLI test")
 
 		// this is the output file in the pod
@@ -621,7 +613,7 @@ func runConformanceTestsAndLogAggregateFailures(oc *exutil.CLI, host, podName st
 	failuresByTestCaseID := map[string]int{}
 
 	for i := 1; i <= iterations; i++ {
-		testResults, err := runConformanceTests(oc, host, podName, 10*time.Minute)
+		testResults, err := runConformanceTests(oc, host, podName, 5*time.Minute)
 		if err != nil {
 			e2e.Logf(err.Error())
 			continue

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -592,8 +592,11 @@ func resolveHost(oc *exutil.CLI, interval, timeout time.Duration, host string) (
 // clients.
 func platformHasHTTP2LoadBalancerService(platformType configv1.PlatformType) bool {
 	switch platformType {
-	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType:
+	case configv1.AzurePlatformType, configv1.GCPPlatformType:
 		return true
+	case configv1.AWSPlatformType:
+		e2e.Logf("AWS support waiting on https://bugzilla.redhat.com/show_bug.cgi?id=1912413")
+		fallthrough
 	default:
 		return false
 	}


### PR DESCRIPTION

Reverts #28515 ; tracked by https://issues.redhat.com/browse/OCPBUGS-36187

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

The HAProxy router should pass the http2 tests failing for aws

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-aggregate periodic-ci-openshift-release-master-ci-4.17-e2e-aws-ovn-upgrade 10
```

CC: @frobware

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
