### PR TITLE
OCPBUGS-37675: Add a version command to openshift-tests

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/openshift/library-go/pkg/serviceability"
+	"github.com/openshift/origin/pkg/cmd"
 	collectdiskcertificates "github.com/openshift/origin/pkg/cmd/openshift-tests/collect-disk-certificates"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/dev"
 	"github.com/openshift/origin/pkg/cmd/openshift-tests/disruption"
@@ -23,6 +24,7 @@ import (
 	run_disruption "github.com/openshift/origin/pkg/cmd/openshift-tests/run-disruption"
 	run_test "github.com/openshift/origin/pkg/cmd/openshift-tests/run-test"
 	run_upgrade "github.com/openshift/origin/pkg/cmd/openshift-tests/run-upgrade"
+	versioncmd "github.com/openshift/origin/pkg/cmd/openshift-tests/version"
 	run_resourcewatch "github.com/openshift/origin/pkg/resourcewatch/cmd"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -60,13 +62,14 @@ func main() {
 	//pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
 	root := &cobra.Command{
-		Long: templates.LongDesc(`
-		OpenShift Tests
-
-		This command verifies behavior of an OpenShift cluster by running remote tests against
+		Long: templates.LongDesc(`This command verifies behavior of an OpenShift cluster by running remote tests against
 		the cluster API that exercise functionality. In general these tests may be disruptive
 		or require elevated privileges - see the descriptions of each test suite.
 		`),
+		// PersistentPreRun to always print the openshift-tests version; this populates
+		// down to subcommands as well. If you need to omit this output for a specific command,
+		// you can override PersistentPreRun to NoPrintVersion instead.
+		PersistentPreRun: cmd.PrintVersion,
 	}
 
 	ioStreams := genericclioptions.IOStreams{
@@ -90,6 +93,7 @@ func main() {
 		run_disruption.NewRunInClusterDisruptionMonitorCommand(ioStreams),
 		collectdiskcertificates.NewRunCollectDiskCertificatesCommand(ioStreams),
 		render.NewRenderCommand(ioStreams),
+		versioncmd.NewVersionCommand(ioStreams),
 	)
 
 	f := flag.CommandLine.Lookup("v")

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	gopkg.in/ini.v1 v1.62.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.2
 	k8s.io/apiextensions-apiserver v0.30.2
 	k8s.io/apimachinery v0.30.2
@@ -282,7 +283,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/cloud-provider v0.30.2 // indirect
 	k8s.io/cluster-bootstrap v0.0.0 // indirect
 	k8s.io/controller-manager v0.30.2 // indirect

--- a/pkg/cmd/openshift-tests/images/images_command.go
+++ b/pkg/cmd/openshift-tests/images/images_command.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/origin/pkg/clioptions/imagesetup"
+	"github.com/openshift/origin/pkg/cmd"
 	"github.com/openshift/origin/test/extended/util/image"
 	"github.com/spf13/cobra"
 	"k8s.io/kube-openapi/pkg/util/sets"
@@ -43,9 +44,9 @@ func NewImagesCommand() *cobra.Command {
 		%[1]s and are provided as-is for testing purposes only. Images are mirrored by the project
 		to the public repository periodically.
 		`, imagesetup.DefaultTestImageMirrorLocation)),
-
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		PersistentPreRun: cmd.NoPrintVersion,
+		SilenceUsage:     true,
+		SilenceErrors:    true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := imagesetup.VerifyTestImageRepoEnvVarUnset(); err != nil {
 				return err

--- a/pkg/cmd/openshift-tests/render/test-report/render_test_report.go
+++ b/pkg/cmd/openshift-tests/render/test-report/render_test_report.go
@@ -7,6 +7,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/pkg/clioptions/imagesetup"
+	"github.com/openshift/origin/pkg/cmd"
 	origingenerated "github.com/openshift/origin/test/extended/util/annotate/generated"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -33,11 +34,11 @@ func NewRenderTestReportCommand(streams genericclioptions.IOStreams) *cobra.Comm
 	f := NewRenderTestReportOptions(streams, imagesetup.DefaultTestImageMirrorLocation)
 
 	cmd := &cobra.Command{
-		Use:   "test-report",
-		Short: "Write manifest indicating how many tests we have for each feature.",
-
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:              "test-report",
+		Short:            "Write manifest indicating how many tests we have for each feature.",
+		PersistentPreRun: cmd.NoPrintVersion,
+		SilenceUsage:     true,
+		SilenceErrors:    true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o, err := f.ToOptions()
 			if err != nil {

--- a/pkg/cmd/openshift-tests/version/version.go
+++ b/pkg/cmd/openshift-tests/version/version.go
@@ -1,0 +1,58 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/openshift/origin/pkg/cmd"
+	"github.com/openshift/origin/pkg/version"
+)
+
+// NewVersionCommand prints out openshift-tests version information, in a similar style to other kube tools,
+// e.g. https://github.com/openshift/kubernetes/blob/6892b57d65d25fb0588693bce3d338d8b8b1d2b4/cmd/kubeadm/app/cmd/version.go#L67
+func NewVersionCommand(streams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Long:  "Report version information for openshift-tests",
+		Short: "Report version information for openshift-tests",
+		// Set persistent pre run to empty so we don't double print version info
+		PersistentPreRun: cmd.NoPrintVersion,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := version.Get()
+			const flag = "output"
+			of, err := cmd.Flags().GetString(flag)
+			if err != nil {
+				return errors.Wrapf(err, "error accessing flag %s for command %s", flag, cmd.Name())
+			}
+			switch of {
+			case "":
+				fmt.Fprintf(streams.Out, "openshift-tests version %s\n", v.GitVersion)
+			case "short":
+				fmt.Fprintf(streams.Out, "%s\n", v.GitVersion)
+			case "yaml":
+				y, err := yaml.Marshal(&v)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(streams.Out, string(y))
+			case "json":
+				y, err := json.MarshalIndent(&v, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(streams.Out, string(y))
+			default:
+				return errors.Errorf("invalid output format: %s", of)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringP("output", "o", "", "Output format; available options are 'yaml', 'json' and 'short'")
+	return cmd
+}

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/version"
+)
+
+// PrintVersion is used as a PersistentPreRun function to ensure we always print the version.
+var PrintVersion = func(cmd *cobra.Command, args []string) {
+	fmt.Fprintf(os.Stdout, "openshift-tests %s\n", version.Get().GitVersion)
+}
+
+// NoPrintVersion is used as an empty PersistentPreRun function so we don't print version info
+// for some commands.
+var NoPrintVersion = func(cmd *cobra.Command, args []string) {
+}


### PR DESCRIPTION
Currently it's not so easy to figure out what version of openshift-tests is actually being run. Not all commands log it.

Adds a dedicated `version` command and ensures it's always printed out on invocation as well.
