### PR TITLE
OCPBUGS-35880: fix pod not returning success on 'Managed cluster should verify that nodes have no unexpected reboots'

### DIFF
--- a/test/extended/machines/display_reboots_pod.yaml
+++ b/test/extended/machines/display_reboots_pod.yaml
@@ -24,7 +24,7 @@ spec:
     - command: ['/bin/bash', '-ec']
       args:
         - |
-          chroot /host-root journalctl -o short-iso -t 'systemd-logind' -g "rebooting" -q
+          chroot /host-root journalctl -o short-iso -t 'systemd-logind' -g "rebooting" -q || true
       image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
       name: reboots
       terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
This PR fixes a bug within https://github.com/openshift/origin/pull/28884 `fix the node reboot test to actually run`. 28884 correctly changed the logic of the pod to propagate bash errors, but [missed](https://github.com/openshift/origin/pull/28884/files#diff-874b016393cfee8472299a3f16736fbe9da4973c3a9daed5b1dd00e7f72e1b2fR27) that journalctl with the '-g' option for grep can return an error if no matches are found. In this case, the matches are reboot messages. So if a machine has never rebooted, then the pod would fail incorrectly.

This PR fixes the errors in CI for the test `Managed cluster should verify that nodes have no unexpected reboots`.
