### PR TITLE
NO-JIRA: add exclusions to restart tests

### DIFF
--- a/pkg/monitortests/node/legacynodemonitortests/exclusions.go
+++ b/pkg/monitortests/node/legacynodemonitortests/exclusions.go
@@ -1,0 +1,26 @@
+package legacynodemonitortests
+
+import "regexp"
+
+func isThisContainerRestartExcluded(locator string) bool {
+	// This is a list of known container restart failures
+	// Our goal is to conquer these restarts.
+	// So we are sadly putting these as exceptions.
+	// If you discover a container restarting more than 3 times, it is a bug and you should investigate it.
+	exceptions := []string{
+		"container/metal3-static-ip-set",      // https://issues.redhat.com/browse/OCPBUGS-39314
+		"container/ingress-operator",          // https://issues.redhat.com/browse/OCPBUGS-39315
+		"container/networking-console-plugin", // https://issues.redhat.com/browse/OCPBUGS-39316
+	}
+
+	for _, val := range exceptions {
+		matched, err := regexp.MatchString(val, locator)
+		if err != nil {
+			return false
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/monitortests/node/legacynodemonitortests/exclusions.go
+++ b/pkg/monitortests/node/legacynodemonitortests/exclusions.go
@@ -1,8 +1,18 @@
 package legacynodemonitortests
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
 
-func isThisContainerRestartExcluded(locator string) bool {
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+)
+
+type Exclusion struct {
+	upgradeJob  bool
+	clusterData platformidentification.ClusterData
+}
+
+func isThisContainerRestartExcluded(locator string, exclusion Exclusion) bool {
 	// This is a list of known container restart failures
 	// Our goal is to conquer these restarts.
 	// So we are sadly putting these as exceptions.
@@ -11,6 +21,17 @@ func isThisContainerRestartExcluded(locator string) bool {
 		"container/metal3-static-ip-set",      // https://issues.redhat.com/browse/OCPBUGS-39314
 		"container/ingress-operator",          // https://issues.redhat.com/browse/OCPBUGS-39315
 		"container/networking-console-plugin", // https://issues.redhat.com/browse/OCPBUGS-39316
+	}
+
+	// Upgrades seem to have a lot of failures.
+	// Let's exclude these for now generally.
+	if exclusion.upgradeJob {
+		return true
+	}
+	for _, val := range exclusion.clusterData.ClusterVersionHistory {
+		if strings.Contains(val, "4.17") {
+			return true
+		}
 	}
 
 	for _, val := range exceptions {

--- a/pkg/monitortests/node/legacynodemonitortests/kubelet.go
+++ b/pkg/monitortests/node/legacynodemonitortests/kubelet.go
@@ -248,8 +248,8 @@ func testContainerFailures(events monitorapi.Intervals) []*junitapi.JUnitTestCas
 	for locator, messages := range containerExits {
 		if len(messages) > 0 {
 			messageSet := sets.NewString(messages...)
-			// Blanket fail for restarts over 3
-			if len(messages) > maxRestartCount {
+			// Blanket fail for restarts over maxRestartCount
+			if !isThisContainerRestartExcluded(locator) && len(messages) > maxRestartCount {
 				excessiveExits = append(excessiveExits, fmt.Sprintf("%s restarted %d times at:\n%s", locator, len(messages), strings.Join(messageSet.List(), "\n")))
 			}
 		}
@@ -287,7 +287,6 @@ func testContainerFailures(events monitorapi.Intervals) []*junitapi.JUnitTestCas
 			},
 		})
 	}
-	testCases = append(testCases, &junitapi.JUnitTestCase{Name: excessiveRestartTestName})
 	return testCases
 }
 

--- a/pkg/monitortests/node/legacynodemonitortests/monitortest.go
+++ b/pkg/monitortests/node/legacynodemonitortests/monitortest.go
@@ -14,6 +14,7 @@ import (
 )
 
 type legacyMonitorTests struct {
+	adminRESTConfig *rest.Config
 }
 
 func NewLegacyTests() monitortestframework.MonitorTest {
@@ -21,6 +22,7 @@ func NewLegacyTests() monitortestframework.MonitorTest {
 }
 
 func (w *legacyMonitorTests) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	w.adminRESTConfig = adminRESTConfig
 	return nil
 }
 
@@ -34,7 +36,7 @@ func (*legacyMonitorTests) ConstructComputedIntervals(ctx context.Context, start
 
 func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
 	junits := []*junitapi.JUnitTestCase{}
-	junits = append(junits, testContainerFailures(finalIntervals)...)
+	junits = append(junits, testContainerFailures(w.adminRESTConfig, finalIntervals)...)
 	junits = append(junits, testDeleteGracePeriodZero(finalIntervals)...)
 	junits = append(junits, testKubeApiserverProcessOverlap(finalIntervals)...)
 	junits = append(junits, testKubeAPIServerGracefulTermination(finalIntervals)...)


### PR DESCRIPTION
Exclusions were found by starting https://search.dptools.openshift.org/?search=container%2Fnetworking-console-plugin+restarted+.*+times+at%3A&maxAge=168h&context=1&type=junit&name=4.18&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job for 4.18.

We filed bugs to hopefully catch these exclusions.

The goal of this PR is to start making this test useful again so we catch bad restarts early. This job was flaking for a long time and many people ignored it.

By making the job fail, we hope to catch actual bugs in our product.