### PR TITLE
NO-JIRA: add api error rate observed by kubelet, kcm, and scheduler

### DIFF
--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -364,7 +364,7 @@ func (b *LocatorBuilder) KubeAPIServerWithLB(loadBalancer string) Locator {
 	return b.Build()
 }
 
-func (b *LocatorBuilder) WithAPIUnreachableFromClient(metric model.Metric, serviceNetworkIP string) Locator {
+func (b *LocatorBuilder) WithAPIUnreachableFromClient(metric model.Metric, serviceNetworkIP, nodeName, nodeRole string) Locator {
 	// the label 'host' is the endpoint used to contact the kube-apiserver
 	getHost := func(metric model.Metric, serviceNetworkIP string) string {
 		host := string(metric["host"])
@@ -385,7 +385,15 @@ func (b *LocatorBuilder) WithAPIUnreachableFromClient(metric model.Metric, servi
 	}
 
 	b.targetType = LocatorTypeAPIUnreachableFromClient
-	b.annotations[LocatorAPIUnreachableHostKey] = getHost(metric, serviceNetworkIP)
+	if host := getHost(metric, serviceNetworkIP); len(host) > 0 {
+		b.annotations[LocatorAPIUnreachableHostKey] = host
+	}
+	if job := string(metric["job"]); len(job) > 0 {
+		b.annotations[LocatorAPIUnreachableComponentKey] = job
+	}
+
+	b.annotations[LocatorNodeKey] = nodeName
+	b.annotations[LocatorNodeRoleKey] = nodeRole
 	return b.Build()
 }
 

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -131,6 +131,7 @@ const (
 	LocatorStatefulSetKey     LocatorKey = "statefulset"
 	LocatorNodeKey            LocatorKey = "node"
 	LocatorMachineKey         LocatorKey = "machine"
+	LocatorNodeRoleKey        LocatorKey = "node-role"
 	LocatorEtcdMemberKey      LocatorKey = "etcd-member"
 	LocatorNameKey            LocatorKey = "name"
 	LocatorHmsgKey            LocatorKey = "hmsg"
@@ -156,6 +157,7 @@ const (
 	LocatorMetricKey                LocatorKey = "metric"
 
 	LocatorAPIUnreachableHostKey                  LocatorKey = "host"
+	LocatorAPIUnreachableComponentKey             LocatorKey = "component"
 	LocatorOnPremKubeapiUnreachableFromHaproxyKey LocatorKey = "onprem-haproxy"
 
 	LocatorTypeKubeletSyncLoopProbeType LocatorKey = "probe"

--- a/pkg/monitortests/kubeapiserver/apiunreachablefromclientmetrics/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/apiunreachablefromclientmetrics/monitortest.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	exutil "github.com/openshift/origin/test/extended/util"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -65,14 +64,14 @@ func NewMonitorTest() monitortestframework.MonitorTest {
 	return &monitorTest{}
 }
 
-type apiUnreachableMonitor struct {
+type queryAnalyzer struct {
 	query    metrics.QueryRunner
 	analyzer metrics.SeriesAnalyzer
-	callback *apiUnreachableCallback
 }
 
 type monitorTest struct {
-	monitor            *apiUnreachableMonitor
+	queryAnalyzers     []queryAnalyzer
+	callback           *apiUnreachableCallback
 	notSupportedReason error
 }
 
@@ -101,24 +100,36 @@ func (test *monitorTest) StartCollection(ctx context.Context, adminRESTConfig *r
 		return err
 	}
 
-	kubeSvc, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(ctx, "kubernetes", metav1.GetOptions{})
+	resolver, err := NewClusterInfoResolver(ctx, kubeClient)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve cluster IP from kubernetes.default.svc - %v", err)
+		return err
 	}
 
-	test.monitor = &apiUnreachableMonitor{
-		query: &metrics.PrometheusQueryRunner{
-			Client:      client,
-			QueryString: `sum(rate(rest_client_requests_total{code="<error>"}[1m])) by(host)`,
-			Step:        time.Minute,
+	test.callback = &apiUnreachableCallback{
+		resolver: resolver,
+	}
+	test.queryAnalyzers = []queryAnalyzer{
+		// rate of client api error by load balancer type
+		{
+			query: &metrics.PrometheusQueryRunner{
+				Client:      client,
+				QueryString: `sum(rate(rest_client_requests_total{code="<error>"}[1m])) by(host)`,
+				Step:        time.Minute,
+			},
+			analyzer: metrics.RateSeriesAnalyzer{},
 		},
-		analyzer: metrics.RateSeriesAnalyzer{},
-		callback: &apiUnreachableCallback{
-			serviceNetworkIP: kubeSvc.Spec.ClusterIP,
+		// api error observed by each kubelet, kcm, and scheduler instance
+		{
+			query: &metrics.PrometheusQueryRunner{
+				Client:      client,
+				QueryString: `sum(rate(rest_client_requests_total{code="<error>", job=~"kubelet|kube-controller-manager|scheduler"}[1m])) by(job, instance)`,
+				Step:        time.Minute,
+			},
+			analyzer: metrics.RateSeriesAnalyzer{},
 		},
 	}
 
-	framework.Logf("monitor[%s]: monitor initialized, service-network-ip: %s", MonitorName, kubeSvc.Spec.ClusterIP)
+	framework.Logf("monitor[%s]: monitor initialized, service-network-ip: %s", MonitorName, resolver.GetKubernetesServiceClusterIP())
 	return nil
 }
 
@@ -127,15 +138,16 @@ func (test *monitorTest) CollectData(ctx context.Context, storageDir string, beg
 		return nil, nil, test.notSupportedReason
 	}
 
-	m := test.monitor
-	if m == nil {
+	if len(test.queryAnalyzers) == 0 {
 		return monitorapi.Intervals{}, nil, fmt.Errorf("monitor test is not initialized")
 	}
-
-	if err := m.analyzer.Analyze(ctx, m.query, beginning, end, m.callback); err != nil {
-		return monitorapi.Intervals{}, nil, err
+	for _, qa := range test.queryAnalyzers {
+		if err := qa.analyzer.Analyze(ctx, qa.query, beginning, end, test.callback); err != nil {
+			return monitorapi.Intervals{}, nil, err
+		}
 	}
-	return m.callback.intervals, nil, nil
+
+	return test.callback.intervals, nil, nil
 }
 
 func (test *monitorTest) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
@@ -156,14 +168,20 @@ func (test *monitorTest) Cleanup(ctx context.Context) error {
 
 // callback passed to the metric analyzer so we can construct the api unreachable intervals
 type apiUnreachableCallback struct {
-	serviceNetworkIP string
-	locator          monitorapi.Locator
-	intervals        monitorapi.Intervals
+	resolver  *clusterInfoResolver
+	locator   monitorapi.Locator
+	intervals monitorapi.Intervals
 }
 
 func (b *apiUnreachableCallback) Name() string { return MonitorName }
 func (b *apiUnreachableCallback) StartSeries(metric prometheustypes.Metric) {
-	b.locator = monitorapi.NewLocator().WithAPIUnreachableFromClient(metric, b.serviceNetworkIP)
+	instanceIP := string(metric["instance"])
+	nodeName, nodeRole, err := b.resolver.GetNodeNameAndRoleFromInstance(instanceIP)
+	if err != nil {
+		framework.Logf("monitor[%s]: failed to get node name for instance: %s", MonitorName, instanceIP)
+	}
+
+	b.locator = monitorapi.NewLocator().WithAPIUnreachableFromClient(metric, b.resolver.serviceNetworkIP, nodeName, nodeRole)
 }
 func (b *apiUnreachableCallback) EndSeries() { b.locator = monitorapi.Locator{} }
 
@@ -177,10 +195,23 @@ func (b *apiUnreachableCallback) NewInterval(metric prometheustypes.Metric, star
 		endTime = end.Timestamp.Time().Add(30 * time.Second)
 	}
 
+	kv := ""
+	for _, label := range []struct {
+		name, key string
+	}{
+		{name: "component", key: "job"},
+		{name: "instance", key: "instance"},
+		{name: "host", key: "host"},
+	} {
+		if value := string(metric[prometheustypes.LabelName(label.key)]); len(value) > 0 {
+			kv = fmt.Sprintf("%s %s=%s", kv, label.name, value)
+		}
+	}
+
 	interval := monitorapi.NewInterval(monitorapi.SourceAPIUnreachableFromClient, monitorapi.Error).
 		Locator(b.locator).
 		Message(monitorapi.NewMessage().
-			HumanMessage(fmt.Sprintf("client observed API error(s), host: %s, duration: %s", string(metric["host"]), endTime.Sub(startTime))).
+			HumanMessage(fmt.Sprintf("client observed API error(s)%s duration=%s", kv, endTime.Sub(startTime))).
 			Reason(monitorapi.APIUnreachableFromClientMetrics)).
 		Display().
 		Build(startTime, endTime)

--- a/pkg/monitortests/kubeapiserver/apiunreachablefromclientmetrics/monitortest_test.go
+++ b/pkg/monitortests/kubeapiserver/apiunreachablefromclientmetrics/monitortest_test.go
@@ -21,10 +21,14 @@ func TestAPIUnreachableMonitor(t *testing.T) {
 	}
 
 	test := monitorTest{
-		monitor: &apiUnreachableMonitor{
-			query:    byteQuery(bytes),
-			analyzer: metrics.RateSeriesAnalyzer{},
-			callback: &apiUnreachableCallback{
+		queryAnalyzers: []queryAnalyzer{
+			{
+				query:    byteQuery(bytes),
+				analyzer: metrics.RateSeriesAnalyzer{},
+			},
+		},
+		callback: &apiUnreachableCallback{
+			resolver: &clusterInfoResolver{
 				serviceNetworkIP: "172.30.0.1",
 			},
 		},

--- a/pkg/monitortests/kubeapiserver/apiunreachablefromclientmetrics/resolver.go
+++ b/pkg/monitortests/kubeapiserver/apiunreachablefromclientmetrics/resolver.go
@@ -1,0 +1,87 @@
+package apiunreachablefromclientmetrics
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// TODO: move this to a reusable package
+func NewClusterInfoResolver(ctx context.Context, client kubernetes.Interface) (*clusterInfoResolver, error) {
+	kubeSvc, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(ctx, "kubernetes", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve cluster IP from kubernetes.default.svc - %v", err)
+	}
+
+	allNodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve nodes - %v", err)
+	}
+	if len(allNodes.Items) == 0 {
+		return nil, fmt.Errorf("unexpected empty list of nodes")
+	}
+	return &clusterInfoResolver{
+		serviceNetworkIP: kubeSvc.Spec.ClusterIP,
+		cache:            populate(allNodes.Items),
+	}, nil
+}
+
+type nodeNameRole struct {
+	name, role string
+}
+
+type clusterInfoResolver struct {
+	serviceNetworkIP string
+	// pre computed hash of IP address to node name and role
+	cache map[string]nodeNameRole
+}
+
+func (r *clusterInfoResolver) GetKubernetesServiceClusterIP() string { return r.serviceNetworkIP }
+func (r *clusterInfoResolver) GetNodeNameAndRoleFromInstance(instance string) (string, string, error) {
+	if len(instance) == 0 {
+		return "", "", fmt.Errorf("instance name is empty")
+	}
+	instanceIP := instance
+	if strings.Contains(instance, ":") {
+		host, _, err := net.SplitHostPort(instance)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get node from instance: %s - %w", instance, err)
+		}
+		instanceIP = host
+	}
+
+	match, ok := r.cache[instanceIP]
+	if !ok {
+		return "", "", fmt.Errorf("did not find a matching node for: %s", instance)
+	}
+	return match.name, match.role, nil
+}
+
+func populate(nodes []corev1.Node) map[string]nodeNameRole {
+	cache := map[string]nodeNameRole{}
+	for i := range nodes {
+		for _, address := range nodes[i].Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				role := getNodeRole(&nodes[i])
+				// TODO: should we get the host name from the addresses in the status?
+				cache[address.Address] = nodeNameRole{name: nodes[i].Name, role: role}
+			}
+		}
+	}
+	return cache
+}
+
+func getNodeRole(node *corev1.Node) string {
+	if _, ok := node.Labels["node-role.kubernetes.io/worker"]; ok {
+		return "worker"
+	}
+	if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok {
+		return "master"
+	}
+	return ""
+}


### PR DESCRIPTION
in addition to the `host` view (load balancer type), api-unreachable breaks it down by kubelet, kcm, and scheduler

![image](https://github.com/user-attachments/assets/f601f7eb-96d1-4531-aba9-e07d5a346761)

taken from: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29070/pull-ci-openshift-origin-main-e2e-vsphere-ovn-etcd-scaling/1909601067327295488

