### PR TITLE
IR-471: Skipping chunksizemib tests

### DIFF
--- a/test/extended/storage/s3_configuration.go
+++ b/test/extended/storage/s3_configuration.go
@@ -30,9 +30,8 @@ var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ChunkSizeMiB][Serial][api
 	o.SetDefaultEventuallyPollingInterval(5 * time.Second)
 
 	g.BeforeEach(func() {
-
-		skipIfNotS3Storage(oc)
-
+		// TODO: Remove this as soon as API and IR chunkSizeMiB is merged
+		g.Skip("ChunkSizeMiB tests are expected to fail currently")
 		imageRegistryConfigClient, err := imageregistry.NewForConfig(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())
 		imageRegistryConfig, err := imageRegistryConfigClient.ImageregistryV1().Configs().Get(ctx, clusterConfigName, metav1.GetOptions{})
@@ -182,5 +181,4 @@ var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ChunkSizeMiB][Serial][api
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(imageRegistryConfig.Spec.Storage.S3.ChunkSizeMiB).NotTo(o.Equal(chunkSize))
 	})
-
 })


### PR DESCRIPTION
Skipping the chunksizemib as it will fail until both IR and API PR merges.

https://github.com/openshift/api/pull/1948 
https://github.com/openshift/cluster-image-registry-operator/pull/1073 

TODO revert the PR once above 2 merges