### PR TITLE
OCPBUGS-36891: Update OWNERS file in origin/test/extended/router

### DIFF
--- a/test/extended/router/OWNERS
+++ b/test/extended/router/OWNERS
@@ -1,14 +1,25 @@
 approvers:
-  - danehans
   - frobware
   - knobunc
   - Miciah
   - miheer
-  - sgreene570
+  - alebedev87
+  - candita
+  - gcs278
+  - rfredette
+  - Thealisyed
+  - grzpiotrowski
 reviewers:
-  - danehans
   - frobware
   - knobunc
   - Miciah
   - miheer
+  - alebedev87
+  - candita
+  - gcs278
+  - rfredette
+  - Thealisyed
+  - grzpiotrowski
+emeritus_approvers:
+  - danehans
   - sgreene570


### PR DESCRIPTION
This PR revises:
Updating the OWNERS file in origin/test/extended/router