### PR TITLE
NO-JIRA: egressfirewall: skip ping tests in case of hypershift kubevirt on Azure infra

### DIFF
--- a/test/extended/kubevirt/migration.go
+++ b/test/extended/kubevirt/migration.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -54,12 +55,12 @@ var _ = Describe("[sig-kubevirt] migration", func() {
 					WithPolling(5*time.Second).
 					Should(Equal(numberOfNodes), "nodes should have ready state before migration")
 
-				setMgmtFramework(mgmtFramework)
+				SetMgmtFramework(mgmtFramework)
 				expectNoError(migrateWorkers(mgmtFramework))
 			})
 			It("should maintain node readiness", func() {
 				By("Check node readiness is as expected")
-				isAWS, err := mgmtClusterIsAWS(mgmtFramework)
+				isAWS, err := MgmtClusterIsType(mgmtFramework, configv1.AWSPlatformType)
 				Expect(err).ToNot(HaveOccurred())
 
 				if isAWS {

--- a/test/extended/kubevirt/services.go
+++ b/test/extended/kubevirt/services.go
@@ -21,7 +21,7 @@ var _ = Describe("[sig-kubevirt] services", func() {
 		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		It("should allow connections to pods from infra cluster pod via NodePort across different infra nodes", func() {
-			oc = setMgmtFramework(mgmtFramework)
+			oc = SetMgmtFramework(mgmtFramework)
 			// This tests connectivity from the infra cluster's pod network to a NodePort
 			// within a nested KubeVirt Hypershift guest cluster.
 			//
@@ -58,7 +58,7 @@ var _ = Describe("[sig-kubevirt] services", func() {
 		})
 
 		It("should allow connections to pods from infra cluster pod via LoadBalancer service across different guest nodes", func() {
-			oc = setMgmtFramework(mgmtFramework)
+			oc = SetMgmtFramework(mgmtFramework)
 			// Within a nested KubeVirt guest cluster, this tests the ability for
 			// LoadBalancer services to route from pod network to pods across infra nodes.
 			// client pod (on infra cluster) -> guest node IP -> LoadBalancer Service -> server pod (on guest cluster)

--- a/test/extended/kubevirt/util.go
+++ b/test/extended/kubevirt/util.go
@@ -364,7 +364,7 @@ func InKubeVirtClusterContext(oc *exutil.CLI, body func()) {
 	)
 }
 
-func setMgmtFramework(mgmtFramework *e2e.Framework) *exutil.CLI {
+func SetMgmtFramework(mgmtFramework *e2e.Framework) *exutil.CLI {
 	_, hcpNamespace, err := exutil.GetHypershiftManagementClusterConfigAndNamespace()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -458,15 +458,15 @@ func expectNoError(err error, explain ...interface{}) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), explain...)
 }
 
-func mgmtClusterIsAWS(f *e2e.Framework) (bool, error) {
-	oc := setMgmtFramework(f)
+func MgmtClusterIsType(f *e2e.Framework, platformType configv1.PlatformType) (bool, error) {
+	oc := SetMgmtFramework(f)
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(),
 		"cluster", metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
 
-	return infra.Spec.PlatformSpec.Type == configv1.AWSPlatformType, nil
+	return infra.Spec.PlatformSpec.Type == platformType, nil
 }
 
 func dumpKubevirtArtifacts(f *e2e.Framework) {

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/test/extended/kubevirt"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
 
@@ -34,12 +35,14 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 
 	egFwoc := exutil.NewCLIWithPodSecurityLevel(egressFWE2E, admissionapi.LevelPrivileged)
 	egFwf := egFwoc.KubeFramework()
+	mgmtFw := e2e.NewDefaultFramework("mgmt-framework")
+	mgmtFw.SkipNamespaceCreation = true
 
 	// The OVNKubernetes subnet plugin supports EgressFirewall objects.
 	InOVNKubernetesContext(
 		func() {
 			g.It("should ensure egressfirewall is created", func() {
-				doEgressFwTest(egFwf, egFwoc, oVNKManifest, true, false)
+				doEgressFwTest(egFwf, mgmtFw, egFwoc, oVNKManifest, true, false)
 			})
 		},
 	)
@@ -47,7 +50,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 	InOpenShiftSDNContext(
 		func() {
 			g.It("should ensure egressnetworkpolicy is created [apigroup:network.openshift.io]", func() {
-				doEgressFwTest(egFwf, egFwoc, openShiftSDNManifest, false, false)
+				doEgressFwTest(egFwf, mgmtFw, egFwoc, openShiftSDNManifest, false, false)
 			})
 		},
 	)
@@ -68,7 +71,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 		infra, err := noegFwoc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
 
-		if platformSupportICMP(infra.Status.PlatformStatus.Type) {
+		if platformSupportICMP(infra.Status.PlatformStatus.Type, mgmtFw) {
 			_, err := noegFwoc.Run("exec").Args(pod, "--", "ping", "-c", "1", "8.8.8.8").Output()
 			expectNoError(err)
 
@@ -93,16 +96,18 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:DNSNameResolver][Feature:Egress
 	// - Update doEgressFwTest and sendEgressFwTraffic functions.
 	wcEgFwOc := exutil.NewCLIWithPodSecurityLevel(wcEgressFWE2E, admissionapi.LevelPrivileged)
 	wcEgFwF := wcEgFwOc.KubeFramework()
+	mgmtFramework := e2e.NewDefaultFramework("mgmt-framework")
+	mgmtFramework.SkipNamespaceCreation = true
 	InOVNKubernetesContext(
 		func() {
 			g.It("should ensure egressfirewall with wildcard dns rules is created", func() {
-				doEgressFwTest(wcEgFwF, wcEgFwOc, oVNKWCManifest, true, true)
+				doEgressFwTest(wcEgFwF, mgmtFramework, wcEgFwOc, oVNKWCManifest, true, true)
 			})
 		},
 	)
 })
 
-func doEgressFwTest(f *e2e.Framework, oc *exutil.CLI, manifest string, nodeSelectorSupport, checkWildcard bool) error {
+func doEgressFwTest(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI, manifest string, nodeSelectorSupport, checkWildcard bool) error {
 	g.By("creating test pod")
 	o.Expect(createTestEgressFw(f, egressFWTestPod)).To(o.Succeed())
 
@@ -119,18 +124,18 @@ func doEgressFwTest(f *e2e.Framework, oc *exutil.CLI, manifest string, nodeSelec
 	err := oc.AsAdmin().Run("create").Args("-f", egFwYaml).Execute()
 	o.Expect(err).NotTo(o.HaveOccurred(), "created egress-firewall object")
 
-	o.Expect(sendEgressFwTraffic(f, oc, egressFWTestPod, nodeSelectorSupport, checkWildcard)).To(o.Succeed())
+	o.Expect(sendEgressFwTraffic(f, mgmtFw, oc, egressFWTestPod, nodeSelectorSupport, checkWildcard)).To(o.Succeed())
 
 	g.By("deleting test pod")
 	deleteTestEgressFw(f)
 	return err
 }
 
-func sendEgressFwTraffic(f *e2e.Framework, oc *exutil.CLI, pod string, nodeSelectorSupport, checkWildcard bool) error {
+func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI, pod string, nodeSelectorSupport, checkWildcard bool) error {
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
 
-	if platformSupportICMP(infra.Status.PlatformStatus.Type) {
+	if platformSupportICMP(infra.Status.PlatformStatus.Type, mgmtFw) {
 		// Test ICMP / Ping to Google’s DNS IP (8.8.8.8) should pass
 		// because we have allow cidr rule for 8.8.8.8
 		g.By("sending traffic that matches allow cidr rule")
@@ -259,11 +264,16 @@ func waitForTestEgressFwPod(f *e2e.Framework, podName string) (string, error) {
 	return podIP, err
 }
 
-func platformSupportICMP(platformType configv1.PlatformType) bool {
+func platformSupportICMP(platformType configv1.PlatformType, framework *e2e.Framework) bool {
 	switch platformType {
-	// Azure has secuirty rules to prevent icmp response from outside the cluster by default
+	// Azure has security rules to prevent icmp response from outside the cluster by default
 	case configv1.AzurePlatformType:
 		return false
+	case configv1.KubevirtPlatformType:
+		kubevirt.SetMgmtFramework(framework)
+		isAzure, err := kubevirt.MgmtClusterIsType(framework, configv1.AzurePlatformType)
+		expectNoError(err)
+		return !isAzure
 	default:
 		return true
 	}


### PR DESCRIPTION
In case the cluster under test is an HCP/HyperShift cluster of the kubevirt provider, and the management cluster is running on Azure, ICMP responses from outside of the cluster to the guest cluster are getting blocked. Thus, skipping the ping tests in that case, in addition to the existing exception.

This blocks https://github.com/openshift/release/pull/52508 from passing a full conformance test with Azure infrastructure.