### PR TITLE
OCPBUGS-39232: Change Operator Installed for Smoke Test

### DIFF
--- a/test/extended/olm/olm.go
+++ b/test/extended/olm/olm.go
@@ -317,7 +317,7 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 		}, 5*time.Minute, time.Second).Should(o.Equal([]string{""}))
 
 		for _, v := range files {
-			configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", v, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace()), "SOURCENAME=redhat-operators", "SOURCENAMESPACE=openshift-marketplace", "PACKAGE=cluster-logging", "CHANNEL=stable").OutputToFile("config.json")
+			configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", v, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace()), "SOURCENAME=redhat-operators", "SOURCENAMESPACE=openshift-marketplace", "PACKAGE=openshift-cert-manager-operator", "CHANNEL=stable-v1").OutputToFile("config.json")
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
The cluster-logging operator is (currently) not available in the 4.17 catalog, so we need to use a different candidate for our smoke test in 4.17+ (at least for now).

I'm open to other suggestions for packages to use for this test.