### PR TITLE
NO-ISSUE: Use external binary name on retry

### DIFF
--- a/pkg/test/ginkgo/test_suite.go
+++ b/pkg/test/ginkgo/test_suite.go
@@ -102,6 +102,8 @@ func (t *testCase) Retry() *testCase {
 	copied := &testCase{
 		name:          t.name,
 		spec:          t.spec,
+		rawName:       t.rawName,
+		binaryName:    t.binaryName,
 		locations:     t.locations,
 		testExclusion: t.testExclusion,
 


### PR DESCRIPTION
https://github.com/openshift/kubernetes/pull/2020#issuecomment-2228519173