### PR TITLE
NO-JIRA: Disable:Broken for [sig-builds][Feature:Builds][Slow] can use private repositories as build input build using an HTTP token should be able to clone source code via an HTTP token [apigroup:build.openshift.io]

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -505,7 +505,7 @@ var Annotations = map[string]string{
 
 	"[sig-builds][Feature:Builds][Slow] can use build secrets build with secrets and configMaps should contain secrets during the source strategy build [apigroup:build.openshift.io][apigroup:image.openshift.io]": "",
 
-	"[sig-builds][Feature:Builds][Slow] can use private repositories as build input build using an HTTP token should be able to clone source code via an HTTP token [apigroup:build.openshift.io]": "",
+	"[sig-builds][Feature:Builds][Slow] can use private repositories as build input build using an HTTP token should be able to clone source code via an HTTP token [apigroup:build.openshift.io]": " [Disabled:Broken]",
 
 	"[sig-builds][Feature:Builds][Slow] can use private repositories as build input build using an ssh private key should be able to clone source code via ssh [apigroup:build.openshift.io]": "",
 

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -53,6 +53,9 @@ var (
 			// https://issues.redhat.com/browse/OCPBUGS-3339
 			`\[sig-devex\]\[Feature:ImageEcosystem\]\[mysql\]\[Slow\] openshift mysql image Creating from a template should instantiate the template`,
 			`\[sig-devex\]\[Feature:ImageEcosystem\]\[mariadb\]\[Slow\] openshift mariadb image Creating from a template should instantiate the template`,
+
+			// https://issues.redhat.com/browse/OCPBUGS-37799
+			`\[sig-builds\]\[Feature:Builds\]\[Slow\] can use private repositories as build input build using an HTTP token should be able to clone source code via an HTTP token \[apigroup:build.openshift.io\]`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {},


### PR DESCRIPTION
```
  2024-08-01T08:20:12.948819264Z Cloning "https://github.com/openshift-github-testing/nodejs-ex-private.git" ...
  2024-08-01T08:20:12.948819264Z I0801 08:20:12.948804       1 source.go:237] git ls-remote --heads https://github.com/openshift-github-testing/nodejs-ex-private.git
  2024-08-01T08:20:12.948840640Z I0801 08:20:12.948824       1 repository.go:450] Executing git ls-remote --heads https://github.com/openshift-github-testing/nodejs-ex-private.git
  2024-08-01T08:20:13.172598703Z I0801 08:20:13.172511       1 repository.go:541] Error executing command: exit status 128
  2024-08-01T08:20:13.172649677Z I0801 08:20:13.172602       1 source.go:237] remote: Invalid username or password.
  2024-08-01T08:20:13.172649677Z fatal: Authentication failed for 'https://github.com/openshift-github-testing/nodejs-ex-private.git/'
  2024-08-01T08:20:13.214624149Z error: failed to fetch requested repository "https://github.com/openshift-github-testing/nodejs-ex-private.git" with provided credentials
```