### PR TITLE
OCPBUGS-36672: Shorten stabilization time for etcd profiles test

### DIFF
--- a/test/extended/etcd/hardware_speed.go
+++ b/test/extended/etcd/hardware_speed.go
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", func
 
 func waitForEtcdToStabilizeOnTheSameRevision(t library.LoggingT, oc *exutil.CLI) error {
 	podClient := oc.AdminKubeClient().CoreV1().Pods("openshift-etcd")
-	return library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "app=etcd", 5, 1*time.Minute, 5*time.Second, 30*time.Minute)
+	return library.WaitForPodsToStabilizeOnTheSameRevision(t, podClient, "app=etcd", 5, 24*time.Second, 5*time.Second, 30*time.Minute)
 }
 
 func expectedStandardHardwareSpeed() map[string]string {


### PR DESCRIPTION
Shorten stabilization time from 5 minutes to 2 minutes