### PR TITLE
NO-JIRA: monitor/recorder: snapshot makes copy before returning events

### DIFF
--- a/pkg/monitor/recorder.go
+++ b/pkg/monitor/recorder.go
@@ -180,7 +180,11 @@ func (m *recorder) RecordAt(t time.Time, conditions ...monitorapi.Condition) {
 func (m *recorder) snapshot() monitorapi.Intervals {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.events
+	eventsCopy := make(monitorapi.Intervals, len(m.events))
+	for i, event := range m.events {
+		eventsCopy[i] = event
+	}
+	return eventsCopy
 }
 
 // Intervals returns all events that occur between from and to, including


### PR DESCRIPTION
In go, passing slices between functions doesn't copy the internal array. 
Instead, a pointer to the same underlying array is shared among all receivers.