### PR TITLE
OCPBUGS-18865: Reapply "Merge pull request #28277 from vrutkovs/in-cluster-fixes-v3"

### DIFF
--- a/pkg/clioptions/iooptions/io_options.go
+++ b/pkg/clioptions/iooptions/io_options.go
@@ -1,8 +1,10 @@
 package iooptions
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"path"
 
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -34,6 +36,11 @@ func (o *OutputFlags) ConfigureIOStreams(streams genericclioptions.IOStreams, st
 	if len(o.OutFile) == 0 {
 		streamSetter.SetIOStreams(streams)
 		return doNothing, nil
+	}
+
+	dir := path.Dir(o.OutFile)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return doNothing, fmt.Errorf("failed to create parentdir %q: %w", dir, err)
 	}
 
 	f, err := os.OpenFile(o.OutFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)

--- a/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
+++ b/pkg/cmd/openshift-tests/monitor/run/run_monitor_command.go
@@ -19,12 +19,11 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/openshift/origin/pkg/defaultmonitortests"
+	"github.com/openshift/origin/pkg/monitor"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/util/templates"
-
-	"github.com/openshift/origin/pkg/defaultmonitortests"
-	"github.com/openshift/origin/pkg/monitor"
 )
 
 type RunMonitorFlags struct {

--- a/pkg/cmd/openshift-tests/run-disruption/disruption.go
+++ b/pkg/cmd/openshift-tests/run-disruption/disruption.go
@@ -6,46 +6,51 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
+	"sync"
 	"syscall"
-	"time"
 
-	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+	"k8s.io/apimachinery/pkg/fields"
 
+	"github.com/openshift/origin/pkg/clioptions/iooptions"
+	"github.com/openshift/origin/pkg/disruption/backend"
+	disruptionci "github.com/openshift/origin/pkg/disruption/ci"
+	"github.com/openshift/origin/pkg/monitor"
+	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	apimachinerywatch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/watch"
 	"k8s.io/kubectl/pkg/util/templates"
-
-	"github.com/openshift/origin/pkg/disruption/backend"
-	"github.com/openshift/origin/pkg/monitor"
-	"github.com/openshift/origin/pkg/monitor/apiserveravailability"
-	"github.com/openshift/origin/pkg/monitor/monitorapi"
-	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
-	"github.com/spf13/cobra"
 )
 
-// RunAPIDisruptionMonitorOptions sets options for api server disruption monitor
-type RunAPIDisruptionMonitorOptions struct {
-	Out, ErrOut io.Writer
+type RunAPIDisruptionMonitorFlags struct {
+	ConfigFlags *genericclioptions.ConfigFlags
+	OutputFlags *iooptions.OutputFlags
 
-	ArtifactDir      string
-	LoadBalancerType string
-	ExtraMessage     string
+	ArtifactDir       string
+	LoadBalancerType  string
+	StopConfigMapName string
+
+	genericclioptions.IOStreams
 }
 
-func NewRunInClusterDisruptionMonitorOptions(ioStreams genericclioptions.IOStreams) *RunAPIDisruptionMonitorOptions {
-	return &RunAPIDisruptionMonitorOptions{
-		Out:    ioStreams.Out,
-		ErrOut: ioStreams.ErrOut,
+func NewRunInClusterDisruptionMonitorFlags(ioStreams genericclioptions.IOStreams) *RunAPIDisruptionMonitorFlags {
+	return &RunAPIDisruptionMonitorFlags{
+		ConfigFlags: genericclioptions.NewConfigFlags(false),
+		OutputFlags: iooptions.NewOutputOptions(),
+		IOStreams:   ioStreams,
 	}
 }
 
 func NewRunInClusterDisruptionMonitorCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
-	disruptionOpt := NewRunInClusterDisruptionMonitorOptions(ioStreams)
+	f := NewRunInClusterDisruptionMonitorFlags(ioStreams)
 	cmd := &cobra.Command{
 		Use:   "run-disruption",
 		Short: "Run API server disruption monitor",
@@ -56,122 +61,183 @@ func NewRunInClusterDisruptionMonitorCommand(ioStreams genericclioptions.IOStrea
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return disruptionOpt.Run()
+			ctx, cancelFn := context.WithCancel(context.Background())
+			defer cancelFn()
+			abortCh := make(chan os.Signal, 2)
+			go func() {
+				<-abortCh
+				fmt.Fprintf(f.ErrOut, "Interrupted, terminating\n")
+				cancelFn()
+
+				sig := <-abortCh
+				fmt.Fprintf(f.ErrOut, "Interrupted twice, exiting (%s)\n", sig)
+				switch sig {
+				case syscall.SIGINT:
+					os.Exit(130)
+				default:
+					os.Exit(0)
+				}
+			}()
+			signal.Notify(abortCh, syscall.SIGINT, syscall.SIGTERM)
+
+			if err := f.Validate(); err != nil {
+				return err
+			}
+
+			o, err := f.ToOptions()
+			if err != nil {
+				return err
+			}
+
+			return o.Run(ctx)
 		},
 	}
-	cmd.Flags().StringVar(&disruptionOpt.ArtifactDir,
-		"artifact-dir", disruptionOpt.ArtifactDir,
-		"The directory where monitor events will be stored.")
-	cmd.Flags().StringVar(&disruptionOpt.LoadBalancerType,
-		"lb-type", disruptionOpt.LoadBalancerType,
-		"Set load balancer type, available options: internal-lb, service-network, external-lb (default)")
-	cmd.Flags().StringVar(&disruptionOpt.ExtraMessage,
-		"extra-message", disruptionOpt.ExtraMessage,
-		"Add custom label to disruption event message")
+
+	f.AddFlags(cmd.Flags())
+
 	return cmd
 }
 
-func (opt *RunAPIDisruptionMonitorOptions) Run() error {
-	restConfig, err := clusterinfo.GetMonitorRESTConfig()
-	if err != nil {
-		return err
+func (f *RunAPIDisruptionMonitorFlags) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&f.LoadBalancerType, "lb-type", f.LoadBalancerType, "Set load balancer type, available options: internal-lb, service-network, external-lb (default)")
+	flags.StringVar(&f.StopConfigMapName, "stop-configmap", f.StopConfigMapName, "the name of the configmap that indicates that this pod should stop all watchers.")
+
+	f.ConfigFlags.AddFlags(flags)
+	f.OutputFlags.BindFlags(flags)
+}
+
+func (f *RunAPIDisruptionMonitorFlags) SetIOStreams(streams genericclioptions.IOStreams) {
+	f.IOStreams = streams
+}
+
+func (f *RunAPIDisruptionMonitorFlags) Validate() error {
+	if len(f.OutputFlags.OutFile) == 0 {
+		return fmt.Errorf("output-file must be specified")
 	}
-
-	lb := backend.ParseStringToLoadBalancerType(opt.LoadBalancerType)
-
-	ctx, cancelFn := context.WithCancel(context.Background())
-	defer cancelFn()
-	abortCh := make(chan os.Signal, 2)
-	go func() {
-		<-abortCh
-		fmt.Fprintf(opt.ErrOut, "Interrupted, terminating\n")
-		// Give some time to store intervals on disk
-		time.Sleep(5 * time.Second)
-		cancelFn()
-		sig := <-abortCh
-		fmt.Fprintf(opt.ErrOut, "Interrupted twice, exiting (%s)\n", sig)
-		switch sig {
-		case syscall.SIGINT:
-			os.Exit(130)
-		default:
-			os.Exit(0)
-		}
-	}()
-	signal.Notify(abortCh, syscall.SIGINT, syscall.SIGTERM)
-
-	recorder, err := StartAPIAvailability(ctx, restConfig, lb)
-	if err != nil {
-		return err
+	if len(f.StopConfigMapName) == 0 {
+		return fmt.Errorf("stop-configmap must be specified")
 	}
-
-	go func() {
-		ticker := time.NewTicker(100 * time.Millisecond)
-		defer ticker.Stop()
-		var last time.Time
-		done := false
-		for !done {
-			select {
-			case <-ticker.C:
-			case <-ctx.Done():
-				done = true
-			}
-			events := recorder.Intervals(last, time.Time{})
-			if len(events) > 0 {
-				for _, event := range events {
-					if !event.From.Equal(event.To) {
-						continue
-					}
-					fmt.Fprintln(opt.Out, event.String())
-				}
-				last = events[len(events)-1].From
-			}
-		}
-	}()
-
-	<-ctx.Done()
-
-	// Store intervals to artifact directory
-	intervals := recorder.Intervals(time.Time{}, time.Time{})
-	if len(opt.ExtraMessage) > 0 {
-		fmt.Fprintf(opt.Out, "\nAppending %s to recorded event message\n", opt.ExtraMessage)
-		for i, event := range intervals {
-			intervals[i].Message.HumanMessage = fmt.Sprintf("%s user-provided-message=%s", event.Message.HumanMessage, opt.ExtraMessage)
-		}
-	}
-
-	eventDir := filepath.Join(opt.ArtifactDir, monitorapi.EventDir)
-	if err := os.MkdirAll(eventDir, os.ModePerm); err != nil {
-		fmt.Printf("Failed to create monitor-events directory, err: %v\n", err)
-		return err
-	}
-
-	timeSuffix := fmt.Sprintf("_%s", time.Now().UTC().Format("20060102-150405"))
-	if err := monitorserialization.EventsToFile(filepath.Join(eventDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)), intervals); err != nil {
-		fmt.Printf("Failed to write event data, err: %v\n", err)
-		return err
-	}
-	fmt.Fprintf(opt.Out, "\nEvent data written, exiting\n")
 
 	return nil
 }
 
-// StartAPIAvailability monitors just the cluster availability
-func StartAPIAvailability(ctx context.Context, restConfig *rest.Config, lb backend.LoadBalancerType) (monitorapi.Recorder, error) {
-	recorder := monitor.NewRecorder()
-
-	client, err := kubernetes.NewForConfig(restConfig)
+func (f *RunAPIDisruptionMonitorFlags) ToOptions() (*RunAPIDisruptionMonitorOptions, error) {
+	originalOutStream := f.IOStreams.Out
+	closeFn, err := f.OutputFlags.ConfigureIOStreams(f.IOStreams, f)
 	if err != nil {
 		return nil, err
 	}
-	if err := controlplane.StartAPIMonitoringUsingNewBackend(ctx, recorder, restConfig, lb); err != nil {
+
+	namespace, _, err := f.ConfigFlags.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return nil, err
+	}
+	if len(namespace) == 0 {
+		return nil, fmt.Errorf("namespace must be specified")
+	}
+
+	restConfig, err := f.ConfigFlags.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
 		return nil, err
 	}
 
-	// read the state of the cluster apiserver client access issues *before* any test (like upgrade) begins
-	intervals, err := apiserveravailability.APIServerAvailabilityIntervalsFromCluster(client, time.Time{}, time.Time{})
-	if err != nil {
-		klog.Errorf("error reading initial apiserver availability: %v", err)
+	return &RunAPIDisruptionMonitorOptions{
+		KubeClient:        kubeClient,
+		KubeClientConfig:  restConfig,
+		OutputFile:        f.OutputFlags.OutFile,
+		LoadBalancerType:  f.LoadBalancerType,
+		StopConfigMapName: f.StopConfigMapName,
+		Namespace:         namespace,
+		CloseFn:           closeFn,
+		OriginalOutFile:   originalOutStream,
+		IOStreams:         f.IOStreams,
+	}, nil
+}
+
+// RunAPIDisruptionMonitorOptions sets options for api server disruption monitor
+type RunAPIDisruptionMonitorOptions struct {
+	KubeClient        kubernetes.Interface
+	KubeClientConfig  *rest.Config
+	OutputFile        string
+	LoadBalancerType  string
+	StopConfigMapName string
+	Namespace         string
+
+	OriginalOutFile io.Writer
+	CloseFn         iooptions.CloseFunc
+	genericclioptions.IOStreams
+}
+
+func (o *RunAPIDisruptionMonitorOptions) Run(ctx context.Context) error {
+	ctx, cancelFn := context.WithCancel(ctx)
+	defer cancelFn()
+
+	fmt.Fprintf(o.Out, "Starting up.")
+
+	startingContent, err := os.ReadFile(o.OutputFile)
+	if err != nil && !os.IsNotExist(err) {
+		return err
 	}
-	recorder.AddIntervals(intervals...)
-	return recorder, nil
+	if len(startingContent) > 0 {
+		// print starting content to the log so that we can simply scrape the log to find all entries at the end.
+		o.OriginalOutFile.Write(startingContent)
+	}
+
+	lb := backend.ParseStringToLoadBalancerType(o.LoadBalancerType)
+
+	recorder := monitor.WrapWithJSONLRecorder(monitor.NewRecorder(), o.IOStreams.Out, nil)
+	samplers, err := controlplane.StartAPIMonitoringUsingNewBackend(ctx, recorder, o.KubeClientConfig, o.KubeClient, lb)
+	if err != nil {
+		return err
+	}
+
+	go func(ctx context.Context) {
+		defer cancelFn()
+		err := o.WaitForStopSignal(ctx)
+		if err != nil {
+			fmt.Fprintf(o.ErrOut, "failure waiting for stop: %v", err)
+		}
+	}(ctx)
+
+	<-ctx.Done()
+
+	fmt.Fprintf(o.Out, "waiting for samplers to stop")
+	wg := sync.WaitGroup{}
+	for i := range samplers {
+		wg.Add(1)
+		func(sampler disruptionci.Sampler) {
+			defer wg.Done()
+			sampler.Stop()
+		}(samplers[i])
+	}
+	wg.Wait()
+	fmt.Fprintf(o.Out, "samplers stopped")
+
+	return nil
+}
+
+func (o *RunAPIDisruptionMonitorOptions) WaitForStopSignal(ctx context.Context) error {
+	defer utilruntime.HandleCrash()
+
+	_, err := watch.UntilWithSync(
+		ctx,
+		cache.NewListWatchFromClient(
+			o.KubeClient.CoreV1().RESTClient(), "configmaps", o.Namespace, fields.OneTermEqualSelector("metadata.name", o.StopConfigMapName)),
+		&corev1.ConfigMap{},
+		nil,
+		func(event apimachinerywatch.Event) (bool, error) {
+			switch event.Type {
+			case apimachinerywatch.Added:
+				return true, nil
+			case apimachinerywatch.Modified:
+				return true, nil
+			}
+			return false, nil
+		},
+	)
+	return err
 }

--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/imageregistry/disruptionimageregistry"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/apiservergracefulrestart"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/auditloganalyzer"
+	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/disruptionnewapiserver"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests"
@@ -39,6 +40,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionserializer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/e2etestanalyzer"
+
 	"github.com/openshift/origin/pkg/monitortests/testframework/intervalserializer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/knownimagechecker"
 	"github.com/openshift/origin/pkg/monitortests/testframework/legacytestframeworkmonitortests"
@@ -106,6 +108,7 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 
 	monitorTestRegistry.AddMonitorTestOrDie("apiserver-availability", "kube-apiserver", disruptionlegacyapiservers.NewAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("apiserver-new-disruption-invariant", "kube-apiserver", disruptionnewapiserver.NewDisruptionInvariant())
+	monitorTestRegistry.AddMonitorTestOrDie("apiserver-incluster-availability", "kube-apiserver", disruptioninclusterapiserver.NewInvariantInClusterDisruption(info))
 
 	monitorTestRegistry.AddMonitorTestOrDie("pod-network-avalibility", "Network / ovn-kubernetes", disruptionpodnetwork.NewPodNetworkAvalibilityInvariant(info))
 	monitorTestRegistry.AddMonitorTestOrDie("service-type-load-balancer-availability", "Networking / router", disruptionserviceloadbalancer.NewAvailabilityInvariant())

--- a/pkg/disruption/ci/host_decoder.go
+++ b/pkg/disruption/ci/host_decoder.go
@@ -12,21 +12,16 @@ import (
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes"
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 // NewAPIServerIdentityToHostNameDecoder returns a new
 // HostNameDecoder instance that is capable of decoding the
 // APIServerIdentity into the human readable hostname.
-func NewAPIServerIdentityToHostNameDecoder(config *rest.Config) (*apiServerIdentityDecoder, error) {
-	clients, err := clientset.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	client := clients.CoordinationV1().Leases(metav1.NamespaceSystem)
+func NewAPIServerIdentityToHostNameDecoder(kubeClient kubernetes.Interface) (*apiServerIdentityDecoder, error) {
+	client := kubeClient.CoordinationV1().Leases(metav1.NamespaceSystem)
 	return &apiServerIdentityDecoder{client: client}, nil
 }
 

--- a/pkg/monitortestframework/types.go
+++ b/pkg/monitortestframework/types.go
@@ -36,6 +36,8 @@ type MonitorTestInitializationInfo struct {
 	DisableMonitorTests []string
 }
 
+type OpenshiftTestImageGetterFunc func(ctx context.Context, adminRESTConfig *rest.Config) (imagePullSpec string, notSupportedReason string, err error)
+
 type MonitorTest interface {
 	// StartCollection is responsible for setting up all resources required for collection of data on the cluster.
 	// An error will not stop execution, but will cause a junit failure that will cause the job run to fail.

--- a/pkg/monitortestlibrary/disruptionlibrary/collect.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/collect.go
@@ -1,0 +1,86 @@
+package disruptionlibrary
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+func CollectIntervalsForPods(ctx context.Context, kubeClient kubernetes.Interface, sig string, namespace string, labelSelector labels.Selector) (monitorapi.Intervals, []*junitapi.JUnitTestCase, []error) {
+	pollerPods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+	})
+	if err != nil {
+		return nil, nil, []error{err}
+	}
+
+	retIntervals := monitorapi.Intervals{}
+	junits := []*junitapi.JUnitTestCase{}
+	errs := []error{}
+	buf := &bytes.Buffer{}
+	podsWithoutIntervals := []string{}
+	for _, pollerPod := range pollerPods.Items {
+		fmt.Fprintf(buf, "\n\nLogs for -n %v pod/%v\n", pollerPod.Namespace, pollerPod.Name)
+		req := kubeClient.CoreV1().Pods(namespace).GetLogs(pollerPod.Name, &corev1.PodLogOptions{})
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		logStream, err := req.Stream(ctx)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		foundInterval := false
+		scanner := bufio.NewScanner(logStream)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			buf.Write(line)
+			buf.Write([]byte("\n"))
+			if len(line) == 0 {
+				continue
+			}
+
+			// not all lines are json, ignore errors.
+			if currInterval, err := monitorserialization.IntervalFromJSON(line); err == nil {
+				retIntervals = append(retIntervals, *currInterval)
+				foundInterval = true
+			}
+		}
+		if !foundInterval {
+			podsWithoutIntervals = append(podsWithoutIntervals, pollerPod.Name)
+		}
+	}
+
+	failures := []string{}
+	if len(podsWithoutIntervals) > 0 {
+		failures = append(failures, fmt.Sprintf("%d pods lacked sampler output: [%v]", len(podsWithoutIntervals), strings.Join(podsWithoutIntervals, ", ")))
+	}
+	if len(pollerPods.Items) == 0 {
+		failures = append(failures, fmt.Sprintf("no pods found for poller %v", labelSelector))
+	}
+
+	logJunit := &junitapi.JUnitTestCase{
+		Name:      fmt.Sprintf("[%s] can collect %v poller pod logs", sig, labelSelector),
+		SystemOut: string(buf.Bytes()),
+	}
+	if len(failures) > 0 {
+		logJunit.FailureOutput = &junitapi.FailureOutput{
+			Output: strings.Join(failures, "\n"),
+		}
+	}
+	junits = append(junits, logJunit)
+
+	return retIntervals, junits, errs
+}

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/clusterrole-monitor.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/clusterrole-monitor.yaml
@@ -1,0 +1,46 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: e2e-disruption-monitor
+rules:
+  - verbs:
+      - list
+    apiGroups:
+      - ''
+      - oauth.openshift.io
+    resources:
+      - oauthclients
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - list
+    apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+  - verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/crb-monitor.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/crb-monitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  generateName: e2e-disruption-monitor-
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: e2e-disruption-monitor
+subjects:
+- kind: ServiceAccount
+  name: disruption-monitor-sa

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/crb-privileged.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/crb-privileged.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  generateName: e2e-disruption-monitor-privileged-
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: disruption-monitor-sa

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-internal-lb.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-internal-lb.yaml
@@ -39,7 +39,7 @@ spec:
               value: "6443"
             - name: LOAD_BALANCER
               value: "internal-lb"
-          image: "image-registry.openshift-image-registry.svc:5000/openshift/tests:latest"
+          image: to-be-replaced
           volumeMounts:
             - mountPath: /var/log/disruption-data
               name: artifacts

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-internal-lb.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-internal-lb.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: internal-lb-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: internal-lb-monitor
+      apiserver.openshift.io/disruption-actor: poller
+  template:
+    metadata:
+      labels:
+        app: internal-lb-monitor
+        apiserver.openshift.io/disruption-actor: poller
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - internal-lb-monitor
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: internal-lb
+          command:
+            - openshift-tests
+            - run-disruption
+            - --output-file=/var/log/disruption-data/monitor-events/internal-lb.txt
+            - --lb-type=$(LOAD_BALANCER)
+            - --stop-configmap=stop-configmap
+          env:
+            - name: KUBERNETES_SERVICE_HOST
+              value: api-int.foo.bar
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            - name: LOAD_BALANCER
+              value: "internal-lb"
+          image: "image-registry.openshift-image-registry.svc:5000/openshift/tests:latest"
+          volumeMounts:
+            - mountPath: /var/log/disruption-data
+              name: artifacts
+      hostNetwork: true
+      serviceAccountName: disruption-monitor-sa
+      securityContext:
+        privileged: true
+        runAsUser: 0
+      volumes:
+        - hostPath:
+            path: /var/log/disruption-data
+            type: DirectoryOrCreate
+          name: artifacts
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/edge
+          effect: NoSchedule

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-localhost.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-localhost.yaml
@@ -37,7 +37,7 @@ spec:
               value: "/kubeconfigs/localhost.kubeconfig"
             - name: LOAD_BALANCER
               value: localhost
-          image: "image-registry.openshift-image-registry.svc:5000/openshift/tests:latest"
+          image: to-be-replaced
           volumeMounts:
             - mountPath: /var/log/disruption-data
               name: artifacts

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-localhost.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-localhost.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: localhost-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: localhost-monitor
+      apiserver.openshift.io/disruption-actor: poller
+  template:
+    metadata:
+      labels:
+        app: localhost-monitor
+        apiserver.openshift.io/disruption-actor: poller
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - localhost-monitor
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: localhost
+          command:
+            - openshift-tests
+            - run-disruption
+            - --output-file=/var/log/disruption-data/monitor-events/localhost-monitor.txt
+            - --lb-type=$(LOAD_BALANCER)
+            - --stop-configmap=stop-configmap
+          env:
+            - name: KUBECONFIG
+              value: "/kubeconfigs/localhost.kubeconfig"
+            - name: LOAD_BALANCER
+              value: localhost
+          image: "image-registry.openshift-image-registry.svc:5000/openshift/tests:latest"
+          volumeMounts:
+            - mountPath: /var/log/disruption-data
+              name: artifacts
+            - mountPath: /kubeconfigs
+              name: node-kubeconfigs
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      hostNetwork: true
+      serviceAccountName: disruption-monitor-sa
+      securityContext:
+        privileged: true
+        runAsUser: 0
+      volumes:
+        - hostPath:
+            path: /var/log/disruption-data
+            type: DirectoryOrCreate
+          name: artifacts
+        - hostPath:
+            path: /etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs
+            type: Directory
+          name: node-kubeconfigs
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-service-network.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-service-network.yaml
@@ -35,7 +35,7 @@ spec:
           env:
             - name: LOAD_BALANCER
               value: service-network
-          image: "image-registry.openshift-image-registry.svc:5000/openshift/tests:latest"
+          image: to-be-replaced
           volumeMounts:
             - mountPath: /var/log/disruption-data
               name: artifacts

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-service-network.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-service-network.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-network-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: service-network-monitor
+      apiserver.openshift.io/disruption-actor: poller
+  template:
+    metadata:
+      labels:
+        app: service-network-monitor
+        apiserver.openshift.io/disruption-actor: poller
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - service-network-monitor
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: service-network
+          command:
+            - openshift-tests
+            - run-disruption
+            - --output-file=/var/log/disruption-data/monitor-events/service-network-monitor.txt
+            - --lb-type=$(LOAD_BALANCER)
+            - --stop-configmap=stop-configmap
+          env:
+            - name: LOAD_BALANCER
+              value: service-network
+          image: "image-registry.openshift-image-registry.svc:5000/openshift/tests:latest"
+          volumeMounts:
+            - mountPath: /var/log/disruption-data
+              name: artifacts
+          securityContext:
+            privileged: true
+            runAsUser: 0
+      serviceAccountName: disruption-monitor-sa
+      securityContext:
+        privileged: true
+        runAsUser: 0
+      volumes:
+        - hostPath:
+            path: /var/log/disruption-data
+            type: DirectoryOrCreate
+          name: artifacts
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/edge
+          effect: NoSchedule

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/namespace.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/namespace.yaml
@@ -6,6 +6,6 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
-    network.openshift.io/incluster-disruption: "true"
+    apiserver.openshift.io/incluster-disruption: "true"
   annotations:
     workload.openshift.io/allowed: management

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/namespace.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/namespace.yaml
@@ -1,0 +1,11 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  generateName: e2e-disruption-monitor-
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    network.openshift.io/incluster-disruption: "true"
+  annotations:
+    workload.openshift.io/allowed: management

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/rb-monitor.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/rb-monitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  generateName: e2e-disruption-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: e2e-disruption-monitor
+subjects:
+- kind: ServiceAccount
+  name: disruption-monitor-sa

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/role-monitor.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/role-monitor.yaml
@@ -1,0 +1,46 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: e2e-disruption-monitor
+rules:
+  - verbs:
+      - list
+    apiGroups:
+      - ''
+      - oauth.openshift.io
+    resources:
+      - oauthclients
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - list
+    apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+  - verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/role-monitor.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/role-monitor.yaml
@@ -1,22 +1,8 @@
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: e2e-disruption-monitor
 rules:
-  - verbs:
-      - list
-    apiGroups:
-      - ''
-      - oauth.openshift.io
-    resources:
-      - oauthclients
-  - verbs:
-      - get
-      - list
-    apiGroups:
-      - ''
-    resources:
-      - namespaces
   - verbs:
       - create
       - get
@@ -28,19 +14,3 @@ rules:
       - ''
     resources:
       - configmaps
-  - verbs:
-      - list
-    apiGroups:
-      - image.openshift.io
-    resources:
-      - imagestreams
-  - verbs:
-      - create
-      - get
-      - list
-      - update
-      - delete
-    apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/serviceaccount.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: disruption-monitor-sa

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
@@ -98,7 +98,7 @@ func (i *InvariantInClusterDisruption) createDeploymentAndWaitToRollout(ctx cont
 		nil,
 		func(event watch.Event) (bool, error) {
 			deployment := event.Object.(*appsv1.Deployment)
-			return deployment.Status.ReadyReplicas == deployment.Status.Replicas, nil
+			return deployment.Status.AvailableReplicas == deployment.Status.Replicas, nil
 		},
 	); watchErr != nil {
 		return fmt.Errorf("deployment %s didn't roll out: %v", deploymentObj.Name, watchErr)

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
@@ -236,7 +236,7 @@ func (i *InvariantInClusterDisruption) createNamespace(ctx context.Context) (str
 
 func (i *InvariantInClusterDisruption) namespaceAlreadyCreated(ctx context.Context) bool {
 	namespaces, err := i.kubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
-		LabelSelector: labels.Set{"network.openshift.io/incluster-disruption": "true"}.AsSelector().String(),
+		LabelSelector: labels.Set{"apiserver.openshift.io/incluster-disruption": "true"}.AsSelector().String(),
 	})
 	if err != nil {
 		return false

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
@@ -1,0 +1,422 @@
+package disruptioninclusterapiserver
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	corev1 "k8s.io/api/core/v1"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+)
+
+var (
+	//go:embed manifests/namespace.yaml
+	namespaceYaml []byte
+	//go:embed manifests/crb-privileged.yaml
+	rbacPrivilegedYaml []byte
+	//go:embed manifests/role-monitor.yaml
+	rbacMonitorRoleYaml []byte
+	//go:embed manifests/crb-monitor.yaml
+	rbacListOauthClientCRBYaml []byte
+	//go:embed manifests/serviceaccount.yaml
+	serviceAccountYaml []byte
+	//go:embed manifests/dep-internal-lb.yaml
+	internalLBDeploymentYaml []byte
+	//go:embed manifests/dep-service-network.yaml
+	serviceNetworkDeploymentYaml []byte
+	//go:embed manifests/dep-localhost.yaml
+	localhostDeploymentYaml []byte
+	rbacPrivilegedCRBName   string
+	rbacMonitorRoleName     string
+	rbacMonitorCRBName      string
+)
+
+type InvariantInClusterDisruption struct {
+	namespaceName               string
+	openshiftTestsImagePullSpec string
+	payloadImagePullSpec        string
+	notSupportedReason          string
+	allNodes                    int32
+	controlPlaneNodes           int32
+
+	adminRESTConfig *rest.Config
+	kubeClient      kubernetes.Interface
+}
+
+func NewInvariantInClusterDisruption(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTest {
+	return &InvariantInClusterDisruption{
+		payloadImagePullSpec: info.UpgradeTargetPayloadImagePullSpec,
+	}
+}
+
+func (i *InvariantInClusterDisruption) createDeploymentAndWaitToRollout(ctx context.Context, deploymentObj *appsv1.Deployment) error {
+
+	client := i.kubeClient.AppsV1().Deployments(deploymentObj.Namespace)
+	_, err := client.Create(ctx, deploymentObj, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating deployment %s: %v", deploymentObj.Namespace, err)
+	}
+	logrus.Infof("in-cluster monitor: deployment %s:\n%#v\n", deploymentObj.Name, deploymentObj.ObjectMeta)
+
+	timeLimitedCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	if _, watchErr := watchtools.UntilWithSync(timeLimitedCtx,
+		cache.NewListWatchFromClient(
+			i.kubeClient.AppsV1().RESTClient(), "deployments", deploymentObj.Namespace, fields.OneTermEqualSelector("metadata.name", deploymentObj.Name)),
+		&appsv1.Deployment{},
+		nil,
+		func(event watch.Event) (bool, error) {
+			deployment := event.Object.(*appsv1.Deployment)
+			return deployment.Status.ReadyReplicas == deployment.Status.Replicas, nil
+		},
+	); watchErr != nil {
+		return fmt.Errorf("deployment %s didn't roll out: %v", deploymentObj.Name, watchErr)
+	}
+	return nil
+}
+
+func (i *InvariantInClusterDisruption) createInternalLBDeployment(ctx context.Context, apiIntHost string) error {
+	deploymentObj := resourceread.ReadDeploymentV1OrDie(internalLBDeploymentYaml)
+	deploymentObj.SetNamespace(i.namespaceName)
+	deploymentObj.Spec.Template.Spec.Containers[0].Env[0].Value = apiIntHost
+	// set amount of deployment replicas to make sure it runs on all nodes
+	deploymentObj.Spec.Replicas = &i.allNodes
+	// we need to use the openshift-tests image of the destination during an upgrade.
+	deploymentObj.Spec.Template.Spec.Containers[0].Image = i.openshiftTestsImagePullSpec
+
+	return i.createDeploymentAndWaitToRollout(ctx, deploymentObj)
+}
+
+func (i *InvariantInClusterDisruption) createServiceNetworkDeployment(ctx context.Context) error {
+	deploymentObj := resourceread.ReadDeploymentV1OrDie(serviceNetworkDeploymentYaml)
+	deploymentObj.SetNamespace(i.namespaceName)
+	// set amount of deployment replicas to make sure it runs on all nodes
+	deploymentObj.Spec.Replicas = &i.allNodes
+	// we need to use the openshift-tests image of the destination during an upgrade.
+	deploymentObj.Spec.Template.Spec.Containers[0].Image = i.openshiftTestsImagePullSpec
+
+	return i.createDeploymentAndWaitToRollout(ctx, deploymentObj)
+}
+
+func (i *InvariantInClusterDisruption) createLocalhostDeployment(ctx context.Context) error {
+	// Don't start localhost deployment on hypershift
+	if i.controlPlaneNodes == 0 {
+		return nil
+	}
+
+	deploymentObj := resourceread.ReadDeploymentV1OrDie(localhostDeploymentYaml)
+	deploymentObj.SetNamespace(i.namespaceName)
+	// set amount of deployment replicas to make sure it runs on control plane nodes
+	deploymentObj.Spec.Replicas = &i.controlPlaneNodes
+	// we need to use the openshift-tests image of the destination during an upgrade.
+	deploymentObj.Spec.Template.Spec.Containers[0].Image = i.openshiftTestsImagePullSpec
+
+	return i.createDeploymentAndWaitToRollout(ctx, deploymentObj)
+}
+
+func (i *InvariantInClusterDisruption) createRBACPrivileged(ctx context.Context) error {
+	rbacPrivilegedObj := resourceread.ReadClusterRoleBindingV1OrDie(rbacPrivilegedYaml)
+	rbacPrivilegedObj.Subjects[0].Namespace = i.namespaceName
+	logrus.Infof("in-cluster monitor: privileged CRB:\n%#v\n", rbacPrivilegedObj)
+
+	client := i.kubeClient.RbacV1().ClusterRoleBindings()
+	obj, err := client.Create(ctx, rbacPrivilegedObj, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("error creating privileged SCC CRB: %v", err)
+	}
+	rbacPrivilegedCRBName = obj.Name
+	return nil
+}
+
+func (i *InvariantInClusterDisruption) createMonitorRole(ctx context.Context) error {
+	rbacMonitorRoleObj := resourceread.ReadClusterRoleV1OrDie(rbacMonitorRoleYaml)
+
+	client := i.kubeClient.RbacV1().ClusterRoles()
+	_, err := client.Create(ctx, rbacMonitorRoleObj, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("error creating oauthclients list role: %v", err)
+	}
+	rbacMonitorRoleName = rbacMonitorRoleObj.Name
+	return nil
+}
+
+func (i *InvariantInClusterDisruption) createMonitorCRB(ctx context.Context) error {
+	rbacMonitorCRBObj := resourceread.ReadClusterRoleBindingV1OrDie(rbacListOauthClientCRBYaml)
+	rbacMonitorCRBObj.Subjects[0].Namespace = i.namespaceName
+	logrus.Infof("in-cluster monitor: monitor role CRB:\n%#v\n", rbacMonitorCRBObj)
+
+	client := i.kubeClient.RbacV1().ClusterRoleBindings()
+	obj, err := client.Create(ctx, rbacMonitorCRBObj, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("error creating oauthclients list CRB: %v", err)
+	}
+	rbacMonitorCRBName = obj.Name
+	return nil
+}
+
+func (i *InvariantInClusterDisruption) createServiceAccount(ctx context.Context) error {
+	serviceAccountObj := resourceread.ReadServiceAccountV1OrDie(serviceAccountYaml)
+	serviceAccountObj.SetNamespace(i.namespaceName)
+	logrus.Infof("in-cluster monitor: serviceaccount created in %s namespace\n", i.namespaceName)
+
+	client := i.kubeClient.CoreV1().ServiceAccounts(i.namespaceName)
+	_, err := client.Create(ctx, serviceAccountObj, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("error creating service account: %v", err)
+	}
+	return nil
+}
+
+func (i *InvariantInClusterDisruption) createNamespace(ctx context.Context) (string, error) {
+	namespaceObj := resourceread.ReadNamespaceV1OrDie(namespaceYaml)
+
+	client := i.kubeClient.CoreV1().Namespaces()
+	actualNamespace, err := client.Create(ctx, namespaceObj, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return "", fmt.Errorf("error creating namespace: %v", err)
+	}
+	logrus.Infof("in-cluster monitor: created namespace %s\n", actualNamespace.Name)
+	return actualNamespace.Name, nil
+}
+
+func (i *InvariantInClusterDisruption) namespaceAlreadyCreated(ctx context.Context) bool {
+	namespaces, err := i.kubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set{"network.openshift.io/incluster-disruption": "true"}.AsSelector().String(),
+	})
+	if err != nil {
+		return false
+	}
+	return len(namespaces.Items) != 0
+}
+
+func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, _ monitorapi.RecorderWriter) error {
+	var err error
+	logrus.Infof("in-cluster monitor: payload image pull spec is %v\n", i.payloadImagePullSpec)
+	if len(i.payloadImagePullSpec) == 0 {
+		configClient, err := configclient.NewForConfig(adminRESTConfig)
+		if err != nil {
+			return err
+		}
+		clusterVersion, err := configClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			i.notSupportedReason = "clusterversion/version not found and no image pull spec specified."
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		i.payloadImagePullSpec = clusterVersion.Status.History[0].Image
+	}
+
+	// runImageExtract extracts src from specified image to dst
+	cmd := exec.Command("oc", "adm", "release", "info", i.payloadImagePullSpec, "--image-for=tests")
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	cmd.Stdout = out
+	cmd.Stderr = errOut
+	if err := cmd.Run(); err != nil {
+		i.notSupportedReason = fmt.Sprintf("unable to determine openshift-tests image: %v: %v", err, errOut.String())
+		return nil
+	}
+	i.openshiftTestsImagePullSpec = strings.TrimSpace(out.String())
+	logrus.Infof("in-cluster monitor: openshift-tests image pull spec is %v\n", i.openshiftTestsImagePullSpec)
+
+	i.adminRESTConfig = adminRESTConfig
+	i.kubeClient, err = kubernetes.NewForConfig(i.adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("error constructing kube client: %v", err)
+	}
+
+	if ok, _ := exutil.IsMicroShiftCluster(i.kubeClient); ok {
+		i.notSupportedReason = "microshift clusters don't have load balancers"
+		return nil
+	}
+
+	// Exit early if another test has already created a namespace
+	if i.namespaceAlreadyCreated(ctx) {
+		i.notSupportedReason = "in-cluster monitor is already running"
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Starting in-cluster monitoring deployments\n")
+	configClient, err := configclient.NewForConfig(i.adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("error constructing openshift config client: %v", err)
+	}
+	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting openshift infrastructure: %v", err)
+	}
+
+	internalAPI, err := url.Parse(infra.Status.APIServerInternalURL)
+	if err != nil {
+		return fmt.Errorf("error parsing api int url: %v", err)
+	}
+	apiIntHost := internalAPI.Hostname()
+
+	allNodes, err := i.kubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting nodes: %v", err)
+	}
+	i.allNodes = int32(len(allNodes.Items))
+
+	controlPlaneNodes, err := i.kubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector().String(),
+	})
+	if err != nil {
+		return fmt.Errorf("error getting control plane nodes: %v", err)
+	}
+	i.controlPlaneNodes = int32(len(controlPlaneNodes.Items))
+
+	namespace, err := i.createNamespace(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating namespace: %v", err)
+	}
+	i.namespaceName = namespace
+
+	err = i.createServiceAccount(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating service accounts: %v", err)
+	}
+	err = i.createRBACPrivileged(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating privileged SCC rolebinding: %v", err)
+	}
+	err = i.createMonitorRole(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating monitor role: %v", err)
+	}
+	err = i.createMonitorCRB(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating monitor rolebinding: %v", err)
+	}
+	err = i.createServiceNetworkDeployment(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating service network deployment: %v", err)
+	}
+	err = i.createLocalhostDeployment(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating localhost: %v", err)
+	}
+	err = i.createInternalLBDeployment(ctx, apiIntHost)
+	if err != nil {
+		return fmt.Errorf("error creating internal LB: %v", err)
+	}
+	return nil
+}
+
+func (i *InvariantInClusterDisruption) CollectData(ctx context.Context, storageDir string, beginning time.Time, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if len(i.notSupportedReason) > 0 {
+		return nil, nil, nil
+	}
+
+	// create the stop collecting configmap and wait for 30s to thing to have stopped.  the 30s is just a guess
+	if _, err := i.kubeClient.CoreV1().ConfigMaps(i.namespaceName).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "stop-collecting"},
+	}, metav1.CreateOptions{}); err != nil {
+		return nil, nil, err
+	}
+
+	// TODO create back-pressure on the configmap
+	select {
+	case <-time.After(30 * time.Second):
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+
+	fmt.Fprintf(os.Stderr, "Collecting data from in-cluster monitoring deployments\n")
+
+	pollerLabel, err := labels.NewRequirement("apiserver.openshift.io/disruption-actor", selection.Equals, []string{"poller"})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	intervals, junits, errs := disruptionlibrary.CollectIntervalsForPods(ctx, i.kubeClient, "Jira: \"kube-apiserver\"", i.namespaceName, labels.NewSelector().Add(*pollerLabel))
+	return intervals, junits, utilerrors.NewAggregate(errs)
+}
+
+func (i *InvariantInClusterDisruption) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, _ monitorapi.ResourcesMap, beginning time.Time, end time.Time) (constructedIntervals monitorapi.Intervals, err error) {
+	return nil, nil
+}
+
+func (i *InvariantInClusterDisruption) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (i *InvariantInClusterDisruption) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (i *InvariantInClusterDisruption) Cleanup(ctx context.Context) error {
+	if len(i.notSupportedReason) > 0 {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Removing in-cluster monitoring namespace\n")
+	nsClient := i.kubeClient.CoreV1().Namespaces()
+	err := nsClient.Delete(ctx, i.namespaceName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error removing namespace %s: %v", i.namespaceName, err)
+	}
+	if !apierrors.IsNotFound(err) {
+		fmt.Fprintf(os.Stderr, "Namespace %s removed\n", i.namespaceName)
+	}
+
+	fmt.Fprintf(os.Stderr, "Removing in-cluster monitoring cluster roles and bindings\n")
+	crbClient := i.kubeClient.RbacV1().ClusterRoleBindings()
+	err = crbClient.Delete(ctx, rbacPrivilegedCRBName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error removing cluster reader CRB: %v", err)
+	}
+	if !apierrors.IsNotFound(err) {
+		fmt.Fprintf(os.Stderr, "CRB %s removed\n", rbacPrivilegedCRBName)
+	}
+
+	err = crbClient.Delete(ctx, rbacMonitorCRBName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error removing monitor CRB: %v", err)
+	}
+	if !apierrors.IsNotFound(err) {
+		fmt.Fprintf(os.Stderr, "CRB %s removed\n", rbacMonitorCRBName)
+	}
+
+	rolesClient := i.kubeClient.RbacV1().ClusterRoles()
+	err = rolesClient.Delete(ctx, rbacMonitorRoleName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("error removing monitor role: %v", err)
+	}
+	if !apierrors.IsNotFound(err) {
+		fmt.Fprintf(os.Stderr, "Role %s removed\n", rbacMonitorRoleName)
+	}
+	return nil
+}

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
@@ -235,13 +235,19 @@ func (i *InvariantInClusterDisruption) createNamespace(ctx context.Context) (str
 }
 
 func (i *InvariantInClusterDisruption) namespaceAlreadyCreated(ctx context.Context) bool {
+	log := logrus.WithField("monitorTest", "apiserver-incluster-availability").WithField("namespace", i.namespaceName).WithField("func", "namespaceAlreadyCreated")
 	namespaces, err := i.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set{"apiserver.openshift.io/incluster-disruption": "true"}.AsSelector().String(),
 	})
 	if err != nil {
+		log.Infof("error: %v", err)
+		return true
+	}
+	if len(namespaces.Items) == 0 {
 		return false
 	}
-	return len(namespaces.Items) != 0
+	log.Infof("namespaces.Items: %v", namespaces.Items)
+	return true
 }
 
 func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, _ monitorapi.RecorderWriter) error {

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/remote.go
@@ -235,7 +235,7 @@ func (i *InvariantInClusterDisruption) createNamespace(ctx context.Context) (str
 }
 
 func (i *InvariantInClusterDisruption) namespaceAlreadyCreated(ctx context.Context) bool {
-	namespaces, err := i.kubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+	namespaces, err := i.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set{"apiserver.openshift.io/incluster-disruption": "true"}.AsSelector().String(),
 	})
 	if err != nil {
@@ -301,7 +301,7 @@ func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, admi
 	if err != nil {
 		return fmt.Errorf("error constructing openshift config client: %v", err)
 	}
-	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	infra, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting openshift infrastructure: %v", err)
 	}
@@ -312,13 +312,13 @@ func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, admi
 	}
 	apiIntHost := internalAPI.Hostname()
 
-	allNodes, err := i.kubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	allNodes, err := i.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting nodes: %v", err)
 	}
 	i.allNodes = int32(len(allNodes.Items))
 
-	controlPlaneNodes, err := i.kubeClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+	controlPlaneNodes, err := i.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector().String(),
 	})
 	if err != nil {

--- a/pkg/monitortests/kubeapiserver/disruptionnewapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptionnewapiserver/monitortest.go
@@ -71,9 +71,5 @@ func (w *newAPIServerDisruptionChecker) WriteContentToStorage(ctx context.Contex
 }
 
 func (w *newAPIServerDisruptionChecker) Cleanup(ctx context.Context) error {
-	if w.notSupportedReason != nil {
-		return w.notSupportedReason
-	}
-
 	return nil
 }

--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -1,13 +1,10 @@
 package disruptionpodnetwork
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"embed"
 	_ "embed"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,8 +25,8 @@ import (
 	k8simage "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
-	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	"github.com/openshift/origin/test/extended/util/image"
 )
@@ -265,72 +262,8 @@ func (pna *podNetworkAvalibility) collectDetailsForPoller(ctx context.Context, t
 	if err != nil {
 		return nil, nil, []error{err}
 	}
-	pollerPods, err := pna.kubeClient.CoreV1().Pods(pna.namespaceName).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.NewSelector().Add(*pollerLabel).Add(*typeLabel).String(),
-	})
-	if err != nil {
-		return nil, nil, []error{err}
-	}
-
-	retIntervals := monitorapi.Intervals{}
-	junits := []*junitapi.JUnitTestCase{}
-	errs := []error{}
-	buf := &bytes.Buffer{}
-	podsWithoutIntervals := []string{}
-	for _, pollerPod := range pollerPods.Items {
-		fmt.Fprintf(buf, "\n\nLogs for -n %v pod/%v\n", pollerPod.Namespace, pollerPod.Name)
-		req := pna.kubeClient.CoreV1().Pods(pna.namespaceName).GetLogs(pollerPod.Name, &corev1.PodLogOptions{})
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		logStream, err := req.Stream(ctx)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-
-		foundInterval := false
-		scanner := bufio.NewScanner(logStream)
-		for scanner.Scan() {
-			line := scanner.Bytes()
-			buf.Write(line)
-			buf.Write([]byte("\n"))
-			if len(line) == 0 {
-				continue
-			}
-
-			// not all lines are json, ignore errors.
-			if currInterval, err := monitorserialization.IntervalFromJSON(line); err == nil {
-				retIntervals = append(retIntervals, *currInterval)
-				foundInterval = true
-			}
-		}
-		if !foundInterval {
-			podsWithoutIntervals = append(podsWithoutIntervals, pollerPod.Name)
-		}
-	}
-
-	failures := []string{}
-	if len(podsWithoutIntervals) > 0 {
-		failures = append(failures, fmt.Sprintf("%d pods lacked sampler output: [%v]", len(podsWithoutIntervals), strings.Join(podsWithoutIntervals, ", ")))
-	}
-	if len(pollerPods.Items) == 0 {
-		failures = append(failures, "no pods found for poller %q", typeOfConnection)
-	}
-
-	logJunit := &junitapi.JUnitTestCase{
-		Name:      fmt.Sprintf("[sig-network] can collect %v poller pod logs", typeOfConnection),
-		SystemOut: string(buf.Bytes()),
-	}
-	if len(failures) > 0 {
-		logJunit.FailureOutput = &junitapi.FailureOutput{
-			Output: strings.Join(failures, "\n"),
-		}
-	}
-	junits = append(junits, logJunit)
-
-	return retIntervals, junits, errs
+	labelSelector := labels.NewSelector().Add(*pollerLabel).Add(*typeLabel)
+	return disruptionlibrary.CollectIntervalsForPods(ctx, pna.kubeClient, "sig-network", pna.namespaceName, labelSelector)
 }
 
 func (pna *podNetworkAvalibility) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (constructedIntervals monitorapi.Intervals, err error) {

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -18,12 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
-
 	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
 	"github.com/openshift/origin/pkg/defaultmonitortests"
 	"github.com/openshift/origin/pkg/monitor"
@@ -31,6 +25,11 @@ import (
 	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/riskanalysis"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 )
 
 const (

--- a/test/extended/operators/manifests/pod.yaml
+++ b/test/extended/operators/manifests/pod.yaml
@@ -52,5 +52,9 @@ spec:
   - emptyDir: {}
     name: shared-dir
   tolerations:
+  # Ensure pod can be scheduled on master nodes
   - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+  # Ensure pod can be scheduled on edge nodes
+  - key: node-role.kubernetes.io/edge
     effect: NoSchedule


### PR DESCRIPTION
This reverts commit 4d66ac7.

* apiserver disruption tests no longer race with network disruption tests (they used the same label for the namespaces so apiserver disruption tests may have mistakenly assumed it was already running)
* added permissions to watch stop-configmap
* improved logging