### PR TITLE
no-jira: e2e: check for deployer RB only when DeploymentConfig is enabled

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -355,11 +355,13 @@ func (c *CLI) setupProject() string {
 		"default",
 		"builder",
 	}
+	defaultRoleBindings := []string{"system:image-pullers", "system:image-builders"}
 	dcEnabled, err := IsCapabilityEnabled(c, configv1.ClusterVersionCapabilityDeploymentConfig)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	if dcEnabled {
 		framework.Logf("%v capability is enabled, adding 'deployer' SA to the list of default SAs", configv1.ClusterVersionCapabilityDeploymentConfig)
 		DefaultServiceAccounts = append(DefaultServiceAccounts, "deployer")
+		defaultRoleBindings = append(defaultRoleBindings, "system:deployers")
 	}
 	for _, sa := range DefaultServiceAccounts {
 		framework.Logf("Waiting for ServiceAccount %q to be provisioned...", sa)
@@ -371,7 +373,7 @@ func (c *CLI) setupProject() string {
 	cancel := func() {}
 	defer func() { cancel() }()
 	// Wait for default role bindings for those SAs
-	for _, name := range []string{"system:image-pullers", "system:image-builders", "system:deployers"} {
+	for _, name := range defaultRoleBindings {
 		framework.Logf("Waiting for RoleBinding %q to be provisioned...", name)
 
 		ctx, cancel = watchtools.ContextWithOptionalTimeout(context.Background(), 3*time.Minute)


### PR DESCRIPTION
Follow up for https://github.com/openshift/origin/pull/28939.

To resolve failing e2e in https://github.com/openshift/cluster-version-operator/pull/1066.