### PR TITLE
WIP monitor tests: fail tests when cert rotation failure noticed

### DIFF
--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/certrotationfailed.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/certrotationfailed.go
@@ -1,0 +1,31 @@
+package legacykubeapiservermonitortests
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+func testCertRotationFailed(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[bz-kube-apiserver] certificate rotation failed"
+
+	failures := []string{}
+	for _, event := range events {
+		if event.Message.Reason == "CertificateUpdateFailed" {
+			failures = append(failures, fmt.Sprintf("%v %v", event.Locator.OldLocator(), event.Message.OldMessage()))
+		}
+	}
+	if len(failures) == 0 {
+		return []*junitapi.JUnitTestCase{{Name: testName}}
+	}
+
+	return []*junitapi.JUnitTestCase{{
+		Name:      testName,
+		SystemOut: strings.Join(failures, "\n"),
+		FailureOutput: &junitapi.FailureOutput{
+			Output: fmt.Sprintf("Certificate rotation failed\n\n%v", strings.Join(failures, "\n")),
+		},
+	}}
+}

--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/monitortest.go
@@ -37,6 +37,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	junits = append(junits, testPodNodeNameIsImmutable(finalIntervals)...)
 	junits = append(junits, testStaticPodLifecycleFailure(finalIntervals, w.adminRESTConfig)...)
 	junits = append(junits, testAPIServerIPTablesAccessDisruption(finalIntervals)...)
+	junits = append(junits, testCertRotationFailed(finalIntervals)...)
 
 	return junits, nil
 }


### PR DESCRIPTION
Throw error if cert rotation failure event is spotted