### PR TITLE
NO-JIRA: Skip cert collection tests on hypershift

### DIFF
--- a/test/extended/operators/certs.go
+++ b/test/extended/operators/certs.go
@@ -96,6 +96,10 @@ var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g
 		if ok, _ := exutil.IsMicroShiftCluster(kubeClient); ok {
 			g.Skip("microshift does not auto-collect TLS.")
 		}
+		configClient := oc.AdminConfigClient()
+		if ok, _ := exutil.IsHypershift(ctx, configClient); ok {
+			g.Skip("hypershift does not auto-collect TLS.")
+		}
 		var err error
 		onDiskPKIContent := &certgraphapi.PKIList{}
 


### PR DESCRIPTION
Hypershift has a different cert structure and tests may flake so skip cert collection for now