### PR TITLE
OCPBUGS-39000: add node-exporter to the list of default SCCs

### DIFF
--- a/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
+++ b/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
@@ -24,6 +24,7 @@ var defaultSCCs = sets.NewString(
 	"hostmount-anyuid",
 	"hostnetwork",
 	"hostnetwork-v2",
+	"node-exporter",
 	"nonroot",
 	"nonroot-v2",
 	"privileged",


### PR DESCRIPTION
The required-scc monitor test checks the list of default SCCs in order to determine whether the assigned SCC is custom or not; that list is missing the `node-exporter` SCC which means that the test will not suggest this to be pinned, as it thinks it is a custom one.