### PR TITLE
WRKLDS-1431: e2e: extend DC testing to Deployments

### DIFF
--- a/test/extended/cli/env.go
+++ b/test/extended/cli/env.go
@@ -11,6 +11,7 @@ var _ = g.Describe("[sig-cli] oc env", func() {
 	defer g.GinkgoRecover()
 
 	var (
+		fileDeployment  = exutil.FixturePath("testdata", "test-deployment.yaml")
 		file            = exutil.FixturePath("testdata", "test-deployment-config.yaml")
 		buildConfigFile = exutil.FixturePath("testdata", "test-buildcli.json")
 		oc              = exutil.NewCLI("oc-env")
@@ -73,6 +74,80 @@ var _ = g.Describe("[sig-cli] oc env", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("set").Args("env", dc, "--list", "--resolve").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("error retrieving reference for PREFIX_FOO_BAR"))
+
+		g.By("setting environment variables for buildconfigs")
+		out, err = oc.Run("set").Args("env", "bc", "--all", "FOO=bar").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("updated"))
+
+		out, err = oc.Run("set").Args("env", "bc", "--all", "--list").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("FOO=bar"))
+
+		out, err = oc.Run("set").Args("env", "bc", "--all", "FOO-").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("updated"))
+	})
+
+	g.It("can set environment variables for deployment [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+		g.By("creating a test-deployment deployment")
+		err := oc.Run("create").Args("-f", fileDeployment).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer oc.Run("delete").Args("-f", fileDeployment).Execute()
+
+		g.By("create a test-buildcli buildconfig")
+		err = oc.Run("create").Args("-f", buildConfigFile).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer oc.Run("delete").Args("-f", buildConfigFile).Execute()
+
+		g.By("setting environment variables for deployment")
+		deploymentName := "deployment/test-deployment"
+
+		out, err := oc.Run("set").Args("env", deploymentName, "FOO=1st").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("updated"))
+
+		out, err = oc.Run("set").Args("env", deploymentName, "FOO=2nd").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("updated"))
+
+		out, err = oc.Run("set").Args("env", deploymentName, "FOO=bar", "--overwrite").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("updated"))
+
+		out, err = oc.Run("set").Args("env", deploymentName, "FOO=zee", "--overwrite=false").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("already has a value"))
+
+		out, err = oc.Run("set").Args("env", deploymentName, "--list").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("FOO=bar"))
+
+		out, err = oc.Run("set").Args("env", deploymentName, "FOO-").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("updated"))
+
+		err = oc.Run("create").Args("secret", "generic", "mysecret", "--from-literal=foo.bar=secret").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err = oc.Run("set").Args("env", "--from=secret/mysecret", "--prefix=PREFIX_", deploymentName, "FOO-").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("updated"))
+
+		out, err = oc.Run("set").Args("env", deploymentName, "--list").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("PREFIX_FOO_BAR from secret mysecret, key foo.bar"))
+
+		out, err = oc.Run("set").Args("env", deploymentName, "--list", "--resolve").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("PREFIX_FOO_BAR=secret"))
+
+		err = oc.Run("delete").Args("secret", "mysecret").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err = oc.Run("set").Args("env", deploymentName, "--list", "--resolve").Output()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("error retrieving reference for PREFIX_FOO_BAR"))
 

--- a/test/extended/cli/run.go
+++ b/test/extended/cli/run.go
@@ -22,4 +22,13 @@ var _ = g.Describe("[sig-cli] oc run", func() {
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(err.Error()).To(o.ContainSubstring("error: Invalid image name \"\\\"InvalidImageValue0192\\\"\": invalid reference format"))
 	})
+
+	g.It("can use --image flag correctly for deployment", func() {
+		_, err := oc.Run("create").Args("deployment", "newdcforimage", "--image=validimagevalue").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		_, err = oc.Run("run").Args("newdcforimage2", "--image=\"InvalidImageValue0192\"").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(err.Error()).To(o.ContainSubstring("error: Invalid image name \"\\\"InvalidImageValue0192\\\"\": invalid reference format"))
+	})
 })

--- a/test/extended/cli/setimage.go
+++ b/test/extended/cli/setimage.go
@@ -19,6 +19,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 
 	var (
 		deploymentConfig = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "test-deployment-config.yaml")
+		deployment       = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "test-deployment.yaml")
 		imageStream      = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "image-streams", "image-streams-centos7.json")
 		oc               = exutil.NewCLIWithPodSecurityLevel("oc-set-image", admissionapi.LevelBaseline)
 	)
@@ -124,6 +125,112 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
 
 		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
+		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+	})
+
+	g.It("can set images for pods and deployments [apigroup:image.openshift.io][Skipped:Disconnected]", func() {
+		g.By("creating test deployment, pod, and image stream")
+		err := oc.Run("create").Args("-f", deployment).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		file, err := writeObjectToFile(newHelloPod())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer os.Remove(file)
+
+		err = oc.Run("create").Args("-f", file).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.Run("create").Args("-f", imageStream).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("waiting for created resources to be ready for testing")
+		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
+			err := oc.Run("get").Args("imagestreamtags", "ruby:3.0-ubi8").Execute()
+			return err == nil, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("testing --local flag validation")
+		out, err := oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--local").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("you must specify resources by --filename when --local is set."))
+
+		g.By("testing --dry-run=client with -o flags")
+		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag", "--dry-run=client").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("test-deployment"))
+		o.Expect(out).To(o.ContainSubstring("deployment.apps/test-deployment image updated (dry run)"))
+
+		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("deployment.apps/test-deployment"))
+
+		g.By("testing basic image updates")
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
+		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+
+		g.By("repeating basic image updates to ensure nothing changed")
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
+		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+
+		g.By("testing invalid image tags")
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:XYZ", "--source=istag").Execute()
+		o.Expect(err).To(o.HaveOccurred())
+
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:XYZ", "--source=isimage").Execute()
+		o.Expect(err).To(o.HaveOccurred())
+
+		g.By("setting a different, valid image on deployment config")
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=nginx").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("nginx"))
+
+		g.By("setting a different, valid image on pod")
+		err = oc.Run("set").Args("image", "pod/hello-openshift", "hello-openshift=nginx").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err = oc.Run("get").Args("pod/hello-openshift", "-o", "jsonpath='{.spec.containers[0].image}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("nginx"))
+
+		g.By("setting a different, valid image tag on pod")
+		err = oc.Run("set").Args("image", "pod/hello-openshift", "hello-openshift=nginx:1.9.1").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err = oc.Run("get").Args("pod/hello-openshift", "-o", "jsonpath='{.spec.containers[0].image}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("nginx:1.9.1"))
+
+		g.By("setting a different, valid image on multiple resources")
+		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
+			err := oc.Run("set").Args("image", "pods,deployments", "*=ruby:3.0-ubi8", "--all", "--source=imagestreamtag").Execute()
+			if err != nil {
+				klog.Warningf("one of pods failed when setting image %v", err)
+				return false, nil
+			}
+			return true, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err = oc.Run("get").Args("pod/hello-openshift", "-o", "jsonpath='{.spec.containers[0].image}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
+		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+
+		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
 		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))

--- a/test/extended/cli/timeout.go
+++ b/test/extended/cli/timeout.go
@@ -40,4 +40,32 @@ var _ = g.Describe("[sig-cli] oc --request-timeout", func() {
 			o.ContainSubstring("context deadline exceeded"),
 			o.ContainSubstring("Client.Timeout exceeded while awaiting headers")))
 	})
+
+	g.It("works as expected for deployment", func() {
+		busyBoxImage := k8simage.GetE2EImage(k8simage.BusyBox)
+		err := oc.Run("create").Args("deployment", "testdc", "--image="+busyBoxImage).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		out, err := oc.Run("get", "deployment/testdc").Args("-w", "-v=5", "--request-timeout=1s").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// timeout is set for both the request and on context in request
+		// seek8s.io/client-go/rest/request.go#request so if we get timeout
+		// from server or from context it's ok
+		o.Expect(out).Should(o.SatisfyAny(o.ContainSubstring("request canceled"), o.ContainSubstring("context deadline exceeded")))
+
+		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=1s").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("testdc"))
+
+		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=1").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.ContainSubstring("testdc"))
+
+		out, err = oc.Run("get", "pods").Args("--watch", "-v=5", "--request-timeout=1s").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).Should(o.SatisfyAny(
+			o.ContainSubstring("request canceled"),
+			o.ContainSubstring("context deadline exceeded"),
+			o.ContainSubstring("Client.Timeout exceeded while awaiting headers")))
+	})
 })

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -227,6 +227,7 @@
 // test/extended/testdata/cmd/test/cmd/testdata/external-service.yaml
 // test/extended/testdata/cmd/test/cmd/testdata/hello-openshift/hello-pod.json
 // test/extended/testdata/cmd/test/cmd/testdata/idling-dc.yaml
+// test/extended/testdata/cmd/test/cmd/testdata/idling-deployment.yaml
 // test/extended/testdata/cmd/test/cmd/testdata/idling-svc-route.yaml
 // test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
 // test/extended/testdata/cmd/test/cmd/testdata/jenkins/jenkins-ephemeral-template.json
@@ -273,6 +274,7 @@
 // test/extended/testdata/cmd/test/cmd/testdata/test-bc.yaml
 // test/extended/testdata/cmd/test/cmd/testdata/test-buildcli.json
 // test/extended/testdata/cmd/test/cmd/testdata/test-deployment-config.yaml
+// test/extended/testdata/cmd/test/cmd/testdata/test-deployment.yaml
 // test/extended/testdata/cmd/test/cmd/testdata/test-docker-build.json
 // test/extended/testdata/cmd/test/cmd/testdata/test-image-stream.json
 // test/extended/testdata/cmd/test/cmd/testdata/test-image.json
@@ -481,6 +483,7 @@
 // test/extended/testdata/test-buildcli.json
 // test/extended/testdata/test-cli-debug.yaml
 // test/extended/testdata/test-deployment-config.yaml
+// test/extended/testdata/test-deployment.yaml
 // test/extended/testdata/test-env-pod.json
 // test/extended/testdata/test-replication-controller.yaml
 // test/extended/testdata/test-secret.json
@@ -36539,6 +36542,66 @@ func testExtendedTestdataCmdTestCmdTestdataIdlingDcYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataCmdTestCmdTestdataIdlingDeploymentYaml = []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generateName: idling-echo-
+  labels:
+    app: idling-echo
+    deployment: idling-echo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: idling-echo
+      deployment: idling-echo
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: idling-echo
+        deployment: idling-echo
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        name: idling-tcp-echo
+        command:
+          - /usr/bin/socat
+          - TCP4-LISTEN:8675,reuseaddr,fork
+          - EXEC:'/bin/cat'
+        ports:
+        - containerPort: 8675
+          protocol: TCP
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        name: idling-udp-echo
+        command:
+          - /usr/bin/socat
+          - UDP4-LISTEN:3090,reuseaddr,fork
+          - EXEC:'/bin/cat'
+        ports:
+        - containerPort: 3090
+          protocol: UDP
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+`)
+
+func testExtendedTestdataCmdTestCmdTestdataIdlingDeploymentYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataCmdTestCmdTestdataIdlingDeploymentYaml, nil
+}
+
+func testExtendedTestdataCmdTestCmdTestdataIdlingDeploymentYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataCmdTestCmdTestdataIdlingDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/cmd/test/cmd/testdata/idling-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataCmdTestCmdTestdataIdlingSvcRouteYaml = []byte(`apiVersion: v1
 kind: List
 metadata: {}
@@ -41681,6 +41744,55 @@ func testExtendedTestdataCmdTestCmdTestdataTestDeploymentConfigYaml() (*asset, e
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/cmd/test/cmd/testdata/test-deployment-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataCmdTestCmdTestdataTestDeploymentYaml = []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: test-deployment
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: test-deployment
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        imagePullPolicy: IfNotPresent
+        name: ruby-helloworld
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 3Gi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - emptyDir: {}
+        name: vol1
+`)
+
+func testExtendedTestdataCmdTestCmdTestdataTestDeploymentYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataCmdTestCmdTestdataTestDeploymentYaml, nil
+}
+
+func testExtendedTestdataCmdTestCmdTestdataTestDeploymentYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataCmdTestCmdTestdataTestDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/cmd/test/cmd/testdata/test-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -53082,6 +53194,55 @@ func testExtendedTestdataTestDeploymentConfigYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataTestDeploymentYaml = []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: test-deployment
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: test-deployment
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        imagePullPolicy: IfNotPresent
+        name: ruby-helloworld
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 3Gi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - emptyDir: {}
+        name: vol1
+`)
+
+func testExtendedTestdataTestDeploymentYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataTestDeploymentYaml, nil
+}
+
+func testExtendedTestdataTestDeploymentYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataTestDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/test-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataTestEnvPodJson = []byte(`{
   "kind":"Pod",
   "apiVersion":"v1",
@@ -55307,6 +55468,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/cmd/test/cmd/testdata/external-service.yaml":                                     testExtendedTestdataCmdTestCmdTestdataExternalServiceYaml,
 	"test/extended/testdata/cmd/test/cmd/testdata/hello-openshift/hello-pod.json":                            testExtendedTestdataCmdTestCmdTestdataHelloOpenshiftHelloPodJson,
 	"test/extended/testdata/cmd/test/cmd/testdata/idling-dc.yaml":                                            testExtendedTestdataCmdTestCmdTestdataIdlingDcYaml,
+	"test/extended/testdata/cmd/test/cmd/testdata/idling-deployment.yaml":                                    testExtendedTestdataCmdTestCmdTestdataIdlingDeploymentYaml,
 	"test/extended/testdata/cmd/test/cmd/testdata/idling-svc-route.yaml":                                     testExtendedTestdataCmdTestCmdTestdataIdlingSvcRouteYaml,
 	"test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json":                  testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json,
 	"test/extended/testdata/cmd/test/cmd/testdata/jenkins/jenkins-ephemeral-template.json":                   testExtendedTestdataCmdTestCmdTestdataJenkinsJenkinsEphemeralTemplateJson,
@@ -55353,6 +55515,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/cmd/test/cmd/testdata/test-bc.yaml":                                              testExtendedTestdataCmdTestCmdTestdataTestBcYaml,
 	"test/extended/testdata/cmd/test/cmd/testdata/test-buildcli.json":                                        testExtendedTestdataCmdTestCmdTestdataTestBuildcliJson,
 	"test/extended/testdata/cmd/test/cmd/testdata/test-deployment-config.yaml":                               testExtendedTestdataCmdTestCmdTestdataTestDeploymentConfigYaml,
+	"test/extended/testdata/cmd/test/cmd/testdata/test-deployment.yaml":                                      testExtendedTestdataCmdTestCmdTestdataTestDeploymentYaml,
 	"test/extended/testdata/cmd/test/cmd/testdata/test-docker-build.json":                                    testExtendedTestdataCmdTestCmdTestdataTestDockerBuildJson,
 	"test/extended/testdata/cmd/test/cmd/testdata/test-image-stream.json":                                    testExtendedTestdataCmdTestCmdTestdataTestImageStreamJson,
 	"test/extended/testdata/cmd/test/cmd/testdata/test-image.json":                                           testExtendedTestdataCmdTestCmdTestdataTestImageJson,
@@ -55561,6 +55724,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/test-buildcli.json":                                                              testExtendedTestdataTestBuildcliJson,
 	"test/extended/testdata/test-cli-debug.yaml":                                                             testExtendedTestdataTestCliDebugYaml,
 	"test/extended/testdata/test-deployment-config.yaml":                                                     testExtendedTestdataTestDeploymentConfigYaml,
+	"test/extended/testdata/test-deployment.yaml":                                                            testExtendedTestdataTestDeploymentYaml,
 	"test/extended/testdata/test-env-pod.json":                                                               testExtendedTestdataTestEnvPodJson,
 	"test/extended/testdata/test-replication-controller.yaml":                                                testExtendedTestdataTestReplicationControllerYaml,
 	"test/extended/testdata/test-secret.json":                                                                testExtendedTestdataTestSecretJson,
@@ -55966,8 +56130,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 								"hello-openshift": {nil, map[string]*bintree{
 									"hello-pod.json": {testExtendedTestdataCmdTestCmdTestdataHelloOpenshiftHelloPodJson, map[string]*bintree{}},
 								}},
-								"idling-dc.yaml":        {testExtendedTestdataCmdTestCmdTestdataIdlingDcYaml, map[string]*bintree{}},
-								"idling-svc-route.yaml": {testExtendedTestdataCmdTestCmdTestdataIdlingSvcRouteYaml, map[string]*bintree{}},
+								"idling-dc.yaml":         {testExtendedTestdataCmdTestCmdTestdataIdlingDcYaml, map[string]*bintree{}},
+								"idling-deployment.yaml": {testExtendedTestdataCmdTestCmdTestdataIdlingDeploymentYaml, map[string]*bintree{}},
+								"idling-svc-route.yaml":  {testExtendedTestdataCmdTestCmdTestdataIdlingSvcRouteYaml, map[string]*bintree{}},
 								"image-streams": {nil, map[string]*bintree{
 									"image-streams-centos7.json": {testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json, map[string]*bintree{}},
 								}},
@@ -56027,6 +56192,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 								"test-bc.yaml":                     {testExtendedTestdataCmdTestCmdTestdataTestBcYaml, map[string]*bintree{}},
 								"test-buildcli.json":               {testExtendedTestdataCmdTestCmdTestdataTestBuildcliJson, map[string]*bintree{}},
 								"test-deployment-config.yaml":      {testExtendedTestdataCmdTestCmdTestdataTestDeploymentConfigYaml, map[string]*bintree{}},
+								"test-deployment.yaml":             {testExtendedTestdataCmdTestCmdTestdataTestDeploymentYaml, map[string]*bintree{}},
 								"test-docker-build.json":           {testExtendedTestdataCmdTestCmdTestdataTestDockerBuildJson, map[string]*bintree{}},
 								"test-image-stream.json":           {testExtendedTestdataCmdTestCmdTestdataTestImageStreamJson, map[string]*bintree{}},
 								"test-image.json":                  {testExtendedTestdataCmdTestCmdTestdataTestImageJson, map[string]*bintree{}},
@@ -56347,6 +56513,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"test-buildcli.json":                   {testExtendedTestdataTestBuildcliJson, map[string]*bintree{}},
 				"test-cli-debug.yaml":                  {testExtendedTestdataTestCliDebugYaml, map[string]*bintree{}},
 				"test-deployment-config.yaml":          {testExtendedTestdataTestDeploymentConfigYaml, map[string]*bintree{}},
+				"test-deployment.yaml":                 {testExtendedTestdataTestDeploymentYaml, map[string]*bintree{}},
 				"test-env-pod.json":                    {testExtendedTestdataTestEnvPodJson, map[string]*bintree{}},
 				"test-replication-controller.yaml":     {testExtendedTestdataTestReplicationControllerYaml, map[string]*bintree{}},
 				"test-secret.json":                     {testExtendedTestdataTestSecretJson, map[string]*bintree{}},

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -335,6 +335,7 @@
 // test/extended/testdata/hello-builder/Dockerfile
 // test/extended/testdata/hello-builder/scripts/assemble
 // test/extended/testdata/hello-builder/scripts/run
+// test/extended/testdata/idling-echo-server-deployment.yaml
 // test/extended/testdata/idling-echo-server-rc.yaml
 // test/extended/testdata/idling-echo-server.yaml
 // test/extended/testdata/image/deployment-with-annotation-trigger.yaml
@@ -44854,6 +44855,113 @@ func testExtendedTestdataHelloBuilderScriptsRun() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataIdlingEchoServerDeploymentYaml = []byte(`apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: idling-echo
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        app: idling-echo
+        deployment: idling-echo
+    strategy:
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          app: idling-echo
+          deployment: idling-echo
+      spec:
+        containers:
+        - image: registry.k8s.io/e2e-test-images/agnhost:2.47
+          name: idling-echo-server
+          args: [ "netexec", "--http-port", "8675", "--udp-port", "3090" ]
+          ports:
+          - containerPort: 8675
+            protocol: TCP
+          - containerPort: 3090
+            protocol: UDP
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: idling-echo
+    labels:
+      app: idling-echo
+  spec:
+    selector:
+      app: idling-echo
+    ports:
+      - port: 8675
+        name: tcp-echo
+        protocol: TCP
+      - port: 3090
+        name: udp-echo
+        protocol: UDP
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: idling-echo
+  spec:
+    to:
+      kind: Service
+      name: idling-echo
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: idling-echo-reencrypt
+  spec:
+    tls:
+      termination: reencrypt
+      # the actual certificate here is not relevant, since we're not
+      # actually serving TLS
+      destinationCACertificate: |-
+        -----BEGIN CERTIFICATE-----
+        MIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
+        CzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl
+        ZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3
+        dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu
+        Y29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP
+        d3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq
+        hkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx
+        EDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv
+        gu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm
+        47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M
+        mNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC
+        MAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd
+        TMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m
+        V7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc
+        yfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j
+        jhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q
+        +Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=
+        -----END CERTIFICATE-----
+    to:
+      kind: Service
+      name: idling-echo
+`)
+
+func testExtendedTestdataIdlingEchoServerDeploymentYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataIdlingEchoServerDeploymentYaml, nil
+}
+
+func testExtendedTestdataIdlingEchoServerDeploymentYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataIdlingEchoServerDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/idling-echo-server-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataIdlingEchoServerRcYaml = []byte(`apiVersion: v1
 kind: List
 items:
@@ -55307,6 +55415,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/hello-builder/Dockerfile":                                                        testExtendedTestdataHelloBuilderDockerfile,
 	"test/extended/testdata/hello-builder/scripts/assemble":                                                  testExtendedTestdataHelloBuilderScriptsAssemble,
 	"test/extended/testdata/hello-builder/scripts/run":                                                       testExtendedTestdataHelloBuilderScriptsRun,
+	"test/extended/testdata/idling-echo-server-deployment.yaml":                                              testExtendedTestdataIdlingEchoServerDeploymentYaml,
 	"test/extended/testdata/idling-echo-server-rc.yaml":                                                      testExtendedTestdataIdlingEchoServerRcYaml,
 	"test/extended/testdata/idling-echo-server.yaml":                                                         testExtendedTestdataIdlingEchoServerYaml,
 	"test/extended/testdata/image/deployment-with-annotation-trigger.yaml":                                   testExtendedTestdataImageDeploymentWithAnnotationTriggerYaml,
@@ -56020,8 +56129,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"run":      {testExtendedTestdataHelloBuilderScriptsRun, map[string]*bintree{}},
 					}},
 				}},
-				"idling-echo-server-rc.yaml": {testExtendedTestdataIdlingEchoServerRcYaml, map[string]*bintree{}},
-				"idling-echo-server.yaml":    {testExtendedTestdataIdlingEchoServerYaml, map[string]*bintree{}},
+				"idling-echo-server-deployment.yaml": {testExtendedTestdataIdlingEchoServerDeploymentYaml, map[string]*bintree{}},
+				"idling-echo-server-rc.yaml":         {testExtendedTestdataIdlingEchoServerRcYaml, map[string]*bintree{}},
+				"idling-echo-server.yaml":            {testExtendedTestdataIdlingEchoServerYaml, map[string]*bintree{}},
 				"image": {nil, map[string]*bintree{
 					"deployment-with-annotation-trigger.yaml": {testExtendedTestdataImageDeploymentWithAnnotationTriggerYaml, map[string]*bintree{}},
 					"test-image.json":                         {testExtendedTestdataImageTestImageJson, map[string]*bintree{}},

--- a/test/extended/testdata/cmd/test/cmd/testdata/idling-deployment.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/idling-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generateName: idling-echo-
+  labels:
+    app: idling-echo
+    deployment: idling-echo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: idling-echo
+      deployment: idling-echo
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: idling-echo
+        deployment: idling-echo
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        name: idling-tcp-echo
+        command:
+          - /usr/bin/socat
+          - TCP4-LISTEN:8675,reuseaddr,fork
+          - EXEC:'/bin/cat'
+        ports:
+        - containerPort: 8675
+          protocol: TCP
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        name: idling-udp-echo
+        command:
+          - /usr/bin/socat
+          - UDP4-LISTEN:3090,reuseaddr,fork
+          - EXEC:'/bin/cat'
+        ports:
+        - containerPort: 3090
+          protocol: UDP
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}

--- a/test/extended/testdata/cmd/test/cmd/testdata/test-deployment.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/test-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: test-deployment
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: test-deployment
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        imagePullPolicy: IfNotPresent
+        name: ruby-helloworld
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 3Gi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - emptyDir: {}
+        name: vol1

--- a/test/extended/testdata/idling-echo-server-deployment.yaml
+++ b/test/extended/testdata/idling-echo-server-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: idling-echo
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        app: idling-echo
+        deployment: idling-echo
+    strategy:
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          app: idling-echo
+          deployment: idling-echo
+      spec:
+        containers:
+        - image: registry.k8s.io/e2e-test-images/agnhost:2.47
+          name: idling-echo-server
+          args: [ "netexec", "--http-port", "8675", "--udp-port", "3090" ]
+          ports:
+          - containerPort: 8675
+            protocol: TCP
+          - containerPort: 3090
+            protocol: UDP
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: idling-echo
+    labels:
+      app: idling-echo
+  spec:
+    selector:
+      app: idling-echo
+    ports:
+      - port: 8675
+        name: tcp-echo
+        protocol: TCP
+      - port: 3090
+        name: udp-echo
+        protocol: UDP
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: idling-echo
+  spec:
+    to:
+      kind: Service
+      name: idling-echo
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: idling-echo-reencrypt
+  spec:
+    tls:
+      termination: reencrypt
+      # the actual certificate here is not relevant, since we're not
+      # actually serving TLS
+      destinationCACertificate: |-
+        -----BEGIN CERTIFICATE-----
+        MIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
+        CzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl
+        ZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3
+        dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu
+        Y29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP
+        d3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq
+        hkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx
+        EDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv
+        gu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm
+        47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M
+        mNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC
+        MAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd
+        TMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m
+        V7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc
+        yfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j
+        jhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q
+        +Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=
+        -----END CERTIFICATE-----
+    to:
+      kind: Service
+      name: idling-echo

--- a/test/extended/testdata/test-deployment.yaml
+++ b/test/extended/testdata/test-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: test-deployment
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: test-deployment
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        imagePullPolicy: IfNotPresent
+        name: ruby-helloworld
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 3Gi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - emptyDir: {}
+        name: vol1

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -661,6 +661,8 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc --request-timeout works as expected [apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] oc --request-timeout works as expected for deployment": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli] oc adm build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io][apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc adm cluster-role-reapers [Serial][apigroup:authorization.openshift.io][apigroup:user.openshift.io]": " [Suite:openshift/conformance/serial]",
@@ -757,6 +759,8 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc debug dissect deployment config debug [apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] oc debug dissect deployment debug": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli] oc debug does not require a real resource on the server": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc debug ensure debug does not depend on a container actually existing for the selected resource [apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
@@ -764,6 +768,8 @@ var Annotations = map[string]string{
 	"[sig-cli] oc debug ensure it works with image streams [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc env can set environment variables [apigroup:apps.openshift.io][apigroup:image.openshift.io][apigroup:build.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-cli] oc env can set environment variables for deployment [apigroup:image.openshift.io][apigroup:build.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc explain list uncovered GroupVersionResources": " [Suite:openshift/conformance/parallel]",
 
@@ -819,6 +825,12 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc help works as expected": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] oc idle Deployments [apigroup:route.openshift.io][apigroup:project.openshift.io][apigroup:image.openshift.io] by all": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-cli] oc idle Deployments [apigroup:route.openshift.io][apigroup:project.openshift.io][apigroup:image.openshift.io] by label": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-cli] oc idle Deployments [apigroup:route.openshift.io][apigroup:project.openshift.io][apigroup:image.openshift.io] by name": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:route.openshift.io][apigroup:project.openshift.io][apigroup:image.openshift.io] by all": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:route.openshift.io][apigroup:project.openshift.io][apigroup:image.openshift.io] by checking previous scale": " [Suite:openshift/conformance/parallel]",
@@ -845,9 +857,13 @@ var Annotations = map[string]string{
 
 	"[sig-cli] oc run can use --image flag correctly [apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cli] oc run can use --image flag correctly for deployment": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli] oc secret creates and retrieves expected": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc service creates and deletes services": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-cli] oc set image can set images for pods and deployments [apigroup:image.openshift.io][Skipped:Disconnected]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc set image can set images for pods and deployments [apigroup:image.openshift.io][apigroup:apps.openshift.io][Skipped:Disconnected]": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1289,6 +1289,16 @@ var Annotations = map[string]string{
 
 	"[sig-network-edge][Feature:Idling] Unidling [apigroup:apps.openshift.io][apigroup:route.openshift.io] should work with UDP": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-network-edge][Feature:Idling] Unidling with Deployments [apigroup:route.openshift.io] should handle many TCP connections by possibly dropping those over a certain bound [Serial]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-network-edge][Feature:Idling] Unidling with Deployments [apigroup:route.openshift.io] should handle many UDP senders (by continuing to drop all packets on the floor) [Serial]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-network-edge][Feature:Idling] Unidling with Deployments [apigroup:route.openshift.io] should work with TCP (when fully idled)": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network-edge][Feature:Idling] Unidling with Deployments [apigroup:route.openshift.io] should work with TCP (while idling)": " [Disabled:Broken]",
+
+	"[sig-network-edge][Feature:Idling] Unidling with Deployments [apigroup:route.openshift.io] should work with UDP": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network] Internal connectivity for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network] external gateway address when using openshift ovn-kubernetes should match the address family of the pod": " [Suite:openshift/conformance/parallel]",

--- a/test/extended/util/annotate/rules.go
+++ b/test/extended/util/annotate/rules.go
@@ -43,6 +43,7 @@ var (
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=2004074
 			`\[sig-network-edge\]\[Feature:Idling\] Unidling \[apigroup:apps.openshift.io\]\[apigroup:route.openshift.io\] should work with TCP \(while idling\)`,
+			`\[sig-network-edge\]\[Feature:Idling\] Unidling with Deployments \[apigroup:route.openshift.io\] should work with TCP \(while idling\)`,
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=2070929
 			`\[sig-network\]\[Feature:EgressIP\]\[apigroup:operator.openshift.io\] \[internal-targets\]`,


### PR DESCRIPTION
Part of simplifying https://github.com/openshift/origin/pull/28957. This PR extends the same e2e testing for Deployments as well. The DCs are already deprecated (yet never planned to be removed from 4.Y) and the DC capability is planned to be disabled by default. This helps to maintain the parity between DCs and Deployments.