### PR TITLE
NO-JIRA: fix: update skip logic for watchdog

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/watchdog.go
+++ b/pkg/monitortestlibrary/allowedalerts/watchdog.go
@@ -82,7 +82,7 @@ func (a *watchdogAlertTest) InvariantCheck(alertIntervals monitorapi.Intervals, 
 
 	// If this is a single node upgrade job, we can skip the test
 	// Or cluster stability is disruptive in which we don't query prometheus alert data
-	if (a.jobType.Topology == "single" && a.jobType.FromRelease == "") || (a.clusterStability != nil && *a.clusterStability == monitortestframework.Disruptive) {
+	if (a.jobType.Topology == "single" && a.jobType.FromRelease != "") || (a.clusterStability != nil && *a.clusterStability == monitortestframework.Disruptive) {
 		return []*junitapi.JUnitTestCase{}, nil
 	}
 


### PR DESCRIPTION
the logic for skipping watch dog check on sno upgrade needs to be inverted since FromRelease will be populated with a string version when the jobtype is a single node upgrade