### PR TITLE
[POC][WIP] a new test for detecting ungraceful kube-apiserver termination by kubelet

### DIFF
--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -178,18 +178,9 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 			for _, auditLog := range auditLogs {
 				lateRequestCounter := 0
 				func() {
-					file, err := os.Open(auditLog)
+					reader, err := newFileWrapper(auditLog)
 					o.Expect(err).NotTo(o.HaveOccurred())
-					defer file.Close()
-
-					var reader io.Reader
-					reader = file
-					if isGzipFileByExtension(file.Name()) {
-						gzipReader, err := gzip.NewReader(file)
-						o.Expect(err).NotTo(o.HaveOccurred())
-						defer gzipReader.Close()
-						reader = gzipReader
-					}
+					defer reader.Close()
 
 					scanner := bufio.NewScanner(reader)
 					for scanner.Scan() {

--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -379,3 +379,7 @@ func IsAuditFile(fileName string) bool {
 
 	return (strings.Contains(fileName, "-audit-") && strings.HasSuffix(fileName, ".log.gz")) || strings.HasSuffix(fileName, "audit.log.gz")
 }
+
+func IsTerminationLog(fileName string) bool {
+	return (strings.Contains(fileName, "-termination-") && strings.HasSuffix(fileName, ".log.gz")) || strings.HasSuffix(fileName, "termination.log.gz")
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -43,6 +43,8 @@ var Annotations = map[string]string{
 
 	"[sig-api-machinery][Feature:APIServer][Late] kube-apiserver terminates within graceful termination period": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-api-machinery][Feature:APIServer][Late] kubelet terminates kube-apiserver gracefully extended": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-api-machinery][Feature:APIServer][Late] kubelet terminates kube-apiserver gracefully": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-api-machinery][Feature:Audit] Basic audit should audit API calls": " [Disabled:SpecialConfig]",


### PR DESCRIPTION
Initially I wanted to compare shutdown related events but after [inspecting](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.18-e2e-gcp-ovn-upgrade/1822964770265894912) I have realised that event's are sometimes not even persisted in the storage.

The new test added by this PR simply looks for the `Previous pod .* did not terminate gracefully string in the -termination.log` files.

This PR could be made simpler and smaller by copying the existing code instead of reusing it.