### PR TITLE
NO-JIRA: riskanalysis: improve request retries

### DIFF
--- a/pkg/riskanalysis/cmd_test.go
+++ b/pkg/riskanalysis/cmd_test.go
@@ -67,8 +67,8 @@ func TestRequestRiskAnalysisSuccessAfterRetry(t *testing.T) {
 
 	tmp := t.TempDir()
 	opt := &Options{SippyURL: url, JUnitDir: tmp}
-	req, _ := http.NewRequest("GET", opt.SippyURL, nil)
-	raContent, err := opt.requestRiskAnalysis(req, client, &mockSleeper{})
+	// req, _ := http.NewRequest("GET", opt.SippyURL, nil)
+	raContent, err := opt.requestRiskAnalysis(make([]byte, 0), client, &mockSleeper{})
 	assert.NoError(t, err, "Failed to read the request content")
 	assert.Equal(t, reqContent, string(raContent))
 
@@ -98,8 +98,8 @@ func TestRequestRiskAnalysisAllRetriesFail(t *testing.T) {
 
 	tmp := t.TempDir()
 	opt := &Options{SippyURL: url, JUnitDir: tmp}
-	req, _ := http.NewRequest("GET", opt.SippyURL, nil)
-	_, err := opt.requestRiskAnalysis(req, client, &mockSleeper{})
+	// req, _ := http.NewRequest("GET", opt.SippyURL, nil)
+	_, err := opt.requestRiskAnalysis(make([]byte, 0), client, &mockSleeper{})
 	assert.Error(t, err, "Should fail to request RA content")
 
 	// Attempt to load JSON from the expected log file


### PR DESCRIPTION
I observed that when a RA http request fails for any reason, retries also fail immediately. Stephen speculated that reusing the request object might be a problem. [What I could find](https://github.com/golang/go/issues/19653#issuecomment-308246367) indicated that would only be a problem in specialized circumstances but it seemed worth trying.