### PR TITLE
NO-JIRA: add basic graceful lease checking

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -44,6 +44,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/testframework/knownimagechecker"
 	"github.com/openshift/origin/pkg/monitortests/testframework/legacytestframeworkmonitortests"
 	"github.com/openshift/origin/pkg/monitortests/testframework/metricsendpointdown"
+	"github.com/openshift/origin/pkg/monitortests/testframework/operatorloganalyzer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/pathologicaleventanalyzer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/timelineserializer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/trackedresourcesserializer"
@@ -180,6 +181,8 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 	monitorTestRegistry.AddMonitorTestOrDie("e2e-test-analyzer", "Test Framework", e2etestanalyzer.NewAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("event-collector", "Test Framework", watchevents.NewEventWatcher())
 	monitorTestRegistry.AddMonitorTestOrDie("clusteroperator-collector", "Test Framework", watchclusteroperators.NewOperatorWatcher())
+	monitorTestRegistry.AddMonitorTestOrDie("initial-and-final-operator-log-scraper", "Test Framework", operatorloganalyzer.InitialAndFinalOperatorLogScraper())
+	monitorTestRegistry.AddMonitorTestOrDie("lease-checker", "Test Framework", operatorloganalyzer.OperatorLeaseCheck())
 
 	monitorTestRegistry.AddMonitorTestOrDie("azure-metrics-collector", "Test Framework", azuremetrics.NewAzureMetricsCollector())
 	monitorTestRegistry.AddMonitorTestOrDie("watch-request-counts-collector", "Test Framework", watchrequestcountscollector.NewWatchRequestCountSerializer())

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -114,7 +114,8 @@ func (m *Monitor) Stop(ctx context.Context) (ResultState, error) {
 	m.junits = append(m.junits, computedJunit...)
 
 	fmt.Fprintf(os.Stderr, "Evaluating tests.\n")
-	finalEvents := m.recorder.Intervals(m.startTime, m.stopTime)
+	// compute intervals based on *all* the intervals.  Individual monitortests can choose how to restrict themselves.
+	finalEvents := m.recorder.Intervals(time.Time{}, time.Time{})
 	filename := fmt.Sprintf("events_used_for_junits_%s.json", m.startTime.UTC().Format("20060102-150405"))
 	if err := monitorserialization.EventsToFile(filepath.Join(m.storageDir, filename), finalEvents); err != nil {
 		fmt.Fprintf(os.Stderr, "error: Failed to junit event info: %v\n", err)

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -222,6 +222,10 @@ const (
 
 	// client metrics show error connecting to the kube-apiserver
 	APIUnreachableFromClientMetrics IntervalReason = "APIUnreachableFromClientMetrics"
+
+	LeaseAcquiring        IntervalReason = "Acquiring"
+	LeaseAcquiringStarted IntervalReason = "StartedAcquiring"
+	LeaseAcquired         IntervalReason = "Acquired"
 )
 
 type AnnotationKey string
@@ -268,6 +272,7 @@ const (
 	ConstructionOwnerNodeLifecycle = "node-lifecycle-constructor"
 	ConstructionOwnerPodLifecycle  = "pod-lifecycle-constructor"
 	ConstructionOwnerEtcdLifecycle = "etcd-lifecycle-constructor"
+	ConstructionOwnerLeaseChecker  = "lease-checker"
 )
 
 type Message struct {

--- a/pkg/monitortestlibrary/podaccess/one_time_pod_log_streamer.go
+++ b/pkg/monitortestlibrary/podaccess/one_time_pod_log_streamer.go
@@ -1,0 +1,90 @@
+package podaccess
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	corev1 "k8s.io/api/core/v1"
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+type OneTimePodStreamer struct {
+	kubeClient    kubernetes.Interface
+	namespace     string
+	podName       string
+	containerName string
+
+	logHandlers []LogHandler
+}
+
+func NewOneTimePodStreamer(kubeClient kubernetes.Interface, namespace, podName, containerName string, logHandlers ...LogHandler) *OneTimePodStreamer {
+	return &OneTimePodStreamer{
+		kubeClient:    kubeClient,
+		namespace:     namespace,
+		podName:       podName,
+		containerName: containerName,
+		logHandlers:   logHandlers,
+	}
+}
+
+func (s *OneTimePodStreamer) ReadLog(ctx context.Context) error {
+	currPod, err := s.kubeClient.CoreV1().Pods(s.namespace).Get(ctx, s.podName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error getting pod to read logs: %w", err)
+	}
+
+	return s.streamLogsReader(ctx, currPod)
+}
+
+// streamLogsReader will run and block until
+// 1. server closes the http connection
+// 2. context is closed.
+func (s *OneTimePodStreamer) streamLogsReader(ctx context.Context, currPod *corev1.Pod) error {
+	locator := monitorapi.NewLocator().ContainerFromPod(currPod, s.containerName)
+	reader, err := s.kubeClient.CoreV1().Pods(s.namespace).GetLogs(s.podName, &kapiv1.PodLogOptions{
+		Container:  s.containerName,
+		Follow:     false,
+		Timestamps: true,
+	}).Stream(ctx)
+	if err != nil {
+		return err
+	}
+
+	scan := bufio.NewScanner(reader)
+	for scan.Scan() {
+		// exit if we have been stopped.
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		line := scan.Text()
+
+		tokens := strings.SplitN(line, " ", 2)
+		timeString := tokens[0]
+		lineTime, err := time.Parse(time.RFC3339, timeString)
+		if err != nil {
+			utilruntime.HandleError(err)
+		}
+
+		currLine := LogLineContent{
+			Instant: lineTime,
+			Pod:     currPod,
+			Locator: locator,
+			Line:    tokens[1],
+		}
+
+		for _, logHandler := range s.logHandlers {
+			logHandler.HandleLogLine(currLine)
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/monitortests/testframework/operatorloganalyzer/operator_lease_check.go
+++ b/pkg/monitortests/testframework/operatorloganalyzer/operator_lease_check.go
@@ -1,0 +1,143 @@
+package operatorloganalyzer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/rest"
+)
+
+type operatorLeaseCheck struct {
+}
+
+func OperatorLeaseCheck() monitortestframework.MonitorTest {
+	return &operatorLeaseCheck{}
+}
+
+func (w *operatorLeaseCheck) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	return nil
+}
+
+func (w *operatorLeaseCheck) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	return nil, nil, nil
+}
+
+func (*operatorLeaseCheck) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	ret := monitorapi.Intervals{}
+
+	leaseIntervals := startingIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		if eventInterval.Message.Reason == monitorapi.LeaseAcquired || eventInterval.Message.Reason == monitorapi.LeaseAcquiringStarted {
+			return true
+		}
+		return false
+	})
+
+	podToLeaseIntervals := map[string][]monitorapi.Interval{}
+
+	for _, interval := range leaseIntervals {
+		podToLeaseIntervals[interval.Locator.OldLocator()] = append(podToLeaseIntervals[interval.Locator.OldLocator()], interval)
+	}
+
+	errs := []error{}
+	for podLocator, perPodLeaseIntervals := range podToLeaseIntervals {
+		var lastAcquiringFrom *time.Time
+		for _, interval := range perPodLeaseIntervals {
+			switch interval.Message.Reason {
+			case monitorapi.LeaseAcquiringStarted:
+				// only overwrite if there isn't one already
+				if lastAcquiringFrom == nil {
+					lastAcquiringFrom = &interval.From
+				}
+
+			case monitorapi.LeaseAcquired:
+				if lastAcquiringFrom == nil {
+					errs = append(errs, fmt.Errorf("missing acquiring stage for %v", podLocator))
+				} else {
+					ret = append(ret, monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Info).
+						Locator(interval.Locator).
+						Message(monitorapi.NewMessage().
+							Reason(monitorapi.LeaseAcquiring).
+							Constructed(monitorapi.ConstructionOwnerLeaseChecker).
+							HumanMessage("Waiting for lease."),
+						).
+						Display().
+						Build(*lastAcquiringFrom, interval.From),
+					)
+					lastAcquiringFrom = nil
+				}
+			}
+
+		}
+	}
+
+	return ret, errors.Join(errs...)
+}
+
+func (*operatorLeaseCheck) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	leaseIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		if eventInterval.Message.Reason == monitorapi.LeaseAcquiring {
+			return true
+		}
+		return false
+	})
+
+	testNameToFailures := map[string][]string{}
+	for _, interval := range leaseIntervals {
+		ns := monitorapi.NamespaceFromLocator(interval.Locator)
+		testName := fmt.Sprintf("[sig-arch] all leases in ns/%s must gracefully release", ns)
+
+		intervalDuration := interval.To.Sub(interval.From)
+		if intervalDuration < 10*time.Second {
+			_, ok := testNameToFailures[testName]
+			if !ok {
+				testNameToFailures[testName] = []string{}
+			}
+			continue
+		}
+
+		testNameToFailures[testName] = append(testNameToFailures[testName], interval.String())
+	}
+
+	ret := []*junitapi.JUnitTestCase{}
+	for testName, failures := range testNameToFailures {
+		if len(failures) == 0 {
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testName,
+			})
+			continue
+		}
+
+		ret = append(ret,
+			&junitapi.JUnitTestCase{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Message: fmt.Sprintf("had %d non-graceful lease releases", len(failures)),
+					Output:  strings.Join(failures, "\n"),
+				},
+				SystemOut: "sysout",
+				SystemErr: "syserr",
+			},
+			// this is nearly always failing, so make it flake to allow us to introduce it.
+			&junitapi.JUnitTestCase{
+				Name: testName,
+			},
+		)
+	}
+
+	return ret, nil
+}
+
+func (w *operatorLeaseCheck) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*operatorLeaseCheck) Cleanup(ctx context.Context) error {
+	// TODO wire up the start to a context we can kill here
+	return nil
+}

--- a/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
+++ b/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
@@ -1,0 +1,147 @@
+package operatorloganalyzer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/openshift/origin/pkg/monitor"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortestlibrary/podaccess"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type operatorLogAnalyzer struct {
+	kubeClient kubernetes.Interface
+}
+
+func InitialAndFinalOperatorLogScraper() monitortestframework.MonitorTest {
+	return &operatorLogAnalyzer{}
+}
+
+func (w *operatorLogAnalyzer) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	var err error
+	w.kubeClient, err = kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	if err := scanAllOperatorPods(ctx, w.kubeClient, newOperatorLogHandler(recorder)); err != nil {
+		return fmt.Errorf("unable to scan operator logs: %w", err)
+	}
+
+	return nil
+}
+
+func scanAllOperatorPods(ctx context.Context, kubeClient kubernetes.Interface, logHandlers ...podaccess.LogHandler) error {
+	pods, err := kubeClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("couldn't list pods: %w", err)
+	}
+
+	errs := []error{}
+	for _, pod := range pods.Items {
+		if !strings.HasPrefix(pod.Namespace, "openshift-") {
+			continue
+		}
+		if !strings.Contains(pod.Name, "operator") {
+			continue
+		}
+		// this is just a basic check to see if we can expect logs to be present. Unready, unhealthy, and failed pods all still have logs.
+		if pod.Status.Phase == corev1.PodPending || pod.Status.Phase == corev1.PodUnknown {
+			continue
+		}
+
+		for _, container := range pod.Spec.Containers {
+			streamer := podaccess.NewOneTimePodStreamer(kubeClient, pod.Namespace, pod.Name, container.Name, logHandlers...)
+			if err := streamer.ReadLog(ctx); err != nil && !apierrors.IsNotFound(err) {
+				errs = append(errs, fmt.Errorf("error reading log for pods/%s -n %s -c %s: %w", pod.Name, pod.Namespace, container.Name, err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (w *operatorLogAnalyzer) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	localRecorder := monitor.NewRecorder()
+	if err := scanAllOperatorPods(ctx, w.kubeClient, newOperatorLogHandlerAfterTime(localRecorder, beginning)); err != nil {
+		return nil, nil, fmt.Errorf("unable to scan operator logs: %w", err)
+	}
+
+	return localRecorder.Intervals(time.Time{}, time.Time{}), nil, nil
+}
+
+func (*operatorLogAnalyzer) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+func (*operatorLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (w *operatorLogAnalyzer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*operatorLogAnalyzer) Cleanup(ctx context.Context) error {
+	// TODO wire up the start to a context we can kill here
+	return nil
+}
+
+type operatorLogHandler struct {
+	recorder  monitorapi.RecorderWriter
+	afterTime *time.Time
+}
+
+func newOperatorLogHandler(recorder monitorapi.RecorderWriter) operatorLogHandler {
+	return operatorLogHandler{
+		recorder: recorder,
+	}
+}
+
+func newOperatorLogHandlerAfterTime(recorder monitorapi.RecorderWriter, afterTime time.Time) operatorLogHandler {
+	return operatorLogHandler{
+		recorder:  recorder,
+		afterTime: &afterTime,
+	}
+}
+
+func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
+	if g.afterTime != nil {
+		if logLine.Instant.Before(*g.afterTime) {
+			return
+		}
+	}
+	switch {
+	case strings.Contains(logLine.Line, "attempting to acquire leader lease"):
+		g.recorder.AddIntervals(
+			monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Info).
+				Locator(logLine.Locator).
+				Message(monitorapi.NewMessage().
+					Reason(monitorapi.LeaseAcquiringStarted).
+					HumanMessage(logLine.Line),
+				).
+				Build(logLine.Instant, logLine.Instant),
+		)
+	case strings.Contains(logLine.Line, "successfully acquired lease"):
+		g.recorder.AddIntervals(
+			monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Info).
+				Locator(logLine.Locator).
+				Message(monitorapi.NewMessage().
+					Reason(monitorapi.LeaseAcquired).
+					HumanMessage(logLine.Line),
+				).
+				Build(logLine.Instant, logLine.Instant),
+		)
+	}
+
+}


### PR DESCRIPTION
It'll be fine....

Adding to identify when leases for operators are non-gracefully released by watching for acquisition time which should be milliseconds long.  When it's longer than 10s, mark failures.  These failures nearly always mean that for some reason the kube-apiserver was inaccessible **for minutes**.