### PR TITLE
OCPBUGS-41550: fix: add check for image registry capability

### DIFF
--- a/test/extended/cpu_partitioning/managed.go
+++ b/test/extended/cpu_partitioning/managed.go
@@ -224,7 +224,7 @@ func createNamespace(oc *exutil.CLI, name string, annotations map[string]string)
 	if err != nil {
 		return err
 	}
-	return exutil.WaitForServiceAccountWithSecret(oc.AdminKubeClient().CoreV1().ServiceAccounts(name), "builder")
+	return exutil.WaitForServiceAccountWithSecret(oc.AdminConfigClient().ConfigV1().ClusterVersions(), oc.AdminKubeClient().CoreV1().ServiceAccounts(name), "builder")
 }
 
 func createDeployment(oc *exutil.CLI, name, namespace string, depLabels map[string]string, podAnnotations map[string]string) error {

--- a/test/extended/pods/graceful-shutdown.go
+++ b/test/extended/pods/graceful-shutdown.go
@@ -340,6 +340,7 @@ func createTestBed(ctx context.Context, oc *exutil.CLI) {
 	err = callRBAC(ctx, oc, true)
 	Expect(err).NotTo(HaveOccurred())
 	err = exutil.WaitForServiceAccountWithSecret(
+		oc.AdminConfigClient().ConfigV1().ClusterVersions(),
 		oc.AdminKubeClient().CoreV1().ServiceAccounts(namespace),
 		serviceAccountName)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When the image registry capability is disabled, service account pull secret and role bindings are not going to be populated. We need to skip waiting for those events when creating namespaces.