### PR TITLE
WIP: Allow udn on sno

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -78,8 +78,15 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				netConfig.namespace = f.Namespace.Name
 				workerNodes, err := getWorkerNodesOrdered(cs)
 				Expect(err).NotTo(HaveOccurred())
-				// TODO: should I skip this on SNO ?... or should I simply put pods the first and last node ?
-				Expect(len(workerNodes)).To(BeNumerically(">=", 2))
+
+				if len(workerNodes) == 1 {
+					workerNodes = append(
+						workerNodes,
+						v1.Node{ObjectMeta: metav1.ObjectMeta{
+							Name: workerNodes[0].Name, Namespace: workerNodes[0].Namespace,
+						}},
+					)
+				}
 
 				clientPodConfig.namespace = f.Namespace.Name
 				clientPodConfig.nodeSelector = map[string]string{nodeHostnameKey: workerNodes[0].Name}

--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -56,7 +56,6 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 		)
 
 		BeforeEach(func() {
-			e2eskipper.Skipf("TODO(kyrtapz): Unskip with https://github.com/openshift/origin/pull/28945")
 			cs = f.ClientSet
 
 			var err error


### PR DESCRIPTION
This PR adapts the UDN tests to run on single node openshift; instead of skipping when there is only a single node, we schedule all workloads on the only available node.
