### PR TITLE
OCPBUGS-34816: Fix conformance tests for #4303

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -382,6 +382,10 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 
 		operatorBoundExceeded := []string{}
 		for _, item := range watchRequestCounts {
+			if len(strings.Split(item.Operator, ":")) < 3 {
+				framework.Logf("Operator %v not recognized", item.Operator)
+				continue
+			}
 			operator := strings.Split(item.Operator, ":")[3]
 			allowedCount, exists := upperBound[operator]
 


### PR DESCRIPTION
The validating admission policies included in the mentioned PR are using a new user declared as system:hosted-cluster-config-operator. This makes the test to fail identifying all the operators querying the KAS.

- https://github.com/openshift/hypershift/pull/4303