### PR TITLE
SDN-4919: Skip network segmentation tests

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -56,6 +56,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 		)
 
 		BeforeEach(func() {
+			e2eskipper.Skipf("TODO(kyrtapz): Unskip with https://github.com/openshift/origin/pull/28945")
 			cs = f.ClientSet
 
 			var err error


### PR DESCRIPTION
Skip the NetworkSegmentation tests temporarily to allow for breaking ovn-kubernetes changes. 
This will be reverted in https://github.com/openshift/origin/pull/28945. 
/cc @tssurya 