### PR TITLE
TRT-1688: Revert "allow etcd log test to flake under vsphere"

### DIFF
--- a/pkg/monitortests/etcd/legacyetcdmonitortests/etcd.go
+++ b/pkg/monitortests/etcd/legacyetcdmonitortests/etcd.go
@@ -69,7 +69,7 @@ func testEtcdShouldNotLogDroppedRaftMessages(events monitorapi.Intervals) []*jun
 // regularly, what we're worried about are the runs showing 30-70k.
 const etcdRequestsTookTooLongLimit = 10000
 
-func testEtcdDoesNotLogExcessiveTookTooLongMessages(events monitorapi.Intervals, isFlaky bool) []*junitapi.JUnitTestCase {
+func testEtcdDoesNotLogExcessiveTookTooLongMessages(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-etcd] etcd should not log excessive took too long messages"
 	success := &junitapi.JUnitTestCase{Name: testName}
 
@@ -95,10 +95,6 @@ func testEtcdDoesNotLogExcessiveTookTooLongMessages(events monitorapi.Intervals,
 		FailureOutput: &junitapi.FailureOutput{
 			Output: msg,
 		},
-	}
-	// see TRT-1688 - conditionally count this as a flake instead of failure
-	if isFlaky {
-		return []*junitapi.JUnitTestCase{failure, success}
 	}
 	return []*junitapi.JUnitTestCase{failure}
 }

--- a/pkg/monitortests/etcd/legacyetcdmonitortests/monitortest.go
+++ b/pkg/monitortests/etcd/legacyetcdmonitortests/monitortest.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
-	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
@@ -17,7 +16,6 @@ import (
 
 type legacyMonitorTests struct {
 	adminRESTConfig    *rest.Config
-	jobType            *platformidentification.JobType
 	notSupportedReason error
 }
 
@@ -47,11 +45,6 @@ func (w *legacyMonitorTests) StartCollection(ctx context.Context, adminRESTConfi
 		return w.notSupportedReason
 	}
 
-	jobType, err := platformidentification.GetJobType(ctx, adminRESTConfig)
-	if err != nil {
-		return fmt.Errorf("unable to determine job type: %v", err)
-	}
-	w.jobType = jobType
 	return nil
 }
 
@@ -72,10 +65,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	junits = append(junits, testEtcdShouldNotLogSlowFdataSyncs(finalIntervals)...)
 	junits = append(junits, testEtcdShouldNotLogDroppedRaftMessages(finalIntervals)...)
 	junits = append(junits, testOperatorStatusChanged(finalIntervals)...)
-
-	// see TRT-1688 - for now, for vsphere, count this test failure as a flake
-	isVsphere := w.jobType.Platform == "vsphere"
-	junits = append(junits, testEtcdDoesNotLogExcessiveTookTooLongMessages(finalIntervals, isVsphere)...)
+	junits = append(junits, testEtcdDoesNotLogExcessiveTookTooLongMessages(finalIntervals)...)
 
 	return junits, nil
 }


### PR DESCRIPTION
Removing the vsphere exclusion as it may obscure useful signal. The affected vsphere tests have not failed since this change, not even to flake.