### PR TITLE
OCPBUGS-38787: [4.15] egressfirewall: skip ping tests in case of hypershift kubevirt on Azure infra

### DIFF
--- a/test/extended/kubevirt/migration.go
+++ b/test/extended/kubevirt/migration.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -54,12 +55,12 @@ var _ = Describe("[sig-kubevirt] migration", func() {
 					WithPolling(5*time.Second).
 					Should(Equal(numberOfNodes), "nodes should have ready state before migration")
 
-				setMgmtFramework(mgmtFramework)
+				SetMgmtFramework(mgmtFramework)
 				expectNoError(migrateWorkers(mgmtFramework))
 			})
 			It("should maintain node readiness", func() {
 				By("Check node readiness is as expected")
-				isAWS, err := mgmtClusterIsAWS(mgmtFramework)
+				isAWS, err := MgmtClusterIsType(mgmtFramework, configv1.AWSPlatformType)
 				Expect(err).ToNot(HaveOccurred())
 
 				if isAWS {

--- a/test/extended/kubevirt/services.go
+++ b/test/extended/kubevirt/services.go
@@ -21,7 +21,7 @@ var _ = Describe("[sig-kubevirt] services", func() {
 		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		It("should allow connections to pods from infra cluster pod via NodePort across different infra nodes", func() {
-			oc = setMgmtFramework(mgmtFramework)
+			oc = SetMgmtFramework(mgmtFramework)
 			// This tests connectivity from the infra cluster's pod network to a NodePort
 			// within a nested KubeVirt Hypershift guest cluster.
 			//
@@ -58,7 +58,7 @@ var _ = Describe("[sig-kubevirt] services", func() {
 		})
 
 		It("should allow connections to pods from infra cluster pod via LoadBalancer service across different guest nodes", func() {
-			oc = setMgmtFramework(mgmtFramework)
+			oc = SetMgmtFramework(mgmtFramework)
 			// Within a nested KubeVirt guest cluster, this tests the ability for
 			// LoadBalancer services to route from pod network to pods across infra nodes.
 			// client pod (on infra cluster) -> guest node IP -> LoadBalancer Service -> server pod (on guest cluster)

--- a/test/extended/kubevirt/util.go
+++ b/test/extended/kubevirt/util.go
@@ -364,7 +364,7 @@ func InKubeVirtClusterContext(oc *exutil.CLI, body func()) {
 	)
 }
 
-func setMgmtFramework(mgmtFramework *e2e.Framework) *exutil.CLI {
+func SetMgmtFramework(mgmtFramework *e2e.Framework) *exutil.CLI {
 	_, hcpNamespace, err := exutil.GetHypershiftManagementClusterConfigAndNamespace()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -458,15 +458,15 @@ func expectNoError(err error, explain ...interface{}) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), explain...)
 }
 
-func mgmtClusterIsAWS(f *e2e.Framework) (bool, error) {
-	oc := setMgmtFramework(f)
+func MgmtClusterIsType(f *e2e.Framework, platformType configv1.PlatformType) (bool, error) {
+	oc := SetMgmtFramework(f)
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(),
 		"cluster", metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
 
-	return infra.Spec.PlatformSpec.Type == configv1.AWSPlatformType, nil
+	return infra.Spec.PlatformSpec.Type == platformType, nil
 }
 
 func dumpKubevirtArtifacts(f *e2e.Framework) {


### PR DESCRIPTION
In case the cluster under test is an HCP/HyperShift cluster of the kubevirt provider, and the management cluster is running on Azure, ICMP responses from outside of the cluster to the guest cluster are getting blocked. Thus, skipping the ping tests in that case, in addition to the existing exception. This is a manual backport of #28916