### PR TITLE
NO-JIRA: fix: add informer handler HasSynced to sync array

### DIFF
--- a/pkg/cmd/openshift-tests/disruption/watch-endpointslice/endpointslice_controller.go
+++ b/pkg/cmd/openshift-tests/disruption/watch-endpointslice/endpointslice_controller.go
@@ -98,7 +98,7 @@ func NewEndpointWatcher(
 	}
 	c.syncHandler = c.syncEndpointSlice
 
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	endpointSliceInformerHandler, _ := endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.queue.Add("checK")
 		},
@@ -109,7 +109,8 @@ func NewEndpointWatcher(
 			c.queue.Add("checK")
 		},
 	})
-	configmapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+
+	configmapInformerHandler, _ := configmapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.queue.Add("checK")
 		},
@@ -120,6 +121,9 @@ func NewEndpointWatcher(
 			c.queue.Add("checK")
 		},
 	})
+
+	c.informersToSync = append(c.informersToSync, endpointSliceInformerHandler.HasSynced, configmapInformerHandler.HasSynced)
+
 	return c
 }
 


### PR DESCRIPTION
adding the handler sync to the informers to sync slice to make sure we wait for them to sync before starting since we dont resync after