### PR TITLE
[release-4.16] OCPBUGS-35880: fix pod not returning success on 'Managed cluster should verify that nodes have no unexpected reboots'

### DIFF
--- a/test/extended/machines/display_reboots_pod.yaml
+++ b/test/extended/machines/display_reboots_pod.yaml
@@ -18,7 +18,7 @@ spec:
         - mountPath: /host-root
           name: host-root
     - command:
-        - exec chroot /host-root journalctl -t 'systemd-logind' -g "rebooting" -q
+        - exec chroot /host-root journalctl -t 'systemd-logind' -g "rebooting" -q || true
       image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
       name: reboots
       terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/origin/pull/28953